### PR TITLE
Fix #679: allow async class methods as dependencies

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -351,7 +351,7 @@ def add_param_to_fields(*, field: Field, dependant: Dependant) -> None:
 
 
 def is_coroutine_callable(call: Callable) -> bool:
-    if inspect.isfunction(call):
+    if inspect.isroutine(call):
         return asyncio.iscoroutinefunction(call)
     if inspect.isclass(call):
         return False

--- a/tests/test_dependency_class.py
+++ b/tests/test_dependency_class.py
@@ -1,0 +1,70 @@
+import pytest
+from fastapi import Depends, FastAPI
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+
+class CallableDependency:
+    def __call__(self, value: str) -> str:
+        return value
+
+
+class AsyncCallableDependency:
+    async def __call__(self, value: str) -> str:
+        return value
+
+
+class MethodsDependency:
+    def synchronous(self, value: str) -> str:
+        return value
+
+    async def asynchronous(self, value: str) -> str:
+        return value
+
+
+callable_dependency = CallableDependency()
+async_callable_dependency = AsyncCallableDependency()
+methods_dependency = MethodsDependency()
+
+
+@app.get("/callable-dependency")
+async def get_callable_dependency(value: str = Depends(callable_dependency)):
+    return value
+
+
+@app.get("/async-callable-dependency")
+async def get_callable_dependency(value: str = Depends(async_callable_dependency)):
+    return value
+
+
+@app.get("/synchronous-method-dependency")
+async def get_synchronous_method_dependency(
+    value: str = Depends(methods_dependency.synchronous),
+):
+    return value
+
+
+@app.get("/asynchronous-method-dependency")
+async def get_asynchronous_method_dependency(
+    value: str = Depends(methods_dependency.asynchronous),
+):
+    return value
+
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "route,value",
+    [
+        ("/callable-dependency", "callable-dependency"),
+        ("/async-callable-dependency", "async-callable-dependency"),
+        ("/synchronous-method-dependency", "synchronous-method-dependency"),
+        ("/asynchronous-method-dependency", "asynchronous-method-dependency"),
+    ],
+)
+def test_class_dependency(route, value):
+    response = client.get(route, params={"value": value})
+    assert response.status_code == 200
+    assert response.json() == value


### PR DESCRIPTION
This is the fix for issue #679: allow to use async class methods as dependencies.

Before, such methods were not correctly detected as coroutine and thus were not awaited but rather sent to `run_in_threadpool`. We ended up then injecting the coroutine instead of its result.

I've used [`inspect.isroutine`](https://docs.python.org/3/library/inspect.html#inspect.isroutine), instead of doing `inspect.isfunction(call) or inspect.ismethod(call)`. It seems to fulfill our need while saving us a check.

I also took this opportunity to add some unit tests to verify the different use cases regarding class dependencies (callable, async callable, sync methods and async methods).

It could also be interesting to mention those possibilities in the [Classes as Dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/classes-as-dependencies/) section of the documentation. What do you think?