### PR TITLE
Fixed order of imports

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -3,7 +3,7 @@
 __version__ = "0.7.1"
 
 from .applications import FastAPI
-from .routing import APIRouter
-from .params import Body, Path, Query, Header, Cookie, Form, File, Security, Depends
-from .exceptions import HTTPException
 from .datastructures import UploadFile
+from .exceptions import HTTPException
+from .params import Body, Cookie, Depends, File, Form, Header, Path, Query, Security
+from .routing import APIRouter

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1,8 +1,5 @@
 from typing import Any, Callable, Dict, List, Optional, Type
 
-from fastapi import routing
-from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
-from fastapi.openapi.utils import get_openapi
 from pydantic import BaseModel
 from starlette.applications import Starlette
 from starlette.exceptions import ExceptionMiddleware, HTTPException
@@ -10,6 +7,10 @@ from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import BaseRoute
+
+from fastapi import routing
+from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.openapi.utils import get_openapi
 
 
 async def http_exception(request: Request, exc: HTTPException) -> JSONResponse:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -1,7 +1,8 @@
 from typing import Callable, List, Sequence
 
-from fastapi.security.base import SecurityBase
 from pydantic.fields import Field
+
+from fastapi.security.base import SecurityBase
 
 param_supported_types = (str, int, float, bool)
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -6,10 +6,6 @@ from decimal import Decimal
 from typing import Any, Callable, Dict, List, Mapping, Sequence, Tuple, Type, Union
 from uuid import UUID
 
-from fastapi import params
-from fastapi.dependencies.models import Dependant, SecurityRequirement
-from fastapi.security.base import SecurityBase
-from fastapi.utils import UnconstrainedConfig, get_path_param_names
 from pydantic import Schema, create_model
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.errors import MissingError
@@ -19,6 +15,11 @@ from pydantic.utils import lenient_issubclass
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import UploadFile
 from starlette.requests import Headers, QueryParams, Request
+
+from fastapi import params
+from fastapi.dependencies.models import Dependant, SecurityRequirement
+from fastapi.security.base import SecurityBase
+from fastapi.utils import UnconstrainedConfig, get_path_param_names
 
 param_supported_types = (
     str,

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -1,5 +1,12 @@
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
+from pydantic.fields import Field
+from pydantic.schema import Schema, field_schema, get_model_name_map
+from pydantic.utils import lenient_issubclass
+from starlette.responses import JSONResponse
+from starlette.routing import BaseRoute
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+
 from fastapi import routing
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import get_flat_dependant
@@ -8,12 +15,6 @@ from fastapi.openapi.constants import METHODS_WITH_BODY, REF_PREFIX
 from fastapi.openapi.models import OpenAPI
 from fastapi.params import Body, Param
 from fastapi.utils import get_flat_models_from_routes, get_model_definitions
-from pydantic.fields import Field
-from pydantic.schema import Schema, field_schema, get_model_name_map
-from pydantic.utils import lenient_issubclass
-from starlette.responses import JSONResponse
-from starlette.routing import BaseRoute
-from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 validation_error_definition = {
     "title": "ValidationError",

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -3,11 +3,6 @@ import inspect
 import logging
 from typing import Any, Callable, List, Optional, Type
 
-from fastapi import params
-from fastapi.dependencies.models import Dependant
-from fastapi.dependencies.utils import get_body_field, get_dependant, solve_dependencies
-from fastapi.encoders import jsonable_encoder
-from fastapi.utils import UnconstrainedConfig
 from pydantic import BaseModel, Schema
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from pydantic.fields import Field
@@ -19,6 +14,12 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import compile_path, get_name, request_response
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+
+from fastapi import params
+from fastapi.dependencies.models import Dependant
+from fastapi.dependencies.utils import get_body_field, get_dependant, solve_dependencies
+from fastapi.encoders import jsonable_encoder
+from fastapi.utils import UnconstrainedConfig
 
 
 def serialize_response(*, field: Field = None, response: Response) -> Any:

--- a/fastapi/security/__init__.py
+++ b/fastapi/security/__init__.py
@@ -1,10 +1,10 @@
-from .api_key import APIKeyQuery, APIKeyHeader, APIKeyCookie
+from .api_key import APIKeyCookie, APIKeyHeader, APIKeyQuery
 from .http import (
+    HTTPAuthorizationCredentials,
     HTTPBasic,
+    HTTPBasicCredentials,
     HTTPBearer,
     HTTPDigest,
-    HTTPBasicCredentials,
-    HTTPAuthorizationCredentials,
 )
-from .oauth2 import OAuth2PasswordRequestForm, OAuth2, OAuth2PasswordBearer
+from .oauth2 import OAuth2, OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from .open_id_connect_url import OpenIdConnect

--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -1,8 +1,9 @@
-from fastapi.openapi.models import APIKey, APIKeyIn
-from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_403_FORBIDDEN
+
+from fastapi.openapi.models import APIKey, APIKeyIn
+from fastapi.security.base import SecurityBase
 
 
 class APIKeyBase(SecurityBase):

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -1,16 +1,17 @@
 import binascii
 from base64 import b64decode
 
+from pydantic import BaseModel
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.status import HTTP_403_FORBIDDEN
+
 from fastapi.openapi.models import (
     HTTPBase as HTTPBaseModel,
     HTTPBearer as HTTPBearerModel,
 )
 from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
-from pydantic import BaseModel
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
-from starlette.status import HTTP_403_FORBIDDEN
 
 
 class HTTPBasicCredentials(BaseModel):

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -1,12 +1,13 @@
 from typing import Optional
 
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.status import HTTP_403_FORBIDDEN
+
 from fastapi.openapi.models import OAuth2 as OAuth2Model, OAuthFlows as OAuthFlowsModel
 from fastapi.params import Form
 from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
-from starlette.status import HTTP_403_FORBIDDEN
 
 
 class OAuth2PasswordRequestForm:

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -1,8 +1,9 @@
-from fastapi.openapi.models import OpenIdConnect as OpenIdConnectModel
-from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_403_FORBIDDEN
+
+from fastapi.openapi.models import OpenIdConnect as OpenIdConnectModel
+from fastapi.security.base import SecurityBase
 
 
 class OpenIdConnect(SecurityBase):

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,12 +1,13 @@
 import re
 from typing import Any, Dict, List, Sequence, Set, Type
 
-from fastapi import routing
-from fastapi.openapi.constants import REF_PREFIX
 from pydantic import BaseConfig, BaseModel
 from pydantic.fields import Field
 from pydantic.schema import get_flat_models_from_fields, model_process_schema
 from starlette.routing import BaseRoute
+
+from fastapi import routing
+from fastapi.openapi.constants import REF_PREFIX
 
 
 class UnconstrainedConfig(BaseConfig):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,4 +1,5 @@
 import pytest
+
 from fastapi import UploadFile
 
 

--- a/tests/test_datetime_custom_encoder.py
+++ b/tests/test_datetime_custom_encoder.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timezone
 
-from fastapi import FastAPI
 from pydantic import BaseModel
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI
 
 
 class ModelWithDatetimeField(BaseModel):

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI
 
 app = FastAPI()
 

--- a/tests/test_include_route.py
+++ b/tests/test_include_route.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, FastAPI
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
+
+from fastapi import APIRouter, FastAPI
 
 app = FastAPI()
 router = APIRouter()

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -2,8 +2,9 @@ from datetime import datetime, timezone
 from enum import Enum
 
 import pytest
-from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
+
+from fastapi.encoders import jsonable_encoder
 
 
 class Person:

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -1,8 +1,9 @@
 from typing import List
 
-from fastapi import FastAPI
 from pydantic import BaseModel
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI
 
 app = FastAPI()
 

--- a/tests/test_multi_query_errors.py
+++ b/tests/test_multi_query_errors.py
@@ -1,7 +1,8 @@
 from typing import List
 
-from fastapi import FastAPI, Query
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI, Query
 
 app = FastAPI()
 

--- a/tests/test_param_class.py
+++ b/tests/test_param_class.py
@@ -1,6 +1,7 @@
+from starlette.testclient import TestClient
+
 from fastapi import FastAPI
 from fastapi.params import Param
-from starlette.testclient import TestClient
 
 app = FastAPI()
 

--- a/tests/test_put_no_body.py
+++ b/tests/test_put_no_body.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI
 
 app = FastAPI()
 

--- a/tests/test_security_api_key_cookie.py
+++ b/tests/test_security_api_key_cookie.py
@@ -1,7 +1,8 @@
-from fastapi import Depends, FastAPI, Security
-from fastapi.security import APIKeyCookie
 from pydantic import BaseModel
 from starlette.testclient import TestClient
+
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import APIKeyCookie
 
 app = FastAPI()
 

--- a/tests/test_security_api_key_header.py
+++ b/tests/test_security_api_key_header.py
@@ -1,7 +1,8 @@
-from fastapi import Depends, FastAPI, Security
-from fastapi.security import APIKeyHeader
 from pydantic import BaseModel
 from starlette.testclient import TestClient
+
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import APIKeyHeader
 
 app = FastAPI()
 

--- a/tests/test_security_api_key_query.py
+++ b/tests/test_security_api_key_query.py
@@ -1,7 +1,8 @@
-from fastapi import Depends, FastAPI, Security
-from fastapi.security import APIKeyQuery
 from pydantic import BaseModel
 from starlette.testclient import TestClient
+
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import APIKeyQuery
 
 app = FastAPI()
 

--- a/tests/test_security_http_base.py
+++ b/tests/test_security_http_base.py
@@ -1,6 +1,7 @@
+from starlette.testclient import TestClient
+
 from fastapi import FastAPI, Security
 from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBase
-from starlette.testclient import TestClient
 
 app = FastAPI()
 

--- a/tests/test_security_http_basic.py
+++ b/tests/test_security_http_basic.py
@@ -1,9 +1,10 @@
 from base64 import b64encode
 
-from fastapi import FastAPI, Security
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from requests.auth import HTTPBasicAuth
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 app = FastAPI()
 

--- a/tests/test_security_http_bearer.py
+++ b/tests/test_security_http_bearer.py
@@ -1,6 +1,7 @@
+from starlette.testclient import TestClient
+
 from fastapi import FastAPI, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from starlette.testclient import TestClient
 
 app = FastAPI()
 

--- a/tests/test_security_http_digest.py
+++ b/tests/test_security_http_digest.py
@@ -1,6 +1,7 @@
+from starlette.testclient import TestClient
+
 from fastapi import FastAPI, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPDigest
-from starlette.testclient import TestClient
 
 app = FastAPI()
 

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -1,9 +1,10 @@
 import pytest
+from pydantic import BaseModel
+from starlette.testclient import TestClient
+
 from fastapi import Depends, FastAPI, Security
 from fastapi.security import OAuth2
 from fastapi.security.oauth2 import OAuth2PasswordRequestFormStrict
-from pydantic import BaseModel
-from starlette.testclient import TestClient
 
 app = FastAPI()
 

--- a/tests/test_security_openid_connect.py
+++ b/tests/test_security_openid_connect.py
@@ -1,7 +1,8 @@
-from fastapi import Depends, FastAPI, Security
-from fastapi.security.open_id_connect_url import OpenIdConnect
 from pydantic import BaseModel
 from starlette.testclient import TestClient
+
+from fastapi import Depends, FastAPI, Security
+from fastapi.security.open_id_connect_url import OpenIdConnect
 
 app = FastAPI()
 

--- a/tests/test_serialize_response.py
+++ b/tests/test_serialize_response.py
@@ -1,9 +1,10 @@
 from typing import List
 
 import pytest
-from fastapi import FastAPI
 from pydantic import BaseModel, ValidationError
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI
 
 app = FastAPI()
 

--- a/tests/test_starlette_exception.py
+++ b/tests/test_starlette_exception.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI, HTTPException
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.testclient import TestClient
+
+from fastapi import FastAPI, HTTPException
 
 app = FastAPI()
 


### PR DESCRIPTION
Running `bash scripts/test-cov-html.sh`
reported errors from the isort checks: 'Imports are incorrectly sorted'
This PR fixes the order of the imports only.
