### PR TITLE
implement toggle to prevent usage of google fonts in redoc

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -56,6 +56,7 @@ def get_redoc_html(
     title: str,
     redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
     redoc_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
+    with_google_fonts: bool = True,
 ) -> HTMLResponse:
     html = f"""
     <!DOCTYPE html>
@@ -65,7 +66,12 @@ def get_redoc_html(
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    """
+    if with_google_fonts:
+        html += """
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    """
+    html += f"""
     <link rel="shortcut icon" href="{redoc_favicon_url}">
     <!--
     ReDoc doesn't change outer page styles

--- a/tests/test_local_docs.py
+++ b/tests/test_local_docs.py
@@ -54,3 +54,14 @@ def test_strings_in_custom_redoc():
     body_content = html.body.decode()
     assert redoc_js_url in body_content
     assert redoc_favicon_url in body_content
+
+
+def test_google_fonts_in_generated_redoc():
+    body_with_google_fonts = get_redoc_html(
+        openapi_url="/docs", title="title"
+    ).body.decode()
+    assert "fonts.googleapis.com" in body_with_google_fonts
+    body_without_google_fonts = get_redoc_html(
+        openapi_url="/docs", title="title", with_google_fonts=False
+    ).body.decode()
+    assert "fonts.googleapis.com" not in body_without_google_fonts


### PR DESCRIPTION
Since it is already possible to prevent the inclusion of third-party javascript and images, the should be possible for css/fonts for the redoc page