### PR TITLE
📝 Fix GZipMiddleware example in "Advanced Middlewares"

### DIFF
--- a/docs/advanced/middleware.md
+++ b/docs/advanced/middleware.md
@@ -76,8 +76,8 @@ Handles GZip responses for any request that includes `"gzip"` in the `Accept-Enc
 
 The middleware will handle both standard and streaming responses.
 
-```Python hl_lines="2  6 7 8"
-{!./src/advanced_middleware/tutorial002.py!}
+```Python hl_lines="2  6"
+{!./src/advanced_middleware/tutorial003.py!}
 ```
 
 The following arguments are supported:


### PR DESCRIPTION
I noticed the Gzip example is the same as the one for TrustedDomains. You already had the example code. I linked to the correct file and changed the highlights. 

This is my first time contributing to this project. Here's what I did:
- [x] read the page on [contributing](https://fastapi.tiangolo.com/contributing/)
- [x] created the environment locally
- [x] ran the script to generate the docs 
- [x] tested the modified docs on browser

Please let me know if I missed something, or if you'd like changes. 
Thanks for building and maintaining such an awesome project :smiley: 