### PR TITLE
Fix unskipped defaults

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -53,7 +53,7 @@ def serialize_response(
         if errors:
             raise ValidationError(errors)
         if skip_defaults and isinstance(response, BaseModel):
-            exclude |= value.__fields_set__.difference(response.__fields_set__)
+            value = response.dict(skip_defaults=skip_defaults)
         return jsonable_encoder(
             value,
             include=include,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -52,6 +52,8 @@ def serialize_response(
             errors.extend(errors_)
         if errors:
             raise ValidationError(errors)
+        if skip_defaults and isinstance(response, BaseModel):
+            exclude |= value.__fields_set__.difference(response.__fields_set__)
         return jsonable_encoder(
             value,
             include=include,

--- a/tests/test_skip_defaults.py
+++ b/tests/test_skip_defaults.py
@@ -4,17 +4,26 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from starlette.testclient import TestClient
 
+app = FastAPI()
+
+
+class SubModel(BaseModel):
+    a: Optional[str] = "foo"
+
+
+class Model(BaseModel):
+    x: Optional[int]
+    sub: SubModel
+
+
+@app.get("/", response_model=Model, response_model_skip_defaults=True)
+def get() -> Model:
+    return Model(sub={})
+
+
+client = TestClient(app)
+
 
 def test_return_defaults():
-    app = FastAPI()
-
-    class Model(BaseModel):
-        x: Optional[int]
-
-    @app.get("/", response_model=Model, response_model_skip_defaults=True)
-    def get_x() -> Model:
-        return Model()
-
-    client = TestClient(app)
     response = client.get("/")
-    assert response.content == b"{}"
+    assert response.json() == {"sub": {}}

--- a/tests/test_skip_defaults.py
+++ b/tests/test_skip_defaults.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.testclient import TestClient
+
+
+def test_return_defaults():
+    app = FastAPI()
+
+    class Model(BaseModel):
+        x: Optional[int]
+
+    @app.get("/", response_model=Model, response_model_skip_defaults=True)
+    def get_x() -> Model:
+        return Model()
+
+    client = TestClient(app)
+    response = client.get("/")
+    print(response)
+    assert response.content == b"{}"

--- a/tests/test_skip_defaults.py
+++ b/tests/test_skip_defaults.py
@@ -17,5 +17,4 @@ def test_return_defaults():
 
     client = TestClient(app)
     response = client.get("/")
-    print(response)
     assert response.content == b"{}"


### PR DESCRIPTION
Addresses https://github.com/tiangolo/fastapi/issues/421

Currently, if you return a `BaseModel` instance in a route with a `BaseModel` response_type, the `skip_defaults` value does not influence the result. This PR fixes this.

-----
**Details**

The source of the problem is that calling `field.validate` on a model results in a new model with the fields set. I dug in on the pydantic side and it looks like this is due to the recent change to re-parse the model with a non-subclass type when response_model is set. If you look in `BaseModel.validate` (which is ultimately called if you follow it deep enough), you can see the precise spot where defaults aren't being skipped:

```python
@classmethod
    def validate(cls: Type['Model'], value: Any) -> 'Model':
        if isinstance(value, dict):
            return cls.parse_obj(value)
        elif isinstance(value, cls):
            return value.copy()
        elif cls.__config__.orm_mode:
            return cls.from_orm(value)
        else:
            with change_exception(DictError, TypeError, ValueError):
                return cls.parse_obj(value)
```

It calls into `parse_obj` on the last line, which subsequently calls `dict` on the object and then parses the dict. Unfortunately, this means defaults don't get skipped.

**I don't think it makes sense to change this on the pydantic side** because otherwise you'd run into problems parsing models with default values into non-subclass models with required values. So, if we want to stick with this approach of creating a new class to force a reparse, we probably need to handle the 

----

That said, I would also be in favor of a larger refactor if we could come up with a way to get the desired field safely without another round of parsing/dumping 😬. But that does seem hard.