### PR TITLE
Reenabled Black --check, issue is fixed

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,9 +14,5 @@ fi
 export PYTHONPATH=./docs/src
 pytest --cov=fastapi --cov=tests --cov=docs/src --cov-report=term-missing ${@}
 mypy fastapi --disallow-untyped-defs --follow-imports=skip
-if [ "${PYTHON_VERSION}" = '3.7' ]; then
-    echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
-else
-    black fastapi tests --check
-fi
+black fastapi tests --check
 isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only --thirdparty fastapi fastapi tests


### PR DESCRIPTION
Reenabled Black --check for python 3.7, issue is fixed.
see https://github.com/ambv/black/issues/494