### PR TITLE
convert json schema const to enum for openapi

### DIFF
--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+
+def test_enum_const_jsonschema_conversion():
+    app = FastAPI()
+
+    class Model(BaseModel):
+        constant = Field("a", const=True)
+
+    @app.get("/", response_model=Model)
+    def f():
+        pass  # pragma: no cover
+
+    openapi = app.openapi()
+    assert isinstance(openapi, dict)
+    assert openapi["components"]["schemas"]["Model"]["properties"] == {
+        "constant": {"title": "Constant", "type": "string", "enum": ["a"]}
+    }


### PR DESCRIPTION
OpenAPI does not support `const`, but JSON schema output by pydantic
can include it. `const` is just syntactic sugar for a single element enum,
so let's convert it instead of just dropping it.

ref: https://json-schema.org/understanding-json-schema/reference/generic.html#constant-values