### PR TITLE
Add optional custom Swagger css/js/favicon urls for docs.

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -110,11 +110,22 @@ class FastAPI(Starlette):
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
+                swagger_keys = [
+                    "swagger_js_url",
+                    "swagger_css_url",
+                    "swagger_favicon_url",
+                ]
+                swagger_args = {
+                    key: self.extra.get(key)
+                    for key in swagger_keys
+                    if self.extra.get(key) is not None
+                }
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=self.title + " - Swagger UI",
                     oauth2_redirect_url=self.swagger_ui_oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
+                    **swagger_args,
                 )
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)


### PR DESCRIPTION
I opened this PR to allow the optional passing of a custom CSS url as a theme, as there are many such themes available. http://ostranme.github.io/swagger-ui-themes/

I didn't want to clutter up the named args in the `FastAPI` constructor, so I am just testing to see if the argument exists in the `self.extra` dictionary. Let me know what you think, if you'd like changes to the PR for the functionality, or aren't willing to accept.

Thanks again for the great work in this project, I really enjoy it!