### PR TITLE
Fix jsonable_encoder for models with Config

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -15,17 +15,12 @@ def jsonable_encoder(
     custom_encoder: dict = {},
 ) -> Any:
     if isinstance(obj, BaseModel):
-        if not obj.Config.json_encoders:
-            return jsonable_encoder(
-                obj.dict(include=include, exclude=exclude, by_alias=by_alias),
-                include_none=include_none,
-            )
-        else:
-            return jsonable_encoder(
-                obj.dict(include=include, exclude=exclude, by_alias=by_alias),
-                include_none=include_none,
-                custom_encoder=obj.Config.json_encoders,
-            )
+        encoder = getattr(obj.Config, "json_encoders", custom_encoder)
+        return jsonable_encoder(
+            obj.dict(include=include, exclude=exclude, by_alias=by_alias),
+            include_none=include_none,
+            custom_encoder=encoder,
+        )
     if isinstance(obj, Enum):
         return obj.value
     if isinstance(obj, (str, int, float, type(None))):

--- a/tests/test_datetime_custom_encoder.py
+++ b/tests/test_datetime_custom_encoder.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime, timezone
 
 from fastapi import FastAPI
@@ -18,7 +17,7 @@ class ModelWithDatetimeField(BaseModel):
 
 
 app = FastAPI()
-model = ModelWithDatetimeField(dt_field=datetime.utcnow())
+model = ModelWithDatetimeField(dt_field=datetime(2019, 1, 1, 8))
 
 
 @app.get("/model", response_model=ModelWithDatetimeField)
@@ -32,4 +31,4 @@ client = TestClient(app)
 def test_dt():
     with client:
         response = client.get("/model")
-    assert json.loads(model.json()) == response.json()
+    assert response.json() == {"dt_field": "2019-01-01T08:00:00+00:00"}


### PR DESCRIPTION
:bug: Fix jsonable_encoder for models with `Config` but without `json_encoders`, and add tests for the involved cases.