### PR TITLE
added support and tests for pydantic dataclasses

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import is_dataclass
 from typing import Any, Dict, List, Sequence, Set, Type, cast
 
 from fastapi import routing
@@ -52,6 +53,8 @@ def get_path_param_names(path: str) -> Set[str]:
 
 def create_cloned_field(field: Field) -> Field:
     original_type = field.type_
+    if is_dataclass(original_type) and hasattr(original_type, "__pydantic_model__"):
+        original_type = original_type.__pydantic_model__  # type: ignore
     use_type = original_type
     if lenient_issubclass(original_type, BaseModel):
         original_type = cast(Type[BaseModel], original_type)

--- a/tests/test_serialize_response_dataclass.py
+++ b/tests/test_serialize_response_dataclass.py
@@ -1,13 +1,14 @@
 from typing import List
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic.dataclasses import dataclass
 from starlette.testclient import TestClient
 
 app = FastAPI()
 
 
-class Item(BaseModel):
+@dataclass
+class Item:
     name: str
     price: float = None
     owner_ids: List[int] = None

--- a/tests/test_validate_response.py
+++ b/tests/test_validate_response.py
@@ -1,0 +1,51 @@
+from typing import List
+
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel, ValidationError
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float = None
+    owner_ids: List[int] = None
+
+
+@app.get("/items/invalid", response_model=Item)
+def get_invalid():
+    return {"name": "invalid", "price": "foo"}
+
+
+@app.get("/items/innerinvalid", response_model=Item)
+def get_innerinvalid():
+    return {"name": "double invalid", "price": "foo", "owner_ids": ["foo", "bar"]}
+
+
+@app.get("/items/invalidlist", response_model=List[Item])
+def get_invalidlist():
+    return [
+        {"name": "foo"},
+        {"name": "bar", "price": "bar"},
+        {"name": "baz", "price": "baz"},
+    ]
+
+
+client = TestClient(app)
+
+
+def test_invalid():
+    with pytest.raises(ValidationError):
+        client.get("/items/invalid")
+
+
+def test_double_invalid():
+    with pytest.raises(ValidationError):
+        client.get("/items/innerinvalid")
+
+
+def test_invalid_list():
+    with pytest.raises(ValidationError):
+        client.get("/items/invalidlist")

--- a/tests/test_validate_response_dataclass.py
+++ b/tests/test_validate_response_dataclass.py
@@ -1,0 +1,53 @@
+from typing import List
+
+import pytest
+from fastapi import FastAPI
+from pydantic import ValidationError
+from pydantic.dataclasses import dataclass
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+
+@dataclass
+class Item:
+    name: str
+    price: float = None
+    owner_ids: List[int] = None
+
+
+@app.get("/items/invalid", response_model=Item)
+def get_invalid():
+    return {"name": "invalid", "price": "foo"}
+
+
+@app.get("/items/innerinvalid", response_model=Item)
+def get_innerinvalid():
+    return {"name": "double invalid", "price": "foo", "owner_ids": ["foo", "bar"]}
+
+
+@app.get("/items/invalidlist", response_model=List[Item])
+def get_invalidlist():
+    return [
+        {"name": "foo"},
+        {"name": "bar", "price": "bar"},
+        {"name": "baz", "price": "baz"},
+    ]
+
+
+client = TestClient(app)
+
+
+def test_invalid():
+    with pytest.raises(ValidationError):
+        client.get("/items/invalid")
+
+
+def test_double_invalid():
+    with pytest.raises(ValidationError):
+        client.get("/items/innerinvalid")
+
+
+def test_invalid_list():
+    with pytest.raises(ValidationError):
+        client.get("/items/invalidlist")


### PR DESCRIPTION
Fixes #265 

Summary of changes:
 - in `fastapi.utils.create_cloned_field` we coerce a pydantic dataclass to its `BaseModel` version using the `__pydantic_model__` attribute
 - changed the `test_serialize_response.py` test to actually test serializing the response and created a separate test `test_validate_response.py` which tests for appropriate `ValidationError`s
 - created `*_dataclass.py` variants of `test_serialize_response` and `test_validate_resonse`