### PR TITLE
Fix typo

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -494,7 +494,7 @@
 
 ## 0.16.0
 
-* Upgrade *path operation* `doctsring` parsing to support proper Markdown descriptions. New documentation at [Path Operation Configuration](https://fastapi.tiangolo.com/tutorial/path-operation-configuration/#description-from-docstring). PR [#163](https://github.com/tiangolo/fastapi/pull/163).
+* Upgrade *path operation* `docstring` parsing to support proper Markdown descriptions. New documentation at [Path Operation Configuration](https://fastapi.tiangolo.com/tutorial/path-operation-configuration/#description-from-docstring). PR [#163](https://github.com/tiangolo/fastapi/pull/163).
 
 * Refactor internal usage of Pydantic to use correct data types. PR [#164](https://github.com/tiangolo/fastapi/pull/164).
 


### PR DESCRIPTION
I found a typo in the release notes.

References:

- https://fastapi.tiangolo.com/release-notes/#0160