### PR TITLE
Enable full Travis for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,11 @@ cache: pip
 python:
     - "3.6"
     - "3.7"
-    - "3.8-dev"
+    - "3.8"
     - "nightly"
 
 matrix:
     allow_failures:
-        - python: "3.8-dev"
         - python: "nightly"
 
 install:


### PR DESCRIPTION
:construction_worker: Enable full Travis for Python 3.8, not only Python 3.8 dev. And remove flag allowing it to fail.

I can do it now that [Uvloop has a version that supports Python 3.8](https://github.com/MagicStack/uvloop/releases/tag/v0.14.0), so Uvicorn supports 3.8, and Starlette supports 3.8. And Pydantic is already testing and supporting 3.8 as well.