### PR TITLE
Fix HTTP Bearer security auto-error

### DIFF
--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -112,10 +112,13 @@ class HTTPBearer(HTTPBase):
             else:
                 return None
         if scheme.lower() != "bearer":
-            raise HTTPException(
-                status_code=HTTP_403_FORBIDDEN,
-                detail="Invalid authentication credentials",
-            )
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN,
+                    detail="Invalid authentication credentials",
+                )
+            else:
+                return None
         return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)
 
 

--- a/tests/test_security_http_bearer_optional.py
+++ b/tests/test_security_http_bearer_optional.py
@@ -64,5 +64,5 @@ def test_security_http_bearer_no_credentials():
 
 def test_security_http_bearer_incorrect_scheme_credentials():
     response = client.get("/users/me", headers={"Authorization": "Basic notreally"})
-    assert response.status_code == 403
-    assert response.json() == {"detail": "Invalid authentication credentials"}
+    assert response.status_code == 200
+    assert response.json() == {"msg": "Create an account first"}


### PR DESCRIPTION
:bug: Fix HTTP Bearer security auto-error.

Currently, even with `auto_error=False`, it would raise an error if there's an Authorization header with an incorrect scheme (e.g. `Basic` instead of `Bearer`).

It should not raise errors automatically if `auto_error=False`, just return `None`.