### PR TITLE
Add tests for path endpoints

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -72,6 +72,91 @@ def get_path_param_required_id(item_id: str = Path(...)):
     return item_id
 
 
+@app.get("/path/param-minlength/{item_id}")
+def get_path_param_min_length(item_id: str = Path(..., min_length = 3)):
+    return item_id
+
+
+@app.get("/path/param-maxlength/{item_id}")
+def get_path_param_max_length(item_id: str = Path(..., max_length = 3)):
+    return item_id
+
+
+@app.get("/path/param-min_maxlength/{item_id}")
+def get_path_param_min_max_length(item_id: str = Path(..., max_length = 3, min_length = 2)):
+    return item_id
+
+
+@app.get("/path/param-gt/{item_id}")
+def get_path_param_gt(item_id: float = Path(..., gt = 3)):
+    return item_id
+
+
+@app.get("/path/param-gt0/{item_id}")
+def get_path_param_gt0(item_id: float = Path(..., gt = 0)):
+    return item_id
+
+
+@app.get("/path/param-ge/{item_id}")
+def get_path_param_ge(item_id: float = Path(..., ge = 3)):
+    return item_id
+
+
+@app.get("/path/param-lt/{item_id}")
+def get_path_param_lt(item_id: float = Path(..., lt = 3)):
+    return item_id
+
+
+@app.get("/path/param-lt0/{item_id}")
+def get_path_param_lt0(item_id: float = Path(..., lt = 0)):
+    return item_id
+
+
+@app.get("/path/param-le/{item_id}")
+def get_path_param_le(item_id: float = Path(..., le = 3)):
+    return item_id
+
+
+@app.get("/path/param-lt-gt/{item_id}")
+def get_path_param_lt_gt(item_id: float = Path(..., lt = 3, gt = 1)):
+    return item_id
+
+
+@app.get("/path/param-le-ge/{item_id}")
+def get_path_param_le_ge(item_id: float = Path(..., le = 3, ge = 1)):
+    return item_id
+
+
+@app.get("/path/param-lt-int/{item_id}")
+def get_path_param_lt_int(item_id: int = Path(..., lt = 3)):
+    return item_id
+
+
+@app.get("/path/param-gt-int/{item_id}")
+def get_path_param_gt_int(item_id: int = Path(..., gt = 3)):
+    return item_id
+
+
+@app.get("/path/param-le-int/{item_id}")
+def get_path_param_le_int(item_id: int = Path(..., le = 3)):
+    return item_id
+
+
+@app.get("/path/param-ge-int/{item_id}")
+def get_path_param_ge_int(item_id: int = Path(..., ge = 3)):
+    return item_id
+
+
+@app.get("/path/param-lt-gt-int/{item_id}")
+def get_path_param_lt_gt_int(item_id: int = Path(..., lt = 3, gt = 1)):
+    return item_id
+
+
+@app.get("/path/param-le-ge-int/{item_id}")
+def get_path_param_le_ge_int(item_id: int = Path(..., le = 3, ge = 1)):
+    return item_id
+
+
 @app.get("/query")
 def get_query(query):
     if query is None:

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -38,6 +38,105 @@ response_not_valid_float = {
     ]
 }
 
+response_at_least_3 = {"detail":[{"loc":["path","item_id"],"msg":"ensure this value has at least 3 characters","type":"value_error.any_str.min_length","ctx":{"limit_value":3}}]}
+
+
+response_at_least_2 = {"detail":[{"loc":["path","item_id"],"msg":"ensure this value has at least 2 characters","type":"value_error.any_str.min_length","ctx":{"limit_value":2}}]}
+
+
+response_maximum_3 = {"detail":[{"loc":["path","item_id"],"msg":"ensure this value has at most 3 characters","type":"value_error.any_str.max_length","ctx":{"limit_value":3}}]}
+
+
+response_greater_than_3 = {
+  "detail": [
+    {
+      "loc": [
+        "path",
+        "item_id"
+      ],
+      "msg": "ensure this value is greater than 3",
+      "type": "value_error.number.not_gt",
+      "ctx": {
+        "limit_value": 3
+      }
+    }
+  ]
+}
+
+
+response_greater_than_0 = {
+  "detail": [
+    {
+      "loc": [
+        "path",
+        "item_id"
+      ],
+      "msg": "ensure this value is greater than 0",
+      "type": "value_error.number.not_gt",
+      "ctx": {
+        "limit_value": 0
+      }
+    }
+  ]
+}
+
+
+response_greater_than_1 = {
+  "detail": [
+    {
+      "loc": [
+        "path",
+        "item_id"
+      ],
+      "msg": "ensure this value is greater than 1",
+      "type": "value_error.number.not_gt",
+      "ctx": {
+        "limit_value": 1
+      }
+    }
+  ]
+}
+
+
+response_greater_than_equal_3 = {"detail":[{"loc":["path","item_id"],"msg":"ensure this value is greater than or equal to 3","type":"value_error.number.not_ge","ctx":{"limit_value":3}}]}
+
+
+response_less_than_3 = {
+  "detail": [
+    {
+      "loc": [
+        "path",
+        "item_id"
+      ],
+      "msg": "ensure this value is less than 3",
+      "type": "value_error.number.not_lt",
+      "ctx": {
+        "limit_value": 3
+      }
+    }
+  ]
+}
+
+
+response_less_than_0 = {
+  "detail": [
+    {
+      "loc": [
+        "path",
+        "item_id"
+      ],
+      "msg": "ensure this value is less than 0",
+      "type": "value_error.number.not_lt",
+      "ctx": {
+        "limit_value": 0
+      }
+    }
+  ]
+}
+
+
+response_less_than_equal_3 = {"detail":[{"loc":["path","item_id"],"msg":"ensure this value is less than or equal to 3","type":"value_error.number.not_le","ctx":{"limit_value":3}}]}
+
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -65,6 +164,57 @@ response_not_valid_float = {
         ("/path/bool/false", 200, False),
         ("/path/param/foo", 200, "foo"),
         ("/path/param-required/foo", 200, "foo"),
+        ("/path/param-minlength/foo", 200, "foo"),
+        ("/path/param-minlength/fo", 422, response_at_least_3),
+        ("/path/param-maxlength/foo", 200, "foo"),
+        ("/path/param-maxlength/foobar", 422, response_maximum_3),
+        ("/path/param-min_maxlength/foo", 200, "foo"),
+        ("/path/param-min_maxlength/foobar", 422, response_maximum_3),
+        ("/path/param-min_maxlength/f", 422, response_at_least_2),
+        ("/path/param-gt/42", 200, 42),
+        ("/path/param-gt/2", 422, response_greater_than_3),
+        ("/path/param-gt0/0.05", 200, 0.05),
+        ("/path/param-gt0/0", 422, response_greater_than_0),
+        ("/path/param-ge/42", 200, 42),
+        ("/path/param-ge/3", 200, 3),
+        ("/path/param-ge/2", 422, response_greater_than_equal_3),
+        ("/path/param-lt/42", 422, response_less_than_3),
+        ("/path/param-lt/2", 200, 2),
+        ("/path/param-lt0/-1", 200, -1),
+        ("/path/param-lt0/0", 422, response_less_than_0),
+        ("/path/param-le/42", 422, response_less_than_equal_3),
+        ("/path/param-le/3", 200, 3),
+        ("/path/param-le/2", 200, 2),
+        ("/path/param-lt-gt/2", 200, 2),
+        ("/path/param-lt-gt/4", 422, response_less_than_3),
+        ("/path/param-lt-gt/0", 422, response_greater_than_1),
+        ("/path/param-le-ge/2", 200, 2),
+        ("/path/param-le-ge/1", 200, 1),
+        ("/path/param-le-ge/3", 200, 3),
+        ("/path/param-le-ge/4", 422, response_less_than_equal_3),
+        ("/path/param-lt-int/2", 200, 2),
+        ("/path/param-lt-int/42", 422, response_less_than_3),
+        ("/path/param-lt-int/2.7", 422, response_not_valid_int),
+        ("/path/param-gt-int/42", 200, 42),
+        ("/path/param-gt-int/2", 422, response_greater_than_3),
+        ("/path/param-gt-int/2.7", 422, response_not_valid_int),
+        ("/path/param-le-int/42", 422, response_less_than_equal_3),
+        ("/path/param-le-int/3", 200, 3),
+        ("/path/param-le-int/2", 200, 2),
+        ("/path/param-le-int/2.7", 422, response_not_valid_int),
+        ("/path/param-ge-int/42", 200, 42),
+        ("/path/param-ge-int/3", 200, 3),
+        ("/path/param-ge-int/2", 422, response_greater_than_equal_3),
+        ("/path/param-ge-int/2.7", 422, response_not_valid_int),
+        ("/path/param-lt-gt-int/2", 200, 2),
+        ("/path/param-lt-gt-int/4", 422, response_less_than_3),
+        ("/path/param-lt-gt-int/0", 422, response_greater_than_1),
+        ("/path/param-lt-gt-int/2.7", 422, response_not_valid_int),
+        ("/path/param-le-ge-int/2", 200, 2),
+        ("/path/param-le-ge-int/1", 200, 1),
+        ("/path/param-le-ge-int/3", 200, 3),
+        ("/path/param-le-ge-int/4", 422, response_less_than_equal_3),
+        ("/path/param-le-ge-int/2.7", 422, response_not_valid_int),
     ],
 )
 def test_get_path(path, expected_status, expected_response):


### PR DESCRIPTION
I have added tests for the path endpoints. These include testing parameters: minlength, maxlength, gt, lt, ge, le and combinations of le-ge and lt-gt. For both ints and floats.