### PR TITLE
Fix default extra response

### DIFF
--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -210,10 +210,6 @@ class Response(BaseModel):
     links: Optional[Dict[str, Union[Link, Reference]]] = None
 
 
-class Responses(BaseModel):
-    default: Response
-
-
 class Operation(BaseModel):
     tags: Optional[List[str]] = None
     summary: Optional[str] = None
@@ -222,7 +218,7 @@ class Operation(BaseModel):
     operationId: Optional[str] = None
     parameters: Optional[List[Union[Parameter, Reference]]] = None
     requestBody: Optional[Union[RequestBody, Reference]] = None
-    responses: Union[Responses, Dict[str, Response]]
+    responses: Dict[str, Response]
     # Workaround OpenAPI recursive reference
     callbacks: Optional[Dict[str, Union[Dict[str, Any], Reference]]] = None
     deprecated: Optional[bool] = None

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -49,7 +49,7 @@ status_code_ranges: Dict[str, str] = {
     "3XX": "Redirection",
     "4XX": "Client Error",
     "5XX": "Server Error",
-    "default": "Default Response",
+    "DEFAULT": "Default Response",
 }
 
 
@@ -205,9 +205,10 @@ def get_openapi_path(
                     response.setdefault(
                         "description", status_text or "Additional Response"
                     )
-                    operation.setdefault("responses", {})[
-                        str(additional_status_code).upper()
-                    ] = response
+                    status_code_key = str(additional_status_code).upper()
+                    if status_code_key == "DEFAULT":
+                        status_code_key = "default"
+                    operation.setdefault("responses", {})[status_code_key] = response
             status_code = str(route.status_code)
             response_schema = {"type": "string"}
             if lenient_issubclass(route.response_class, JSONResponse):

--- a/tests/test_additional_responses_router.py
+++ b/tests/test_additional_responses_router.py
@@ -26,6 +26,7 @@ async def b():
     responses={
         "400": {"description": "Error with str"},
         "5xx": {"description": "Error with range, lower"},
+        "default": {"description": "A default response"},
     },
 )
 async def c():
@@ -74,6 +75,7 @@ openapi_schema = {
                         "description": "Successful Response",
                         "content": {"application/json": {"schema": {}}},
                     },
+                    "default": {"description": "A default response"},
                 },
                 "summary": "C",
                 "operationId": "c_c_get",


### PR DESCRIPTION
Fix `"default"` extra response, when combined with responses with status codes and status code ranges.

Continuation of #435.