### PR TITLE
Fixed Typo in [EN] tutorial: body-fields

### DIFF
--- a/docs/en/docs/tutorial/body-fields.md
+++ b/docs/en/docs/tutorial/body-fields.md
@@ -39,7 +39,7 @@ You can then use `Field` with model attributes:
 
 You can declare extra information in `Field`, `Query`, `Body`, etc. And it will be included in the generated JSON Schema.
 
-You will learn more about it later to declare examples examples.
+You will learn more about it later to declare examples.
 
 ## Recap
 

--- a/docs/en/docs/tutorial/body-fields.md
+++ b/docs/en/docs/tutorial/body-fields.md
@@ -39,7 +39,7 @@ You can then use `Field` with model attributes:
 
 You can declare extra information in `Field`, `Query`, `Body`, etc. And it will be included in the generated JSON Schema.
 
-You will learn more about it later to declare examples.
+You will learn more about adding extra information later in the docs, when learning to declare examples.
 
 ## Recap
 


### PR DESCRIPTION
Removed duplicate examples word in body documentation

resolves #1296 