### PR TITLE
add body to RequestValidationError for easier tracing and debugging

### DIFF
--- a/docs/src/handling_errors/tutorial006.py
+++ b/docs/src/handling_errors/tutorial006.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.exception_handlers import (
+    http_exception_handler,
+    request_validation_exception_handler,
+)
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+app = FastAPI()
+
+
+@app.exception_handler(StarletteHTTPException)
+async def custom_http_exception_handler(request, exc):
+    print(f"OMG! An HTTP error!: {exc}")
+    return await http_exception_handler(request, exc)
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request, exc):
+    print(f"OMG! The client sent invalid data!: {exc}")
+    return await request_validation_exception_handler(request, exc)
+
+
+@app.get("/items/{item_id}")
+async def read_item(item_id: int):
+    if item_id == 3:
+        raise HTTPException(status_code=418, detail="Nope! I don't like 3.")
+    return {"item_id": item_id}

--- a/docs/tutorial/custom-request-and-route.md
+++ b/docs/tutorial/custom-request-and-route.md
@@ -16,7 +16,6 @@ Some use cases include:
 * Converting non-JSON request bodies to JSON (e.g. [`msgpack`](https://msgpack.org/index.html)).
 * Decompressing gzip-compressed request bodies.
 * Automatically logging all request bodies.
-* Accessing the request body in an exception handler.
 
 ## Handling custom request body encodings
 
@@ -71,6 +70,11 @@ But because of our changes in `GzipRequest.body`, the request body will be autom
 
 ## Accessing the request body in an exception handler
 
+!!! tip
+    To solve this same problem, it's probably a lot easier to [use the `body` in a custom handler for `RequestValidationError`](https://fastapi.tiangolo.com/tutorial/handling-errors/#use-the-requestvalidationerror-body).
+
+    But this example is still valid and it shows how to interact with the internal components.
+
 We can also use this same approach to access the request body in an exception handler.
 
 All we need to do is handle the request inside a `try`/`except` block:
@@ -89,12 +93,12 @@ If an exception occurs, the`Request` instance will still be in scope, so we can 
 
 You can also set the `route_class` parameter of an `APIRouter`:
 
-```Python hl_lines="25"
+```Python hl_lines="28"
 {!./src/custom_request_and_route/tutorial003.py!}
 ```
 
 In this example, the *path operations* under the `router` will use the custom `TimedRoute` class, and will have an extra `X-Response-Time` header in the response with the time it took to generate the response:
 
-```Python hl_lines="15 16 17 18 19"
+```Python hl_lines="15 16 17 18 19 20 21 22"
 {!./src/custom_request_and_route/tutorial003.py!}
 ```

--- a/docs/tutorial/handling-errors.md
+++ b/docs/tutorial/handling-errors.md
@@ -176,6 +176,47 @@ For example, you could want to return a plain text response instead of JSON for 
 {!./src/handling_errors/tutorial004.py!}
 ```
 
+### Use the `RequestValidationError` body
+
+The `RequestValidationError` contains the `body` it received with invalid data.
+
+You could use it while developing your app to log the body and debug it, return it to the user, etc.
+
+```Python hl_lines="16"
+{!./src/handling_errors/tutorial005.py!}
+```
+
+Now try sending an invalid item like:
+
+```JSON
+{
+  "title": "towel",
+  "size": "XL"
+}
+```
+
+You will receive a response telling you that the data is invalid containing the received body:
+
+```JSON hl_lines="13 14 15 16"
+{
+  "detail": [
+    {
+      "loc": [
+        "body",
+        "item",
+        "size"
+      ],
+      "msg": "value is not a valid integer",
+      "type": "type_error.integer"
+    }
+  ],
+  "body": {
+    "title": "towel",
+    "size": "XL"
+  }
+}
+```
+
 #### FastAPI's `HTTPException` vs Starlette's `HTTPException`
 
 **FastAPI** has its own `HTTPException`.

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -21,7 +21,8 @@ WebSocketErrorModel = create_model("WebSocket")
 
 
 class RequestValidationError(ValidationError):
-    def __init__(self, errors: Sequence[ErrorList]) -> None:
+    def __init__(self, errors: Sequence[ErrorList], body: Any) -> None:
+        self.body = body
         if PYDANTIC_1:
             super().__init__(errors, RequestErrorModel)
         else:

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -21,7 +21,7 @@ WebSocketErrorModel = create_model("WebSocket")
 
 
 class RequestValidationError(ValidationError):
-    def __init__(self, errors: Sequence[ErrorList], body: Any) -> None:
+    def __init__(self, errors: Sequence[ErrorList], *, body: Any = None) -> None:
         self.body = body
         if PYDANTIC_1:
             super().__init__(errors, RequestErrorModel)

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -120,7 +120,7 @@ def get_request_handler(
         )
         values, errors, background_tasks, sub_response, _ = solved_result
         if errors:
-            raise RequestValidationError(errors)
+            raise RequestValidationError(errors, body)
         else:
             assert dependant.call is not None, "dependant.call must be a function"
             if is_coroutine:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -120,7 +120,7 @@ def get_request_handler(
         )
         values, errors, background_tasks, sub_response, _ = solved_result
         if errors:
-            raise RequestValidationError(errors, body)
+            raise RequestValidationError(errors, body=body)
         else:
             assert dependant.call is not None, "dependant.call must be a function"
             if is_coroutine:


### PR DESCRIPTION
FastAPI is awesome, and it's schema validation is one of it's key elements. 
While debugging issues in production, the current errors data isn't sufficient to understand if it's a bad schema definition (when the API is used by multiple sources, in different ways) or really a client defect.
Adding the body data to the error can help trace problems and reproducing the issue.
