### PR TITLE
Add support for custom route class

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -315,11 +315,13 @@ class APIRouter(routing.Router):
         redirect_slashes: bool = True,
         default: ASGIApp = None,
         dependency_overrides_provider: Any = None,
+        route_class: Type[APIRoute] = APIRoute,
     ) -> None:
         super().__init__(
             routes=routes, redirect_slashes=redirect_slashes, default=default
         )
         self.dependency_overrides_provider = dependency_overrides_provider
+        self.route_class = route_class
 
     def add_api_route(
         self,
@@ -345,7 +347,7 @@ class APIRouter(routing.Router):
         response_class: Type[Response] = JSONResponse,
         name: str = None,
     ) -> None:
-        route = APIRoute(
+        route = self.route_class(
             path,
             endpoint=endpoint,
             response_model=response_model,


### PR DESCRIPTION
This change would make it substantially easier to override the default route-matching behavior. In particular, this could simplify the implementation of version-based routing as discussed in https://github.com/tiangolo/fastapi/issues/200

I created a pull request for this to aid in discussion since it was only a three line change, but before merging it would probably merit some updates to docs and tests.

In the absence of interest, I'll be happy to just close the pull request unmerged.