### PR TITLE
Fix markdown code section rendering error in SQL tutorial

### DIFF
--- a/docs/advanced/sql-databases-peewee.md
+++ b/docs/advanced/sql-databases-peewee.md
@@ -429,31 +429,31 @@ Repeat the same process with the 10 tabs. This time all of them will wait and yo
 
 * `sql_app/database.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases_peewee/sql_app/database.py!}
 ```
 
 * `sql_app/models.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases_peewee/sql_app/models.py!}
 ```
 
 * `sql_app/schemas.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases_peewee/sql_app/schemas.py!}
 ```
 
 * `sql_app/crud.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases_peewee/sql_app/crud.py!}
 ```
 
 * `sql_app/main.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases_peewee/sql_app/main.py!}
 ```
 

--- a/docs/tutorial/sql-databases.md
+++ b/docs/tutorial/sql-databases.md
@@ -558,31 +558,31 @@ For example, in a background task worker with <a href="http://www.celeryproject.
 
 * `sql_app/database.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases/sql_app/database.py!}
 ```
 
 * `sql_app/models.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases/sql_app/models.py!}
 ```
 
 * `sql_app/schemas.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases/sql_app/schemas.py!}
 ```
 
 * `sql_app/crud.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases/sql_app/crud.py!}
 ```
 
 * `sql_app/main.py`:
 
-```Python hl_lines=""
+```Python
 {!./src/sql_databases/sql_app/main.py!}
 ```
 


### PR DESCRIPTION
Currently the [Migrations](https://fastapi.tiangolo.com/tutorial/sql-databases/#migrations) section and below is rendering incorrectly because of unused `hl_lines` sections. I think this should fix it.