### PR TITLE
Add test for templates in prefix path used for include_router

### DIFF
--- a/tests/test_router_prefix_with_template.py
+++ b/tests/test_router_prefix_with_template.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, FastAPI
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+router = APIRouter()
+
+
+@router.get("/users/{id}")
+def read_user(segment: str, id: str):
+    return {"segment": segment, "id": id}
+
+
+app.include_router(router, prefix="/{segment}")
+
+
+client = TestClient(app)
+
+
+def test_get():
+    response = client.get("/seg/users/foo")
+    assert response.status_code == 200
+    assert response.json() == {"segment": "seg", "id": "foo"}


### PR DESCRIPTION
:white_check_mark: Add test for templates in `prefix` path used for `include_router`.

This tests #161. Which seems to be working as expected.