### PR TITLE
Fix callable class generator dependencies

### DIFF
--- a/tests/test_dependency_class.py
+++ b/tests/test_dependency_class.py
@@ -1,3 +1,5 @@
+from typing import AsyncGenerator, Generator
+
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
@@ -10,9 +12,19 @@ class CallableDependency:
         return value
 
 
+class CallableGenDependency:
+    def __call__(self, value: str) -> Generator[str, None, None]:
+        yield value
+
+
 class AsyncCallableDependency:
     async def __call__(self, value: str) -> str:
         return value
+
+
+class AsyncCallableGenDependency:
+    async def __call__(self, value: str) -> AsyncGenerator[str, None]:
+        yield value
 
 
 class MethodsDependency:
@@ -22,9 +34,17 @@ class MethodsDependency:
     async def asynchronous(self, value: str) -> str:
         return value
 
+    def synchronous_gen(self, value: str) -> Generator[str, None, None]:
+        yield value
+
+    async def asynchronous_gen(self, value: str) -> AsyncGenerator[str, None]:
+        yield value
+
 
 callable_dependency = CallableDependency()
+callable_gen_dependency = CallableGenDependency()
 async_callable_dependency = AsyncCallableDependency()
+async_callable_gen_dependency = AsyncCallableGenDependency()
 methods_dependency = MethodsDependency()
 
 
@@ -33,14 +53,33 @@ async def get_callable_dependency(value: str = Depends(callable_dependency)):
     return value
 
 
+@app.get("/callable-gen-dependency")
+async def get_callable_gen_dependency(value: str = Depends(callable_gen_dependency)):
+    return value
+
+
 @app.get("/async-callable-dependency")
 async def get_callable_dependency(value: str = Depends(async_callable_dependency)):
+    return value
+
+
+@app.get("/async-callable-gen-dependency")
+async def get_callable_gen_dependency(
+    value: str = Depends(async_callable_gen_dependency),
+):
     return value
 
 
 @app.get("/synchronous-method-dependency")
 async def get_synchronous_method_dependency(
     value: str = Depends(methods_dependency.synchronous),
+):
+    return value
+
+
+@app.get("/synchronous-method-gen-dependency")
+async def get_synchronous_method_gen_dependency(
+    value: str = Depends(methods_dependency.synchronous_gen),
 ):
     return value
 
@@ -52,6 +91,13 @@ async def get_asynchronous_method_dependency(
     return value
 
 
+@app.get("/asynchronous-method-gen-dependency")
+async def get_asynchronous_method_gen_dependency(
+    value: str = Depends(methods_dependency.asynchronous_gen),
+):
+    return value
+
+
 client = TestClient(app)
 
 
@@ -59,9 +105,13 @@ client = TestClient(app)
     "route,value",
     [
         ("/callable-dependency", "callable-dependency"),
+        ("/callable-gen-dependency", "callable-gen-dependency"),
         ("/async-callable-dependency", "async-callable-dependency"),
+        ("/async-callable-gen-dependency", "async-callable-gen-dependency"),
         ("/synchronous-method-dependency", "synchronous-method-dependency"),
+        ("/synchronous-method-gen-dependency", "synchronous-method-gen-dependency"),
         ("/asynchronous-method-dependency", "asynchronous-method-dependency"),
+        ("/asynchronous-method-gen-dependency", "asynchronous-method-gen-dependency"),
     ],
 )
 def test_class_dependency(route, value):


### PR DESCRIPTION
Fixes/related to #1204 

Resolving dependencies uses `inspect.isgeneratorfunction` and `inspect.isasyncgenfunction` which match async methods and functions, but not a class (or other callable) that has an async generator `__call__` method.

It also adds 4 new test cases to ensure that dependencies work as expected for class methods that yield instead of return values.