### PR TITLE
Docs - Adjust response JSON for tutorial first steps

### DIFF
--- a/docs/tutorial/first-steps.md
+++ b/docs/tutorial/first-steps.md
@@ -37,7 +37,7 @@ Open your browser at <a href="http://127.0.0.1:8000" target="_blank">http://127.
 You will see the JSON response as:
 
 ```JSON
-{"hello": "world"}
+{"message": "Hello World"}
 ```
 
 ### Interactive API docs


### PR DESCRIPTION
Just a fix for clarity.

The [first steps](https://fastapi.tiangolo.com/tutorial/first-steps/) part of the tutorial had a mismatch between the json response to be expected and the code example.