### PR TITLE
Mypy && Depends

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -11,6 +11,8 @@ from .param_functions import (
     Body,
     Cookie,
     Depends,
+    depends,
+    depends_on,
     File,
     Form,
     Header,

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Sequence, TypeVar, Optional, Type
 
 from fastapi import params
 
@@ -236,6 +236,17 @@ def File(  # noqa: N802
         regex=regex,
         **extra,
     )
+
+
+D = TypeVar("D")
+
+
+def depends_on(func: Callable[..., D]) -> D:
+    return params.Depends(dependency=func)  # type: ignore
+
+
+def depends(dependency_type: Optional[Type[D]] = None) -> D:
+    return params.Depends(dependency=dependency_type)  # type: ignore
 
 
 def Depends(dependency: Callable = None) -> Any:  # noqa: N802

--- a/tests/test_security_api_key_cookie.py
+++ b/tests/test_security_api_key_cookie.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI, Security
+from fastapi import depends_on, FastAPI, Security
 from fastapi.security import APIKeyCookie
 from pydantic import BaseModel
 from starlette.testclient import TestClient
@@ -18,7 +18,7 @@ def get_current_user(oauth_header: str = Security(api_key)):
 
 
 @app.get("/users/me")
-def read_current_user(current_user: User = Depends(get_current_user)):
+def read_current_user(current_user: User = depends_on(get_current_user)):
     return current_user
 
 

--- a/tests/test_security_api_key_cookie_optional.py
+++ b/tests/test_security_api_key_cookie_optional.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import Depends, FastAPI, Security
+from fastapi import depends_on, FastAPI, Security
 from fastapi.security import APIKeyCookie
 from pydantic import BaseModel
 from starlette.testclient import TestClient
@@ -22,7 +22,7 @@ def get_current_user(oauth_header: Optional[str] = Security(api_key)):
 
 
 @app.get("/users/me")
-def read_current_user(current_user: User = Depends(get_current_user)):
+def read_current_user(current_user: User = depends_on(get_current_user)):
     if current_user is None:
         return {"msg": "Create an account first"}
     else:


### PR DESCRIPTION
I've recently been using FastAPI with mypy. Mostly this has been working really well but I've run into problems when using `Depends` as it doesn't type correctly. For example the following:
```python
    @app.get("/")
    async def read_root(user: User = Depends(get_current_user)):
        pass
```
will raise the following error in mypy:
```
error: Incompatible default for argument "user" (default has type "Depends", argument has type "User")
```

One solution I thought of is in this PR. Providing functions `depends` and `depends_on` means the typing can match whilst still working in the same way.

What do you think? (The same approach could work for the other functions in `param_functions.py`)