### PR TITLE
Alphabetically sort schemas

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -283,7 +283,7 @@ def get_openapi(
                 if path_definitions:
                     definitions.update(path_definitions)
     if definitions:
-        components.setdefault("schemas", {}).update(definitions)
+        components["schemas"] = {k: definitions[k] for k in sorted(definitions)}
     if components:
         output["components"] = components
     output["paths"] = paths


### PR DESCRIPTION
Modify openapi spec generation to include schemas in alphabetical order.

-----

Right now, the schemas occur in a haphazard order in the generated OpenAPI spec (and therefore also at the bottom of the swagger docs), since it is generated based on the order in which schemas are encountered during the spec generation process.

This change would cause the definitions to occur in alphabetical order.