### PR TITLE
Added test for repeating cookies in response headers

### DIFF
--- a/tests/test_repeated_cookie_headers.py
+++ b/tests/test_repeated_cookie_headers.py
@@ -1,0 +1,33 @@
+from fastapi import Depends, FastAPI, Cookie, status, Response
+from fastapi.testclient import TestClient
+
+
+app = FastAPI()
+
+
+def set_cookie(*, response: Response):
+    response.set_cookie('cookie-name', 'cookie-value')
+    return {}
+
+
+def set_indirect_cookie(*, dep: str = Depends(set_cookie)):
+    return dep
+
+
+@app.get("/directCookie")
+def get_direct_cookie(dep: str = Depends(set_cookie)):
+    return {"dep": dep}
+
+
+@app.get("/indirectCookie")
+def get_indirect_cookie(dep: str = Depends(set_indirect_cookie)):
+    return {"dep": dep}
+
+
+client = TestClient(app)
+
+
+def test_cookie_is_set_once():
+    direct_response = client.get("/directCookie")
+    indirect_response = client.get("/indirectCookie")
+    assert direct_response.headers['set-cookie'] == indirect_response.headers['set-cookie']


### PR DESCRIPTION
Found this issue using fastapi.  I haven't tracked down the cause.  It seems every additional layer of redirection doubles the cookies in the header.  No clue if this would actually break anything, but it seems like incorrect behavior at any rate.