### PR TITLE
Add Python 3.8 to CI for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache: pip
 python:
     - "3.6"
     - "3.7"
+    - "3.8-dev"
 
 install:
     - pip install flit


### PR DESCRIPTION
:construction_worker: Add Python 3.8 to CI for tests.