### PR TITLE
OpenAPI schema generation: Don't convert all enums into str

### DIFF
--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -101,7 +101,7 @@ class SchemaBase(BaseModel):
     maxProperties: Optional[int] = Field(None, gte=0)
     minProperties: Optional[int] = Field(None, gte=0)
     required: Optional[List[str]] = None
-    enum: Optional[Union[List[int], List[float], List[str]]] = None
+    enum: Optional[List[Any]] = None
     type: Optional[str] = None
     allOf: Optional[List[Any]] = None
     oneOf: Optional[List[Any]] = None

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -101,7 +101,7 @@ class SchemaBase(BaseModel):
     maxProperties: Optional[int] = Field(None, gte=0)
     minProperties: Optional[int] = Field(None, gte=0)
     required: Optional[List[str]] = None
-    enum: Optional[List[str]] = None
+    enum: Optional[Union[List[int], List[float], List[str]]] = None
     type: Optional[str] = None
     allOf: Optional[List[Any]] = None
     oneOf: Optional[List[Any]] = None


### PR DESCRIPTION
Before doing this,the type of  values in `enum` could be at odds with `type` field.