### PR TITLE
Fix path and query parameters receiving dict as valid

### DIFF
--- a/docs/src/query_params_str_validations/tutorial013.py
+++ b/docs/src/query_params_str_validations/tutorial013.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI, Query
+
+app = FastAPI()
+
+
+@app.get("/items/")
+async def read_items(q: list = Query(None)):
+    query_items = {"q": q}
+    return query_items

--- a/docs/tutorial/query-params-str-validations.md
+++ b/docs/tutorial/query-params-str-validations.md
@@ -183,6 +183,19 @@ the default of `q` will be: `["foo", "bar"]` and your response will be:
 }
 ```
 
+#### Using `list`
+
+You can also use `list` directly instead of `List[str]`:
+
+```Python hl_lines="7"
+{!./src/query_params_str_validations/tutorial013.py!}
+```
+
+!!! note
+    Have in mind that in this case, FastAPI won't check the contents of the list.
+
+    For example, `List[int]` would check (and document) that the contents of the list are integers. But `list` alone wouldn't.
+
 ## Declare more metadata
 
 You can add more information about the parameter.

--- a/tests/test_invalid_path_param.py
+++ b/tests/test_invalid_path_param.py
@@ -1,0 +1,77 @@
+from typing import Dict, List, Tuple
+
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+def test_invalid_sequence():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        class Item(BaseModel):
+            title: str
+
+        @app.get("/items/{id}")
+        def read_items(id: List[Item]):
+            pass  # pragma: no cover
+
+
+def test_invalid_tuple():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        class Item(BaseModel):
+            title: str
+
+        @app.get("/items/{id}")
+        def read_items(id: Tuple[Item, Item]):
+            pass  # pragma: no cover
+
+
+def test_invalid_dict():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        class Item(BaseModel):
+            title: str
+
+        @app.get("/items/{id}")
+        def read_items(id: Dict[str, Item]):
+            pass  # pragma: no cover
+
+
+def test_invalid_simple_list():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        @app.get("/items/{id}")
+        def read_items(id: list):
+            pass  # pragma: no cover
+
+
+def test_invalid_simple_tuple():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        @app.get("/items/{id}")
+        def read_items(id: tuple):
+            pass  # pragma: no cover
+
+
+def test_invalid_simple_set():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        @app.get("/items/{id}")
+        def read_items(id: set):
+            pass  # pragma: no cover
+
+
+def test_invalid_simple_dict():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        @app.get("/items/{id}")
+        def read_items(id: dict):
+            pass  # pragma: no cover

--- a/tests/test_invalid_sequence_param.py
+++ b/tests/test_invalid_sequence_param.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import pytest
 from fastapi import FastAPI, Query
@@ -26,4 +26,28 @@ def test_invalid_tuple():
 
         @app.get("/items/")
         def read_items(q: Tuple[Item, Item] = Query(None)):
+            pass  # pragma: no cover
+
+
+def test_invalid_dict():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        class Item(BaseModel):
+            title: str
+
+        @app.get("/items/")
+        def read_items(q: Dict[str, Item] = Query(None)):
+            pass  # pragma: no cover
+
+
+def test_invalid_simple_dict():
+    with pytest.raises(AssertionError):
+        app = FastAPI()
+
+        class Item(BaseModel):
+            title: str
+
+        @app.get("/items/")
+        def read_items(q: dict = Query(None)):
             pass  # pragma: no cover

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
@@ -31,7 +31,7 @@ openapi_schema = {
                 "parameters": [
                     {
                         "required": False,
-                        "schema": {"title": "Q", "type": "array", "items": {}},
+                        "schema": {"title": "Q", "type": "array"},
                         "name": "q",
                         "in": "query",
                     }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
@@ -1,6 +1,6 @@
 from starlette.testclient import TestClient
 
-from query_params_str_validations.tutorial011 import app
+from query_params_str_validations.tutorial013 import app
 
 client = TestClient(app)
 
@@ -31,11 +31,7 @@ openapi_schema = {
                 "parameters": [
                     {
                         "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
+                        "schema": {"title": "Q", "type": "array", "items": {}},
                         "name": "q",
                         "in": "query",
                     }


### PR DESCRIPTION
Fix path and query parameters receiving `dict` as valid.

It should be taken as a body.

It was introduced in https://github.com/tiangolo/fastapi/pull/278.

This should solve #286.