### PR TITLE
Add documentation for static swagger (#112)

### DIFF
--- a/docs/src/extending_openapi/tutorial002.py
+++ b/docs/src/extending_openapi/tutorial002.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI
+from fastapi.openapi.docs import (
+    get_redoc_html,
+    get_swagger_ui_html,
+    get_swagger_ui_oauth2_redirect_html
+)
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+
+
+app = FastAPI(docs_url=None, redoc_url=None)
+
+
+async def swagger_ui_html(req: Request) -> HTMLResponse:
+    return get_swagger_ui_html(
+        openapi_url=app.openapi_url,
+        title=app.title + ' - Swagger UI',
+        oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
+        swagger_js_url='/static/swagger-ui-bundle.js',
+        swagger_css_url='/static/swagger-ui.css',
+    )
+
+app.add_route('/docs', swagger_ui_html, include_in_schema=False)
+
+if app.swagger_ui_oauth2_redirect_url:
+    async def swagger_ui_redirect(req: Request) -> HTMLResponse:
+        return get_swagger_ui_oauth2_redirect_html()
+
+    app.add_route(
+        app.swagger_ui_oauth2_redirect_url,
+        swagger_ui_redirect,
+        include_in_schema=False
+    )
+
+
+async def redoc_html(req: Request) -> HTMLResponse:
+    return get_redoc_html(
+        openapi_url=app.openapi_url,
+        title=app.title + ' - ReDoc',
+        redoc_js_url='/static/redoc.standalone.js',
+    )
+
+app.add_route('/redoc', redoc_html, include_in_schema=False)

--- a/docs/src/extending_openapi/tutorial002.py
+++ b/docs/src/extending_openapi/tutorial002.py
@@ -4,13 +4,15 @@ from fastapi.openapi.docs import (
     get_swagger_ui_html,
     get_swagger_ui_oauth2_redirect_html,
 )
-from starlette.requests import Request
-from starlette.responses import HTMLResponse
+from starlette.staticfiles import StaticFiles
 
 app = FastAPI(docs_url=None, redoc_url=None)
 
+app.mount("/static", StaticFiles(directory="static"), name="static")
 
-async def swagger_ui_html(req: Request) -> HTMLResponse:
+
+@app.get("/docs", include_in_schema=False)
+async def custom_swagger_ui_html():
     return get_swagger_ui_html(
         openapi_url=app.openapi_url,
         title=app.title + " - Swagger UI",
@@ -20,19 +22,13 @@ async def swagger_ui_html(req: Request) -> HTMLResponse:
     )
 
 
-app.add_route("/docs", swagger_ui_html, include_in_schema=False)
-
-if app.swagger_ui_oauth2_redirect_url:
-
-    async def swagger_ui_redirect(req: Request) -> HTMLResponse:
-        return get_swagger_ui_oauth2_redirect_html()
-
-    app.add_route(
-        app.swagger_ui_oauth2_redirect_url, swagger_ui_redirect, include_in_schema=False
-    )
+@app.get(app.swagger_ui_oauth2_redirect_url, include_in_schema=False)
+async def swagger_ui_redirect():
+    return get_swagger_ui_oauth2_redirect_html()
 
 
-async def redoc_html(req: Request) -> HTMLResponse:
+@app.get("/redoc", include_in_schema=False)
+async def redoc_html():
     return get_redoc_html(
         openapi_url=app.openapi_url,
         title=app.title + " - ReDoc",
@@ -40,4 +36,6 @@ async def redoc_html(req: Request) -> HTMLResponse:
     )
 
 
-app.add_route("/redoc", redoc_html, include_in_schema=False)
+@app.get("/users/{username}")
+async def read_user(username: str):
+    return {"message": f"Hello {username}"}

--- a/docs/src/extending_openapi/tutorial002.py
+++ b/docs/src/extending_openapi/tutorial002.py
@@ -2,11 +2,10 @@ from fastapi import FastAPI
 from fastapi.openapi.docs import (
     get_redoc_html,
     get_swagger_ui_html,
-    get_swagger_ui_oauth2_redirect_html
+    get_swagger_ui_oauth2_redirect_html,
 )
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
-
 
 app = FastAPI(docs_url=None, redoc_url=None)
 
@@ -14,30 +13,31 @@ app = FastAPI(docs_url=None, redoc_url=None)
 async def swagger_ui_html(req: Request) -> HTMLResponse:
     return get_swagger_ui_html(
         openapi_url=app.openapi_url,
-        title=app.title + ' - Swagger UI',
+        title=app.title + " - Swagger UI",
         oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
-        swagger_js_url='/static/swagger-ui-bundle.js',
-        swagger_css_url='/static/swagger-ui.css',
+        swagger_js_url="/static/swagger-ui-bundle.js",
+        swagger_css_url="/static/swagger-ui.css",
     )
 
-app.add_route('/docs', swagger_ui_html, include_in_schema=False)
+
+app.add_route("/docs", swagger_ui_html, include_in_schema=False)
 
 if app.swagger_ui_oauth2_redirect_url:
+
     async def swagger_ui_redirect(req: Request) -> HTMLResponse:
         return get_swagger_ui_oauth2_redirect_html()
 
     app.add_route(
-        app.swagger_ui_oauth2_redirect_url,
-        swagger_ui_redirect,
-        include_in_schema=False
+        app.swagger_ui_oauth2_redirect_url, swagger_ui_redirect, include_in_schema=False
     )
 
 
 async def redoc_html(req: Request) -> HTMLResponse:
     return get_redoc_html(
         openapi_url=app.openapi_url,
-        title=app.title + ' - ReDoc',
-        redoc_js_url='/static/redoc.standalone.js',
+        title=app.title + " - ReDoc",
+        redoc_js_url="/static/redoc.standalone.js",
     )
 
-app.add_route('/redoc', redoc_html, include_in_schema=False)
+
+app.add_route("/redoc", redoc_html, include_in_schema=False)

--- a/docs/tutorial/extending-openapi.md
+++ b/docs/tutorial/extending-openapi.md
@@ -100,19 +100,19 @@ Let's assume that these files are places in the applications ``/static/`` path.
 
 To replace the builtin methods, set the ``docs_url`` (for Swagger) and ``redoc_url`` (for ReDoc) to None when creating the app, so FastAPI won't set its own versions up.
 
-```Python hl_lines="11"
+```Python hl_lines="10"
 {!./src/extending_openapi/tutorial002.py!}
 ```
 
 Next, set up your own functions that return the HTML, setting the urls to the files to the destination of your liking:
 
-```Python hl_lines="14 15 16 17 18 19 20 21 25 26 27 36 37 38 39 40 41"
+```Python hl_lines="13 14 15 16 17 18 19 20 25 27 28 35 36 37 38 39 40"
 {!./src/extending_openapi/tutorial002.py!}
 ```
 
 The functions need to be added as routes, using the paths that would normally sit in the two variables ``docs_url`` and ``redoc_url``. The example uses the default values:
 
-```Python hl_lines="23 29 30 31 32 33 43"
+```Python hl_lines="23 30 31 32 43"
 {!./src/extending_openapi/tutorial002.py!}
 ```
 

--- a/docs/tutorial/extending-openapi.md
+++ b/docs/tutorial/extending-openapi.md
@@ -88,3 +88,32 @@ Now you can replace the `.openapi()` method with your new function.
 Once you go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a> you will see that you are using your custom logo (in this example, **FastAPI**'s logo):
 
 <img src="/img/tutorial/extending-openapi/image01.png">
+
+
+## Self-hosting javascript and CSS
+
+Javascript and CSS for both Swagger UI and ReDoc are included using a CDN. For setups where a custom CDN is to be used or where the application should provide the files itself, the paths need to be changed.
+
+`Swagger` uses the files ``swagger-ui-bundle.js`` and ``swagger-ui.css``, while `ReDoc` needs ``redoc.standalone.js``.
+
+Let's assume that these files are places in the applications ``/static/`` path.
+
+To replace the builtin methods, set the ``docs_url`` (for Swagger) and ``redoc_url`` (for ReDoc) to None when creating the app, so FastAPI won't set its own versions up.
+
+```Python hl_lines="11"
+{!./src/extending_openapi/tutorial002.py!}
+```
+
+Next, set up your own functions that return the HTML, setting the urls to the files to the destination of your liking:
+
+```Python hl_lines="14 15 16 17 18 19 20 21 25 26 27 36 37 38 39 40 41"
+{!./src/extending_openapi/tutorial002.py!}
+```
+
+The functions need to be added as routes, using the paths that would normally sit in the two variables ``docs_url`` and ``redoc_url``. The example uses the default values:
+
+```Python hl_lines="23 29 30 31 32 33 43"
+{!./src/extending_openapi/tutorial002.py!}
+```
+
+Of course, it is possible to overwrite only one of the functions, simply by not supplying ``None`` to the one that is to be left at the defaults.

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial002.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial002.py
@@ -12,6 +12,12 @@ def test_swagger_ui_html():
     assert "/static/swagger-ui.css" in response.text
 
 
+def test_swagger_ui_oauth2_redirect_html():
+    response = client.get("/docs/oauth2-redirect")
+    assert response.status_code == 200
+    assert "window.opener.swaggerUIRedirectOauth2" in response.text
+
+
 def test_redoc_html():
     response = client.get("/redoc")
     assert response.status_code == 200

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial002.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial002.py
@@ -1,24 +1,42 @@
+import os
+from pathlib import Path
+
+import pytest
 from starlette.testclient import TestClient
 
-from extending_openapi.tutorial002 import app
 
-client = TestClient(app)
+@pytest.fixture(scope="module")
+def client():
+    static_dir: Path = Path(os.getcwd()) / "static"
+    print(static_dir)
+    static_dir.mkdir(exist_ok=True)
+    from extending_openapi.tutorial002 import app
+
+    with TestClient(app) as client:
+        yield client
+    static_dir.rmdir()
 
 
-def test_swagger_ui_html():
+def test_swagger_ui_html(client: TestClient):
     response = client.get("/docs")
     assert response.status_code == 200
     assert "/static/swagger-ui-bundle.js" in response.text
     assert "/static/swagger-ui.css" in response.text
 
 
-def test_swagger_ui_oauth2_redirect_html():
+def test_swagger_ui_oauth2_redirect_html(client: TestClient):
     response = client.get("/docs/oauth2-redirect")
     assert response.status_code == 200
     assert "window.opener.swaggerUIRedirectOauth2" in response.text
 
 
-def test_redoc_html():
+def test_redoc_html(client: TestClient):
     response = client.get("/redoc")
     assert response.status_code == 200
     assert "/static/redoc.standalone.js" in response.text
+
+
+def test_api(client: TestClient):
+    response = client.get("/users/john")
+    assert response.status_code == 200
+    assert response.json()["message"] == "Hello john"

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial002.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial002.py
@@ -1,0 +1,18 @@
+from starlette.testclient import TestClient
+
+from extending_openapi.tutorial002 import app
+
+client = TestClient(app)
+
+
+def test_swagger_ui_html():
+    response = client.get("/docs")
+    assert response.status_code == 200
+    assert "/static/swagger-ui-bundle.js" in response.text
+    assert "/static/swagger-ui.css" in response.text
+
+
+def test_redoc_html():
+    response = client.get("/redoc")
+    assert response.status_code == 200
+    assert "/static/redoc.standalone.js" in response.text


### PR DESCRIPTION
This adds an example for overwriting the location for the JS and CSS
files for the docs and redoc endpoints.