### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 
 matrix:
     allow_failures:
+        - python: "3.8-dev"
         - python: "nightly"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ cache: pip
 python:
     - "3.6"
     - "3.7"
+    - "3.8-dev"
+    - "nightly"
+
+matrix:
+    allow_failures:
+        - python: "nightly"
 
 install:
     - pip install flit


### PR DESCRIPTION
Hello Sebastián,

Classifiers at `pyproject.toml` says that Python 3.8 is supported already, but there are no tests for this version on Travis CI.
This PR enables tests for Python `3.8-dev` and `nightly`.

Best regards!