### PR TITLE
fix: typo in First Steps doc

### DIFF
--- a/docs/tutorial/first-steps.md
+++ b/docs/tutorial/first-steps.md
@@ -37,7 +37,7 @@ Open your browser at <a href="http://127.0.0.1:8000" target="_blank">http://127.
 You will see the JSON response as:
 
 ```JSON
-{"hello": "world"}
+{"message": "Hello World"}
 ```
 
 ### Interactive API docs


### PR DESCRIPTION
In first program example function returns`{"message": "Hello World"}` instead of `{"hello": "world"}` (see https://fastapi.tiangolo.com/tutorial/first-steps/).