### PR TITLE
bugfix bug ID #821

### DIFF
--- a/docs/src/query_params/tutorial003.py
+++ b/docs/src/query_params/tutorial003.py
@@ -6,7 +6,7 @@ app = FastAPI()
 @app.get("/items/{item_id}")
 async def read_item(item_id: str, q: str = None, short: bool = False):
     item = {"item_id": item_id}
-    if q:
+    if q is not None and len(q) > 0:
         item.update({"q": q})
     if not short:
         item.update(

--- a/docs/src/query_params/tutorial003.py
+++ b/docs/src/query_params/tutorial003.py
@@ -6,7 +6,7 @@ app = FastAPI()
 @app.get("/items/{item_id}")
 async def read_item(item_id: str, q: str = None, short: bool = False):
     item = {"item_id": item_id}
-    if q is not None and len(q) > 0:
+    if q is not None:
         item.update({"q": q})
     if not short:
         item.update(

--- a/docs/src/query_params/tutorial004.py
+++ b/docs/src/query_params/tutorial004.py
@@ -8,7 +8,7 @@ async def read_user_item(
     user_id: int, item_id: str, q: str = None, short: bool = False
 ):
     item = {"item_id": item_id, "owner_id": user_id}
-    if q is not None and len(q) > 0:
+    if q is not None:
         item.update({"q": q})
     if not short:
         item.update(

--- a/docs/src/query_params/tutorial004.py
+++ b/docs/src/query_params/tutorial004.py
@@ -8,7 +8,7 @@ async def read_user_item(
     user_id: int, item_id: str, q: str = None, short: bool = False
 ):
     item = {"item_id": item_id, "owner_id": user_id}
-    if q:
+    if q is not None and len(q) > 0:
         item.update({"q": q})
     if not short:
         item.update(

--- a/docs/src/query_params_str_validations/tutorial001.py
+++ b/docs/src/query_params_str_validations/tutorial001.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = None):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial001.py
+++ b/docs/src/query_params_str_validations/tutorial001.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = None):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial002.py
+++ b/docs/src/query_params_str_validations/tutorial002.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, max_length=50)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial002.py
+++ b/docs/src/query_params_str_validations/tutorial002.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, max_length=50)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial003.py
+++ b/docs/src/query_params_str_validations/tutorial003.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, min_length=3, max_length=50)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial003.py
+++ b/docs/src/query_params_str_validations/tutorial003.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, min_length=3, max_length=50)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial004.py
+++ b/docs/src/query_params_str_validations/tutorial004.py
@@ -8,6 +8,6 @@ async def read_items(
     q: str = Query(None, min_length=3, max_length=50, regex="^fixedquery$")
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial004.py
+++ b/docs/src/query_params_str_validations/tutorial004.py
@@ -8,6 +8,6 @@ async def read_items(
     q: str = Query(None, min_length=3, max_length=50, regex="^fixedquery$")
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial007.py
+++ b/docs/src/query_params_str_validations/tutorial007.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, title="Query string", min_length=3)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial007.py
+++ b/docs/src/query_params_str_validations/tutorial007.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, title="Query string", min_length=3)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial008.py
+++ b/docs/src/query_params_str_validations/tutorial008.py
@@ -13,6 +13,6 @@ async def read_items(
     )
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial008.py
+++ b/docs/src/query_params_str_validations/tutorial008.py
@@ -13,6 +13,6 @@ async def read_items(
     )
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial009.py
+++ b/docs/src/query_params_str_validations/tutorial009.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, alias="item-query")):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial009.py
+++ b/docs/src/query_params_str_validations/tutorial009.py
@@ -6,6 +6,6 @@ app = FastAPI()
 @app.get("/items/")
 async def read_items(q: str = Query(None, alias="item-query")):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial010.py
+++ b/docs/src/query_params_str_validations/tutorial010.py
@@ -17,6 +17,6 @@ async def read_items(
     )
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q is not None and len(q) > 0:
+    if q is not None:
         results.update({"q": q})
     return results

--- a/docs/src/query_params_str_validations/tutorial010.py
+++ b/docs/src/query_params_str_validations/tutorial010.py
@@ -17,6 +17,6 @@ async def read_items(
     )
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
+    if q is not None and len(q) > 0:
         results.update({"q": q})
     return results


### PR DESCRIPTION
[BUG] [DOC] None should be checked with is None in docs #821

Hi All

the library and the documentation are fantastic

I am a QA eng., and teach Python for my colleagues.
I saw in some examples that None is checked as it would be a boolean expression
for example:
https://fastapi.tiangolo.com/tutorial/body/

async def create_item(item_id: int, item: Item, q: str = None):
result = {"item_id": item_id, **item.dict()}
if q:

I saw that the documentation is written for beginners too.
I think checking the None as it would be a boolean expression in the docs encourages beginners to use this formula instead of checking with is operator. And it is not good, because not None will them result unexpected results.

These examples should be corrected.

BR,
George