### PR TITLE
Fix failure to serialize pydantic errors that are not directly json serializable

### DIFF
--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -1,3 +1,4 @@
+from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
@@ -19,5 +20,6 @@ async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
     return JSONResponse(
-        status_code=HTTP_422_UNPROCESSABLE_ENTITY, content={"detail": exc.errors()}
+        status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+        content={"detail": jsonable_encoder(exc.errors())},
     )


### PR DESCRIPTION
Applies `jsonable_encoder` to pydantic error output in case the context is not JSON serializable.

Closes https://github.com/tiangolo/fastapi/issues/743