### PR TITLE
Fix same function names in different modules with composite bodies

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -8,7 +8,11 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.openapi.constants import METHODS_WITH_BODY, REF_PREFIX
 from fastapi.openapi.models import OpenAPI
 from fastapi.params import Body, Param
-from fastapi.utils import get_flat_models_from_routes, get_model_definitions
+from fastapi.utils import (
+    generate_operation_id_for_path,
+    get_flat_models_from_routes,
+    get_model_definitions,
+)
 from pydantic.fields import Field
 from pydantic.schema import field_schema, get_model_name_map
 from pydantic.utils import lenient_issubclass
@@ -113,10 +117,7 @@ def generate_operation_id(*, route: routing.APIRoute, method: str) -> str:
     if route.operation_id:
         return route.operation_id
     path: str = route.path_format
-    operation_id = route.name + path
-    operation_id = operation_id.replace("{", "_").replace("}", "_").replace("/", "_")
-    operation_id = operation_id + "_" + method.lower()
-    return operation_id
+    return generate_operation_id_for_path(name=route.name, path=path, method=method)
 
 
 def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -93,3 +93,10 @@ def create_cloned_field(field: Field) -> Field:
     new_field.shape = field.shape
     new_field._populate_validators()
     return new_field
+
+
+def generate_operation_id_for_path(*, name: str, path: str, method: str) -> str:
+    operation_id = name + path
+    operation_id = operation_id.replace("{", "_").replace("}", "_").replace("/", "_")
+    operation_id = operation_id + "_" + method.lower()
+    return operation_id

--- a/tests/test_modules_same_name_body/app/a.py
+++ b/tests/test_modules_same_name_body/app/a.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter, Body
+
+router = APIRouter()
+
+
+@router.post("/compute")
+def compute(a: int = Body(...), b: str = Body(...)):
+    return {"a": a, "b": b}

--- a/tests/test_modules_same_name_body/app/b.py
+++ b/tests/test_modules_same_name_body/app/b.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter, Body
+
+router = APIRouter()
+
+
+@router.post("/compute/")
+def compute(a: int = Body(...), b: str = Body(...)):
+    return {"a": a, "b": b}

--- a/tests/test_modules_same_name_body/app/main.py
+++ b/tests/test_modules_same_name_body/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+from . import a, b
+
+app = FastAPI()
+
+app.include_router(a.router, prefix="/a")
+app.include_router(b.router, prefix="/b")

--- a/tests/test_modules_same_name_body/test_main.py
+++ b/tests/test_modules_same_name_body/test_main.py
@@ -1,0 +1,155 @@
+from starlette.testclient import TestClient
+
+from .app.main import app
+
+client = TestClient(app)
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "Fast API", "version": "0.1.0"},
+    "paths": {
+        "/a/compute": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+                "summary": "Compute",
+                "operationId": "compute_a_compute_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_compute_a_compute_post"
+                            }
+                        }
+                    },
+                    "required": True,
+                },
+            }
+        },
+        "/b/compute/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+                "summary": "Compute",
+                "operationId": "compute_b_compute__post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_compute_b_compute__post"
+                            }
+                        }
+                    },
+                    "required": True,
+                },
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "Body_compute_b_compute__post": {
+                "title": "Body_compute_b_compute__post",
+                "required": ["a", "b"],
+                "type": "object",
+                "properties": {
+                    "a": {"title": "A", "type": "integer"},
+                    "b": {"title": "B", "type": "string"},
+                },
+            },
+            "Body_compute_a_compute_post": {
+                "title": "Body_compute_a_compute_post",
+                "required": ["a", "b"],
+                "type": "object",
+                "properties": {
+                    "a": {"title": "A", "type": "integer"},
+                    "b": {"title": "B", "type": "string"},
+                },
+            },
+            "ValidationError": {
+                "title": "ValidationError",
+                "required": ["loc", "msg", "type"],
+                "type": "object",
+                "properties": {
+                    "loc": {
+                        "title": "Location",
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "msg": {"title": "Message", "type": "string"},
+                    "type": {"title": "Error Type", "type": "string"},
+                },
+            },
+            "HTTPValidationError": {
+                "title": "HTTPValidationError",
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "title": "Detail",
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/ValidationError"},
+                    }
+                },
+            },
+        }
+    },
+}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == openapi_schema
+
+
+def test_post_a():
+    data = {"a": 2, "b": "foo"}
+    response = client.post("/a/compute", json=data)
+    assert response.status_code == 200
+    data = response.json()
+
+
+def test_post_a_invalid():
+    data = {"a": "bar", "b": "foo"}
+    response = client.post("/a/compute", json=data)
+    assert response.status_code == 422
+
+
+def test_post_b():
+    data = {"a": 2, "b": "foo"}
+    response = client.post("/b/compute/", json=data)
+    assert response.status_code == 200
+    data = response.json()
+
+
+def test_post_b_invalid():
+    data = {"a": "bar", "b": "foo"}
+    response = client.post("/b/compute/", json=data)
+    assert response.status_code == 422

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -66,7 +66,7 @@ openapi_schema = {
                     "content": {
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Body_read_current_user"
+                                "$ref": "#/components/schemas/Body_read_current_user_login_post"
                             }
                         }
                     },
@@ -90,8 +90,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_read_current_user": {
-                "title": "Body_read_current_user",
+            "Body_read_current_user_login_post": {
+                "title": "Body_read_current_user_login_post",
                 "required": ["grant_type", "username", "password"],
                 "type": "object",
                 "properties": {

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -73,7 +73,7 @@ openapi_schema = {
                     "content": {
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Body_read_current_user"
+                                "$ref": "#/components/schemas/Body_read_current_user_login_post"
                             }
                         }
                     },
@@ -97,8 +97,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_read_current_user": {
-                "title": "Body_read_current_user",
+            "Body_read_current_user_login_post": {
+                "title": "Body_read_current_user_login_post",
                 "required": ["grant_type", "username", "password"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -14,7 +14,7 @@ openapi_schema = {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "title": "Response_Read_Notes",
+                                    "title": "Response_Read_Notes_Notes__Get",
                                     "type": "array",
                                     "items": {"$ref": "#/components/schemas/Note"},
                                 }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -40,7 +40,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Body_update_item"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                            }
                         }
                     },
                     "required": True,
@@ -70,8 +72,8 @@ openapi_schema = {
                     "full_name": {"title": "Full_Name", "type": "string"},
                 },
             },
-            "Body_update_item": {
-                "title": "Body_update_item",
+            "Body_update_item_items__item_id__put": {
+                "title": "Body_update_item_items__item_id__put",
                 "required": ["item", "user", "importance"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_body_schema/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_schema/test_tutorial001.py
@@ -41,7 +41,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Body_update_item"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                            }
                         }
                     },
                     "required": True,
@@ -71,8 +73,8 @@ openapi_schema = {
                     "tax": {"title": "Tax", "type": "number"},
                 },
             },
-            "Body_update_item": {
-                "title": "Body_update_item",
+            "Body_update_item_items__item_id__put": {
+                "title": "Body_update_item_items__item_id__put",
                 "required": ["item"],
                 "type": "object",
                 "properties": {"item": {"$ref": "#/components/schemas/Item"}},

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
@@ -44,7 +44,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Body_read_items"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
+                            }
                         }
                     }
                 },
@@ -53,8 +55,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_read_items": {
-                "title": "Body_read_items",
+            "Body_read_items_items__item_id__put": {
+                "title": "Body_read_items_items__item_id__put",
                 "type": "object",
                 "properties": {
                     "start_datetime": {

--- a/tests/test_tutorial/test_extra_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial003.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "title": "Response_Read_Item",
+                                    "title": "Response_Read_Item_Items__Item_Id__Get",
                                     "anyOf": [
                                         {"$ref": "#/components/schemas/PlaneItem"},
                                         {"$ref": "#/components/schemas/CarItem"},

--- a/tests/test_tutorial/test_extra_models/test_tutorial004.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial004.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "title": "Response_Read_Items",
+                                    "title": "Response_Read_Items_Items__Get",
                                     "type": "array",
                                     "items": {"$ref": "#/components/schemas/Item"},
                                 }

--- a/tests/test_tutorial/test_extra_models/test_tutorial005.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial005.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "title": "Response_Read_Keyword_Weights",
+                                    "title": "Response_Read_Keyword_Weights_Keyword-Weights__Get",
                                     "type": "object",
                                     "additionalProperties": {"type": "number"},
                                 }

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -33,7 +33,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "multipart/form-data": {
-                            "schema": {"$ref": "#/components/schemas/Body_create_file"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_create_file_files__post"
+                            }
                         }
                     },
                     "required": True,
@@ -64,7 +66,7 @@ openapi_schema = {
                     "content": {
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file"
+                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
                             }
                         }
                     },
@@ -75,16 +77,16 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_create_file": {
-                "title": "Body_create_file",
+            "Body_create_upload_file_uploadfile__post": {
+                "title": "Body_create_upload_file_uploadfile__post",
                 "required": ["file"],
                 "type": "object",
                 "properties": {
                     "file": {"title": "File", "type": "string", "format": "binary"}
                 },
             },
-            "Body_create_upload_file": {
-                "title": "Body_create_upload_file",
+            "Body_create_file_files__post": {
+                "title": "Body_create_file_files__post",
                 "required": ["file"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_request_files/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002.py
@@ -33,7 +33,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "multipart/form-data": {
-                            "schema": {"$ref": "#/components/schemas/Body_create_files"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_create_files_files__post"
+                            }
                         }
                     },
                     "required": True,
@@ -64,7 +66,7 @@ openapi_schema = {
                     "content": {
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files"
+                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
                             }
                         }
                     },
@@ -87,8 +89,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_create_files": {
-                "title": "Body_create_files",
+            "Body_create_upload_files_uploadfiles__post": {
+                "title": "Body_create_upload_files_uploadfiles__post",
                 "required": ["files"],
                 "type": "object",
                 "properties": {
@@ -99,8 +101,8 @@ openapi_schema = {
                     }
                 },
             },
-            "Body_create_upload_files": {
-                "title": "Body_create_upload_files",
+            "Body_create_files_files__post": {
+                "title": "Body_create_files_files__post",
                 "required": ["files"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -32,7 +32,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "application/x-www-form-urlencoded": {
-                            "schema": {"$ref": "#/components/schemas/Body_login"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_login_login__post"
+                            }
                         }
                     },
                     "required": True,
@@ -42,8 +44,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_login": {
-                "title": "Body_login",
+            "Body_login_login__post": {
+                "title": "Body_login_login__post",
                 "required": ["username", "password"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -34,7 +34,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "multipart/form-data": {
-                            "schema": {"$ref": "#/components/schemas/Body_create_file"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_create_file_files__post"
+                            }
                         }
                     },
                     "required": True,
@@ -44,8 +46,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_create_file": {
-                "title": "Body_create_file",
+            "Body_create_file_files__post": {
+                "title": "Body_create_file_files__post",
                 "required": ["file", "fileb", "token"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -31,7 +31,9 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "application/x-www-form-urlencoded": {
-                            "schema": {"$ref": "#/components/schemas/Body_login"}
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_login_token_post"
+                            }
                         }
                     },
                     "required": True,
@@ -54,8 +56,8 @@ openapi_schema = {
     },
     "components": {
         "schemas": {
-            "Body_login": {
-                "title": "Body_login",
+            "Body_login_token_post": {
+                "title": "Body_login_token_post",
                 "required": ["username", "password"],
                 "type": "object",
                 "properties": {

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -42,7 +42,7 @@ openapi_schema = {
                     "content": {
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/Body_login_for_access_token"
+                                "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
                             }
                         }
                     },
@@ -116,8 +116,8 @@ openapi_schema = {
                     "token_type": {"title": "Token_Type", "type": "string"},
                 },
             },
-            "Body_login_for_access_token": {
-                "title": "Body_login_for_access_token",
+            "Body_login_for_access_token_token_post": {
+                "title": "Body_login_for_access_token_token_post",
                 "required": ["username", "password"],
                 "type": "object",
                 "properties": {
@@ -177,6 +177,12 @@ openapi_schema = {
 }
 
 
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == openapi_schema
+
+
 def get_access_token(username="johndoe", password="secret", scope=None):
     data = {"username": username, "password": password}
     if scope:
@@ -185,12 +191,6 @@ def get_access_token(username="johndoe", password="secret", scope=None):
     content = response.json()
     access_token = content.get("access_token")
     return access_token
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
 
 
 def test_login():

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases.py
@@ -16,7 +16,7 @@ openapi_schema = {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "title": "Response_Read_Users",
+                                    "title": "Response_Read_Users_Users__Get",
                                     "type": "array",
                                     "items": {"$ref": "#/components/schemas/User"},
                                 }
@@ -168,7 +168,7 @@ openapi_schema = {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "title": "Response_Read_Items",
+                                    "title": "Response_Read_Items_Items__Get",
                                     "type": "array",
                                     "items": {"$ref": "#/components/schemas/Item"},
                                 }


### PR DESCRIPTION
Fix same function names in different modules with composite bodies.

Currently, if two *path operation functions* are named the same, in two separate modules, and receive several body parameters, they are converted into a composite body JSON Schema for OpenAPI.

But the names are generated based on the *path operation* name, and if the name is not assigned but autogenerated (based on the function name), two JSON Schemas could have the same name, breaking the OpenAPI generation.

This PR re-implements the name generation for composite bodies and response JSON Schemas in OpenAPI.

An explicit example can be found in the added tests.

This also means that it's now possible to use `.include_router` multiple times with the *same* router, under different `prefix`es, and it will work. For example, it can be used to expose the same router under different API prefixes (e.g. `/api/v2` and `/api/latest`).

This fixes #284