### PR TITLE
added option to also check for unknown query parameters

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -146,6 +146,12 @@ So, when you need to declare a value as required while using `Query`, you can us
 
 This will let **FastAPI** know that this parameter is required.
 
+## Check for unknowns
+
+By default FastAPI will ignore any unknown query or body parameters.
+If you would like to also validate for unknown query or body parameters you can
+pass the optional `check_unknown=True` parameter of the FastAPI application.
+
 ## Query parameter list / multiple values
 
 When you define a query parameter explicitly with `Query` you can also declare it to receive a list of values, or said in other way, to receive multiple values.

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -52,6 +52,7 @@ class FastAPI(Starlette):
         openapi_prefix: str = "",
         root_path: str = "",
         root_path_in_servers: bool = True,
+        check_unknown: bool = False,
         **extra: Any,
     ) -> None:
         self.default_response_class = default_response_class
@@ -62,6 +63,7 @@ class FastAPI(Starlette):
             dependency_overrides_provider=self,
             on_startup=on_startup,
             on_shutdown=on_shutdown,
+            check_unknown=check_unknown,
         )
         self.exception_handlers = (
             {} if exception_handlers is None else dict(exception_handlers)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -593,9 +593,9 @@ async def solve_dependencies(
             body_values,
             body_errors,
         ) = await request_body_to_args(  # body_params checked above
-            required_params=dependant.body_params, 
-            received_body=body, 
-            check_unknown=check_unknown
+            required_params=dependant.body_params,
+            received_body=body,
+            check_unknown=check_unknown,
         )
         values.update(body_values)
         errors.extend(body_errors)
@@ -735,8 +735,8 @@ async def request_body_to_args(
             else:
                 values[field.name] = v_
     if check_unknown:
-        for field in left_body_params:
-            errors.append(ErrorWrapper(ExtraError(), loc=("body", field)))
+        for key in left_body_params:
+            errors.append(ErrorWrapper(ExtraError(), loc=("body", key)))
     return values, errors
 
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -475,7 +475,7 @@ async def solve_dependencies(
     dependency_overrides_provider: Optional[Any] = None,
     dependency_cache: Optional[Dict[Tuple[Callable, Tuple[str]], Any]] = None,
     check_unknown: bool = False,
-    left_query_params: Optional[Set] = None,
+    left_query_params: Optional[Set[str]] = None,
 ) -> Tuple[
     Dict[str, Any],
     List[ErrorWrapper],
@@ -664,7 +664,6 @@ async def request_body_to_args(
 ) -> Tuple[Dict[str, Any], List[ErrorWrapper]]:
     values = {}
     errors = []
-    left_body_params = set(received_body)
     if required_params:
         field = required_params[0]
         field_info = field.field_info
@@ -673,6 +672,10 @@ async def request_body_to_args(
         if field_alias_omitted:
             received_body = {field.alias: received_body}
 
+        if received_body is not None:
+            left_body_params = set(received_body)
+        else:
+            left_body_params = set()
         for field in required_params:
             left_body_params.discard(field.alias)
             loc: Tuple[str, ...]

--- a/tests/test_check_unknown.py
+++ b/tests/test_check_unknown.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from fastapi import Depends, FastAPI
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
@@ -21,16 +19,21 @@ def duplicate_dependency(item: Item):
 
 
 @app_check.post("/with-check-unknown")
-async def endpoint(item: Item,item2: Item):
-    return [item,item2]
+async def endpoint_check(item: Item, item2: Item):
+    return [item, item2]
+
 
 @app_no_check.post("/without-check-unknown")
-async def endpoint(item: Item,item2: Item):
-    return [item,item2]
+async def endpoint_no_check(item: Item, item2: Item):
+    return [item, item2]
 
 
 def test_unknown_with_check():
-    response = client_ceck.post("/with-check-unknown", json={"item": {"data": "myitem"},"item2":{"data":"item2"},"data":"any"},params={'limit':12})
+    response = client_ceck.post(
+        "/with-check-unknown",
+        json={"item": {"data": "myitem"}, "item2": {"data": "item2"}, "data": "any"},
+        params={"limit": 12},
+    )
     assert response.status_code == 422, response.text
     assert response.json() == {
         "detail": [
@@ -43,12 +46,16 @@ def test_unknown_with_check():
                 "loc": ["body", "data"],
                 "msg": "extra fields not permitted",
                 "type": "value_error.extra",
-            }
+            },
         ]
     }
 
 
 def test_unknown_without_check():
-    response = client_no_check.post("/without-check-unknown", json={"item": {"data": "myitem"},"item2":{"data":"item2"},"data":"any"},params={'limit':12})
+    response = client_no_check.post(
+        "/without-check-unknown",
+        json={"item": {"data": "myitem"}, "item2": {"data": "item2"}, "data": "any"},
+        params={"limit": 12},
+    )
     assert response.status_code == 200, response.text
-    assert response.json() == [{'data':'myitem'},{'data':'item2'}]
+    assert response.json() == [{"data": "myitem"}, {"data": "item2"}]

--- a/tests/test_check_unknown.py
+++ b/tests/test_check_unknown.py
@@ -14,10 +14,6 @@ class Item(BaseModel):
     data: str
 
 
-def duplicate_dependency(item: Item):
-    return item
-
-
 @app_check.post("/with-check-unknown")
 async def endpoint_check(item: Item, item2: Item):
     return [item, item2]
@@ -49,6 +45,14 @@ def test_unknown_with_check():
             },
         ]
     }
+
+def test_known_with_check():
+    response = client_ceck.post(
+        "/with-check-unknown",
+        json={"item": {"data": "myitem"}, "item2": {"data": "item2"}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == [{"data": "myitem"}, {"data": "item2"}]
 
 
 def test_unknown_without_check():

--- a/tests/test_check_unknown.py
+++ b/tests/test_check_unknown.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+app_no_check = FastAPI(check_unknown=False)
+
+app_check = FastAPI(check_unknown=True)
+
+client_no_check = TestClient(app_no_check)
+client_ceck = TestClient(app_check)
+
+
+class Item(BaseModel):
+    data: str
+
+
+def duplicate_dependency(item: Item):
+    return item
+
+
+@app_check.post("/with-check-unknown")
+async def endpoint(item: Item,item2: Item):
+    return [item,item2]
+
+@app_no_check.post("/without-check-unknown")
+async def endpoint(item: Item,item2: Item):
+    return [item,item2]
+
+
+def test_unknown_with_check():
+    response = client_ceck.post("/with-check-unknown", json={"item": {"data": "myitem"},"item2":{"data":"item2"},"data":"any"},params={'limit':12})
+    assert response.status_code == 422, response.text
+    assert response.json() == {
+        "detail": [
+            {
+                "loc": ["query", "limit"],
+                "msg": "extra fields not permitted",
+                "type": "value_error.extra",
+            },
+            {
+                "loc": ["body", "data"],
+                "msg": "extra fields not permitted",
+                "type": "value_error.extra",
+            }
+        ]
+    }
+
+
+def test_unknown_without_check():
+    response = client_no_check.post("/without-check-unknown", json={"item": {"data": "myitem"},"item2":{"data":"item2"},"data":"any"},params={'limit':12})
+    assert response.status_code == 200, response.text
+    assert response.json() == [{'data':'myitem'},{'data':'item2'}]

--- a/tests/test_check_unknown.py
+++ b/tests/test_check_unknown.py
@@ -46,6 +46,7 @@ def test_unknown_with_check():
         ]
     }
 
+
 def test_known_with_check():
     response = client_ceck.post(
         "/with-check-unknown",

--- a/tests/test_check_unknown.py
+++ b/tests/test_check_unknown.py
@@ -7,7 +7,7 @@ app_no_check = FastAPI(check_unknown=False)
 app_check = FastAPI(check_unknown=True)
 
 client_no_check = TestClient(app_no_check)
-client_ceck = TestClient(app_check)
+client_check = TestClient(app_check)
 
 
 class Item(BaseModel):
@@ -25,7 +25,7 @@ async def endpoint_no_check(item: Item, item2: Item):
 
 
 def test_unknown_with_check():
-    response = client_ceck.post(
+    response = client_check.post(
         "/with-check-unknown",
         json={"item": {"data": "myitem"}, "item2": {"data": "item2"}, "data": "any"},
         params={"limit": 12},
@@ -48,7 +48,7 @@ def test_unknown_with_check():
 
 
 def test_known_with_check():
-    response = client_ceck.post(
+    response = client_check.post(
         "/with-check-unknown",
         json={"item": {"data": "myitem"}, "item2": {"data": "item2"}},
     )


### PR DESCRIPTION
Currently unknown query parameters are just ignored by fastapi, I feel that it should be at least possible to change the behaviour to return a validation error also for unknown.

It adresses #1190 

* not yet documented
* not yet any testing
* maybe different path to pass that option
* maybe rename to something else, maybe could be thought to generally
  check unknowns, however for models, pydantic has to be adapted