### PR TITLE
FIX: #1149 Use the correct docs_src file for GZipMiddleware example

### DIFF
--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -79,7 +79,7 @@ Handles GZip responses for any request that includes `"gzip"` in the `Accept-Enc
 The middleware will handle both standard and streaming responses.
 
 ```Python hl_lines="2  6 7 8"
-{!../../../docs_src/advanced_middleware/tutorial002.py!}
+{!../../../docs_src/advanced_middleware/tutorial003.py!}
 ```
 
 The following arguments are supported:


### PR DESCRIPTION
Fixes #1149 