### PR TITLE
Add type-checking for dependencies

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -243,12 +243,12 @@ T = TypeVar("T")
 
 @overload
 def Depends(dependency: Callable[..., T], *, use_cache: bool = True) -> T:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def Depends(dependency: None = None, *, use_cache: bool = True) -> Any:
-    ...
+    ...  # pragma: no cover
 
 
 def Depends(  # noqa: N802
@@ -264,14 +264,14 @@ def Security(
     scopes: Sequence[str] = None,
     use_cache: bool = True,
 ) -> T:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def Security(
     dependency: None = None, *, scopes: Sequence[str] = None, use_cache: bool = True
 ) -> Any:
-    ...
+    ...  # pragma: no cover
 
 
 def Security(  # noqa: N802

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Sequence, TypeVar, overload
 
 from fastapi import params
 
@@ -238,10 +238,40 @@ def File(  # noqa: N802
     )
 
 
+T = TypeVar("T")
+
+
+@overload
+def Depends(dependency: Callable[..., T], *, use_cache: bool = True) -> T:
+    ...
+
+
+@overload
+def Depends(dependency: None = None, *, use_cache: bool = True) -> Any:
+    ...
+
+
 def Depends(  # noqa: N802
     dependency: Callable = None, *, use_cache: bool = True
 ) -> Any:
     return params.Depends(dependency=dependency, use_cache=use_cache)
+
+
+@overload
+def Security(
+    dependency: Callable[..., T],
+    *,
+    scopes: Sequence[str] = None,
+    use_cache: bool = True,
+) -> T:
+    ...
+
+
+@overload
+def Security(
+    dependency: None = None, *, scopes: Sequence[str] = None, use_cache: bool = True
+) -> Any:
+    ...
 
 
 def Security(  # noqa: N802


### PR DESCRIPTION
This change ensures that the following error is caught by mypy:
```python
def get_type_2() -> Type2:
    return Type2()

@app.get("/")
def endpoint(x: Type1 = Depends(get_type_2)):
    return ""
```
-----
* The type of `Depends(callable)` is the type of the result of `callable`.
* When `Depends()` is used without a callable, the result is treated as Any (since the type is guaranteed to be that of the annotation anyway).
* If you want the result of the `Depends` function to be type-hinted as an actual `Depends` class instance, you can use the `Depends` class directly, rather than the function.

@tiangolo let me know if you'd like me to create an issue for discussion.