### PR TITLE
Replace `pip` with `python3 -m pip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ FastAPI stands on the shoulders of giants:
 ## Installation
 
 ```bash
-$ pip install fastapi
+$ python3 -m pip install fastapi
 ```
 
 You will also need an ASGI server, for production such as <a href="http://www.uvicorn.org" target="_blank">Uvicorn</a> or <a href="https://gitlab.com/pgjones/hypercorn" target="_blank">Hypercorn</a>.
 
 ```bash
-$ pip install uvicorn
+$ python3 -m pip install uvicorn
 ```
 
 ## Example

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ In this case, your `Dockerfile` could look like:
 ```Dockerfile
 FROM python:3.7
 
-RUN pip install fastapi uvicorn
+RUN python3 -m pip install fastapi uvicorn
 
 EXPOSE 80
 
@@ -242,13 +242,13 @@ You just need to install an ASGI compatible server like:
 * <a href="https://www.uvicorn.org/" target="_blank">Uvicorn</a>, a lightning-fast ASGI server, built on uvloop and httptools.
 
 ```bash
-pip install uvicorn
+python3 -m pip install uvicorn
 ```
 
 * <a href="https://gitlab.com/pgjones/hypercorn" target="_blank">Hypercorn</a>, an ASGI server also compatible with HTTP/2.
 
 ```bash
-pip install hypercorn
+python3 -m pip install hypercorn
 ```
 
 ...or any other ASGI server.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,13 +90,13 @@ FastAPI stands on the shoulders of giants:
 ## Installation
 
 ```bash
-$ pip install fastapi
+$ python3 -m pip install fastapi
 ```
 
 You will also need an ASGI server, for production such as <a href="http://www.uvicorn.org" target="_blank">Uvicorn</a> or <a href="https://gitlab.com/pgjones/hypercorn" target="_blank">Hypercorn</a>.
 
 ```bash
-$ pip install uvicorn
+$ python3 -m pip install uvicorn
 ```
 
 ## Example

--- a/docs/tutorial/intro.md
+++ b/docs/tutorial/intro.md
@@ -29,7 +29,7 @@ The first step is to install FastAPI.
 For the tutorial, you might want to install it with all the optional dependencies and features:
 
 ```bash
-pip install fastapi[all]
+python3 -m pip install fastapi[all]
 ```
 
 ...that also includes `uvicorn`, that you can use as the server that runs your code.
@@ -40,13 +40,13 @@ pip install fastapi[all]
     This is what you would probably do once you want to deploy your application to production:
 
     ```
-    pip install fastapi
+    python3 -m pip install fastapi
     ```
 
     Also install `uvicorn` to work as the server:
 
     ```
-    pip install uvicorn
+    python3 -m pip install uvicorn
     ```
 
     And the same for each of the optional dependencies that you want to use.

--- a/docs/tutorial/request-files.md
+++ b/docs/tutorial/request-files.md
@@ -3,7 +3,7 @@ You can define files to be uploaded by the client using `File`.
 !!! info
     To receive uploaded files, first install [`python-multipart`](https://andrew-d.github.io/python-multipart/).
 
-    E.g. `pip install python-multipart`.
+    E.g. `python3 -m pip install python-multipart`.
 
     This is because uploaded files are sent as "form data".
 

--- a/docs/tutorial/request-forms-and-files.md
+++ b/docs/tutorial/request-forms-and-files.md
@@ -3,7 +3,7 @@ You can define files and form fields at the same time using `File` and `Form`.
 !!! info
     To receive uploaded files and/or form data, first install [`python-multipart`](https://andrew-d.github.io/python-multipart/).
 
-    E.g. `pip install python-multipart`.
+    E.g. `python3 -m pip install python-multipart`.
 
 ## Import `File` and `Form`
 

--- a/docs/tutorial/request-forms.md
+++ b/docs/tutorial/request-forms.md
@@ -3,7 +3,7 @@ When you need to receive form fields instead of JSON, you can use `Form`.
 !!! info
     To use forms, first install [`python-multipart`](https://andrew-d.github.io/python-multipart/).
 
-    E.g. `pip install python-multipart`.
+    E.g. `python3 -m pip install python-multipart`.
 
 ## Import `Form`
 

--- a/docs/tutorial/security/first-steps.md
+++ b/docs/tutorial/security/first-steps.md
@@ -27,7 +27,7 @@ Copy the example in a file `main.py`:
 !!! info
     First install [`python-multipart`](https://andrew-d.github.io/python-multipart/).
 
-    E.g. `pip install python-multipart`.
+    E.g. `python3 -m pip install python-multipart`.
 
     This is because **OAuth2** uses "form data" for sending the `username` and `password`.
 

--- a/docs/tutorial/security/oauth2-jwt.md
+++ b/docs/tutorial/security/oauth2-jwt.md
@@ -29,7 +29,7 @@ If you want to play with JWT tokens and see how they work, check <a href="https:
 We need to install `PyJWT` to generate and verify the JWT tokens in Python:
 
 ```bash
-pip install pyjwt
+python3 -m pip install pyjwt
 ```
 
 ## Password hashing
@@ -57,7 +57,7 @@ The recommended algorithm is "Bcrypt".
 So, install PassLib with Bcrypt:
 
 ```bash
-pip install passlib[bcrypt]
+python3 -m pip install passlib[bcrypt]
 ```
 
 !!! tip

--- a/docs/tutorial/static-files.md
+++ b/docs/tutorial/static-files.md
@@ -5,7 +5,7 @@ You can serve static files automatically from a directory using <a href="https:/
 First you need to install `aiofiles`:
 
 ```bash
-pip install aiofiles
+python3 -m pip install aiofiles
 ```
 
 ## Use `StaticFiles`

--- a/docs/tutorial/templates.md
+++ b/docs/tutorial/templates.md
@@ -9,13 +9,13 @@ Starlette has utilities to configure it easily that you can use directly in your
 Install `jinja2`:
 
 ```bash
-pip install jinja2
+python3 -m pip install jinja2
 ```
 
 If you need to also serve static files (as in this example), install `aiofiles`:
 
 ```bash
-pip install aiofiles
+python3 -m pip install aiofiles
 ```
 
 ## Using `Jinja2Templates`

--- a/docs/tutorial/testing.md
+++ b/docs/tutorial/testing.md
@@ -117,7 +117,7 @@ When you need your event handlers (`startup` and `shutdown`) to run in your test
 After that, you just need to install `pytest`:
 
 ```bash
-pip install pytest
+python3 -m pip install pytest
 ```
 
 It will detect the files and tests automatically, execute them, and report the results back to you.

--- a/scripts/netlify-docs.sh
+++ b/scripts/netlify-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Install pipenv to be able to install from Pipfile
-pip install pipenv
+python3 -m pip install pipenv
 # Install Pipfile including --dev, to install mkdocs and plugins
 pipenv install --dev
 # Finally, run mkdocs


### PR DESCRIPTION
Heya,

If I understood https://github.com/tiangolo/fastapi/issues/531 correctly this PR should take care of replacing every occurence of `pip` with `python3 -m pip`. 

Let me know if you have any feedback. 

Thanks!