### PR TITLE
Update badge for coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://travis-ci.com/tiangolo/fastapi.svg?branch=master" alt="Build Status">
 </a>
 <a href="https://codecov.io/gh/tiangolo/fastapi" target="_blank">
-    <img src="https://codecov.io/gh/tiangolo/fastapi/branch/master/graph/badge.svg" alt="Coverage">
+    <img src="https://img.shields.io/codecov/c/github/tiangolo/fastapi" alt="Coverage">
 </a>
 <a href="https://pypi.org/project/fastapi" target="_blank">
     <img src="https://badge.fury.io/py/fastapi.svg" alt="Package version">

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -9,7 +9,7 @@
     <img src="https://travis-ci.com/tiangolo/fastapi.svg?branch=master" alt="Build Status">
 </a>
 <a href="https://codecov.io/gh/tiangolo/fastapi" target="_blank">
-    <img src="https://codecov.io/gh/tiangolo/fastapi/branch/master/graph/badge.svg" alt="Coverage">
+    <img src="https://img.shields.io/codecov/c/github/tiangolo/fastapi" alt="Coverage">
 </a>
 <a href="https://pypi.org/project/fastapi" target="_blank">
     <img src="https://badge.fury.io/py/fastapi.svg" alt="Package version">

--- a/docs/es/docs/index.md
+++ b/docs/es/docs/index.md
@@ -9,7 +9,7 @@
     <img src="https://travis-ci.com/tiangolo/fastapi.svg?branch=master" alt="Build Status">
 </a>
 <a href="https://codecov.io/gh/tiangolo/fastapi" target="_blank">
-    <img src="https://codecov.io/gh/tiangolo/fastapi/branch/master/graph/badge.svg" alt="Coverage">
+    <img src="https://img.shields.io/codecov/c/github/tiangolo/fastapi" alt="Coverage">
 </a>
 <a href="https://pypi.org/project/fastapi" target="_blank">
     <img src="https://badge.fury.io/py/fastapi.svg" alt="Package version">


### PR DESCRIPTION
:art: Update badge for coverage. Use Shields.io, as Codecov's one shows coverage for the last PR from a fork from `master`.

So, it some times shows 99%, or 40% or different things, if a PR that is not yet merged has a lower coverage.