### PR TITLE
Fix GZipMiddleware code block linking to TrustedHostMiddleware

### DIFF
--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -78,8 +78,8 @@ Handles GZip responses for any request that includes `"gzip"` in the `Accept-Enc
 
 The middleware will handle both standard and streaming responses.
 
-```Python hl_lines="2  6 7 8"
-{!../../../docs_src/advanced_middleware/tutorial002.py!}
+```Python hl_lines="2  6"
+{!../../../docs_src/advanced_middleware/tutorial003.py!}
 ```
 
 The following arguments are supported:


### PR DESCRIPTION
In https://fastapi.tiangolo.com/advanced/middleware/#gzipmiddleware

### **BEFORE**

![image](https://user-images.githubusercontent.com/2302748/77056663-06b89f00-69d3-11ea-8d00-1a9897ca1d46.png)

### **AFTER**

![image](https://user-images.githubusercontent.com/2302748/77056731-2780f480-69d3-11ea-83d7-7d5e1aa2dc8b.png)



