### PR TITLE
Rename a function in tutorial

### DIFF
--- a/docs_src/path_params/tutorial004.py
+++ b/docs_src/path_params/tutorial004.py
@@ -4,5 +4,5 @@ app = FastAPI()
 
 
 @app.get("/files/{file_path:path}")
-async def read_user_me(file_path: str):
+async def read_file(file_path: str):
     return {"file_path": file_path}

--- a/tests/test_tutorial/test_path_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial004.py
@@ -26,8 +26,8 @@ openapi_schema = {
                         },
                     },
                 },
-                "summary": "Read User Me",
-                "operationId": "read_user_me_files__file_path__get",
+                "summary": "Read File",
+                "operationId": "read_file_files__file_path__get",
                 "parameters": [
                     {
                         "required": True,


### PR DESCRIPTION
[Path Parameters - FastAPI](https://fastapi.tiangolo.com/tutorial/path-params/#path-convertor)

```python
from fastapi import FastAPI

app = FastAPI()


@app.get("/files/{file_path:path}")
async def read_user_me(file_path: str):
    return {"file_path": file_path}
```

I changed the name of the above function from `read_user_me` to `read_file`.