### PR TITLE
Allow to set custom scheme for 4xx responses

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -221,7 +221,7 @@ def get_openapi_path(
             if (all_route_params or route.body_field) and not any(
                 [
                     status in operation["responses"]
-                    for status in [http422, "4xx", "default"]
+                    for status in [http422, "4XX", "default"]
                 ]
             ):
                 operation["responses"][http422] = {


### PR DESCRIPTION
Code from https://github.com/tiangolo/fastapi/pull/437 checks for custom schemas on response, 
but it missed the fact that all codes are uppercased in https://github.com/tiangolo/fastapi/blob/master/fastapi/openapi/utils.py#L196