### PR TITLE
Replace 400 codes with 401 in security tutorial

### DIFF
--- a/docs_src/security/tutorial003.py
+++ b/docs_src/security/tutorial003.py
@@ -66,7 +66,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme)):
 
 async def get_current_active_user(current_user: User = Depends(get_current_user)):
     if current_user.disabled:
-        raise HTTPException(status_code=400, detail="Inactive user")
+        raise HTTPException(status_code=401, detail="Inactive user")
     return current_user
 
 
@@ -74,11 +74,11 @@ async def get_current_active_user(current_user: User = Depends(get_current_user)
 async def login(form_data: OAuth2PasswordRequestForm = Depends()):
     user_dict = fake_users_db.get(form_data.username)
     if not user_dict:
-        raise HTTPException(status_code=400, detail="Incorrect username or password")
+        raise HTTPException(status_code=401, detail="Incorrect username or password")
     user = UserInDB(**user_dict)
     hashed_password = fake_hash_password(form_data.password)
     if not hashed_password == user.hashed_password:
-        raise HTTPException(status_code=400, detail="Incorrect username or password")
+        raise HTTPException(status_code=401, detail="Incorrect username or password")
 
     return {"access_token": user.username, "token_type": "bearer"}
 

--- a/docs_src/security/tutorial004.py
+++ b/docs_src/security/tutorial004.py
@@ -108,7 +108,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme)):
 
 async def get_current_active_user(current_user: User = Depends(get_current_user)):
     if current_user.disabled:
-        raise HTTPException(status_code=400, detail="Inactive user")
+        raise HTTPException(status_code=401, detail="Inactive user")
     return current_user
 
 

--- a/docs_src/security/tutorial005.py
+++ b/docs_src/security/tutorial005.py
@@ -140,7 +140,7 @@ async def get_current_active_user(
     current_user: User = Security(get_current_user, scopes=["me"])
 ):
     if current_user.disabled:
-        raise HTTPException(status_code=400, detail="Inactive user")
+        raise HTTPException(status_code=401, detail="Inactive user")
     return current_user
 
 
@@ -148,7 +148,7 @@ async def get_current_active_user(
 async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
-        raise HTTPException(status_code=400, detail="Incorrect username or password")
+        raise HTTPException(status_code=401, detail="Incorrect username or password")
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
         data={"sub": user.username, "scopes": form_data.scopes},

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -125,13 +125,13 @@ def test_login_incorrect_password():
     response = client.post(
         "/token", data={"username": "johndoe", "password": "incorrect"}
     )
-    assert response.status_code == 400, response.text
+    assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Incorrect username or password"}
 
 
 def test_login_incorrect_username():
     response = client.post("/token", data={"username": "foo", "password": "secret"})
-    assert response.status_code == 400, response.text
+    assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Incorrect username or password"}
 
 
@@ -172,5 +172,5 @@ def test_incorrect_token_type():
 
 def test_inactive_user():
     response = client.get("/users/me", headers={"Authorization": "Bearer alice"})
-    assert response.status_code == 400, response.text
+    assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Inactive user"}

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -205,13 +205,13 @@ def test_login_incorrect_password():
     response = client.post(
         "/token", data={"username": "johndoe", "password": "incorrect"}
     )
-    assert response.status_code == 400, response.text
+    assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Incorrect username or password"}
 
 
 def test_login_incorrect_username():
     response = client.post("/token", data={"username": "foo", "password": "secret"})
-    assert response.status_code == 400, response.text
+    assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Incorrect username or password"}
 
 
@@ -318,7 +318,7 @@ def test_token_inactive_user():
     response = client.get(
         "/users/me", headers={"Authorization": f"Bearer {access_token}"}
     )
-    assert response.status_code == 400, response.text
+    assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Inactive user"}
 
 


### PR DESCRIPTION
[From this](https://stackoverflow.com/questions/32752578/whats-the-appropriate-http-status-code-to-return-if-a-user-tries-logging-in-wit) it looks like 401 is more appropriate.

Feel free to close if you think 400 is better (ie. to emphasize it can be customized).

Side note: Looks like PRs are piling up. Just an idea, perhaps you would benefit from giving more people merge access so you don't get bored of all these tiny docs PRs. Something I read once talked about someone's philosophy of giving repo write access to every single contributor since they argued this would increase the quality of contributions and bad actors are very sparse. Of course this wouldn't be wise in a larger repository like this, but I think it puts the risk of bad actors/suboptimal code contributions versus PR suffocation into perspective.