### PR TITLE
Fix typos whilst I read the docs

### DIFF
--- a/docs/tutorial/async-sql-databases.md
+++ b/docs/tutorial/async-sql-databases.md
@@ -41,7 +41,7 @@ Later, for your production application, you might want to use a database server 
 ```
 
 !!! tip
-    If you where connecting to a different database (e.g. PostgreSQL), you would need to change the `DATABASE_URL`.
+    If you were connecting to a different database (e.g. PostgreSQL), you would need to change the `DATABASE_URL`.
 
 ## Create the tables
 

--- a/docs/tutorial/dependencies/classes-as-dependencies.md
+++ b/docs/tutorial/dependencies/classes-as-dependencies.md
@@ -2,7 +2,7 @@ Before diving deeper into the **Dependency Injection** system, let's upgrade the
 
 ## A `dict` from the previous example
 
-In the previous example, we where returning a `dict` from our dependency ("dependable"):
+In the previous example, we were returning a `dict` from our dependency ("dependable"):
 
 ```Python hl_lines="7"
 {!./src/dependencies/tutorial001.py!}

--- a/docs/tutorial/dependencies/classes-as-dependencies.md
+++ b/docs/tutorial/dependencies/classes-as-dependencies.md
@@ -2,7 +2,7 @@ Before diving deeper into the **Dependency Injection** system, let's upgrade the
 
 ## A `dict` from the previous example
 
-In the previous example, we were returning a `dict` from our dependency ("dependable"):
+In the previous example, we are returning a `dict` from our dependency ("dependable"):
 
 ```Python hl_lines="7"
 {!./src/dependencies/tutorial001.py!}


### PR DESCRIPTION
Change 'where' to 'were'