### PR TITLE
fix docs type UrlStr -> HttpUrl

### DIFF
--- a/docs/src/body_nested_models/tutorial005.py
+++ b/docs/src/body_nested_models/tutorial005.py
@@ -1,13 +1,13 @@
 from typing import Set
 
 from fastapi import FastAPI
-from pydantic import BaseModel, UrlStr
+from pydantic import BaseModel, HttpUrl
 
 app = FastAPI()
 
 
 class Image(BaseModel):
-    url: UrlStr
+    url: HttpUrl
     name: str
 
 

--- a/docs/src/body_nested_models/tutorial006.py
+++ b/docs/src/body_nested_models/tutorial006.py
@@ -1,13 +1,13 @@
 from typing import List, Set
 
 from fastapi import FastAPI
-from pydantic import BaseModel, UrlStr
+from pydantic import BaseModel, HttpUrl
 
 app = FastAPI()
 
 
 class Image(BaseModel):
-    url: UrlStr
+    url: HttpUrl
     name: str
 
 

--- a/docs/src/body_nested_models/tutorial007.py
+++ b/docs/src/body_nested_models/tutorial007.py
@@ -1,13 +1,13 @@
 from typing import List, Set
 
 from fastapi import FastAPI
-from pydantic import BaseModel, UrlStr
+from pydantic import BaseModel, HttpUrl
 
 app = FastAPI()
 
 
 class Image(BaseModel):
-    url: UrlStr
+    url: HttpUrl
     name: str
 
 

--- a/docs/src/body_nested_models/tutorial008.py
+++ b/docs/src/body_nested_models/tutorial008.py
@@ -1,13 +1,13 @@
 from typing import List
 
 from fastapi import FastAPI
-from pydantic import BaseModel, UrlStr
+from pydantic import BaseModel, HttpUrl
 
 app = FastAPI()
 
 
 class Image(BaseModel):
-    url: UrlStr
+    url: HttpUrl
     name: str
 
 

--- a/docs/tutorial/body-nested-models.md
+++ b/docs/tutorial/body-nested-models.md
@@ -118,7 +118,7 @@ Apart from normal singular types like `str`, `int`, `float`, etc. You can use mo
 
 To see all the options you have, checkout the docs for <a href="https://pydantic-docs.helpmanual.io/#exotic-types" target="_blank">Pydantic's exotic types</a>. You will see some examples in the next chapter.
 
-For example, as in the `Image` model we have a `url` field, we can declare it to be instead of a `str`, a Pydantic's `UrlStr`:
+For example, as in the `Image` model we have a `url` field, we can declare it to be instead of a `str`, a Pydantic's `HttpUrl`:
 
 ```Python hl_lines="4 10"
 {!./src/body_nested_models/tutorial005.py!}


### PR DESCRIPTION
In latest `pydantic`, the type `UrlStr` had deleted and `HttpUrl` can instead it.
