### PR TITLE
Add param functions, to override types, to make mypy happy

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -7,5 +7,15 @@ from starlette.background import BackgroundTasks
 from .applications import FastAPI
 from .datastructures import UploadFile
 from .exceptions import HTTPException
-from .params import Body, Cookie, Depends, File, Form, Header, Path, Query, Security
+from .param_functions import (
+    Body,
+    Cookie,
+    Depends,
+    File,
+    Form,
+    Header,
+    Path,
+    Query,
+    Security,
+)
 from .routing import APIRouter

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -66,7 +66,7 @@ def get_sub_dependant(
         dependency_scopes = depends.scopes
         security_scopes.extend(dependency_scopes)
     if isinstance(dependency, SecurityBase):
-        use_scopes = []
+        use_scopes: List[str] = []
         if isinstance(dependency, (OAuth2, OpenIdConnect)):
             use_scopes = security_scopes
         security_requirement = SecurityRequirement(

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -1,0 +1,248 @@
+from typing import Any, Callable, Sequence
+
+from fastapi import params
+
+
+def Path(  # noqa: N802
+    default: Any,
+    *,
+    alias: str = None,
+    title: str = None,
+    description: str = None,
+    gt: float = None,
+    ge: float = None,
+    lt: float = None,
+    le: float = None,
+    min_length: int = None,
+    max_length: int = None,
+    regex: str = None,
+    deprecated: bool = None,
+    **extra: Any,
+) -> Any:
+    return params.Path(
+        default=default,
+        alias=alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        regex=regex,
+        deprecated=deprecated,
+        **extra,
+    )
+
+
+def Query(  # noqa: N802
+    default: Any,
+    *,
+    alias: str = None,
+    title: str = None,
+    description: str = None,
+    gt: float = None,
+    ge: float = None,
+    lt: float = None,
+    le: float = None,
+    min_length: int = None,
+    max_length: int = None,
+    regex: str = None,
+    deprecated: bool = None,
+    **extra: Any,
+) -> Any:
+    return params.Query(
+        default,
+        alias=alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        regex=regex,
+        deprecated=deprecated,
+        **extra,
+    )
+
+
+def Header(  # noqa: N802
+    default: Any,
+    *,
+    alias: str = None,
+    convert_underscores: bool = True,
+    title: str = None,
+    description: str = None,
+    gt: float = None,
+    ge: float = None,
+    lt: float = None,
+    le: float = None,
+    min_length: int = None,
+    max_length: int = None,
+    regex: str = None,
+    deprecated: bool = None,
+    **extra: Any,
+) -> Any:
+    return params.Header(
+        default,
+        alias=alias,
+        convert_underscores=convert_underscores,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        regex=regex,
+        deprecated=deprecated,
+        **extra,
+    )
+
+
+def Cookie(  # noqa: N802
+    default: Any,
+    *,
+    alias: str = None,
+    title: str = None,
+    description: str = None,
+    gt: float = None,
+    ge: float = None,
+    lt: float = None,
+    le: float = None,
+    min_length: int = None,
+    max_length: int = None,
+    regex: str = None,
+    deprecated: bool = None,
+    **extra: Any,
+) -> Any:
+    return params.Cookie(
+        default,
+        alias=alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        regex=regex,
+        deprecated=deprecated,
+        **extra,
+    )
+
+
+def Body(  # noqa: N802
+    default: Any,
+    *,
+    embed: bool = False,
+    media_type: str = "application/json",
+    alias: str = None,
+    title: str = None,
+    description: str = None,
+    gt: float = None,
+    ge: float = None,
+    lt: float = None,
+    le: float = None,
+    min_length: int = None,
+    max_length: int = None,
+    regex: str = None,
+    **extra: Any,
+) -> Any:
+    return params.Body(
+        default,
+        embed=embed,
+        media_type=media_type,
+        alias=alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        regex=regex,
+        **extra,
+    )
+
+
+def Form(  # noqa: N802
+    default: Any,
+    *,
+    media_type: str = "application/x-www-form-urlencoded",
+    alias: str = None,
+    title: str = None,
+    description: str = None,
+    gt: float = None,
+    ge: float = None,
+    lt: float = None,
+    le: float = None,
+    min_length: int = None,
+    max_length: int = None,
+    regex: str = None,
+    **extra: Any,
+) -> Any:
+    return params.Form(
+        default,
+        media_type=media_type,
+        alias=alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        regex=regex,
+        **extra,
+    )
+
+
+def File(  # noqa: N802
+    default: Any,
+    *,
+    media_type: str = "multipart/form-data",
+    alias: str = None,
+    title: str = None,
+    description: str = None,
+    gt: float = None,
+    ge: float = None,
+    lt: float = None,
+    le: float = None,
+    min_length: int = None,
+    max_length: int = None,
+    regex: str = None,
+    **extra: Any,
+) -> Any:
+    return params.File(
+        default,
+        media_type=media_type,
+        alias=alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        regex=regex,
+        **extra,
+    )
+
+
+def Depends(dependency: Callable = None) -> Any:  # noqa: N802
+    return params.Depends(dependency=dependency)
+
+
+def Security(  # noqa: N802
+    dependency: Callable = None, scopes: Sequence[str] = None
+) -> Any:
+    return params.Security(dependency=dependency, scopes=scopes)


### PR DESCRIPTION
:sparkles: Add param functions, to override types, to make `mypy` happy.

This would solve https://github.com/tiangolo/fastapi/issues/219 and other cases of `mypy` complaining about the default types.

## Simple solution

The simplest approach would be to make `mypy` ignore the types in those parameters, using comments with `# type: ignore` like in:

```Python
from fastapi import FastAPI, Path, Query

app = FastAPI()


@app.get("/items/{item_id}")
async def read_items(  # type: ignore
    item_id: int = Path(..., title="The ID of the item to get"),
    q: str = Query(None, alias="item-query"),  
):
    results = {"item_id": item_id}
    if q:
        results.update({"q": q})
    return results
```

### Drawback

But asking all the users to add comments to ignore type checks each time they use these classes would be difficult and cumbersome (for end users/developers).

## Reason

The issue is that `mypy` is right, from the typing point of view. Putting an instance of `Query` as the "default value" of a parameter with type `str` is not really correct (from the typing point of view).

But here in FastAPI we are "hacking" the typing system, and extending its use to the extreme (which has proven to work really well for many users/use-cases). The *path operation function* is only called by FastAPI (not by the user or any other code), and FastAPI makes sure to pass the correct type, those classes are only for meta-information, used by FastAPI.

## Alternatives

I tried overriding the type declaration of the parameter classes, but there's no way to achieve that.

Then I tried adding a typing stub (`parameters.pyi`), but although it removed `mypy` errors, there where other errors in places used by FastAPI internally.

And then, by relaxing the type declarations to avoid the internal errors, the type hints of those parameters were also lost for final users.

There's a lot of work (and code) there just to have completion for all those parameters in classes... One of the main objectives is for FastAPI to be as comfortable for final developers as possible, even if that is at the expense of the developers of the library itself (me and the community that submits PRs :grin: ).

## Final solution

Here's the solution. We can't override the type declaration of a class (the class itself).

But we can override the return type declaration of a function.

So, I converted all these parameter classes exposed by FastAPI (`Depends`, `Query`, `File`, etc) to functions. But then, as the function is actually called when the code is run and FastAPI needs to inspect it afterwards when the app is running, each of these functions returns the original class instances.

So, the default values of the parameters are actually those classes, and can be checked by the rest of the FastAPI code (dependencies, etc).