### PR TITLE
Tiny serialization method optimization

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -42,25 +42,6 @@ def _jsonable_encoder(
     custom_encoder: dict,
     sqlalchemy_safe: bool,
 ) -> Any:
-    if isinstance(obj, BaseModel):
-        encoder = getattr(obj.Config, "json_encoders", custom_encoder)
-        return _jsonable_encoder(
-            obj.dict(
-                include=include,
-                exclude=exclude,
-                by_alias=by_alias,
-                skip_defaults=skip_defaults,
-            ),
-            include=include,
-            exclude=exclude,
-            by_alias=by_alias,
-            skip_defaults=skip_defaults,
-            include_none=include_none,
-            custom_encoder=encoder,
-            sqlalchemy_safe=sqlalchemy_safe,
-        )
-    if isinstance(obj, Enum):
-        return obj.value
     if isinstance(obj, (str, int, float, type(None))):
         return obj
     if isinstance(obj, dict):
@@ -113,6 +94,26 @@ def _jsonable_encoder(
                 )
             )
         return encoded_list
+
+    if isinstance(obj, BaseModel):
+        encoder = getattr(obj.Config, "json_encoders", custom_encoder)
+        return _jsonable_encoder(
+            obj.dict(
+                include=include,
+                exclude=exclude,
+                by_alias=by_alias,
+                skip_defaults=skip_defaults,
+            ),
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            skip_defaults=skip_defaults,
+            include_none=include_none,
+            custom_encoder=encoder,
+            sqlalchemy_safe=sqlalchemy_safe,
+        )
+    if isinstance(obj, Enum):
+        return obj.value
     errors: List[Exception] = []
     try:
         if custom_encoder and type(obj) in custom_encoder:

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -125,10 +125,14 @@ def _jsonable_encoder(
         errors.append(e)
         try:
             data = dict(obj)
+            if not data:
+                return data
         except Exception as e:
             errors.append(e)
             try:
                 data = vars(obj)
+                if not data:
+                    return data
             except Exception as e:
                 errors.append(e)
                 raise ValueError(errors)

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from types import GeneratorType
-from typing import Any, List, Set
+from typing import Any, List, Set, Optional
 
 from pydantic import BaseModel
 from pydantic.json import ENCODERS_BY_TYPE
@@ -34,7 +34,8 @@ def jsonable_encoder(
 
 def _jsonable_encoder(
     obj: Any,
-    include: Set[str],
+    *,
+    include: Optional[Set[str]],
     exclude: Set[str],
     by_alias: bool,
     skip_defaults: bool,

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from types import GeneratorType
-from typing import Any, List, Set, Optional
+from typing import Any, List, Optional, Set
 
 from pydantic import BaseModel
 from pydantic.json import ENCODERS_BY_TYPE

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -99,3 +99,18 @@ def test_encode_model_with_alias_raises():
 def test_encode_model_with_alias():
     model = ModelWithAlias(Foo="Bar")
     assert jsonable_encoder(model) == {"Foo": "Bar"}
+
+
+def test_unknown_type_value_and_empty_dict():
+    class _Unknown:
+        def __iter__(self):
+            return iter([])
+
+    assert jsonable_encoder({"k": _Unknown()}) == {"k": {}}
+
+
+def test_unknown_type_value_and_empty_vars():
+    class _Unknown:
+        pass
+
+    assert jsonable_encoder({"k": _Unknown()}) == {"k": {}}


### PR DESCRIPTION
This is tiny performance optimization.

refs #360  ([gists](https://gist.github.com/podhmo/adebe386eaf298b5fb7a1689f57f027e#file-test_serial_speed-py))

original code (before)

```console
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: ~/venvs/my/individual-sandbox/daily/20190708/example_fastapi
plugins: cov-2.7.1
collected 1 item

test_serial_speed.py::test_routes 
-------------------------------- live log call ---------------------------------
INFO     test_serial_speed:test_serial_speed.py:48 route1: 0.031059980392456055
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route1, 3.0471584796905518, ['http_status:200', 'http_method:GET', 'time:wall']
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route1, 3.04316, ['http_status:200', 'http_method:GET', 'time:cpu']
INFO     test_serial_speed:test_serial_speed.py:68 route1: 0.029019832611083984
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route2, 3.367730140686035, ['http_status:200', 'http_method:GET', 'time:wall']
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route2, 3.364335, ['http_status:200', 'http_method:GET', 'time:cpu']
INFO     test_serial_speed:test_serial_speed.py:84 route1: 0.0014355182647705078
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route4, 2.1561036109924316, ['http_status:200', 'http_method:GET', 'time:wall']
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route4, 2.1537700000000006, ['http_status:200', 'http_method:GET', 'time:cpu']
PASSED

=========================== 1 passed in 8.81 seconds ===========================
```

after

```console
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: ~/venvs/my/individual-sandbox/daily/20190708/example_fastapi
plugins: cov-2.7.1
collected 1 item

test_serial_speed.py::test_routes 
-------------------------------- live log call ---------------------------------
INFO     test_serial_speed:test_serial_speed.py:48 route1: 0.02889871597290039
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route1, 2.2630717754364014, ['http_status:200', 'http_method:GET', 'time:wall']
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route1, 2.260655, ['http_status:200', 'http_method:GET', 'time:cpu']
INFO     test_serial_speed:test_serial_speed.py:68 route1: 0.028612375259399414
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route2, 2.529733896255493, ['http_status:200', 'http_method:GET', 'time:wall']
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route2, 2.527283, ['http_status:200', 'http_method:GET', 'time:cpu']
INFO     test_serial_speed:test_serial_speed.py:84 route1: 0.0014500617980957031
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route4, 1.5969781875610352, ['http_status:200', 'http_method:GET', 'time:wall']
INFO     test_serial_speed:test_serial_speed.py:19 app.test_serial_speed.route4, 1.595663, ['http_status:200', 'http_method:GET', 'time:cpu']
PASSED

=========================== 1 passed in 6.63 seconds ===========================
```