### PR TITLE
Fix body parsing

### DIFF
--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -166,6 +166,30 @@ def test_openapi_schema():
                 ]
             },
         ),
+        (
+            "/items/5",
+            [],
+            422,
+            {
+                "detail": [
+                    {
+                        "loc": ["body", "item"],
+                        "msg": "field required",
+                        "type": "value_error.missing",
+                    },
+                    {
+                        "loc": ["body", "user"],
+                        "msg": "field required",
+                        "type": "value_error.missing",
+                    },
+                    {
+                        "loc": ["body", "importance"],
+                        "msg": "field required",
+                        "type": "value_error.missing",
+                    },
+                ]
+            },
+        ),
     ],
 )
 def test_post_body(path, body, expected_status, expected_response):


### PR DESCRIPTION
Closes #914 

I believe this is the "correct" way to fix this issue, as the provided body could be invalid in a number of ways, and this should handle anything that json could get parsed into. (The error message also seems appropriate to me even for malformed bodies.)

There was actually already a test for this, but it only checked for a (malformed) body of `None`, not `[]`, so it was easy to add a test case as another parametric case.

