### PR TITLE
Make OAuth2PasswordRequestFormStrict importable from fastapi.security package

### DIFF
--- a/fastapi/security/__init__.py
+++ b/fastapi/security/__init__.py
@@ -10,6 +10,7 @@ from .oauth2 import (
     OAuth2,
     OAuth2PasswordBearer,
     OAuth2PasswordRequestForm,
+    OAuth2PasswordRequestFormStrict,
     SecurityScopes,
 )
 from .open_id_connect_url import OpenIdConnect


### PR DESCRIPTION
Unfortunately, everything from `fastapi.security.oauth2` available from `fastapi.security` package, except `OAuth2PasswordRequestFormStrict`. I've added the missing entry.