### PR TITLE
Update enum examples to use str, and improve Swagger UI in examples.

### DIFF
--- a/docs/src/path_params/tutorial005.py
+++ b/docs/src/path_params/tutorial005.py
@@ -3,7 +3,7 @@ from enum import Enum
 from fastapi import FastAPI
 
 
-class ModelName(Enum):
+class ModelName(str, Enum):
     alexnet = "alexnet"
     resnet = "resnet"
     lenet = "lenet"

--- a/docs/tutorial/path-params.md
+++ b/docs/tutorial/path-params.md
@@ -119,7 +119,9 @@ If you have a *path operation* that receives a *path parameter*, but you want th
 
 ### Create an `Enum` class
 
-Import `Enum` and create a sub-class that inherits from it.
+Import `Enum` and create a sub-class that inherits from `str` and from `Enum`.
+
+By inheriting from `str` the API docs will be able to know that the values must be of type `string` and will be able to render correctly.
 
 And create class attributes with fixed values, those fixed values will be the available valid values:
 

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -35,6 +35,7 @@ openapi_schema = {
                         "schema": {
                             "title": "Model_Name",
                             "enum": ["alexnet", "resnet", "lenet"],
+                            "type": "string",
                         },
                         "name": "model_name",
                         "in": "path",


### PR DESCRIPTION
:memo: Update enum examples to use str, and improve Swagger UI in examples.

Related to https://github.com/tiangolo/fastapi/issues/329 and https://github.com/tiangolo/fastapi/issues/60