### PR TITLE
Add deeplinking to Swagger UI

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -31,7 +31,8 @@ def get_swagger_ui_html(*, openapi_url: str, title: str) -> HTMLResponse:
         SwaggerUIBundle.presets.apis,
         SwaggerUIBundle.SwaggerUIStandalonePreset
         ],
-        layout: "BaseLayout"
+        layout: "BaseLayout",
+        deepLinking: true
  
     })
     </script>


### PR DESCRIPTION
This will update the Swagger UI URL when clicking on an endpoint so the URL can more easily be shared.