### PR TITLE
Prevent adding HTTP 422 to the responses when all params are optional

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -222,7 +222,8 @@ def get_openapi_path(
             ] = response_schema
 
             http422 = str(HTTP_422_UNPROCESSABLE_ENTITY)
-            if (all_route_params or route.body_field) and not any(
+            required_route_params = [route_param for route_param in all_route_params if route_param.required]
+            if (required_route_params or route.body_field) and not any(
                 [
                     status in operation["responses"]
                     for status in [http422, "4XX", "default"]


### PR DESCRIPTION
Heya 👋,

After reading https://github.com/tiangolo/fastapi/issues/497 I thought I'd give it a try. This PR will prevent HTTP 422 responses from being added to the operation when it only has optional arguments. It should fix the bug that occurs in the code of #497 : 

```
from fastapi.applications import FastAPI
from fastapi import APIRouter
app = FastAPI(docs_url="/")
router = APIRouter()


@router.get('/router')
async def handler(code: str = ''):
    print(code)
    return "hello world"


app.include_router(router)

if __name__ == '__main__':
    import uvicorn
    uvicorn.run(app, port=8001, reload=True)
```

### How to test:
1. Setup environment with the example code above
1. Acknowledge that the swagger ui shows a HTTP 422 as possible response code
1. Checkout PR
1. Acknowledge that the swagger ui no longer shows HTTP 422 as a possible response code.
1. Change your route params to have a required route
1. Acknowledge that the HTTP 422 is now back 🎉 
 