### PR TITLE
    this change fixes an issue we encountered with pydantic validator…

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -96,7 +96,6 @@ def create_cloned_field(field: ModelField) -> ModelField:
         use_type = create_model(original_type.__name__, __base__=original_type)
         for f in original_type.__fields__.values():
             use_type.__fields__[f.name] = create_cloned_field(f)
-        use_type.__validators__ = original_type.__validators__
     if PYDANTIC_1:
         new_field = ModelField(
             name=field.name,

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -93,9 +93,7 @@ def create_cloned_field(field: ModelField) -> ModelField:
     use_type = original_type
     if lenient_issubclass(original_type, BaseModel):
         original_type = cast(Type[BaseModel], original_type)
-        use_type = create_model(
-            original_type.__name__, __config__=original_type.__config__
-        )
+        use_type = create_model(original_type.__name__, __base__=original_type)
         for f in original_type.__fields__.values():
             use_type.__fields__[f.name] = create_cloned_field(f)
         use_type.__validators__ = original_type.__validators__

--- a/tests/test_filter_pydantic_sub_model.py
+++ b/tests/test_filter_pydantic_sub_model.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from starlette.testclient import TestClient
 
 app = FastAPI()
@@ -17,6 +17,11 @@ class ModelA(BaseModel):
     name: str
     description: str = None
     model_b: ModelB
+
+    @validator("model_b")
+    def check_model_b(cls, model_b, values):
+        assert isinstance(model_b, ModelB)
+        return model_b
 
 
 async def get_model_c() -> ModelC:

--- a/tests/test_filter_pydantic_sub_model.py
+++ b/tests/test_filter_pydantic_sub_model.py
@@ -8,9 +8,19 @@ app = FastAPI()
 class ModelB(BaseModel):
     username: str
 
+    @validator("username")
+    def check_username(cls, username, values):
+        assert username == username.lower()
+        return username
+
 
 class ModelC(ModelB):
     password: str
+
+    @validator("password")
+    def check_password(cls, password, values):
+        assert len(password) >= 8
+        return password
 
 
 class ModelA(BaseModel):


### PR DESCRIPTION
… decorators

    - create_model() is now called using a __base__ parameter vs. a __config__ parameter
    - isinstance comparisons now work as expected
    - unit test created for #889 still passes as before
    - apply black formatting