### PR TITLE
Make adding openapi route configurable

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -31,6 +31,7 @@ class FastAPI(Starlette):
         title: str = "Fast API",
         description: str = "",
         version: str = "0.1.0",
+        add_openapi_route: bool = True,
         openapi_url: Optional[str] = "/openapi.json",
         openapi_prefix: str = "",
         docs_url: Optional[str] = "/docs",
@@ -50,6 +51,7 @@ class FastAPI(Starlette):
         self.title = title
         self.description = description
         self.version = version
+        self.add_openapi_route = add_openapi_route
         self.openapi_url = openapi_url
         self.openapi_prefix = openapi_prefix.rstrip("/")
         self.docs_url = docs_url
@@ -84,11 +86,13 @@ class FastAPI(Starlette):
     def setup(self) -> None:
         if self.openapi_url:
 
-            async def openapi(req: Request) -> JSONResponse:
-                return JSONResponse(self.openapi())
+            if self.add_openapi_route:
+                async def openapi(req: Request) -> JSONResponse:
+                    return JSONResponse(self.openapi())
 
-            self.add_route(self.openapi_url, openapi, include_in_schema=False)
+                self.add_route(self.openapi_url, openapi, include_in_schema=False)
             openapi_url = self.openapi_prefix + self.openapi_url
+
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -87,6 +87,7 @@ class FastAPI(Starlette):
         if self.openapi_url:
 
             if self.add_openapi_route:
+
                 async def openapi(req: Request) -> JSONResponse:
                     return JSONResponse(self.openapi())
 


### PR DESCRIPTION
This is an example of a [Starlette application](https://gist.github.com/alimcmaster1/c5146abad6a0b1f60ea009b589ec309d)  - the following change makes it possible for users to use a Starlette schema endpoint as a source for the docs.

Making it simple to migrate from Starlette to FastAPI:

`app = Starlette()`

`app = FastAPI(add_openapi_route=False, openapi_url='/schema')`

cc. @tiangolo  to review.