### PR TITLE
Fix #259: generate OpenAPI docs for responses with no content.

### DIFF
--- a/docs/tutorial/additional-responses.md
+++ b/docs/tutorial/additional-responses.md
@@ -5,10 +5,9 @@
 
 You can declare additional responses, with additional status codes, media types, descriptions, etc.
 
-Those additional responses will be included in the OpenAPI schema, so they will also appear in the API docs. 
+Those additional responses will be included in the OpenAPI schema, so they will also appear in the API docs.
 
 But for those additional responses you have to make sure you return a `Response` like `JSONResponse` directly, with your status code and content.
-
 
 ## Additional Response with `model`
 
@@ -176,7 +175,9 @@ For example, you can add an additional media type of `image/png`, declaring that
     Notice that you have to return the image using a `FileResponse` directly.
 
 !!! info
-    Unless you specify a different media type explicitly in your `responses` parameter, FastAPI will assume the response has the same media type as the response class used by your main response (default `application/json`).  But if you have specified a custom response class with `None` as its media type, FastAPI will use `application/json` for any additional response that has an associated model.
+    Unless you specify a different media type explicitly in your `responses` parameter, FastAPI will assume the response has the same media type as the main response class (default `application/json`).
+
+    But if you have specified a custom response class with `None` as its media type, FastAPI will use `application/json` for any additional response that has an associated model.
 
 ## Combining information
 

--- a/docs/tutorial/additional-responses.md
+++ b/docs/tutorial/additional-responses.md
@@ -5,9 +5,10 @@
 
 You can declare additional responses, with additional status codes, media types, descriptions, etc.
 
-Those additional responses will be included in the OpenAPI schema, so they will also appear in the API docs.
+Those additional responses will be included in the OpenAPI schema, so they will also appear in the API docs. 
 
 But for those additional responses you have to make sure you return a `Response` like `JSONResponse` directly, with your status code and content.
+
 
 ## Additional Response with `model`
 
@@ -173,6 +174,9 @@ For example, you can add an additional media type of `image/png`, declaring that
 
 !!! note
     Notice that you have to return the image using a `FileResponse` directly.
+
+!!! info
+    Unless you specify a different media type explicitly in your `responses` parameter, FastAPI will assume the response has the same media type as the response class used by your main response (default `application/json`).  But if you have specified a custom response class with `None` as its media type, FastAPI will use `application/json` for any additional response that has an associated model.
 
 ## Combining information
 

--- a/docs/tutorial/custom-response.md
+++ b/docs/tutorial/custom-response.md
@@ -15,6 +15,9 @@ The contents that you return from your *path operation function* will be put ins
 
 And if that `Response` has a JSON media type (`application/json`), like is the case with the `JSONResponse` and `UJSONResponse`, the data you return will be automatically converted (and filtered) with any Pydantic `response_model` that you declared in the *path operation decorator*.
 
+!!! note
+    If you use a response class with no media type, FastAPI will expect your response to have no content, so it will not document the response format in its generated OpenAPI docs.
+
 ## Use `UJSONResponse`
 
 For example, if you are squeezing performance, you can install and use `ujson` and set the response to be Starlette's `UJSONResponse`.

--- a/docs/tutorial/response-status-code.md
+++ b/docs/tutorial/response-status-code.md
@@ -23,8 +23,9 @@ It will:
 <img src="/img/tutorial/response-status-code/image01.png">
 
 !!! note
-    Some response codes (see the next section) indicate that the response does not have a body.  FastAPI knows this, and will produce OpenAPI docs that state there is no response body.
+    Some response codes (see the next section) indicate that the response does not have a body.
 
+    FastAPI knows this, and will produce OpenAPI docs that state there is no response body.
 
 ## About HTTP status codes
 
@@ -41,7 +42,7 @@ In short:
 * **`200`** and above are for "Successful" responses. These are the ones you would use the most.
     * `200` is the default status code, which means everything was "OK".
     * Another example would be `201`, "Created". It is commonly used after creating a new record in the database.
-    * A special case is `204`, "No Content".  This response is used when there is no content to return to the client, and so the response must not have a body. 
+    * A special case is `204`, "No Content".  This response is used when there is no content to return to the client, and so the response must not have a body.
 * **`300`** and above are for "Redirection".  Responses with these status codes may or may not have a body, except for `304`, "Not Modified", which must not have one.
 * **`400`** and above are for "Client error" responses. These are the second type you would probably use the most.
     * An example is `404`, for a "Not Found" response.

--- a/docs/tutorial/response-status-code.md
+++ b/docs/tutorial/response-status-code.md
@@ -22,6 +22,9 @@ It will:
 
 <img src="/img/tutorial/response-status-code/image01.png">
 
+!!! note
+    Some response codes (see the next section) indicate that the response does not have a body.  FastAPI knows this, and will produce OpenAPI docs that state there is no response body.
+
 
 ## About HTTP status codes
 
@@ -34,11 +37,12 @@ These status codes have a name associated to recognize them, but the important p
 
 In short:
 
-* `100` and above are for "Information". You rarely use them directly.
+* `100` and above are for "Information". You rarely use them directly.  Responses with these status codes cannot have a body.
 * **`200`** and above are for "Successful" responses. These are the ones you would use the most.
     * `200` is the default status code, which means everything was "OK".
     * Another example would be `201`, "Created". It is commonly used after creating a new record in the database.
-* `300` and above are for "Redirection". 
+    * A special case is `204`, "No Content".  This response is used when there is no content to return to the client, and so the response must not have a body. 
+* **`300`** and above are for "Redirection".  Responses with these status codes may or may not have a body, except for `304`, "Not Modified", which must not have one.
 * **`400`** and above are for "Client error" responses. These are the second type you would probably use the most.
     * An example is `404`, for a "Not Found" response.
     * For generic errors from the client, you can just use `400`.

--- a/fastapi/openapi/constants.py
+++ b/fastapi/openapi/constants.py
@@ -1,2 +1,3 @@
 METHODS_WITH_BODY = set(("POST", "PUT", "DELETE", "PATCH"))
+STATUS_CODES_WITH_NO_BODY = set((100, 101, 102, 103, 204, 304))
 REF_PREFIX = "#/components/schemas/"

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -17,6 +17,7 @@ from fastapi.utils import create_cloned_field, generate_operation_id_for_path
 from pydantic import BaseConfig, BaseModel, Schema
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from pydantic.fields import Field
+from fastapi.openapi.constants import STATUS_CODES_WITH_NO_BODY
 from pydantic.utils import lenient_issubclass
 from starlette import routing
 from starlette.concurrency import run_in_threadpool
@@ -215,6 +216,9 @@ class APIRoute(routing.Route):
         )
         self.response_model = response_model
         if self.response_model:
+            assert (
+                status_code not in STATUS_CODES_WITH_NO_BODY
+            ), f"Status code {status_code} must not have a response body"
             response_name = "Response_" + self.unique_id
             self.response_field: Optional[Field] = Field(
                 name=response_name,
@@ -256,6 +260,9 @@ class APIRoute(routing.Route):
             assert isinstance(response, dict), "An additional response must be a dict"
             model = response.get("model")
             if model:
+                assert (
+                    additional_status_code not in STATUS_CODES_WITH_NO_BODY
+                ), f"Status code {additional_status_code} must not have a response body"
                 assert lenient_issubclass(
                     model, BaseModel
                 ), "A response model must be a Pydantic model"

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -13,11 +13,11 @@ from fastapi.dependencies.utils import (
 )
 from fastapi.encoders import DictIntStrAny, SetIntStr, jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
+from fastapi.openapi.constants import STATUS_CODES_WITH_NO_BODY
 from fastapi.utils import create_cloned_field, generate_operation_id_for_path
 from pydantic import BaseConfig, BaseModel, Schema
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from pydantic.fields import Field
-from fastapi.openapi.constants import STATUS_CODES_WITH_NO_BODY
 from pydantic.utils import lenient_issubclass
 from starlette import routing
 from starlette.concurrency import run_in_threadpool

--- a/tests/test_response_class_no_mediatype.py
+++ b/tests/test_response_class_no_mediatype.py
@@ -1,0 +1,114 @@
+import typing
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.responses import JSONResponse, Response
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+
+class JsonApiResponse(JSONResponse):
+    media_type = "application/vnd.api+json"
+
+
+class Error(BaseModel):
+    status: str
+    title: str
+
+
+class JsonApiError(BaseModel):
+    errors: typing.List[Error]
+
+
+@app.get(
+    "/a",
+    response_class=Response,
+    responses={500: {"description": "Error", "model": JsonApiError}},
+)
+async def a():
+    pass  # pragma: no cover
+
+
+@app.get("/b", responses={500: {"description": "Error", "model": Error}})
+async def b():
+    pass  # pragma: no cover
+
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "Fast API", "version": "0.1.0"},
+    "paths": {
+        "/a": {
+            "get": {
+                "responses": {
+                    "500": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/JsonApiError"}
+                            }
+                        },
+                    },
+                    "200": {"description": "Successful Response"},
+                },
+                "summary": "A",
+                "operationId": "a_a_get",
+            }
+        },
+        "/b": {
+            "get": {
+                "responses": {
+                    "500": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    },
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                },
+                "summary": "B",
+                "operationId": "b_b_get",
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "Error": {
+                "title": "Error",
+                "required": ["status", "title"],
+                "type": "object",
+                "properties": {
+                    "status": {"title": "Status", "type": "string"},
+                    "title": {"title": "Title", "type": "string"},
+                },
+            },
+            "JsonApiError": {
+                "title": "JsonApiError",
+                "required": ["errors"],
+                "type": "object",
+                "properties": {
+                    "errors": {
+                        "title": "Errors",
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/Error"},
+                    }
+                },
+            },
+        }
+    },
+}
+
+
+client = TestClient(app)
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == openapi_schema

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -1,0 +1,108 @@
+import typing
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.responses import JSONResponse, Response
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+
+class JsonApiResponse(JSONResponse):
+    media_type = "application/vnd.api+json"
+
+
+class Error(BaseModel):
+    status: str
+    title: str
+
+
+class JsonApiError(BaseModel):
+    errors: typing.List[Error]
+
+
+@app.get(
+    "/a",
+    status_code=204,
+    response_class=JsonApiResponse,
+    responses={500: {"description": "Error", "model": JsonApiError}},
+)
+async def a():
+    pass  # pragma: no cover
+
+
+@app.get("/b", responses={204: {"description": "No Content"}})
+async def b():
+    pass  # pragma: no cover
+
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "Fast API", "version": "0.1.0"},
+    "paths": {
+        "/a": {
+            "get": {
+                "responses": {
+                    "500": {
+                        "description": "Error",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {"$ref": "#/components/schemas/JsonApiError"}
+                            }
+                        },
+                    },
+                    "204": {"description": "Successful Response"},
+                },
+                "summary": "A",
+                "operationId": "a_a_get",
+            }
+        },
+        "/b": {
+            "get": {
+                "responses": {
+                    "204": {"description": "No Content"},
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                },
+                "summary": "B",
+                "operationId": "b_b_get",
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "Error": {
+                "title": "Error",
+                "required": ["status", "title"],
+                "type": "object",
+                "properties": {
+                    "status": {"title": "Status", "type": "string"},
+                    "title": {"title": "Title", "type": "string"},
+                },
+            },
+            "JsonApiError": {
+                "title": "JsonApiError",
+                "required": ["errors"],
+                "type": "object",
+                "properties": {
+                    "errors": {
+                        "title": "Errors",
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/Error"},
+                    }
+                },
+            },
+        }
+    },
+}
+
+
+client = TestClient(app)
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == openapi_schema

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -2,7 +2,7 @@ import typing
 
 from fastapi import FastAPI
 from pydantic import BaseModel
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
 
 app = FastAPI()


### PR DESCRIPTION
This is a backwards-compatible change, as far as I know, for responses that explicitly return content.  There are two basic changes:

* FastAPI now knows which response codes do not return bodies, and suppresses the `content` element in their API docs.
* If the response_class for a route has no media type, FastAPI assumes that it will not return content.  (If this route specifies additional responses that do return content, those responses are assumed to return `application/json` content and use an appropriate response class.)

This change introduces two new test files which check the new logic and keep the code coverage at 100%.

This change also updates the tutorial documentation to reflect the new functionality.