### PR TITLE
Starlette #493 workaround

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -61,7 +61,7 @@ def get_app(
             logging.error(f"Error getting request body: {e}")
             raise HTTPException(
                 status_code=400, detail="There was an error parsing the body"
-            )
+            ) from e
         values, errors, background_tasks = await solve_dependencies(
             request=request, dependant=dependant, body=body
         )


### PR DESCRIPTION
Hi @tiangolo , I'm creating this PR to workaround an issue with Starlette (https://github.com/encode/starlette/issues/493) that avoid developers from reading the Request.Body inside a Middleware or Exception Handler, in my specific case I need to get the original content from body when a JSON deserialization generates an error, with the change bellow I'm able to retrieve the original exception and thus the original content that FastApi tried to parse. It is a really small change that I see no harm. 

While it help me it also provides better exception handling for other developers.