### PR TITLE
Refactor logging

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -2,7 +2,8 @@ from enum import Enum
 from types import GeneratorType
 from typing import Any, Dict, List, Set, Union
 
-from fastapi.utils import PYDANTIC_1, logger
+from fastapi.logger import logger
+from fastapi.utils import PYDANTIC_1
 from pydantic import BaseModel
 from pydantic.json import ENCODERS_BY_TYPE
 
@@ -23,9 +24,9 @@ def jsonable_encoder(
 ) -> Any:
     if skip_defaults is not None:
         logger.warning(  # pragma: nocover
-            "skip_defaults in jsonable_encoder has been deprecated in \
-            favor of exclude_unset to keep in line with Pydantic v1, support for it \
-                will be removed soon."
+            "skip_defaults in jsonable_encoder has been deprecated in favor of "
+            "exclude_unset to keep in line with Pydantic v1, support for it will be "
+            "removed soon."
         )
     if include is not None and not isinstance(include, set):
         include = set(include)

--- a/fastapi/logger.py
+++ b/fastapi/logger.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("fastapi")

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from fastapi.utils import logger
+from fastapi.logger import logger
 from pydantic import BaseModel
 
 try:
@@ -21,9 +21,9 @@ try:
         # TODO: remove when removing support for Pydantic < 1.0.0
         from pydantic.types import EmailStr  # type: ignore
 except ImportError:  # pragma: no cover
-    logger.warning(
+    logger.info(
         "email-validator not installed, email fields will be treated as str.\n"
-        + "To install, run: pip install email-validator"
+        "To install, run: pip install email-validator"
     )
 
     class EmailStr(str):  # type: ignore

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -8,11 +8,11 @@ from fastapi.dependencies.utils import (
     get_body_field,
     get_dependant,
     get_parameterless_sub_dependant,
-    logger,
     solve_dependencies,
 )
 from fastapi.encoders import DictIntStrAny, SetIntStr, jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
+from fastapi.logger import logger
 from fastapi.openapi.constants import STATUS_CODES_WITH_NO_BODY
 from fastapi.utils import (
     PYDANTIC_1,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,6 +1,5 @@
 import asyncio
 import inspect
-import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union
 
 from fastapi import params
@@ -9,6 +8,7 @@ from fastapi.dependencies.utils import (
     get_body_field,
     get_dependant,
     get_parameterless_sub_dependant,
+    logger,
     solve_dependencies,
 )
 from fastapi.encoders import DictIntStrAny, SetIntStr, jsonable_encoder
@@ -108,7 +108,7 @@ def get_request_handler(
                     if body_bytes:
                         body = await request.json()
         except Exception as e:
-            logging.error(f"Error getting request body: {e}")
+            logger.error(f"Error getting request body: {e}")
             raise HTTPException(
                 status_code=400, detail="There was an error parsing the body"
             ) from e

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,16 +1,14 @@
-import logging
 import re
 from dataclasses import is_dataclass
 from typing import Any, Dict, List, Sequence, Set, Type, cast
 
 from fastapi import routing
+from fastapi.logger import logger
 from fastapi.openapi.constants import REF_PREFIX
 from pydantic import BaseConfig, BaseModel, create_model
 from pydantic.schema import get_flat_models_from_fields, model_process_schema
 from pydantic.utils import lenient_issubclass
 from starlette.routing import BaseRoute
-
-logger = logging.getLogger("fastapi")
 
 try:
     from pydantic.fields import FieldInfo, ModelField
@@ -22,8 +20,8 @@ except ImportError:  # pragma: nocover
     from pydantic import Schema as FieldInfo  # type: ignore
 
     logger.warning(
-        "Pydantic versions < 1.0.0 are deprecated in FastAPI and support will be \
-            removed soon"
+        "Pydantic versions < 1.0.0 are deprecated in FastAPI and support will be "
+        "removed soon."
     )
     PYDANTIC_1 = False
 
@@ -39,9 +37,9 @@ def get_field_info(field: ModelField) -> FieldInfo:
 # TODO: remove when removing support for Pydantic < 1.0.0
 def warning_response_model_skip_defaults_deprecated() -> None:
     logger.warning(  # pragma: nocover
-        "response_model_skip_defaults has been deprecated in favor \
-                of response_model_exclude_unset to keep in line with Pydantic v1, \
-                support for it will be removed soon."
+        "response_model_skip_defaults has been deprecated in favor of "
+        "response_model_exclude_unset to keep in line with Pydantic v1, support for "
+        "it will be removed soon."
     )
 
 


### PR DESCRIPTION
:loud_sound: Refactor logging.

* Use the same logger everywhere to make sure the custom `fastapi` logger is used.
* Update logging strings to fix format.
* Update log level of `email-validator` errors to `INFO`, not `WARNING`.