### PR TITLE
Add support for contextmanager-style dependencies

### DIFF
--- a/docs/src/dependencies/tutorial008.py
+++ b/docs/src/dependencies/tutorial008.py
@@ -1,9 +1,4 @@
-from fastapi import Depends, FastAPI
-from sqlalchemy.orm import Session
-
 from sql_databases.sql_app.database import SessionLocal
-
-app = FastAPI()
 
 
 async def get_db():
@@ -12,8 +7,3 @@ async def get_db():
         yield db
     finally:
         db.close()
-
-
-@app.get("/get-db-check")
-async def db_session_dependency_check(db: Session = Depends(get_db)):
-    return isinstance(db, Session)

--- a/docs/src/dependencies/tutorial008.py
+++ b/docs/src/dependencies/tutorial008.py
@@ -1,0 +1,19 @@
+from fastapi import Depends, FastAPI
+from sqlalchemy.orm import Session
+
+from sql_databases.sql_app.database import SessionLocal
+
+app = FastAPI()
+
+
+async def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.get("/get-db-check")
+async def db_session_dependency_check(db: Session = Depends(get_db)):
+    return isinstance(db, Session)

--- a/docs/src/dependencies/tutorial009.py
+++ b/docs/src/dependencies/tutorial009.py
@@ -1,0 +1,17 @@
+from sql_databases.sql_app.database import SessionLocal
+
+
+class ContextSessionLocal:
+    def __init__(self):
+        self.db = SessionLocal()
+
+    def __enter__(self):
+        return self.db
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.db.close()
+
+
+async def get_db():
+    with ContextSessionLocal() as db:
+        yield db

--- a/docs/tutorial/dependencies/advanced-dependencies.md
+++ b/docs/tutorial/dependencies/advanced-dependencies.md
@@ -71,3 +71,27 @@ checker(q="somequery")
     In the chapters about security, you will be using utility functions that are implemented in this same way.
 
     If you understood all this, you already know how those utility tools for security work underneath.
+
+## Context Manager Dependencies
+
+FastAPI supports dependencies that require both setup and teardown through the use of appropriate generator or
+async generator functions.
+
+For example, this would enable you to eliminate the use of middleware while implementing
+the `get_db` dependency from the
+[SQL Databases](https://fastapi.tiangolo.com/tutorial/sql-databases/) section of the tutorial:
+
+ ```Python hl_lines="9"
+{!./src/dependencies/tutorial008.py!}
+```
+
+Only the code prior to and including the `yield` statement is executed during the handling
+of the request. The value yielded by the `yield` statement is injected into endpoint
+calls (and other dependencies). Finally, the code following the `yield` statement is executed
+as a `BackgroundTask`, and so is executed only after the response has been delivered.
+
+!!! info
+    Any function that is valid for use with the
+    [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager)
+    or [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager)
+    decorators should be valid for use as a fastapi dependency, and will be handled as described above.

--- a/docs/tutorial/dependencies/advanced-dependencies.md
+++ b/docs/tutorial/dependencies/advanced-dependencies.md
@@ -81,17 +81,33 @@ For example, this would enable you to eliminate the use of middleware while impl
 the `get_db` dependency from the
 [SQL Databases](https://fastapi.tiangolo.com/tutorial/sql-databases/) section of the tutorial:
 
- ```Python hl_lines="9"
+```Python hl_lines="4"
 {!./src/dependencies/tutorial008.py!}
 ```
 
-Only the code prior to and including the `yield` statement is executed during the handling
-of the request. The value yielded by the `yield` statement is injected into endpoint
-calls (and other dependencies). Finally, the code following the `yield` statement is executed
-as a `BackgroundTask`, and so is executed only after the response has been delivered.
+Only the code prior to and including the `yield` statement is executed before sending a response:
+```Python hl_lines="5 6 7"
+{!./src/dependencies/tutorial008.py!}
+```
+
+The yielded value is what is injected into endpoint calls and other dependencies:
+```Python hl_lines="7"
+{!./src/dependencies/tutorial008.py!}
+```
+
+The code following the `yield` statement is executed as a `BackgroundTask` after the response has been delivered:
+```Python hl_lines="8 9"
+{!./src/dependencies/tutorial008.py!}
+```
 
 !!! info
     Any function that is valid for use with the
     [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager)
     or [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager)
     decorators should be valid for use as a fastapi dependency, and will be handled as described above.
+
+This approach can be made compatible with traditional context managers and async context managers by using
+`with` or `async with` statements inside the dependency function: 
+```Python hl_lines="16"
+{!./src/dependencies/tutorial009.py!}
+```

--- a/tests/test_dependency_contextmanager.py
+++ b/tests/test_dependency_contextmanager.py
@@ -1,10 +1,11 @@
 from typing import Dict
 
 import pytest
-from fastapi import Depends, FastAPI
+from fastapi import Depends
 from starlette.testclient import TestClient
 
-app = FastAPI()
+from dependencies.tutorial008 import app
+
 state = {"/async": "asyncgen not started", "/sync": "generator not started"}
 
 
@@ -105,3 +106,9 @@ def test_invalid_context_dependency(endpoint, message):
     with pytest.raises(RuntimeError) as exc_info:
         client.get(endpoint)
     assert str(exc_info.value) == message
+
+
+def test_docs():
+    response = client.get("/get-db-check")
+    assert response.status_code == 200
+    assert response.content == b"true"

--- a/tests/test_dependency_contextmanager.py
+++ b/tests/test_dependency_contextmanager.py
@@ -1,0 +1,107 @@
+from typing import Dict
+
+import pytest
+from fastapi import Depends, FastAPI
+from starlette.testclient import TestClient
+
+app = FastAPI()
+state = {"/async": "asyncgen not started", "/sync": "generator not started"}
+
+
+async def get_state():
+    return state
+
+
+async def asyncgen_state(state: Dict[str, str] = Depends(get_state)) -> str:
+    state["/async"] = "asyncgen started"
+    yield state["/async"]
+    state["/async"] = "asyncgen completed"
+
+
+async def generator_state(state: Dict[str, str] = Depends(get_state)) -> str:
+    state["/sync"] = "generator started"
+    yield state["/sync"]
+    state["/sync"] = "generator completed"
+
+
+async def invalid_asyncgen_no_yield() -> int:
+    if False:
+        yield
+    return
+
+
+async def invalid_asyncgen_multi_yield() -> int:
+    yield 1
+    yield 2
+
+
+def invalid_generator_no_yield() -> int:
+    if False:
+        yield
+    return
+
+
+def invalid_generator_multi_yield() -> int:
+    yield 1
+    yield 2
+
+
+@app.get("/async")
+async def get_async(state: str = Depends(asyncgen_state)):
+    return state
+
+
+@app.get("/sync")
+async def get_sync(state: str = Depends(generator_state)):
+    return state
+
+
+@app.get("/no-yield/async")
+async def error_no_yield_async(invalid: int = Depends(invalid_asyncgen_no_yield)):
+    pass  # pragma: no cover
+
+
+@app.get("/multi-yield/async")
+async def error_multi_yield_async(invalid: int = Depends(invalid_asyncgen_multi_yield)):
+    pass  # pragma: no cover
+
+
+@app.get("/no-yield/sync")
+async def error_no_yield_sync(count: int = Depends(invalid_generator_no_yield)):
+    pass  # pragma: no cover
+
+
+@app.get("/multi-yield/sync")
+async def error_multi_yield_sync(count: int = Depends(invalid_generator_multi_yield)):
+    pass  # pragma: no cover
+
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "endpoint,label", [("/async", "asyncgen"), ("/sync", "generator")]
+)
+def test_async_state(endpoint, label):
+    assert state[endpoint] == f"{label} not started"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+    assert response.json() == f"{label} started"
+
+    assert state[endpoint] == f"{label} completed"
+
+
+@pytest.mark.parametrize(
+    "endpoint,message",
+    [
+        ("/no-yield/async", "generator didn't yield"),
+        ("/no-yield/sync", "generator didn't yield"),
+        ("/multi-yield/async", "generator didn't stop"),
+        ("/multi-yield/sync", "generator didn't stop"),
+    ],
+)
+def test_invalid_context_dependency(endpoint, message):
+    with pytest.raises(RuntimeError) as exc_info:
+        client.get(endpoint)
+    assert str(exc_info.value) == message

--- a/tests/test_dependency_contextmanager.py
+++ b/tests/test_dependency_contextmanager.py
@@ -1,11 +1,10 @@
 from typing import Dict
 
 import pytest
-from fastapi import Depends
+from fastapi import Depends, FastAPI
 from starlette.testclient import TestClient
 
-from dependencies.tutorial008 import app
-
+app = FastAPI()
 state = {"/async": "asyncgen not started", "/sync": "generator not started"}
 
 
@@ -106,9 +105,3 @@ def test_invalid_context_dependency(endpoint, message):
     with pytest.raises(RuntimeError) as exc_info:
         client.get(endpoint)
     assert str(exc_info.value) == message
-
-
-def test_docs():
-    response = client.get("/get-db-check")
-    assert response.status_code == 200
-    assert response.content == b"true"

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases.py
@@ -1,5 +1,8 @@
+import pytest
 from starlette.testclient import TestClient
 
+from dependencies.tutorial008 import get_db as get_db_override_1
+from dependencies.tutorial009 import get_db as get_db_override_2
 from sql_databases.sql_app.main import app, get_db
 
 client = TestClient(app)
@@ -353,9 +356,8 @@ def test_read_items():
     assert "description" in first_item
 
 
-def test_contextmanager_override():
-    from dependencies.tutorial008 import get_db as get_db_override
-
+@pytest.mark.parametrize("get_db_override", [get_db_override_1, get_db_override_2])
+def test_contextmanager_override(get_db_override):
     app.dependency_overrides[get_db] = get_db_override
     try:
         test_get_user()

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases.py
@@ -1,6 +1,6 @@
 from starlette.testclient import TestClient
 
-from sql_databases.sql_app.main import app
+from sql_databases.sql_app.main import app, get_db
 
 client = TestClient(app)
 
@@ -351,3 +351,16 @@ def test_read_items():
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+def test_contextmanager_override():
+    from dependencies.tutorial008 import get_db as get_db_override
+
+    app.dependency_overrides[get_db] = get_db_override
+    try:
+        test_get_user()
+        test_inexistent_user()
+        test_get_users()
+        test_read_items()
+    finally:
+        del app.dependency_overrides[get_db]


### PR DESCRIPTION
This pull request adds support for contextmanager style dependencies. 

In particular, dependencies of the following form would be supported:

```python
def get_dependency():
    value = do_setup()
    yield value  # the value received by the endpoint
    do_cleanup()  # handled in a background task after returning the response
```

Async contextmanager dependencies are also supported. (See the tests for examples of each, along with a demonstration of error handling.)

I've opened the pull request as a draft because I still need to add tutorial examples and/or other docs, but I am not currently aware of any remaining issues in the implementation.

(Please let me know if you see any.)