### PR TITLE
Handle automatic embedding with Depends

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -703,20 +703,13 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         return None
     first_param = flat_dependant.body_params[0]
     field_info = get_field_info(first_param)
-    should_not_embed = not getattr(field_info, "embed", None)
-    if should_not_embed:
-        if len(flat_dependant.body_params) == 1:
-            should_not_embed = True
-        elif len(flat_dependant.body_params) == 2:
-            should_not_embed = (
-                flat_dependant.body_params[0].name == flat_dependant.body_params[1].name
-            )
-        else:
-            should_not_embed = False
-
-    if should_not_embed:
+    embed = getattr(field_info, "embed", None)
+    body_param_names_set = set([param.name for param in flat_dependant.body_params])
+    if len(body_param_names_set) == 1 and not embed:
         return get_schema_compatible_field(field=first_param)
-    # If we embed, then internally ensure that all fields are embedded
+    # If one field requires to embed, all have to be embedded
+    # in case a sub-dependency is evaluated with a single unique body field
+    # That is combined (embedded) with other body fields
     for param in flat_dependant.body_params:
         setattr(get_field_info(param), "embed", True)
     model_name = "Body_" + name

--- a/tests/test_dependency_duplicates.py
+++ b/tests/test_dependency_duplicates.py
@@ -1,0 +1,65 @@
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+app = FastAPI()
+
+client = TestClient(app)
+
+
+class Item(BaseModel):
+    data: str
+
+
+def duplicate_dependency(item: Item):
+    return item
+
+
+def dependency(item2: Item):
+    return item2
+
+
+@app.post("/with-duplicates")
+async def with_duplicates(item: Item, item2: Item = Depends(duplicate_dependency)):
+    return [item, item2]
+
+
+@app.post("/no-duplicates")
+async def no_duplicates(item: Item, item2: Item = Depends(dependency)):
+    return [item, item2]
+
+
+@pytest.mark.parametrize(
+    "params,status_code,expected",
+    [
+        (
+            {"item": {"data": "myitem"}},
+            422,
+            {
+                "detail": [
+                    {
+                        "loc": ["body", "item2"],
+                        "msg": "field required",
+                        "type": "value_error.missing",
+                    }
+                ]
+            },
+        ),
+        (
+            {"item": {"data": "myitem"}, "item2": {"data": "myitem2"}},
+            200,
+            [{"data": "myitem"}, {"data": "myitem2"}],
+        ),
+    ],
+)
+def test_no_duplicates(params, status_code, expected):
+    response = client.post("/no-duplicates", json=params)
+    assert response.status_code == status_code
+    assert response.json() == expected
+
+
+def test_duplicates():
+    response = client.post("/with-duplicates", json={"data": "myitem"})
+    assert response.status_code == 200
+    assert response.json() == [{"data": "myitem"}, {"data": "myitem"}]

--- a/tests/test_dependency_duplicates.py
+++ b/tests/test_dependency_duplicates.py
@@ -1,4 +1,5 @@
-import pytest
+from typing import List
+
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
@@ -20,6 +21,12 @@ def dependency(item2: Item):
     return item2
 
 
+def sub_duplicate_dependency(
+    item: Item, sub_item: Item = Depends(duplicate_dependency)
+):
+    return [item, sub_item]
+
+
 @app.post("/with-duplicates")
 async def with_duplicates(item: Item, item2: Item = Depends(duplicate_dependency)):
     return [item, item2]
@@ -30,36 +37,196 @@ async def no_duplicates(item: Item, item2: Item = Depends(dependency)):
     return [item, item2]
 
 
-@pytest.mark.parametrize(
-    "params,status_code,expected",
-    [
-        (
-            {"item": {"data": "myitem"}},
-            422,
-            {
-                "detail": [
-                    {
-                        "loc": ["body", "item2"],
-                        "msg": "field required",
-                        "type": "value_error.missing",
-                    }
-                ]
+@app.post("/with-duplicates-sub")
+async def no_duplicates_sub(
+    item: Item, sub_items: List[Item] = Depends(sub_duplicate_dependency)
+):
+    return [item, sub_items]
+
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "FastAPI", "version": "0.1.0"},
+    "paths": {
+        "/with-duplicates": {
+            "post": {
+                "summary": "With Duplicates",
+                "operationId": "with_duplicates_with_duplicates_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/Item"}
+                        }
+                    },
+                    "required": True,
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/no-duplicates": {
+            "post": {
+                "summary": "No Duplicates",
+                "operationId": "no_duplicates_no_duplicates_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_no_duplicates_no_duplicates_post"
+                            }
+                        }
+                    },
+                    "required": True,
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/with-duplicates-sub": {
+            "post": {
+                "summary": "No Duplicates Sub",
+                "operationId": "no_duplicates_sub_with_duplicates_sub_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/Item"}
+                        }
+                    },
+                    "required": True,
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "Body_no_duplicates_no_duplicates_post": {
+                "title": "Body_no_duplicates_no_duplicates_post",
+                "required": ["item", "item2"],
+                "type": "object",
+                "properties": {
+                    "item": {"$ref": "#/components/schemas/Item"},
+                    "item2": {"$ref": "#/components/schemas/Item"},
+                },
             },
-        ),
-        (
-            {"item": {"data": "myitem"}, "item2": {"data": "myitem2"}},
-            200,
-            [{"data": "myitem"}, {"data": "myitem2"}],
-        ),
-    ],
-)
-def test_no_duplicates(params, status_code, expected):
-    response = client.post("/no-duplicates", json=params)
-    assert response.status_code == status_code
-    assert response.json() == expected
+            "HTTPValidationError": {
+                "title": "HTTPValidationError",
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "title": "Detail",
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/ValidationError"},
+                    }
+                },
+            },
+            "Item": {
+                "title": "Item",
+                "required": ["data"],
+                "type": "object",
+                "properties": {"data": {"title": "Data", "type": "string"}},
+            },
+            "ValidationError": {
+                "title": "ValidationError",
+                "required": ["loc", "msg", "type"],
+                "type": "object",
+                "properties": {
+                    "loc": {
+                        "title": "Location",
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "msg": {"title": "Message", "type": "string"},
+                    "type": {"title": "Error Type", "type": "string"},
+                },
+            },
+        }
+    },
+}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == openapi_schema
+
+
+def test_no_duplicates_invalid():
+    response = client.post("/no-duplicates", json={"item": {"data": "myitem"}})
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "loc": ["body", "item2"],
+                "msg": "field required",
+                "type": "value_error.missing",
+            }
+        ]
+    }
+
+
+def test_no_duplicates():
+    response = client.post(
+        "/no-duplicates",
+        json={"item": {"data": "myitem"}, "item2": {"data": "myitem2"}},
+    )
+    assert response.status_code == 200
+    assert response.json() == [{"data": "myitem"}, {"data": "myitem2"}]
 
 
 def test_duplicates():
     response = client.post("/with-duplicates", json={"data": "myitem"})
     assert response.status_code == 200
     assert response.json() == [{"data": "myitem"}, {"data": "myitem"}]
+
+
+def test_sub_duplicates():
+    response = client.post("/with-duplicates-sub", json={"data": "myitem"})
+    assert response.status_code == 200
+    assert response.json() == [
+        {"data": "myitem"},
+        [{"data": "myitem"}, {"data": "myitem"}],
+    ]


### PR DESCRIPTION
Two issues:
1) Whether or not to embed automatically wasn't taking into account the fact that `flat_dependant.body_params` could have repeated fields with the same name (Such as from a dependency chain). Fix: Look at unique names in `flat_dependant.body_params`, and do not embed if there's only one unique name and embed is false.
2) When processing the param body, automatically embedded bodies were sometimes processed incorrectly because we look at `Depends` parameters one-by-one. Ideally we look at ALL body parameters, but this doesn't seem to be available at the time when we process dependency bodies. The fix here is to set the `embed` parameter on field info for all params. (Not sure if there's a better fix).

TODO:
This case is undefined behavior and currently doesn't throw an error but perhaps it should? (Multiple types for the same body)
```
from fastapi import FastAPI, Depends, Body
from pydantic import BaseModel

app = FastAPI(title='test')

class Item(BaseModel):
    data: str

def dependency(item: str):
    return item

@app.post("/no-duplicates")
async def no_duplicates(item: Item, item2: Item = Depends(dependency)):
    return [item, item2]
```