### PR TITLE
📝 Fix broken layout in middleware docs

### DIFF
--- a/docs/tutorial/middleware.md
+++ b/docs/tutorial/middleware.md
@@ -28,8 +28,7 @@ The middleware function receives:
 !!! tip
     Have in mind that custom proprietary headers can be added <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers" class="external-link" target="_blank">using the 'X-' prefix</a>.
 
-    But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations ([CORS (Cross-Origin Resource Sharing)
-](cors.md){.internal-link target=_blank}) using the parameter `expose_headers` documented in <a href="https://www.starlette.io/middleware/#corsmiddleware" class="external-link" target="_blank">Starlette's CORS docs</a>.
+    But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations ([CORS (Cross-Origin Resource Sharing)](cors.md){.internal-link target=_blank}) using the parameter `expose_headers` documented in <a href="https://www.starlette.io/middleware/#corsmiddleware" class="external-link" target="_blank">Starlette's CORS docs</a>.
 
 ### Before and after the `response`
 


### PR DESCRIPTION
Current broken layout: https://fastapi.tiangolo.com/tutorial/middleware/#__code_0

Fixes #937.