### PR TITLE
Improve naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ def read_item(item_id: int, q: str = None):
 
 
 @app.put("/items/{item_id}")
-def create_item(item_id: int, item: Item):
+def update_item(item_id: int, item: Item):
     return {"item_name": item.name, "item_id": item_id}
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -220,7 +220,7 @@ def read_item(item_id: int, q: str = None):
 
 
 @app.put("/items/{item_id}")
-def create_item(item_id: int, item: Item):
+def update_item(item_id: int, item: Item):
     return {"item_name": item.name, "item_id": item_id}
 ```
 

--- a/docs/src/handling_errors/tutorial001.py
+++ b/docs/src/handling_errors/tutorial001.py
@@ -6,7 +6,7 @@ items = {"foo": "The Foo Wrestlers"}
 
 
 @app.get("/items/{item_id}")
-async def create_item(item_id: str):
+async def read_item(item_id: str):
     if item_id not in items:
         raise HTTPException(status_code=404, detail="Item not found")
     return {"item": items[item_id]}

--- a/docs/src/handling_errors/tutorial002.py
+++ b/docs/src/handling_errors/tutorial002.py
@@ -6,7 +6,7 @@ items = {"foo": "The Foo Wrestlers"}
 
 
 @app.get("/items-header/{item_id}")
-async def create_item_header(item_id: str):
+async def read_item_header(item_id: str):
     if item_id not in items:
         raise HTTPException(
             status_code=404,

--- a/docs/src/security/tutorial004.py
+++ b/docs/src/security/tutorial004.py
@@ -112,7 +112,7 @@ async def get_current_active_user(current_user: User = Depends(get_current_user)
 
 
 @app.post("/token", response_model=Token)
-async def route_login_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
         raise HTTPException(status_code=400, detail="Incorrect username or password")

--- a/docs/src/security/tutorial005.py
+++ b/docs/src/security/tutorial005.py
@@ -138,7 +138,7 @@ async def get_current_active_user(
 
 
 @app.post("/token", response_model=Token)
-async def route_login_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
         raise HTTPException(status_code=400, detail="Incorrect username or password")

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -124,7 +124,7 @@ def generate_operation_id(*, route: routing.APIRoute, method: str) -> str:
 def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:
     if route.summary:
         return route.summary
-    return route.name.replace("_", " ").title() + " " + method.title()
+    return route.name.replace("_", " ").title()
 
 
 def get_openapi_operation_metadata(*, route: routing.APIRoute, method: str) -> Dict:

--- a/tests/test_additional_properties.py
+++ b/tests/test_additional_properties.py
@@ -41,7 +41,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Foo Post",
+                "summary": "Foo",
                 "operationId": "foo_foo_post",
                 "requestBody": {
                     "content": {

--- a/tests/test_additional_response_extra.py
+++ b/tests/test_additional_response_extra.py
@@ -30,7 +30,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Item Get",
+                "summary": "Read Item",
                 "operationId": "read_item_items__get",
             }
         }

--- a/tests/test_additional_responses_router.py
+++ b/tests/test_additional_responses_router.py
@@ -35,7 +35,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     },
                 },
-                "summary": "A Get",
+                "summary": "A",
                 "operationId": "a_a_get",
             }
         },
@@ -48,7 +48,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     },
                 },
-                "summary": "B Get",
+                "summary": "B",
                 "operationId": "b_b_get",
             }
         },
@@ -61,7 +61,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     },
                 },
-                "summary": "C Get",
+                "summary": "C",
                 "operationId": "c_c_get",
             }
         },

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -17,7 +17,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Non Operation Get",
+                "summary": "Non Operation",
                 "operationId": "non_operation_api_route_get",
             }
         },
@@ -29,7 +29,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Non Decorated Route Get",
+                "summary": "Non Decorated Route",
                 "operationId": "non_decorated_route_non_decorated_route_get",
             }
         },
@@ -41,7 +41,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Get Text Get",
+                "summary": "Get Text",
                 "operationId": "get_text_text_get",
             }
         },
@@ -63,7 +63,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Id Get",
+                "summary": "Get Id",
                 "operationId": "get_id_path__item_id__get",
                 "parameters": [
                     {
@@ -93,7 +93,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Str Id Get",
+                "summary": "Get Str Id",
                 "operationId": "get_str_id_path_str__item_id__get",
                 "parameters": [
                     {
@@ -123,7 +123,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Int Id Get",
+                "summary": "Get Int Id",
                 "operationId": "get_int_id_path_int__item_id__get",
                 "parameters": [
                     {
@@ -153,7 +153,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Float Id Get",
+                "summary": "Get Float Id",
                 "operationId": "get_float_id_path_float__item_id__get",
                 "parameters": [
                     {
@@ -183,7 +183,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Bool Id Get",
+                "summary": "Get Bool Id",
                 "operationId": "get_bool_id_path_bool__item_id__get",
                 "parameters": [
                     {
@@ -213,7 +213,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Id Get",
+                "summary": "Get Path Param Id",
                 "operationId": "get_path_param_id_path_param__item_id__get",
                 "parameters": [
                     {
@@ -243,7 +243,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Required Id Get",
+                "summary": "Get Path Param Required Id",
                 "operationId": "get_path_param_required_id_path_param-required__item_id__get",
                 "parameters": [
                     {
@@ -273,7 +273,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Min Length Get",
+                "summary": "Get Path Param Min Length",
                 "operationId": "get_path_param_min_length_path_param-minlength__item_id__get",
                 "parameters": [
                     {
@@ -307,7 +307,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Max Length Get",
+                "summary": "Get Path Param Max Length",
                 "operationId": "get_path_param_max_length_path_param-maxlength__item_id__get",
                 "parameters": [
                     {
@@ -341,7 +341,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Min Max Length Get",
+                "summary": "Get Path Param Min Max Length",
                 "operationId": "get_path_param_min_max_length_path_param-min_maxlength__item_id__get",
                 "parameters": [
                     {
@@ -376,7 +376,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Gt Get",
+                "summary": "Get Path Param Gt",
                 "operationId": "get_path_param_gt_path_param-gt__item_id__get",
                 "parameters": [
                     {
@@ -410,7 +410,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Gt0 Get",
+                "summary": "Get Path Param Gt0",
                 "operationId": "get_path_param_gt0_path_param-gt0__item_id__get",
                 "parameters": [
                     {
@@ -444,7 +444,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Ge Get",
+                "summary": "Get Path Param Ge",
                 "operationId": "get_path_param_ge_path_param-ge__item_id__get",
                 "parameters": [
                     {
@@ -478,7 +478,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Lt Get",
+                "summary": "Get Path Param Lt",
                 "operationId": "get_path_param_lt_path_param-lt__item_id__get",
                 "parameters": [
                     {
@@ -512,7 +512,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Lt0 Get",
+                "summary": "Get Path Param Lt0",
                 "operationId": "get_path_param_lt0_path_param-lt0__item_id__get",
                 "parameters": [
                     {
@@ -546,7 +546,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Le Get",
+                "summary": "Get Path Param Le",
                 "operationId": "get_path_param_le_path_param-le__item_id__get",
                 "parameters": [
                     {
@@ -580,7 +580,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Lt Gt Get",
+                "summary": "Get Path Param Lt Gt",
                 "operationId": "get_path_param_lt_gt_path_param-lt-gt__item_id__get",
                 "parameters": [
                     {
@@ -615,7 +615,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Le Ge Get",
+                "summary": "Get Path Param Le Ge",
                 "operationId": "get_path_param_le_ge_path_param-le-ge__item_id__get",
                 "parameters": [
                     {
@@ -650,7 +650,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Lt Int Get",
+                "summary": "Get Path Param Lt Int",
                 "operationId": "get_path_param_lt_int_path_param-lt-int__item_id__get",
                 "parameters": [
                     {
@@ -684,7 +684,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Gt Int Get",
+                "summary": "Get Path Param Gt Int",
                 "operationId": "get_path_param_gt_int_path_param-gt-int__item_id__get",
                 "parameters": [
                     {
@@ -718,7 +718,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Le Int Get",
+                "summary": "Get Path Param Le Int",
                 "operationId": "get_path_param_le_int_path_param-le-int__item_id__get",
                 "parameters": [
                     {
@@ -752,7 +752,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Ge Int Get",
+                "summary": "Get Path Param Ge Int",
                 "operationId": "get_path_param_ge_int_path_param-ge-int__item_id__get",
                 "parameters": [
                     {
@@ -786,7 +786,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Lt Gt Int Get",
+                "summary": "Get Path Param Lt Gt Int",
                 "operationId": "get_path_param_lt_gt_int_path_param-lt-gt-int__item_id__get",
                 "parameters": [
                     {
@@ -821,7 +821,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Path Param Le Ge Int Get",
+                "summary": "Get Path Param Le Ge Int",
                 "operationId": "get_path_param_le_ge_int_path_param-le-ge-int__item_id__get",
                 "parameters": [
                     {
@@ -856,7 +856,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Get",
+                "summary": "Get Query",
                 "operationId": "get_query_query_get",
                 "parameters": [
                     {
@@ -886,7 +886,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Optional Get",
+                "summary": "Get Query Optional",
                 "operationId": "get_query_optional_query_optional_get",
                 "parameters": [
                     {
@@ -916,7 +916,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Type Get",
+                "summary": "Get Query Type",
                 "operationId": "get_query_type_query_int_get",
                 "parameters": [
                     {
@@ -946,7 +946,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Type Optional Get",
+                "summary": "Get Query Type Optional",
                 "operationId": "get_query_type_optional_query_int_optional_get",
                 "parameters": [
                     {
@@ -976,7 +976,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Type Optional Get",
+                "summary": "Get Query Type Optional",
                 "operationId": "get_query_type_optional_query_int_default_get",
                 "parameters": [
                     {
@@ -1006,7 +1006,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Param Get",
+                "summary": "Get Query Param",
                 "operationId": "get_query_param_query_param_get",
                 "parameters": [
                     {
@@ -1036,7 +1036,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Param Required Get",
+                "summary": "Get Query Param Required",
                 "operationId": "get_query_param_required_query_param-required_get",
                 "parameters": [
                     {
@@ -1066,7 +1066,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Query Param Required Type Get",
+                "summary": "Get Query Param Required Type",
                 "operationId": "get_query_param_required_type_query_param-required_int_get",
                 "parameters": [
                     {

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -72,7 +72,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Items Get",
+                "summary": "Get Items",
                 "operationId": "get_items_items__item_id__get",
                 "parameters": [
                     {
@@ -100,7 +100,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Delete Item Delete",
+                "summary": "Delete Item",
                 "operationId": "delete_item_items__item_id__delete",
                 "parameters": [
                     {
@@ -136,7 +136,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Options Item Options",
+                "summary": "Options Item",
                 "operationId": "options_item_items__item_id__options",
                 "parameters": [
                     {
@@ -164,7 +164,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Head Item Head",
+                "summary": "Head Item",
                 "operationId": "head_item_items__item_id__head",
                 "parameters": [
                     {
@@ -192,7 +192,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Patch Item Patch",
+                "summary": "Patch Item",
                 "operationId": "patch_item_items__item_id__patch",
                 "parameters": [
                     {
@@ -228,7 +228,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Trace Item Trace",
+                "summary": "Trace Item",
                 "operationId": "trace_item_items__item_id__trace",
                 "parameters": [
                     {
@@ -258,7 +258,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Get Not Decorated Get",
+                "summary": "Get Not Decorated",
                 "operationId": "get_not_decorated_items-not-decorated__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -42,7 +42,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Save Item No Body Post",
+                "summary": "Save Item No Body",
                 "operationId": "save_item_no_body_items__post",
                 "requestBody": {
                     "content": {

--- a/tests/test_multi_query_errors.py
+++ b/tests/test_multi_query_errors.py
@@ -36,7 +36,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "parameters": [
                     {

--- a/tests/test_put_no_body.py
+++ b/tests/test_put_no_body.py
@@ -34,7 +34,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Save Item No Body Put",
+                "summary": "Save Item No Body",
                 "operationId": "save_item_no_body_items__item_id__put",
                 "parameters": [
                     {

--- a/tests/test_security_api_key_cookie.py
+++ b/tests/test_security_api_key_cookie.py
@@ -36,7 +36,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"APIKeyCookie": []}],
             }

--- a/tests/test_security_api_key_cookie_optional.py
+++ b/tests/test_security_api_key_cookie_optional.py
@@ -43,7 +43,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"APIKeyCookie": []}],
             }

--- a/tests/test_security_api_key_header.py
+++ b/tests/test_security_api_key_header.py
@@ -36,7 +36,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"APIKeyHeader": []}],
             }

--- a/tests/test_security_api_key_header_optional.py
+++ b/tests/test_security_api_key_header_optional.py
@@ -42,7 +42,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"APIKeyHeader": []}],
             }

--- a/tests/test_security_api_key_query.py
+++ b/tests/test_security_api_key_query.py
@@ -36,7 +36,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"APIKeyQuery": []}],
             }

--- a/tests/test_security_api_key_query_optional.py
+++ b/tests/test_security_api_key_query_optional.py
@@ -42,7 +42,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"APIKeyQuery": []}],
             }

--- a/tests/test_security_http_base.py
+++ b/tests/test_security_http_base.py
@@ -26,7 +26,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPBase": []}],
             }

--- a/tests/test_security_http_base_optional.py
+++ b/tests/test_security_http_base_optional.py
@@ -32,7 +32,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPBase": []}],
             }

--- a/tests/test_security_http_basic.py
+++ b/tests/test_security_http_basic.py
@@ -29,7 +29,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPBasic": []}],
             }

--- a/tests/test_security_http_basic_optional.py
+++ b/tests/test_security_http_basic_optional.py
@@ -32,7 +32,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPBasic": []}],
             }

--- a/tests/test_security_http_bearer.py
+++ b/tests/test_security_http_bearer.py
@@ -26,7 +26,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPBearer": []}],
             }

--- a/tests/test_security_http_bearer_optional.py
+++ b/tests/test_security_http_bearer_optional.py
@@ -32,7 +32,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPBearer": []}],
             }

--- a/tests/test_security_http_digest.py
+++ b/tests/test_security_http_digest.py
@@ -26,7 +26,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPDigest": []}],
             }

--- a/tests/test_security_http_digest_optional.py
+++ b/tests/test_security_http_digest_optional.py
@@ -32,7 +32,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"HTTPDigest": []}],
             }

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -60,7 +60,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Current User Post",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_login_post",
                 "requestBody": {
                     "content": {
@@ -82,7 +82,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"OAuth2": []}],
             }

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -67,7 +67,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Current User Post",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_login_post",
                 "requestBody": {
                     "content": {
@@ -89,7 +89,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"OAuth2": []}],
             }

--- a/tests/test_security_oauth2_password_bearer_optional.py
+++ b/tests/test_security_oauth2_password_bearer_optional.py
@@ -30,7 +30,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "security": [{"OAuth2PasswordBearer": []}],
             }

--- a/tests/test_security_openid_connect.py
+++ b/tests/test_security_openid_connect.py
@@ -36,7 +36,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"OpenIdConnect": []}],
             }

--- a/tests/test_security_openid_connect_optional.py
+++ b/tests/test_security_openid_connect_optional.py
@@ -42,7 +42,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Current User Get",
+                "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"OpenIdConnect": []}],
             }

--- a/tests/test_starlette_exception.py
+++ b/tests/test_starlette_exception.py
@@ -49,7 +49,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create Item Get",
+                "summary": "Create Item",
                 "operationId": "create_item_items__item_id__get",
                 "parameters": [
                     {
@@ -79,7 +79,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create Item Get",
+                "summary": "Create Item",
                 "operationId": "create_item_starlette-items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial001.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial001.py
@@ -38,7 +38,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Item Get",
+                "summary": "Read Item",
                 "operationId": "read_item_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial002.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial002.py
@@ -34,7 +34,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Item Get",
+                "summary": "Read Item",
                 "operationId": "read_item_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial003.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial003.py
@@ -39,7 +39,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Item Get",
+                "summary": "Read Item",
                 "operationId": "read_item_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial004.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial004.py
@@ -37,7 +37,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Item Get",
+                "summary": "Read Item",
                 "operationId": "read_item_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_application_configuration/test_tutorial001.py
+++ b/tests/test_tutorial/test_application_configuration/test_tutorial001.py
@@ -20,7 +20,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         }

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -22,7 +22,7 @@ openapi_schema = {
                         },
                     }
                 },
-                "summary": "Read Notes Get",
+                "summary": "Read Notes",
                 "operationId": "read_notes_notes__get",
             },
             "post": {
@@ -46,7 +46,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create Note Post",
+                "summary": "Create Note",
                 "operationId": "create_note_notes__post",
                 "requestBody": {
                     "content": {

--- a/tests/test_tutorial/test_bigger_applications/test_main.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main.py
@@ -18,7 +18,7 @@ openapi_schema = {
                     }
                 },
                 "tags": ["users"],
-                "summary": "Read Users Get",
+                "summary": "Read Users",
                 "operationId": "read_users_users__get",
             }
         },
@@ -31,7 +31,7 @@ openapi_schema = {
                     }
                 },
                 "tags": ["users"],
-                "summary": "Read User Me Get",
+                "summary": "Read User Me",
                 "operationId": "read_user_me_users_me_get",
             }
         },
@@ -54,7 +54,7 @@ openapi_schema = {
                     },
                 },
                 "tags": ["users"],
-                "summary": "Read User Get",
+                "summary": "Read User",
                 "operationId": "read_user_users__username__get",
                 "parameters": [
                     {
@@ -76,7 +76,7 @@ openapi_schema = {
                     },
                 },
                 "tags": ["items"],
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         },
@@ -100,7 +100,7 @@ openapi_schema = {
                     },
                 },
                 "tags": ["items"],
-                "summary": "Read Item Get",
+                "summary": "Read Item",
                 "operationId": "read_item_items__item_id__get",
                 "parameters": [
                     {
@@ -131,7 +131,7 @@ openapi_schema = {
                     },
                 },
                 "tags": ["custom", "items"],
-                "summary": "Update Item Put",
+                "summary": "Update Item",
                 "operationId": "update_item_items__item_id__put",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create Item Post",
+                "summary": "Create Item",
                 "operationId": "create_item_items__post",
                 "requestBody": {
                     "content": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Update Item Put",
+                "summary": "Update Item",
                 "operationId": "update_item_items__item_id__put",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_body_schema/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_schema/test_tutorial001.py
@@ -28,7 +28,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Update Item Put",
+                "summary": "Update Item",
                 "operationId": "update_item_items__item_id__put",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_custom_response/test_tutorial001.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial001.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         }

--- a/tests/test_tutorial/test_custom_response/test_tutorial004.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial004.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {"text/html": {"schema": {"type": "string"}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         }

--- a/tests/test_tutorial/test_dependencies/test_tutorial001.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "parameters": [
                     {
@@ -69,7 +69,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Users Get",
+                "summary": "Read Users",
                 "operationId": "read_users_users__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_dependencies/test_tutorial004.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_events/test_tutorial001.py
+++ b/tests/test_tutorial/test_events/test_tutorial001.py
@@ -24,7 +24,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_events/test_tutorial002.py
+++ b/tests/test_tutorial/test_events/test_tutorial002.py
@@ -14,7 +14,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         }

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
@@ -21,7 +21,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         }

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Put",
+                "summary": "Read Items",
                 "operationId": "read_items_items__item_id__put",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_extra_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial003.py
@@ -36,7 +36,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Item Get",
+                "summary": "Read Item",
                 "operationId": "read_item_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_extra_models/test_tutorial004.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial004.py
@@ -24,7 +24,7 @@ openapi_schema = {
                         },
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         }

--- a/tests/test_tutorial/test_first_steps/test_tutorial001.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial001.py
@@ -17,7 +17,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Root Get",
+                "summary": "Root",
                 "operationId": "root__get",
             }
         }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial001.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial001.py
@@ -26,8 +26,8 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create Item Get",
-                "operationId": "create_item_items__item_id__get",
+                "summary": "Read Item",
+                "operationId": "read_item_items__item_id__get",
                 "parameters": [
                     {
                         "required": True,

--- a/tests/test_tutorial/test_handling_errors/test_tutorial002.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial002.py
@@ -26,8 +26,8 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create Item Header Get",
-                "operationId": "create_item_header_items-header__item_id__get",
+                "summary": "Read Item Header",
+                "operationId": "read_item_header_items-header__item_id__get",
                 "parameters": [
                     {
                         "required": True,

--- a/tests/test_tutorial/test_header_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001.py
@@ -28,7 +28,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "some_specific_id_you_define",
             }
         }

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
@@ -18,7 +18,7 @@ openapi_schema = {
                     }
                 },
                 "tags": ["items"],
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
             }
         },
@@ -31,7 +31,7 @@ openapi_schema = {
                     }
                 },
                 "tags": ["users"],
-                "summary": "Read Users Get",
+                "summary": "Read Users",
                 "operationId": "read_users_users__get",
             }
         },
@@ -44,7 +44,7 @@ openapi_schema = {
                     }
                 },
                 "tags": ["items"],
-                "summary": "Read Elements Get",
+                "summary": "Read Elements",
                 "operationId": "read_elements_elements__get",
                 "deprecated": True,
             }

--- a/tests/test_tutorial/test_query_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial005.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read User Item Get",
+                "summary": "Read User Item",
                 "operationId": "read_user_item_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_query_params/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read User Item Get",
+                "summary": "Read User Item",
                 "operationId": "read_user_item_items__item_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
@@ -26,7 +26,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -28,7 +28,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create File Post",
+                "summary": "Create File",
                 "operationId": "create_file_files__post",
                 "requestBody": {
                     "content": {
@@ -58,7 +58,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create Upload File Post",
+                "summary": "Create Upload File",
                 "operationId": "create_upload_file_uploadfile__post",
                 "requestBody": {
                     "content": {

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -27,7 +27,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Login Post",
+                "summary": "Login",
                 "operationId": "login_login__post",
                 "requestBody": {
                     "content": {

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -29,7 +29,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create File Post",
+                "summary": "Create File",
                 "operationId": "create_file_files__post",
                 "requestBody": {
                     "content": {

--- a/tests/test_tutorial/test_response_model/test_tutorial003.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003.py
@@ -30,7 +30,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Create User Post",
+                "summary": "Create User",
                 "operationId": "create_user_user__post",
                 "requestBody": {
                     "content": {

--- a/tests/test_tutorial/test_security/test_tutorial001.py
+++ b/tests/test_tutorial/test_security/test_tutorial001.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Items Get",
+                "summary": "Read Items",
                 "operationId": "read_items_items__get",
                 "security": [{"OAuth2PasswordBearer": []}],
             }

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -26,7 +26,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Login Post",
+                "summary": "Login",
                 "operationId": "login_token_post",
                 "requestBody": {
                     "content": {
@@ -46,7 +46,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Users Me Get",
+                "summary": "Read Users Me",
                 "operationId": "read_users_me_users_me_get",
                 "security": [{"OAuth2PasswordBearer": []}],
             }

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -36,13 +36,13 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Route Login Access Token",
-                "operationId": "route_login_access_token_token_post",
+                "summary": "Login For Access Token",
+                "operationId": "login_for_access_token_token_post",
                 "requestBody": {
                     "content": {
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Body_route_login_access_token"
+                                "$ref": "#/components/schemas/Body_login_for_access_token"
                             }
                         }
                     },
@@ -83,8 +83,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_route_login_access_token": {
-                "title": "Body_route_login_access_token",
+            "Body_login_for_access_token": {
+                "title": "Body_login_for_access_token",
                 "required": ["username", "password"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -36,7 +36,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Route Login Access Token Post",
+                "summary": "Route Login Access Token",
                 "operationId": "route_login_access_token_token_post",
                 "requestBody": {
                     "content": {
@@ -62,7 +62,7 @@ openapi_schema = {
                         },
                     }
                 },
-                "summary": "Read Users Me Get",
+                "summary": "Read Users Me",
                 "operationId": "read_users_me_users_me__get",
                 "security": [{"OAuth2PasswordBearer": ["me"]}],
             }
@@ -75,7 +75,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Own Items Get",
+                "summary": "Read Own Items",
                 "operationId": "read_own_items_users_me_items__get",
                 "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
             }

--- a/tests/test_tutorial/test_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial001.py
@@ -26,7 +26,7 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read User Get",
+                "summary": "Read User",
                 "operationId": "read_user_users__user_id__get",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_sub_applications/test_tutorial001.py
+++ b/tests/test_tutorial/test_sub_applications/test_tutorial001.py
@@ -16,7 +16,7 @@ openapi_schema_main = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Main Get",
+                "summary": "Read Main",
                 "operationId": "read_main_app_get",
             }
         }
@@ -34,7 +34,7 @@ openapi_schema_sub = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Sub Get",
+                "summary": "Read Sub",
                 "operationId": "read_sub_sub_get",
             }
         }

--- a/tests/test_tutorial/test_testing/test_main.py
+++ b/tests/test_tutorial/test_testing/test_main.py
@@ -12,7 +12,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Main Get",
+                "summary": "Read Main",
                 "operationId": "read_main__get",
             }
         }

--- a/tests/test_tutorial/test_testing/test_tutorial001.py
+++ b/tests/test_tutorial/test_testing/test_tutorial001.py
@@ -12,7 +12,7 @@ openapi_schema = {
                         "content": {"application/json": {"schema": {}}},
                     }
                 },
-                "summary": "Read Main Get",
+                "summary": "Read Main",
                 "operationId": "read_main__get",
             }
         }


### PR DESCRIPTION
Improve naming of path operations.

A path operation function that receives `GET` requests named `def read_users()`, up to now produces, a documentation UI of "Read Users Get".

After this PR, the generated name will be "Read Users".

With this, it's easier to encourage good function naming that can be re-used by OpenAPI, automatic API docs, and later, an automatic UI admin frontend with sensible names.