### PR TITLE
Background task

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -3,6 +3,8 @@ import inspect
 import logging
 from typing import Any, Callable, List, Optional, Type
 
+from starlette.background import BackgroundTask
+
 from fastapi import params
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import get_body_field, get_dependant, solve_dependencies

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,35 +1,15 @@
-from starlette.background import BackgroundTasks
-from starlette.requests import Request
-from starlette.responses import JSONResponse
+from fastapi import FastAPI
+from starlette.background import BackgroundTask, BackgroundTasks
 from starlette.testclient import TestClient
 
-from fastapi import FastAPI, Depends
 
-
-def test_multiple_tasks():
+def test_multiple_tasks_fastapistyle():
     TASK_COUNTER = 0
+
     def increment(amount):
         nonlocal TASK_COUNTER
         TASK_COUNTER += amount
-    app = FastAPI()
-    @app.route("/")
-    async def root(request: Request):
-        tasks = BackgroundTasks()
-        tasks.add_task(increment, amount=1)
-        tasks.add_task(increment, amount=2)
-        tasks.add_task(increment, amount=3)
-        message = {'status': 'successful'}
-        return JSONResponse(message, background=tasks)
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.json() == {'status': 'successful'}
-    assert TASK_COUNTER == 1 + 2 + 3
 
-def test_multiple_tasks2():
-    TASK_COUNTER = 0
-    def increment(amount):
-        nonlocal TASK_COUNTER
-        TASK_COUNTER += amount
     app = FastAPI()
 
     @app.get("/")
@@ -38,11 +18,32 @@ def test_multiple_tasks2():
         tasks.add_task(increment, amount=1)
         tasks.add_task(increment, amount=2)
         tasks.add_task(increment, amount=3)
-        message = {'status': 'successful'}
+        message = {"status": "successful", "background": tasks}
+        return message
+        # message = {'status': 'successful'}
+        # return JSONResponse(message, background=tasks)
 
-        return JSONResponse(message, background=tasks)
     client = TestClient(app)
     response = client.get("/")
-    assert response.json() == {'status': 'successful'}
+    assert response.json() == {"status": "successful"}
     assert TASK_COUNTER == 1 + 2 + 3
 
+
+def test_async_task():
+    TASK_COMPLETE = False
+
+    async def async_task():
+        nonlocal TASK_COMPLETE
+        TASK_COMPLETE = True
+
+    app = FastAPI()
+
+    @app.get("/")
+    async def root():
+        task = BackgroundTask(async_task)
+        return {"status": "successful", "background": task}
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.json() == {"status": "successful"}
+    assert TASK_COMPLETE

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,77 +1,48 @@
-from starlette.background import BackgroundTask, BackgroundTasks
-from starlette.responses import Response
+from starlette.background import BackgroundTasks
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
 
-
-def test_async_task():
-    TASK_COMPLETE = False
-
-    async def async_task():
-        nonlocal TASK_COMPLETE
-        TASK_COMPLETE = True
-
-    task = BackgroundTask(async_task)
-
-    def app(scope):
-        async def asgi(receive, send):
-            response = Response(
-                "task initiated", media_type="text/plain", background=task
-            )
-            await response(receive, send)
-
-        return asgi
-
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.text == "task initiated"
-    assert TASK_COMPLETE
-
-
-def test_sync_task():
-    TASK_COMPLETE = False
-
-    def sync_task():
-        nonlocal TASK_COMPLETE
-        TASK_COMPLETE = True
-
-    task = BackgroundTask(sync_task)
-
-    def app(scope):
-        async def asgi(receive, send):
-            response = Response(
-                "task initiated", media_type="text/plain", background=task
-            )
-            await response(receive, send)
-
-        return asgi
-
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.text == "task initiated"
-    assert TASK_COMPLETE
+from fastapi import FastAPI, Depends
 
 
 def test_multiple_tasks():
     TASK_COUNTER = 0
-
     def increment(amount):
         nonlocal TASK_COUNTER
         TASK_COUNTER += amount
-
-    def app(scope):
-        async def asgi(receive, send):
-            tasks = BackgroundTasks()
-            tasks.add_task(increment, amount=1)
-            tasks.add_task(increment, amount=2)
-            tasks.add_task(increment, amount=3)
-            response = Response(
-                "tasks initiated", media_type="text/plain", background=tasks
-            )
-            await response(receive, send)
-
-        return asgi
-
+    app = FastAPI()
+    @app.route("/")
+    async def root(request: Request):
+        tasks = BackgroundTasks()
+        tasks.add_task(increment, amount=1)
+        tasks.add_task(increment, amount=2)
+        tasks.add_task(increment, amount=3)
+        message = {'status': 'successful'}
+        return JSONResponse(message, background=tasks)
     client = TestClient(app)
     response = client.get("/")
-    assert response.text == "tasks initiated"
+    assert response.json() == {'status': 'successful'}
     assert TASK_COUNTER == 1 + 2 + 3
+
+def test_multiple_tasks2():
+    TASK_COUNTER = 0
+    def increment(amount):
+        nonlocal TASK_COUNTER
+        TASK_COUNTER += amount
+    app = FastAPI()
+
+    @app.get("/")
+    async def root():
+        tasks = BackgroundTasks()
+        tasks.add_task(increment, amount=1)
+        tasks.add_task(increment, amount=2)
+        tasks.add_task(increment, amount=3)
+        message = {'status': 'successful'}
+
+        return JSONResponse(message, background=tasks)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.json() == {'status': 'successful'}
+    assert TASK_COUNTER == 1 + 2 + 3
+

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,0 +1,77 @@
+from starlette.background import BackgroundTask, BackgroundTasks
+from starlette.responses import Response
+from starlette.testclient import TestClient
+
+
+def test_async_task():
+    TASK_COMPLETE = False
+
+    async def async_task():
+        nonlocal TASK_COMPLETE
+        TASK_COMPLETE = True
+
+    task = BackgroundTask(async_task)
+
+    def app(scope):
+        async def asgi(receive, send):
+            response = Response(
+                "task initiated", media_type="text/plain", background=task
+            )
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.text == "task initiated"
+    assert TASK_COMPLETE
+
+
+def test_sync_task():
+    TASK_COMPLETE = False
+
+    def sync_task():
+        nonlocal TASK_COMPLETE
+        TASK_COMPLETE = True
+
+    task = BackgroundTask(sync_task)
+
+    def app(scope):
+        async def asgi(receive, send):
+            response = Response(
+                "task initiated", media_type="text/plain", background=task
+            )
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.text == "task initiated"
+    assert TASK_COMPLETE
+
+
+def test_multiple_tasks():
+    TASK_COUNTER = 0
+
+    def increment(amount):
+        nonlocal TASK_COUNTER
+        TASK_COUNTER += amount
+
+    def app(scope):
+        async def asgi(receive, send):
+            tasks = BackgroundTasks()
+            tasks.add_task(increment, amount=1)
+            tasks.add_task(increment, amount=2)
+            tasks.add_task(increment, amount=3)
+            response = Response(
+                "tasks initiated", media_type="text/plain", background=tasks
+            )
+            await response(receive, send)
+
+        return asgi
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.text == "tasks initiated"
+    assert TASK_COUNTER == 1 + 2 + 3


### PR DESCRIPTION
This is a rough attempt at solving the use case of using Starlette BackgroundTask within FastAPI without using a JSONResponse, see #59 

Rough because it hacks the Response object by poping an eventual `background` kwarg:  it means `background` as a key becomes kind of a reserved kwarg, so this isn't really satisfactory.

Maybe a better API would be to push those tasks in the dependency scheme, but I couldn't get my head around.

Or maybe simply we should just use JSONResponse in that case, no hard feelings on this, the PR was more to have a basis for discussion.