### PR TITLE
Better JSON Decode error handling

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import json
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union
 
 from fastapi import params
@@ -147,6 +148,8 @@ def get_request_handler(
                     body_bytes = await request.body()
                     if body_bytes:
                         body = await request.json()
+        except json.JSONDecodeError as e:
+            raise RequestValidationError([ErrorWrapper(e, ("body", e.pos))], body=e.doc)
         except Exception as e:
             logger.error(f"Error getting request body: {e}")
             raise HTTPException(

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -176,5 +176,20 @@ def test_post_body(path, body, expected_status, expected_response):
 
 def test_post_broken_body():
     response = client.post("/items/", data={"name": "Foo", "price": 50.5})
-    assert response.status_code == 400
-    assert response.json() == {"detail": "There was an error parsing the body"}
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "ctx": {
+                    "colno": 1,
+                    "doc": "name=Foo&price=50.5",
+                    "lineno": 1,
+                    "msg": "Expecting value",
+                    "pos": 0,
+                },
+                "loc": ["body", 0],
+                "msg": "Expecting value: line 1 column 1 (char 0)",
+                "type": "value_error.jsondecode",
+            }
+        ]
+    }

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -193,3 +195,7 @@ def test_post_broken_body():
             }
         ]
     }
+    with patch("json.loads", side_effect=Exception):
+        response = client.post("/items/", json={"test": "test2"})
+        assert response.status_code == 400, response.text
+    assert response.json() == {"detail": "There was an error parsing the body"}


### PR DESCRIPTION
I was annoyed by the fact that if JSON parsing fails for the body you receive HTTP Exception 400.
I think RequestValidationError is a better suit for the case, for the client to realize what have he done wrong exactly (position of wrong character) and body to be part of the exception (so it can be logged)
