### PR TITLE
fix open api prefix is invalid :bug:

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -104,9 +104,9 @@ class FastAPI(Starlette):
 
             async def openapi(req: Request) -> JSONResponse:
                 return JSONResponse(self.openapi())
-
-            self.add_route(self.openapi_url, openapi, include_in_schema=False)
             openapi_url = self.openapi_prefix + self.openapi_url
+            self.add_route(openapi_url, openapi, include_in_schema=False)
+
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -104,6 +104,7 @@ class FastAPI(Starlette):
 
             async def openapi(req: Request) -> JSONResponse:
                 return JSONResponse(self.openapi())
+
             openapi_url = self.openapi_prefix + self.openapi_url
             self.add_route(openapi_url, openapi, include_in_schema=False)
 

--- a/tests/test_swagger_associated_url.py
+++ b/tests/test_swagger_associated_url.py
@@ -2,9 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 app = FastAPI(
-    docs_url="/my_docs_url",
-    redoc_url="/my_redoc_url",
-    openapi_prefix="/prefix",
+    docs_url="/my_docs_url", redoc_url="/my_redoc_url", openapi_prefix="/prefix"
 )
 
 client = TestClient(app)

--- a/tests/test_swagger_associated_url.py
+++ b/tests/test_swagger_associated_url.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app = FastAPI(
+    docs_url="/my_docs_url",
+    redoc_url="/my_redoc_url",
+    openapi_prefix="/prefix",
+)
+
+client = TestClient(app)
+
+
+def test_docs_url():
+    response = client.get("/my_docs_url")
+    assert response.status_code == 200, response.text
+
+
+def test_redoc_url():
+    response = client.get("/my_redoc_url")
+    assert response.status_code == 200, response.text
+
+
+def test_openapi_prefix():
+    response = client.get("/prefix/openapi.json")
+    assert response.status_code == 200, response.text

--- a/tests/test_tutorial/test_sub_applications/test_tutorial001.py
+++ b/tests/test_tutorial/test_sub_applications/test_tutorial001.py
@@ -55,7 +55,7 @@ def test_main():
 
 
 def test_openapi_schema_sub():
-    response = client.get("/subapi/openapi.json")
+    response = client.get("/subapi/subapi/openapi.json")
     assert response.status_code == 200, response.text
     assert response.json() == openapi_schema_sub
 


### PR DESCRIPTION
create for #1284 
I can't make sure this is a bug. 
I'm not be familiar with openapi.
If this is not a bug, I will close this pr.
@tiangolo 