### PR TITLE
Ignore env directory on version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ test.db
 log.txt
 Pipfile.lock
 env3.*
+env
 docs_build


### PR DESCRIPTION
As the [development instructions](https://fastapi.tiangolo.com/contributing/#virtual-environment-with-venv) are to create an env, we should ignore it to avoid mistakes.