### PR TITLE
Remove reparse

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -1,9 +1,69 @@
 from enum import Enum
+from functools import partial
 from types import GeneratorType
-from typing import Any, Dict, List, Set, Union
+from typing import Any, Dict, List, Set, Type, Union
 
 from pydantic import BaseModel
+from pydantic.fields import Field
 from pydantic.json import ENCODERS_BY_TYPE
+from pydantic.utils import lenient_issubclass
+
+
+class SecureFieldValue:
+    def __init__(self, model: BaseModel, secure_model_type: Type[BaseModel]):
+        self.model = model
+        self.secure_model_type = secure_model_type
+
+    def dict(
+        self,
+        include: Set[str] = None,
+        exclude: Set[str] = None,
+        by_alias: bool = False,
+        skip_defaults: bool = False,
+    ) -> Dict[str, Any]:
+        return secure_dict(
+            self.model,
+            self.secure_model_type,
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            skip_defaults=skip_defaults,
+        )
+
+
+def get_secure_field_value(v: Any, field: Field) -> Any:
+    if isinstance(v, BaseModel) and lenient_issubclass(field.type_, BaseModel):
+        return SecureFieldValue(v, field.type_)
+    return v
+
+
+def secure_dict(
+    model: BaseModel,
+    model_type: Type[BaseModel],
+    *,
+    include: Set[str] = None,
+    exclude: Set[str] = None,
+    by_alias: bool = False,
+    skip_defaults: bool = False
+) -> Dict[str, Any]:
+    """
+    Based on pydantic.BaseModel.dict
+    """
+    get_key = model._get_key_factory(by_alias)
+    get_key = partial(get_key, model.fields)
+
+    return_keys = model._calculate_keys(
+        include=include, exclude=exclude, skip_defaults=skip_defaults
+    )
+    if return_keys is None:
+        return_keys = set(model.__values__.keys())
+    return_keys = return_keys.intersection(model_type.__fields__.keys())
+    response = {}
+    for k, v in model.__values__.items():
+        if k not in return_keys:
+            continue
+        response[get_key(k)] = get_secure_field_value(v, model_type.__fields__[k])
+    return response
 
 SetIntStr = Set[Union[int, str]]
 DictIntStrAny = Dict[Union[int, str], Any]
@@ -24,7 +84,9 @@ def jsonable_encoder(
     if exclude is not None and not isinstance(exclude, set):
         exclude = set(exclude)
     if isinstance(obj, BaseModel):
-        encoder = getattr(obj.Config, "json_encoders", custom_encoder)
+        obj = SecureFieldValue(obj, type(obj))
+    if isinstance(obj, SecureFieldValue):
+        encoder = getattr(obj.model.Config, "json_encoders", custom_encoder)
         return jsonable_encoder(
             obj.dict(
                 include=include,
@@ -32,6 +94,7 @@ def jsonable_encoder(
                 by_alias=by_alias,
                 skip_defaults=skip_defaults,
             ),
+            skip_defaults=skip_defaults,
             include_none=include_none,
             custom_encoder=encoder,
             sqlalchemy_safe=sqlalchemy_safe,
@@ -42,6 +105,8 @@ def jsonable_encoder(
         return obj
     if isinstance(obj, dict):
         encoded_dict = {}
+        if exclude is None:
+            exclude = set()
         for key, value in obj.items():
             if (
                 (

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -56,10 +56,10 @@ def secure_dict(
         include=include, exclude=exclude, skip_defaults=skip_defaults
     )
     if return_keys is None:
-        return_keys = set(model.__values__.keys())
+        return_keys = set(model.__dict__.keys())
     return_keys = return_keys.intersection(model_type.__fields__.keys())
     response = {}
-    for k, v in model.__values__.items():
+    for k, v in model.__dict__.items():
         if k not in return_keys:
             continue
         response[get_key(k)] = get_secure_field_value(v, model_type.__fields__[k])

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,4 +1,5 @@
 import asyncio
+from dataclasses import is_dataclass
 import inspect
 import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union
@@ -218,6 +219,8 @@ class APIRoute(routing.Route):
         self.unique_id = generate_operation_id_for_path(
             name=self.name, path=self.path_format, method=list(methods)[0]
         )
+        if is_dataclass(response_model) and hasattr(response_model, "__pydantic_model__"):
+            response_model = response_model.__pydantic_model__  # type: ignore
         self.response_model = response_model
         if self.response_model:
             assert lenient_issubclass(

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,13 +1,11 @@
 import re
-from dataclasses import is_dataclass
-from typing import Any, Dict, List, Sequence, Set, Type, cast
+from typing import Any, Dict, List, Sequence, Set, Type
 
 from fastapi import routing
 from fastapi.openapi.constants import REF_PREFIX
-from pydantic import BaseConfig, BaseModel, Schema, create_model
+from pydantic import BaseModel
 from pydantic.fields import Field
 from pydantic.schema import get_flat_models_from_fields, model_process_schema
-from pydantic.utils import lenient_issubclass
 from starlette.routing import BaseRoute
 
 
@@ -49,53 +47,6 @@ def get_model_definitions(
 
 def get_path_param_names(path: str) -> Set[str]:
     return {item.strip("{}") for item in re.findall("{[^}]*}", path)}
-
-
-def create_cloned_field(field: Field) -> Field:
-    original_type = field.type_
-    if is_dataclass(original_type) and hasattr(original_type, "__pydantic_model__"):
-        original_type = original_type.__pydantic_model__  # type: ignore
-    use_type = original_type
-    if lenient_issubclass(original_type, BaseModel):
-        original_type = cast(Type[BaseModel], original_type)
-        use_type = create_model(  # type: ignore
-            original_type.__name__,
-            __config__=original_type.__config__,
-            __validators__=original_type.__validators__,
-        )
-        for f in original_type.__fields__.values():
-            use_type.__fields__[f.name] = f
-    new_field = Field(
-        name=field.name,
-        type_=use_type,
-        class_validators={},
-        default=None,
-        required=False,
-        model_config=BaseConfig,
-        schema=Schema(None),
-    )
-    new_field.has_alias = field.has_alias
-    new_field.alias = field.alias
-    new_field.class_validators = field.class_validators
-    new_field.default = field.default
-    new_field.required = field.required
-    new_field.model_config = field.model_config
-    new_field.schema = field.schema
-    new_field.allow_none = field.allow_none
-    new_field.validate_always = field.validate_always
-    if field.sub_fields:
-        new_field.sub_fields = [
-            create_cloned_field(sub_field) for sub_field in field.sub_fields
-        ]
-    if field.key_field:
-        new_field.key_field = create_cloned_field(field.key_field)
-    new_field.validators = field.validators
-    new_field.whole_pre_validators = field.whole_pre_validators
-    new_field.whole_post_validators = field.whole_post_validators
-    new_field.parse_json = field.parse_json
-    new_field.shape = field.shape
-    new_field._populate_validators()
-    return new_field
 
 
 def generate_operation_id_for_path(*, name: str, path: str, method: str) -> str:

--- a/tests/test_serialize_secure_response.py
+++ b/tests/test_serialize_secure_response.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from fastapi import FastAPI
 from pydantic import BaseModel
 from starlette.testclient import TestClient
@@ -37,6 +39,13 @@ def get_secure():
     return item
 
 
+@app.get("/item/secure-list", response_model=List[Item])
+def get_secure():
+    sub_item = SensitiveSubItem(sub_name="sub_item", sub_secret="sub_secret")
+    item = SensitiveItem(name="item", sub_item=sub_item, secret="secret")
+    return [item]
+
+
 client = TestClient(app)
 
 
@@ -45,6 +54,12 @@ def test_secure_serialization():
         "name": "item",
         "sub_item": {"sub_name": "sub_item"},
     }
+
+
+def test_secure_list_serialization():
+    assert client.get("/item/secure").json() == [
+        {"name": "item", "sub_item": {"sub_name": "sub_item"}}
+    ]
 
 
 def test_insecure_serialization():

--- a/tests/test_serialize_secure_response.py
+++ b/tests/test_serialize_secure_response.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+
+class SubItem(BaseModel):
+    sub_name: str
+
+
+class Item(BaseModel):
+    name: str
+    sub_item: SubItem
+
+
+class SensitiveSubItem(SubItem):
+    sub_secret: str
+
+
+class SensitiveItem(Item):
+    secret: str
+    sub_item: SensitiveSubItem
+
+
+@app.get("/item/insecure", response_model=SensitiveItem)
+def get_insecure():
+    sub_item = SensitiveSubItem(sub_name="sub_item", sub_secret="sub_secret")
+    item = SensitiveItem(name="item", sub_item=sub_item, secret="secret")
+    return item
+
+
+@app.get("/item/secure", response_model=Item)
+def get_secure():
+    sub_item = SensitiveSubItem(sub_name="sub_item", sub_secret="sub_secret")
+    item = SensitiveItem(name="item", sub_item=sub_item, secret="secret")
+    return item
+
+
+client = TestClient(app)
+
+
+def test_secure_serialization():
+    assert client.get("/item/secure").json() == {
+        "name": "item",
+        "sub_item": {"sub_name": "sub_item"},
+    }
+
+
+def test_insecure_serialization():
+    assert client.get("/item/insecure").json() == {
+        "name": "item",
+        "sub_item": {"sub_name": "sub_item", "sub_secret": "sub_secret"},
+        "secret": "secret",
+    }


### PR DESCRIPTION
This is a work in progress attempt to remove the use of the secure cloned field.

The remaining issues relate to:
1. Generic field types parameterized by pydantic models (e.g., `List[MyModel]`)
1. Some outstanding issues with pydantic dataclasses

I'm opening this despite the fact that it currently fails to share the implementation idea (and maybe get some feedback).