### PR TITLE
add a switch to disable all output docs in fastapi

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -28,10 +28,10 @@ from starlette.types import Receive, Scope, Send
 
 
 class _DocsVisibilitySettings(BaseSettings):
-    fastapi_disable_all_docs: bool = False
-    fastapi_disable_openapi_docs = False
-    fastapi_disable_swagger_docs: bool = False
-    fastapi_disable_redocs: bool = False
+    fastapi_enable_all_docs: bool = True
+    fastapi_enable_openapi_docs = True
+    fastapi_enable_swagger_docs: bool = True
+    fastapi_enable_redocs: bool = True
 
 
 class FastAPI(Starlette):
@@ -109,10 +109,10 @@ class FastAPI(Starlette):
         return self.openapi_schema
 
     def setup(self) -> None:
-        if not self.__docs_visibility_settings.fastapi_disable_all_docs:
+        if self.__docs_visibility_settings.fastapi_enable_all_docs:
             if (
                 self.openapi_url
-                and not self.__docs_visibility_settings.fastapi_disable_openapi_docs
+                and self.__docs_visibility_settings.fastapi_enable_openapi_docs
             ):
 
                 async def openapi(req: Request) -> JSONResponse:
@@ -123,8 +123,8 @@ class FastAPI(Starlette):
             if (
                 self.openapi_url
                 and self.docs_url
-                and not self.__docs_visibility_settings.fastapi_disable_swagger_docs
-                and not self.__docs_visibility_settings.fastapi_disable_openapi_docs
+                and self.__docs_visibility_settings.fastapi_enable_swagger_docs
+                and self.__docs_visibility_settings.fastapi_enable_openapi_docs
             ):
 
                 async def swagger_ui_html(req: Request) -> HTMLResponse:
@@ -150,8 +150,8 @@ class FastAPI(Starlette):
             if (
                 self.openapi_url
                 and self.redoc_url
-                and not self.__docs_visibility_settings.fastapi_disable_redocs
-                and not self.__docs_visibility_settings.fastapi_disable_openapi_docs
+                and self.__docs_visibility_settings.fastapi_enable_redocs
+                and self.__docs_visibility_settings.fastapi_enable_openapi_docs
             ):
 
                 async def redoc_html(req: Request) -> HTMLResponse:

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -87,7 +87,7 @@ class FastAPI(Starlette):
         if self.docs_url or self.redoc_url:
             assert self.openapi_url, "The openapi_url is required for the docs"
         self.openapi_schema: Optional[Dict[str, Any]] = None
-        self.__disable_all_outpu_docs = disable_all_output_docs
+        self.__disable_all_output_docs = disable_all_output_docs
         self.setup()
 
     def openapi(self) -> Dict:
@@ -104,7 +104,7 @@ class FastAPI(Starlette):
 
     def setup(self) -> None:
         if (
-            not self.__disable_all_outpu_docs
+            not self.__disable_all_output_docs
             and os.getenv("FASTAPT_ENVIRONMENT") != "PRODUCTION"
         ):
             if self.openapi_url:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,4 +1,8 @@
+import os
+
 import pytest
+
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from .main import app
@@ -1135,6 +1139,22 @@ def test_swagger_ui():
         f"oauth2RedirectUrl: window.location.origin + '/docs/oauth2-redirect'"
         in response.text
     )
+
+
+def test_swagger_ui_disabled_by_environment_variable():
+    os.environ["FASTAPT_ENVIRONMENT"] = "PRODUCTION"
+    temp_app = FastAPI()
+    temp_client = TestClient(temp_app)
+    response = temp_client.get("/docs")
+    assert response.status_code == 404
+    del os.environ["FASTAPT_ENVIRONMENT"]
+
+
+def test_swagger_ui_disabled_by_init_variable():
+    temp_app = FastAPI(disable_all_output_docs=True)
+    temp_client = TestClient(temp_app)
+    response = temp_client.get("/docs")
+    assert response.status_code == 404
 
 
 def test_swagger_ui_oauth2_redirect():

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1167,6 +1167,15 @@ def test_disabled_redocs_by_environment_variable():
     del os.environ["FASTAPI_DISABLE_REDOCS"]
 
 
+def test_disabled_swagger_by_environment_variable():
+    os.environ["FASTAPI_DISABLE_SWAGGER_DOCS"] = "True"
+    temp_app = FastAPI()
+    temp_client = TestClient(temp_app)
+    response = temp_client.get("/docs")
+    assert response.status_code == 404
+    del os.environ["FASTAPI_DISABLE_SWAGGER_DOCS"]
+
+
 def test_swagger_ui_oauth2_redirect():
     response = client.get("/docs/oauth2-redirect")
     assert response.status_code == 200, response.text

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1140,20 +1140,31 @@ def test_swagger_ui():
     )
 
 
-def test_swagger_ui_disabled_by_environment_variable():
-    os.environ["FASTAPT_ENVIRONMENT"] = "PRODUCTION"
+def test_disabled_all_docs_by_environment_variable():
+    os.environ["FASTAPI_DISABLE_ALL_DOCS"] = "True"
     temp_app = FastAPI()
     temp_client = TestClient(temp_app)
     response = temp_client.get("/docs")
     assert response.status_code == 404
-    del os.environ["FASTAPT_ENVIRONMENT"]
+    del os.environ["FASTAPI_DISABLE_ALL_DOCS"]
 
 
-def test_swagger_ui_disabled_by_init_variable():
-    temp_app = FastAPI(disable_all_output_docs=True)
+def test_disabled_openapi_by_environment_variable():
+    os.environ["FASTAPI_DISABLE_OPENAPI_DOCS"] = "True"
+    temp_app = FastAPI()
     temp_client = TestClient(temp_app)
-    response = temp_client.get("/docs")
+    response = temp_client.get("/openapi.json")
     assert response.status_code == 404
+    del os.environ["FASTAPI_DISABLE_OPENAPI_DOCS"]
+
+
+def test_disabled_redocs_by_environment_variable():
+    os.environ["FASTAPI_DISABLE_REDOCS"] = "True"
+    temp_app = FastAPI()
+    temp_client = TestClient(temp_app)
+    response = temp_client.get("/redoc")
+    assert response.status_code == 404
+    del os.environ["FASTAPI_DISABLE_REDOCS"]
 
 
 def test_swagger_ui_oauth2_redirect():

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1141,39 +1141,39 @@ def test_swagger_ui():
 
 
 def test_disabled_all_docs_by_environment_variable():
-    os.environ["FASTAPI_DISABLE_ALL_DOCS"] = "True"
+    os.environ["FASTAPI_ENABLE_ALL_DOCS"] = "False"
     temp_app = FastAPI()
     temp_client = TestClient(temp_app)
     response = temp_client.get("/docs")
     assert response.status_code == 404
-    del os.environ["FASTAPI_DISABLE_ALL_DOCS"]
+    del os.environ["FASTAPI_ENABLE_ALL_DOCS"]
 
 
 def test_disabled_openapi_by_environment_variable():
-    os.environ["FASTAPI_DISABLE_OPENAPI_DOCS"] = "True"
+    os.environ["FASTAPI_ENABLE_OPENAPI_DOCS"] = "False"
     temp_app = FastAPI()
     temp_client = TestClient(temp_app)
     response = temp_client.get("/openapi.json")
     assert response.status_code == 404
-    del os.environ["FASTAPI_DISABLE_OPENAPI_DOCS"]
+    del os.environ["FASTAPI_ENABLE_OPENAPI_DOCS"]
 
 
 def test_disabled_redocs_by_environment_variable():
-    os.environ["FASTAPI_DISABLE_REDOCS"] = "True"
+    os.environ["FASTAPI_ENABLE_REDOCS"] = "False"
     temp_app = FastAPI()
     temp_client = TestClient(temp_app)
     response = temp_client.get("/redoc")
     assert response.status_code == 404
-    del os.environ["FASTAPI_DISABLE_REDOCS"]
+    del os.environ["FASTAPI_ENABLE_REDOCS"]
 
 
 def test_disabled_swagger_by_environment_variable():
-    os.environ["FASTAPI_DISABLE_SWAGGER_DOCS"] = "True"
+    os.environ["FASTAPI_ENABLE_SWAGGER_DOCS"] = "False"
     temp_app = FastAPI()
     temp_client = TestClient(temp_app)
     response = temp_client.get("/docs")
     assert response.status_code == 404
-    del os.environ["FASTAPI_DISABLE_SWAGGER_DOCS"]
+    del os.environ["FASTAPI_ENABLE_SWAGGER_DOCS"]
 
 
 def test_swagger_ui_oauth2_redirect():


### PR DESCRIPTION
add a switch to disable output docs in the production environment. They can use the system environment variable or use  `disable_all_output_docs` variable  to disable output docs in an explicit way