### PR TITLE
docs(body-nested-models): image > images

### DIFF
--- a/docs/src/body_nested_models/tutorial005.py
+++ b/docs/src/body_nested_models/tutorial005.py
@@ -1,8 +1,7 @@
 from typing import Set
 
 from fastapi import FastAPI
-from pydantic import BaseModel
-from pydantic.types import UrlStr
+from pydantic import BaseModel, UrlStr
 
 app = FastAPI()
 

--- a/docs/src/body_nested_models/tutorial006.py
+++ b/docs/src/body_nested_models/tutorial006.py
@@ -18,7 +18,7 @@ class Item(BaseModel):
     price: float
     tax: float = None
     tags: Set[str] = []
-    image: List[Image] = None
+    images: List[Image] = None
 
 
 @app.put("/items/{item_id}")

--- a/docs/src/body_nested_models/tutorial006.py
+++ b/docs/src/body_nested_models/tutorial006.py
@@ -1,8 +1,7 @@
 from typing import List, Set
 
 from fastapi import FastAPI
-from pydantic import BaseModel
-from pydantic.types import UrlStr
+from pydantic import BaseModel, UrlStr
 
 app = FastAPI()
 

--- a/docs/src/body_nested_models/tutorial007.py
+++ b/docs/src/body_nested_models/tutorial007.py
@@ -18,7 +18,7 @@ class Item(BaseModel):
     price: float
     tax: float = None
     tags: Set[str] = []
-    image: List[Image] = None
+    images: List[Image] = None
 
 
 class Offer(BaseModel):

--- a/docs/src/body_nested_models/tutorial007.py
+++ b/docs/src/body_nested_models/tutorial007.py
@@ -1,8 +1,7 @@
 from typing import List, Set
 
 from fastapi import FastAPI
-from pydantic import BaseModel
-from pydantic.types import UrlStr
+from pydantic import BaseModel, UrlStr
 
 app = FastAPI()
 

--- a/docs/src/body_nested_models/tutorial008.py
+++ b/docs/src/body_nested_models/tutorial008.py
@@ -1,8 +1,7 @@
 from typing import List
 
 from fastapi import FastAPI
-from pydantic import BaseModel
-from pydantic.types import UrlStr
+from pydantic import BaseModel, UrlStr
 
 app = FastAPI()
 

--- a/docs/tutorial/body-nested-models.md
+++ b/docs/tutorial/body-nested-models.md
@@ -120,7 +120,7 @@ To see all the options you have, checkout the docs for <a href="https://pydantic
 
 For example, as in the `Image` model we have a `url` field, we can declare it to be instead of a `str`, a Pydantic's `UrlStr`:
 
-```Python hl_lines="5 11"
+```Python hl_lines="4 10"
 {!./src/body_nested_models/tutorial005.py!}
 ```
 
@@ -130,7 +130,7 @@ The string will be checked to be a valid URL, and documented in JSON Schema / Op
 
 You can also use Pydantic models as subtypes of `list`, `set`, etc:
 
-```Python hl_lines="21"
+```Python hl_lines="20"
 {!./src/body_nested_models/tutorial006.py!}
 ```
 
@@ -167,7 +167,7 @@ This will expect (convert, validate, document, etc) a JSON body like:
 
 You can define arbitrarily deeply nested models:
 
-```Python hl_lines="10 15 21 24 28"
+```Python hl_lines="9 14 20 23 27"
 {!./src/body_nested_models/tutorial007.py!}
 ```
 
@@ -184,7 +184,7 @@ images: List[Image]
 
 as in:
 
-```Python hl_lines="16"
+```Python hl_lines="15"
 {!./src/body_nested_models/tutorial008.py!}
 ```
 

--- a/docs/tutorial/security/oauth2-jwt.md
+++ b/docs/tutorial/security/oauth2-jwt.md
@@ -22,7 +22,7 @@ If you want to play with JWT tokens and see how they work, check <a href="https:
 
 ## Install `PyJWT`
 
-We need to install `PyJWT` to generate and verity the JWT tokens in Python:
+We need to install `PyJWT` to generate and verify the JWT tokens in Python:
 
 ```bash
 pip install pyjwt

--- a/docs/tutorial/security/oauth2-jwt.md
+++ b/docs/tutorial/security/oauth2-jwt.md
@@ -198,7 +198,7 @@ Many packages that simplify it a lot have to make many compromises with the data
 
 **FastAPI** doesn't make any compromise with any database, data model or tool.
 
-It gives you all the flexibility to chose the ones that fit your project the best.
+It gives you all the flexibility to choose the ones that fit your project the best.
 
 And you can use directly many well maintained and widely used packages like `passlib` and `pyjwt`, because **FastAPI** doesn't require any complex mechanisms to integrate external packages.
 


### PR DESCRIPTION
Added the missing `s` for images.

Also not sure if you want to change it but as far as I can see you can import `UrlStr` directly from `pydantic`. You can remove line 5 and change line 4 to `from pydantic import BaseModel, UrlStr`

PS:  @tiangolo Really enjoying reading the documents. Well done!