### PR TITLE
Export startlette status as a var instead of directly from startlette

### DIFF
--- a/docs/src/wsgi/tutorial001.py
+++ b/docs/src/wsgi/tutorial001.py
@@ -1,6 +1,6 @@
-from flask import Flask, escape, request
 from fastapi import FastAPI
 from fastapi.middleware.wsgi import WSGIMiddleware
+from flask import Flask, escape, request
 
 flask_app = Flask(__name__)
 

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -2,7 +2,8 @@
 
 __version__ = "0.52.0"
 
-from starlette import status
+from starlette import status as starlette_status
+status = starlette_status
 
 from .applications import FastAPI
 from .background import BackgroundTasks

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -3,7 +3,6 @@
 __version__ = "0.52.0"
 
 from starlette import status as starlette_status
-status = starlette_status
 
 from .applications import FastAPI
 from .background import BackgroundTasks
@@ -24,3 +23,5 @@ from .requests import Request
 from .responses import Response
 from .routing import APIRouter
 from .websockets import WebSocket
+
+status = starlette_status


### PR DESCRIPTION
I'm not sure if this is worth doing but it shouldn't cause any harm(?).

Doing the import like this tricks PyCharm into showing `fastapi.status` instead of `startlette.status`...
<img width="351" alt="Screen Shot 2020-03-04 at 12 33 14 AM" src="https://user-images.githubusercontent.com/1762009/75859904-c096f500-5daf-11ea-8aea-79ca6645c9dc.png">
