### PR TITLE
Apply openapi_prefix to redirect URL

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -40,7 +40,7 @@ class FastAPI(Starlette):
         default_response_class: Type[Response] = JSONResponse,
         docs_url: Optional[str] = "/docs",
         redoc_url: Optional[str] = "/redoc",
-        swagger_ui_oauth2_redirect_url: str = "/docs/oauth2-redirect",
+        swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
         swagger_ui_init_oauth: Optional[dict] = None,
         middleware: Sequence[Middleware] = None,
         exception_handlers: Dict[Union[int, Type[Exception]], Callable] = None,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -40,7 +40,7 @@ class FastAPI(Starlette):
         default_response_class: Type[Response] = JSONResponse,
         docs_url: Optional[str] = "/docs",
         redoc_url: Optional[str] = "/redoc",
-        swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
+        swagger_ui_oauth2_redirect_url: str = "/docs/oauth2-redirect",
         swagger_ui_init_oauth: Optional[dict] = None,
         middleware: Sequence[Middleware] = None,
         exception_handlers: Dict[Union[int, Type[Exception]], Callable] = None,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -40,7 +40,7 @@ class FastAPI(Starlette):
         default_response_class: Type[Response] = JSONResponse,
         docs_url: Optional[str] = "/docs",
         redoc_url: Optional[str] = "/redoc",
-        swagger_ui_oauth2_redirect_url: str = "/docs/oauth2-redirect",
+        swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
         swagger_ui_init_oauth: Optional[dict] = None,
         middleware: Sequence[Middleware] = None,
         exception_handlers: Dict[Union[int, Type[Exception]], Callable] = None,
@@ -110,11 +110,15 @@ class FastAPI(Starlette):
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
+                if self.swagger_ui_oauth2_redirect_url:
+                    redirect_url = self.openapi_prefix + str(
+                        self.swagger_ui_oauth2_redirect_url
+                    )
+
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=self.openapi_prefix
-                    + self.swagger_ui_oauth2_redirect_url,
+                    oauth2_redirect_url=redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                 )
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -110,10 +110,15 @@ class FastAPI(Starlette):
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
+                if isinstance(self.openapi_prefix, str):
+                    redirect_url_temp = self.openapi_prefix + self.swagger_ui_oauth2_redirect_url
+                else:
+                    redirect_url_temp = self.swagger_ui_oauth2_redirect_url
+
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=self.openapi_prefix + self.swagger_ui_oauth2_redirect_url,
+                    oauth2_redirect_url=redirect_url_temp,
                     init_oauth=self.swagger_ui_init_oauth,
                 )
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -40,7 +40,7 @@ class FastAPI(Starlette):
         default_response_class: Type[Response] = JSONResponse,
         docs_url: Optional[str] = "/docs",
         redoc_url: Optional[str] = "/redoc",
-        swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
+        swagger_ui_oauth2_redirect_url: str = "/docs/oauth2-redirect",
         swagger_ui_init_oauth: Optional[dict] = None,
         middleware: Sequence[Middleware] = None,
         exception_handlers: Dict[Union[int, Type[Exception]], Callable] = None,
@@ -113,7 +113,7 @@ class FastAPI(Starlette):
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=self.openapi_prefix + str(self.swagger_ui_oauth2_redirect_url),
+                    oauth2_redirect_url=self.openapi_prefix + self.swagger_ui_oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                 )
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -110,15 +110,10 @@ class FastAPI(Starlette):
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
-                if isinstance(self.swagger_ui_oauth2_redirect_url, str):
-                    redirect_url_temp = self.openapi_prefix + self.swagger_ui_oauth2_redirect_url
-                else:
-                    redirect_url_temp = self.swagger_ui_oauth2_redirect_url
-
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=redirect_url_temp,
+                    oauth2_redirect_url=self.openapi_prefix + str(self.swagger_ui_oauth2_redirect_url),
                     init_oauth=self.swagger_ui_init_oauth,
                 )
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -114,6 +114,8 @@ class FastAPI(Starlette):
                     redirect_url_temp = self.openapi_prefix + str(
                         self.swagger_ui_oauth2_redirect_url
                     )
+                else:
+                    redirect_url_temp = self.swagger_ui_oauth2_redirect_url
 
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -110,12 +110,12 @@ class FastAPI(Starlette):
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
+                redirect_url_temp: Optional[str] = self.swagger_ui_oauth2_redirect_url
+
                 if self.swagger_ui_oauth2_redirect_url:
                     redirect_url_temp = self.openapi_prefix + str(
                         self.swagger_ui_oauth2_redirect_url
                     )
-                else:
-                    redirect_url_temp = self.swagger_ui_oauth2_redirect_url
 
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -110,7 +110,7 @@ class FastAPI(Starlette):
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
-                if isinstance(self.openapi_prefix, str):
+                if isinstance(self.swagger_ui_oauth2_redirect_url, str):
                     redirect_url_temp = self.openapi_prefix + self.swagger_ui_oauth2_redirect_url
                 else:
                     redirect_url_temp = self.swagger_ui_oauth2_redirect_url

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -113,7 +113,8 @@ class FastAPI(Starlette):
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=self.openapi_prefix + self.swagger_ui_oauth2_redirect_url,
+                    oauth2_redirect_url=self.openapi_prefix
+                    + self.swagger_ui_oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                 )
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -111,14 +111,14 @@ class FastAPI(Starlette):
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
                 if self.swagger_ui_oauth2_redirect_url:
-                    redirect_url = self.openapi_prefix + str(
+                    redirect_url_temp = self.openapi_prefix + str(
                         self.swagger_ui_oauth2_redirect_url
                     )
 
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=redirect_url,
+                    oauth2_redirect_url=redirect_url_temp,
                     init_oauth=self.swagger_ui_init_oauth,
                 )
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -113,7 +113,7 @@ class FastAPI(Starlette):
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=self.swagger_ui_oauth2_redirect_url,
+                    oauth2_redirect_url=self.openapi_prefix + self.swagger_ui_oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                 )
 


### PR DESCRIPTION
For my application I need to use Apache as a Reverse Proxy, like this:
```
<VirtualHost *:80>
    ServerName ${SERVER_NAME}
    DocumentRoot ${SERVER_DOCUMENT_ROOT}
    ##  Other Redirects
    
    ## FastApi App
    Redirect permanent /app    ${SERVER_NAME}:/app
</VirtualHost>

<VirtualHost *:443>
    ProxyPass         "/app" "http://localhost:57012"
    ProxyPassReverse  "/app" "http://localhost:57012"

```
In order to do this, I have to setup the fastapi app with the following settings:

```
app = FastAPI(
    title="app",
    description="Ipsum Lorem",
    openapi_prefix="/app",
    swagger_ui_init_oauth={"clientId": "app-id",},
)
```
The openapi_prefix is needed to set up the application behind a reverse proxy as carefully explained in FastApi documentation, otherwise `openapi.json` is not served in the right place. But, for some reason this openapi_prefix was not being applied on the oauth2 redirect_uri in the swagger html generator.