### PR TITLE
Only use default parameter values for path parameters (#450)

### DIFF
--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -4,7 +4,7 @@ from starlette.testclient import TestClient
 app = FastAPI()
 
 
-user_router = APIRouter()  # pylint: disable=invalid-name
+user_router = APIRouter()
 item_router = APIRouter()  # pylint: disable=invalid-name
 
 

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -5,7 +5,7 @@ app = FastAPI()
 
 
 user_router = APIRouter()
-item_router = APIRouter()  # pylint: disable=invalid-name
+item_router = APIRouter()
 
 
 @user_router.get("/")

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -52,7 +52,6 @@ def test_get_users():
 
 def test_get_user():
     """Check that /users/{user_id} returns expected data"""
-    """
     response = client.get("/users/abc123")
     assert response.status_code == 200
     assert response.json() == {"user_id": "abc123"}

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -58,9 +58,7 @@ def test_get_user():
 
 
 def test_get_items_1():
-    """Check that /items returns expected data
-
-    """
+    """Check that /items returns expected data"""
     response = client.get("/items")
     assert response.status_code == 200
     assert response.json() == [
@@ -70,52 +68,42 @@ def test_get_items_1():
 
 
 def test_get_items_2():
-    """Check that /items returns expected data with user_id specified
-
-    """
+    """Check that /items returns expected data with user_id specified"""
     response = client.get("/items?user_id=abc123")
     assert response.status_code == 200
     assert response.json() == [{"item_id": "i2", "user_id": "abc123"}]
 
 
 def test_get_item_1():
-    """Check that /items/{}item_id} returns expected data
-
-    """
+    """Check that /items/{item_id} returns expected data"""
     response = client.get("/items/item01")
     assert response.status_code == 200
     assert response.json() == {"item_id": "item01"}
 
 
 def test_get_item_2():
-    """Check that /items/{}item_id} returns expected data with user_id specified
-
-    """
+    """Check that /items/{item_id} returns expected data with user_id specified"""
     response = client.get("/items/item01?user_id=abc123")
     assert response.status_code == 200
     assert response.json() == {"item_id": "item01", "user_id": "abc123"}
 
 
 def test_get_users_items():
-    """Check that /users/{user_id}/items returns expected data
-
-    """
+    """Check that /users/{user_id}/items returns expected data"""
     response = client.get("/users/abc123/items")
     assert response.status_code == 200
     assert response.json() == [{"item_id": "i2", "user_id": "abc123"}]
 
 
 def test_get_users_item():
-    """Check that /users/{user_id}/items returns expected data
-
-    """
+    """Check that /users/{user_id}/items returns expected data"""
     response = client.get("/users/abc123/items/item01")
     assert response.status_code == 200
     assert response.json() == {"item_id": "item01", "user_id": "abc123"}
 
 
 def test_schema_1():
-    """Check that the user_id is a required path parameter under /users
+    """Check that the user_id is a required path parameter under /users"""
     response = client.get("/openapi.json")
     assert response.status_code == 200
     r = response.json()

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -52,7 +52,6 @@ def test_get_users():
 
 def test_get_user():
     """Check that /users/{user_id} returns expected data"""
-
     """
     response = client.get("/users/abc123")
     assert response.status_code == 200

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -44,7 +44,7 @@ client = TestClient(app)
 
 
 def test_get_users():
-    """Check that /users returns expected data
+    """Check that /users returns expected data"""
 
     """
     response = client.get("/users")

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, FastAPI
 from starlette.testclient import TestClient
 
-app = FastAPI()  # pylint: disable=invalid-name
+app = FastAPI()
 
 
 user_router = APIRouter()  # pylint: disable=invalid-name

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -137,7 +137,6 @@ def test_schema_1():
 
 def test_schema_2():
     """Check that the user_id is an optional query parameter under /items"""
-    """
     response = client.get("/openapi.json")
     assert response.status_code == 200
     r = response.json()

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -1,0 +1,156 @@
+from fastapi import APIRouter, FastAPI
+from starlette.testclient import TestClient
+
+app = FastAPI()  # pylint: disable=invalid-name
+
+
+user_router = APIRouter()  # pylint: disable=invalid-name
+item_router = APIRouter()  # pylint: disable=invalid-name
+
+
+@user_router.get("/")
+def get_users():
+    return [{"user_id": "u1"}, {"user_id": "u2"}]
+
+
+@user_router.get("/{user_id}")
+def get_user(user_id: str):
+    return {"user_id": user_id}
+
+
+@item_router.get("/")
+def get_items(user_id: str = None):
+    if user_id is None:
+        return [{"item_id": "i1", "user_id": "u1"}, {"item_id": "i2", "user_id": "u2"}]
+    else:
+        return [{"item_id": "i2", "user_id": user_id}]
+
+
+@item_router.get("/{item_id}")
+def get_item(item_id: str, user_id: str = None):
+    if user_id is None:
+        return {"item_id": item_id}
+    else:
+        return {"item_id": item_id, "user_id": user_id}
+
+
+app.include_router(user_router, prefix="/users")
+app.include_router(item_router, prefix="/items")
+
+app.include_router(item_router, prefix="/users/{user_id}/items")
+
+
+client = TestClient(app)  # pylint: disable=invalid-name
+
+
+def test_get_users():
+    """Check that /users returns expected data
+
+    """
+    response = client.get("/users")
+    assert response.status_code == 200
+    assert response.json() == [{"user_id": "u1"}, {"user_id": "u2"}]
+
+
+def test_get_user():
+    """Check that /users/{user_id} returns expected data
+
+    """
+    response = client.get("/users/abc123")
+    assert response.status_code == 200
+    assert response.json() == {"user_id": "abc123"}
+
+
+def test_get_items_1():
+    """Check that /items returns expected data
+
+    """
+    response = client.get("/items")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"item_id": "i1", "user_id": "u1"},
+        {"item_id": "i2", "user_id": "u2"},
+    ]
+
+
+def test_get_items_2():
+    """Check that /items returns expected data with user_id specified
+
+    """
+    response = client.get("/items?user_id=abc123")
+    assert response.status_code == 200
+    assert response.json() == [{"item_id": "i2", "user_id": "abc123"}]
+
+
+def test_get_item_1():
+    """Check that /items/{}item_id} returns expected data
+
+    """
+    response = client.get("/items/item01")
+    assert response.status_code == 200
+    assert response.json() == {"item_id": "item01"}
+
+
+def test_get_item_2():
+    """Check that /items/{}item_id} returns expected data with user_id specified
+
+    """
+    response = client.get("/items/item01?user_id=abc123")
+    assert response.status_code == 200
+    assert response.json() == {"item_id": "item01", "user_id": "abc123"}
+
+
+def test_get_users_items():
+    """Check that /users/{user_id}/items returns expected data
+
+    """
+    response = client.get("/users/abc123/items")
+    assert response.status_code == 200
+    assert response.json() == [{"item_id": "i2", "user_id": "abc123"}]
+
+
+def test_get_users_item():
+    """Check that /users/{user_id}/items returns expected data
+
+    """
+    response = client.get("/users/abc123/items/item01")
+    assert response.status_code == 200
+    assert response.json() == {"item_id": "item01", "user_id": "abc123"}
+
+
+def test_schema_1():
+    """Check that the user_id is a required path parameter under /users
+
+    """
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    r = response.json()
+
+    d = {
+        "required": True,
+        "schema": {"title": "User_Id", "type": "string"},
+        "name": "user_id",
+        "in": "path",
+    }
+
+    assert d in r["paths"]["/users/{user_id}"]["get"]["parameters"]
+    assert d in r["paths"]["/users/{user_id}/items/"]["get"]["parameters"]
+
+
+def test_schema_2():
+    """Check that the user_id is an optional query parameter under /items
+
+    """
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    r = response.json()
+
+    d = {
+        "required": False,
+        "schema": {"title": "User_Id", "type": "string"},
+        "name": "user_id",
+        "in": "query",
+    }
+
+    assert d in r["paths"]["/items/{item_id}"]["get"]["parameters"]
+    assert d in r["paths"]["/items/"]["get"]["parameters"]

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -45,7 +45,6 @@ client = TestClient(app)
 
 def test_get_users():
     """Check that /users returns expected data"""
-    """
     response = client.get("/users")
     assert response.status_code == 200
     assert response.json() == [{"user_id": "u1"}, {"user_id": "u2"}]

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -137,7 +137,6 @@ def test_schema_1():
 
 def test_schema_2():
     """Check that the user_id is an optional query parameter under /items"""
-
     """
     response = client.get("/openapi.json")
     assert response.status_code == 200

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -45,7 +45,6 @@ client = TestClient(app)
 
 def test_get_users():
     """Check that /users returns expected data"""
-
     """
     response = client.get("/users")
     assert response.status_code == 200

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -120,7 +120,6 @@ def test_get_users_item():
 
 def test_schema_1():
     """Check that the user_id is a required path parameter under /users
-
     """
     response = client.get("/openapi.json")
     assert response.status_code == 200

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -40,7 +40,7 @@ app.include_router(item_router, prefix="/items")
 app.include_router(item_router, prefix="/users/{user_id}/items")
 
 
-client = TestClient(app)  # pylint: disable=invalid-name
+client = TestClient(app)
 
 
 def test_get_users():

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -136,7 +136,7 @@ def test_schema_1():
 
 
 def test_schema_2():
-    """Check that the user_id is an optional query parameter under /items
+    """Check that the user_id is an optional query parameter under /items"""
 
     """
     response = client.get("/openapi.json")

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -120,7 +120,6 @@ def test_get_users_item():
 
 def test_schema_1():
     """Check that the user_id is a required path parameter under /users
-    """
     response = client.get("/openapi.json")
     assert response.status_code == 200
     r = response.json()

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -51,7 +51,7 @@ def test_get_users():
 
 
 def test_get_user():
-    """Check that /users/{user_id} returns expected data
+    """Check that /users/{user_id} returns expected data"""
 
     """
     response = client.get("/users/abc123")


### PR DESCRIPTION
This change allows endpoint functions to be defined with parameters with defaults, but for those defaults to be ignored if the function parameter subsequently appears as a path parameter. The default value is only operative if the parameter is a query parameter.

This change includes a new set of tests for this functionality.