### PR TITLE
Allow subclasses of known types to be encoded with superclass encoder

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -126,15 +126,17 @@ def jsonable_encoder(
         return encoded_list
 
     if custom_encoder:
-        if type(obj) in custom_encoder:
-            return custom_encoder[type(obj)](obj)
+        for base in obj.__class__.__mro__:
+            if base in custom_encoder:
+                return custom_encoder[base](obj)
         else:
             for encoder_type, encoder in custom_encoder.items():
                 if isinstance(obj, encoder_type):
                     return encoder(obj)
 
-    if type(obj) in ENCODERS_BY_TYPE:
-        return ENCODERS_BY_TYPE[type(obj)](obj)
+    for base in obj.__class__.__mro__:
+        if base in ENCODERS_BY_TYPE:
+            return ENCODERS_BY_TYPE[base](obj)
     for encoder, classes_tuple in encoders_by_class_tuples.items():
         if isinstance(obj, classes_tuple):
             return encoder(obj)

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -43,6 +43,14 @@ class Unserializable:
         raise NotImplementedError()
 
 
+class Subclass(datetime):
+    pass
+
+
+class ModelWithSubclass(BaseModel):
+    dt_field: Subclass
+
+
 class ModelWithCustomEncoder(BaseModel):
     dt_field: datetime
 
@@ -89,6 +97,11 @@ def test_encode_class():
     assert jsonable_encoder(pet) == {"name": "Firulais", "owner": {"name": "Foo"}}
 
 
+def test_encode_subclass():
+    model = ModelWithSubclass(dt_field=Subclass(2020, 2, 2, 2, 2, 2))
+    assert jsonable_encoder(model) == {"dt_field": "2020-02-02T02:02:02"}
+
+
 def test_encode_dictable():
     person = DictablePerson(name="Foo")
     pet = DictablePet(owner=person, name="Firulais")
@@ -103,6 +116,11 @@ def test_encode_unsupported():
 
 def test_encode_custom_json_encoders_model():
     model = ModelWithCustomEncoder(dt_field=datetime(2019, 1, 1, 8))
+    assert jsonable_encoder(model) == {"dt_field": "2019-01-01T08:00:00+00:00"}
+
+
+def test_encode_custom_json_encoders_model_with_subclass():
+    model = ModelWithCustomEncoder(dt_field=Subclass(2019, 1, 1, 8))
     assert jsonable_encoder(model) == {"dt_field": "2019-01-01T08:00:00+00:00"}
 
 


### PR DESCRIPTION
Implementation of https://github.com/samuelcolvin/pydantic/pull/1291 which was closed due to performance concerns, another option was attempted but found to be 50% slower in a related issue here: https://github.com/samuelcolvin/pydantic/issues/1157#issuecomment-572450669

I have not seen the same results in benchmarking pydantic, so I wanted to open this here to see if the performance impact is the same.