### PR TITLE
this change fixes an issue we encountered with pydantic validator dec…

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -94,7 +94,7 @@ def create_cloned_field(field: ModelField) -> ModelField:
     if lenient_issubclass(original_type, BaseModel):
         original_type = cast(Type[BaseModel], original_type)
         use_type = create_model(
-            original_type.__name__, __config__=original_type.__config__
+            original_type.__name__, __base__=original_type
         )
         for f in original_type.__fields__.values():
             use_type.__fields__[f.name] = create_cloned_field(f)

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -93,9 +93,7 @@ def create_cloned_field(field: ModelField) -> ModelField:
     use_type = original_type
     if lenient_issubclass(original_type, BaseModel):
         original_type = cast(Type[BaseModel], original_type)
-        use_type = create_model(
-            original_type.__name__, __config__=original_type.__config__
-        )
+        use_type = create_model(original_type.__name__, __base__=original_type)
         for f in original_type.__fields__.values():
             use_type.__fields__[f.name] = create_cloned_field(f)
         use_type.__validators__ = original_type.__validators__

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -93,9 +93,7 @@ def create_cloned_field(field: ModelField) -> ModelField:
     use_type = original_type
     if lenient_issubclass(original_type, BaseModel):
         original_type = cast(Type[BaseModel], original_type)
-        use_type = create_model(
-            original_type.__name__, __base__=original_type
-        )
+        use_type = create_model(original_type.__name__, __base__=original_type)
         for f in original_type.__fields__.values():
             use_type.__fields__[f.name] = create_cloned_field(f)
         use_type.__validators__ = original_type.__validators__

--- a/tests/test_filter_pydantic_sub_model.py
+++ b/tests/test_filter_pydantic_sub_model.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from starlette.testclient import TestClient
 
 app = FastAPI()
@@ -17,6 +17,11 @@ class ModelA(BaseModel):
     name: str
     description: str = None
     model_b: ModelB
+
+    @validator("model_b")
+    def check_model_b(cls, model_b, values):
+        assert isinstance(model_b, ModelB)
+        return model_b
 
 
 async def get_model_c() -> ModelC:

--- a/tests/test_filter_pydantic_sub_model.py
+++ b/tests/test_filter_pydantic_sub_model.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from starlette.testclient import TestClient
 
 app = FastAPI()
@@ -17,6 +17,11 @@ class ModelA(BaseModel):
     name: str
     description: str = None
     model_b: ModelB
+
+    @validator('model_b')
+    def check_model_b(cls, model_b, values):
+        assert(isinstance(model_b, ModelB))
+        return model_b
 
 
 async def get_model_c() -> ModelC:

--- a/tests/test_filter_pydantic_sub_model.py
+++ b/tests/test_filter_pydantic_sub_model.py
@@ -18,9 +18,9 @@ class ModelA(BaseModel):
     description: str = None
     model_b: ModelB
 
-    @validator('model_b')
+    @validator("model_b")
     def check_model_b(cls, model_b, values):
-        assert(isinstance(model_b, ModelB))
+        assert isinstance(model_b, ModelB)
         return model_b
 
 


### PR DESCRIPTION
…orators

- create_model() is now called using a __base__ parameter vs. a __config__ parameter
- isinstance comparisons now work as expected
- unit test created for #889 still passes as before