### PR TITLE
Moved endpoint execution outside of get_request_handler for profiling

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -87,12 +87,14 @@ async def serialize_response(
         return jsonable_encoder(response)
 
 
-async def _run_endpoint(dependant: Dependant, values: Dict[str, Any]) -> Any:
+async def run_endpoint_function(
+    *, dependant: Dependant, values: Dict[str, Any], is_coroutine: bool
+) -> Any:
     # Only called by get_request_handler. Has been split into its own function to
     # facilitate profiling endpoints, since inner functions are harder to profile.
     assert dependant.call is not None, "dependant.call must be a function"
 
-    if asyncio.iscoroutinefunction(dependant.call):
+    if is_coroutine:
         return await dependant.call(**values)
     else:
         return await run_in_threadpool(dependant.call, **values)
@@ -139,7 +141,9 @@ def get_request_handler(
         if errors:
             raise RequestValidationError(errors, body=body)
         else:
-            raw_response = await _run_endpoint(dependant, values)
+            raw_response = await run_endpoint_function(
+                dependant=dependant, values=values, is_coroutine=is_coroutine
+            )
 
             if isinstance(raw_response, Response):
                 if raw_response.background is None:


### PR DESCRIPTION
At the reccomendation of @tiangolo in https://github.com/tiangolo/fastapi/issues/701#issuecomment-585319420, I have moved the endpoint execution section from `routing.get_request_handler.<locals>.app` to a separate function (currently named `_run_endpoint`) in order to facilitate profiling. Internal functions and callable object properties make it difficult for profilers to identify the function object being called, and since each request is only associated to one endpoint (not counting dependencies), this makes possible to simply profile "the endpoit that was used" for any given request.