### PR TITLE
use isinstance() instead of type() to do typechecking in encoders.py

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -107,12 +107,15 @@ def jsonable_encoder(
         return encoded_list
     errors: List[Exception] = []
     try:
-        if custom_encoder and type(obj) in custom_encoder:
-            encoder = custom_encoder[type(obj)]
+        custom_encoder_function = next(
+            (v for k, v in custom_encoder.items() if isinstance(obj, k)), None
+        )
+        if custom_encoder_function is not None:
+            encoder = custom_encoder_function
         else:
-            encoder = ENCODERS_BY_TYPE[type(obj)]
+            encoder = next(v for k, v in ENCODERS_BY_TYPE.items() if isinstance(obj, k))
         return encoder(obj)
-    except KeyError as e:
+    except StopIteration as e:
         errors.append(e)
         try:
             data = dict(obj)

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -105,12 +105,21 @@ def jsonable_encoder(
                 )
             )
         return encoded_list
-    for encoder_type, encoder in custom_encoder.items():
-        if isinstance(obj, encoder_type):
-            return encoder(obj)
+
+    if custom_encoder:
+        if type(obj) in custom_encoder:
+            return custom_encoder[type(obj)](obj)
+        else:
+            for encoder_type, encoder in custom_encoder.items():
+                if isinstance(obj, encoder_type):
+                    return encoder(obj)
+
+    if type(obj) in ENCODERS_BY_TYPE:
+        return ENCODERS_BY_TYPE[type(obj)](obj)
     for encoder_type, encoder in ENCODERS_BY_TYPE.items():
         if isinstance(obj, encoder_type):
             return encoder(obj)
+
     errors: List[Exception] = []
     try:
         data = dict(obj)

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -105,27 +105,22 @@ def jsonable_encoder(
                 )
             )
         return encoded_list
+    for encoder_type, encoder in custom_encoder.items():
+        if isinstance(obj, encoder_type):
+            return encoder(obj)
+    for encoder_type, encoder in ENCODERS_BY_TYPE.items():
+        if isinstance(obj, encoder_type):
+            return encoder(obj)
     errors: List[Exception] = []
     try:
-        custom_encoder_function = next(
-            (v for k, v in custom_encoder.items() if isinstance(obj, k)), None
-        )
-        if custom_encoder_function is not None:
-            encoder = custom_encoder_function
-        else:
-            encoder = next(v for k, v in ENCODERS_BY_TYPE.items() if isinstance(obj, k))
-        return encoder(obj)
-    except StopIteration as e:
+        data = dict(obj)
+    except Exception as e:
         errors.append(e)
         try:
-            data = dict(obj)
+            data = vars(obj)
         except Exception as e:
             errors.append(e)
-            try:
-                data = vars(obj)
-            except Exception as e:
-                errors.append(e)
-                raise ValueError(errors)
+            raise ValueError(errors)
     return jsonable_encoder(
         data,
         by_alias=by_alias,

--- a/tests/test_inherited_custom_class.py
+++ b/tests/test_inherited_custom_class.py
@@ -29,7 +29,7 @@ class MyUuid:
 @app.get("/fast_uuid")
 def return_fast_uuid():
     # I don't want to import asyncpg for this test so I made my own UUID
-    # Import asyncpg and uncomment the two lines below for the actual bug..
+    # Import asyncpg and uncomment the two lines below for the actual bug
 
     # from asyncpg.pgproto import pgproto
     # asyncpg_uuid = pgproto.UUID("a10ff360-3b1e-4984-a26f-d3ab460bdb51")

--- a/tests/test_inherited_custom_class.py
+++ b/tests/test_inherited_custom_class.py
@@ -1,0 +1,50 @@
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+app = FastAPI()
+
+
+class MyUuid:
+    def __init__(self, uuid_string: str):
+        self.uuid = uuid_string
+
+    def __str__(self):
+        return self.uuid
+
+    @property
+    def __class__(self):
+        return uuid.UUID
+
+    @property
+    def __dict__(self):
+        """Spoof a missing __dict__ by raising TypeError, this is how
+        asyncpg.pgroto.pgproto.UUID behaves"""
+        raise TypeError("vars() argument must have __dict__ attribute")
+
+
+@app.get("/fast_uuid")
+def return_fast_uuid():
+    # I don't want to import asyncpg for this test so I made my own UUID
+    # Import asyncpg and uncomment the two lines below for the actual bug..
+
+    # from asyncpg.pgproto import pgproto
+    # asyncpg_uuid = pgproto.UUID("a10ff360-3b1e-4984-a26f-d3ab460bdb51")
+
+    asyncpg_uuid = MyUuid("a10ff360-3b1e-4984-a26f-d3ab460bdb51")
+    assert isinstance(asyncpg_uuid, uuid.UUID)
+    assert type(asyncpg_uuid) != uuid.UUID
+    with pytest.raises(TypeError):
+        vars(asyncpg_uuid)
+    return {"fast_uuid": asyncpg_uuid}
+
+
+client = TestClient(app)
+
+
+def test_dt():
+    with client:
+        response = client.get("/fast_uuid")
+    assert response.json() == {"fast_uuid": "a10ff360-3b1e-4984-a26f-d3ab460bdb51"}


### PR DESCRIPTION
This should resolve #755

I have used a generator and the `next` keyword to write this. I think it works nicely but if you think it's not super readable I can also unroll it into a for loop or something.