### PR TITLE
Allow callables (as functools.partial) in path operations

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -335,9 +335,7 @@ class APIRoute(routing.Route):
         self.include_in_schema = include_in_schema
         self.response_class = response_class
 
-        assert inspect.isfunction(endpoint) or inspect.ismethod(
-            endpoint
-        ), f"An endpoint must be a function or method"
+        assert callable(endpoint), f"An endpoint must be a callable"
         self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
         for depends in self.dependencies[::-1]:
             self.dependant.dependencies.insert(

--- a/tests/test_callable_endpoint.py
+++ b/tests/test_callable_endpoint.py
@@ -1,0 +1,24 @@
+from functools import partial
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+
+def main(some_arg, q: str = None):
+    return {"some_arg": some_arg, "q": q}
+
+
+endpoint = partial(main, "foo")
+
+app = FastAPI()
+
+app.get("/")(endpoint)
+
+
+client = TestClient(app)
+
+
+def test_partial():
+    response = client.get("/?q=bar")
+    data = response.json()
+    assert data == {"some_arg": "foo", "q": "bar"}


### PR DESCRIPTION
:sparkles: Allow callables (as `functools.partial`) in path operations.

This would fix/related to #757