### PR TITLE
fixed small typo in tutorial

### DIFF
--- a/docs/tutorial/extra-models.md
+++ b/docs/tutorial/extra-models.md
@@ -3,7 +3,7 @@ Continuing with the previous example, it will be common to have more than one re
 This is especially the case for user models, because:
 
 * The **input model** needs to be able to have a password.
-* The **output model** should do not have a password.
+* The **output model** should not have a password.
 * The **database model** would probably need to have a hashed password.
 
 !!! danger


### PR DESCRIPTION
### Small Typo 

I have removed a redundant extra word within `docs/tutorials/extra-models.md`

Current:

* The **output model** should do not have a password

Proposed:

* The **output model** should not have a password

A very minor typo. Thanks for the great tutorial and effort that has gone into creating the documentation. :100: 