### PR TITLE
Clarify docs for APIRouter dependencies

### DIFF
--- a/docs/tutorial/bigger-applications.md
+++ b/docs/tutorial/bigger-applications.md
@@ -246,7 +246,7 @@ We can also add a list of `tags` that will be applied to all the *path operation
 
 And we can add predefined `responses` that will be included in all the *path operations* too.
 
-And we can add a list of `dependencies` that will be added to all the *path operations* in the router and will be executed/solved for each request made to them.
+And we can add a list of `dependencies` that will be added to all the *path operations* in the router and will be executed/solved for each request made to them. Note that, much like dependencies in *path operation decorators*, no value will be passed to your *path operation function*.
 
 ```Python hl_lines="8 9 10 14 15 16 17 18 19 20"
 {!./src/bigger_applications/app/main.py!}


### PR DESCRIPTION
Someone might expect that the dependencies specified on an APIRouter be passed along to their path operation functions, though the behavior is closer to dependencies specified in path operation decorators. Being explicit here will make the behavior unambiguous.

This is especially true for someone who might be jumping around in the documentation and who wouldn't necessarily have read [dependencies in path operation decorators](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/).