### PR TITLE
Add notes about using `typing.Dict` inplace of a Pydantic model

### DIFF
--- a/docs/tutorial/body-updates.md
+++ b/docs/tutorial/body-updates.md
@@ -95,3 +95,5 @@ In summary, to apply partial updates you would:
     So, if you want to receive partial updates that can omit all the attributes, you need to have a model with all the attributes marked as optional (with default values or `None`).
 
     To distinguish from the models with all optional values for **updates** and models with required values for **creation**, you can use the ideas described in [Extra Models](extra-models.md){.internal-link target=_blank}.
+
+    Alternatively you can use a type annotation of `typing.Dict` in place of a Pydantic model.

--- a/docs/tutorial/body.md
+++ b/docs/tutorial/body.md
@@ -138,8 +138,8 @@ The function parameters will be recognized as follows:
 
 * If the parameter is also declared in the **path**, it will be used as a path parameter.
 * If the parameter is of a **singular type** (like `int`, `float`, `str`, `bool`, etc) it will be interpreted as a **query** parameter.
-* If the parameter is declared to be of the type of a **Pydantic model**, it will be interpreted as a request **body**.
+* If the parameter is declared to be of the type of a **Pydantic model** or a **typing.Dict**, it will be interpreted as a request **body**.
 
 ## Without Pydantic
 
-If you don't want to use Pydantic models, you can also use **Body** parameters. See the docs for [Body - Multiple Parameters: Singular values in body](body-multiple-params.md#singular-values-in-body){.internal-link target=_blank}.
+If you don't want to use Pydantic models, you can just use **typing.Dict** or use **Body** parameters. See the docs for [Body - Multiple Parameters: Singular values in body](body-multiple-params.md#singular-values-in-body){.internal-link target=_blank}.


### PR DESCRIPTION
There are good recommendations for Models and partial updates with PATCH.
However, I believe it's worth pointing out that `typing.Dict` can be used in place of a pydantic model.

https://fastapi.tiangolo.com/tutorial/body-updates/#partial-updates-recap
https://fastapi.tiangolo.com/tutorial/extra-models/

```python
from typing import Dict

@app.patch("/items/{id}")
def patch_item(item_patch: Dict):
```