### PR TITLE
Fix path encoding

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from pathlib import PurePath
 from types import GeneratorType
 from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
@@ -73,6 +74,8 @@ def jsonable_encoder(
         )
     if isinstance(obj, Enum):
         return obj.value
+    if isinstance(obj, PurePath):
+        return str(obj)
     if isinstance(obj, (str, int, float, type(None))):
         return obj
     if isinstance(obj, dict):

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path, PosixPath, WindowsPath
 
 import pytest
 from fastapi.encoders import jsonable_encoder
@@ -69,6 +70,10 @@ class ModelWithAlias(BaseModel):
     foo: str = Field(..., alias="Foo")
 
 
+class ModelWithPath(BaseModel):
+    path: Path
+
+
 def test_encode_class():
     person = Person(name="Foo")
     pet = Pet(owner=person, name="Firulais")
@@ -120,3 +125,8 @@ def test_custom_encoders():
         instance, custom_encoder={safe_datetime: lambda o: o.isoformat()}
     )
     assert encoded_instance["dt_field"] == instance.dt_field.isoformat()
+
+
+def test_encode_model_with_path():
+    model = ModelWithPath(path="/foo/bar")
+    assert jsonable_encoder(model) == {"path": "/foo/bar"}

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -70,12 +70,16 @@ class ModelWithAlias(BaseModel):
     foo: str = Field(..., alias="Foo")
 
 
-@pytest.fixture(name="model_with_path", params=[PurePath, PurePosixPath, PureWindowsPath])
+@pytest.fixture(
+    name="model_with_path", params=[PurePath, PurePosixPath, PureWindowsPath]
+)
 def fixture_model_with_path(request):
     class Config:
         arbitrary_types_allowed = True
 
-    ModelWithPath = create_model("ModelWithPath", path=(request.param, ...), __config__=Config)
+    ModelWithPath = create_model(
+        "ModelWithPath", path=(request.param, ...), __config__=Config
+    )
     return ModelWithPath(path=request.param("/foo", "bar"))
 
 
@@ -133,5 +137,8 @@ def test_custom_encoders():
 
 
 def test_encode_model_with_path(model_with_path):
-    expected = "\\foo\\bar" if isinstance(model_with_path.path, PureWindowsPath) else "/foo/bar"
+    if isinstance(model_with_path.path, PureWindowsPath):
+        expected = "\\foo\\bar"
+    else:
+        expected = "/foo/bar"
     assert jsonable_encoder(model_with_path) == {"path": expected}


### PR DESCRIPTION
This PR adds a case to `jsonable_encoder` so that `pathlib.PurePath` objects are serializable. Related to https://github.com/tiangolo/fastapi/issues/563.

I know there was some discussion in that thread about how to handle the OS-dependent `str` representations of `pathlib.Path` objects. Perhaps I'm misunderstanding something, but shouldn't users who need OS-agnostic treatment of paths be using `pathlib.Pure*Path` types to get `str` representations in their native form, no matter where their code is running?

/cc @devtud