### PR TITLE
Renamed startup_event to shutdown_event

### DIFF
--- a/docs/src/events/tutorial002.py
+++ b/docs/src/events/tutorial002.py
@@ -4,7 +4,7 @@ app = FastAPI()
 
 
 @app.on_event("shutdown")
-def startup_event():
+def shutdown_event():
     with open("log.txt", mode="a") as log:
         log.write("Application shutdown")
 


### PR DESCRIPTION
I think this is a copy and paste error, that causes an error if you copy both startup and shutdown events in your server file.