### PR TITLE
Bugfix for duplicated headers from indirect dependencies

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -486,9 +486,10 @@ async def solve_dependencies(
             sub_dependency_cache,
         ) = solved_result
         sub_response = cast(Response, sub_response)
-        response.headers.raw.extend(sub_response.headers.raw)
-        if sub_response.status_code:
-            response.status_code = sub_response.status_code
+        if sub_response is not response:
+            response.headers.raw.extend(sub_response.headers.raw)
+            if sub_response.status_code:
+                response.status_code = sub_response.status_code
         dependency_cache.update(sub_dependency_cache)
         if sub_errors:
             errors.extend(sub_errors)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -482,14 +482,9 @@ async def solve_dependencies(
             sub_values,
             sub_errors,
             background_tasks,
-            sub_response,
+            _,  # the subdependency returns the same response we have
             sub_dependency_cache,
         ) = solved_result
-        sub_response = cast(Response, sub_response)
-        if sub_response is not response:
-            response.headers.raw.extend(sub_response.headers.raw)
-            if sub_response.status_code:
-                response.status_code = sub_response.status_code
         dependency_cache.update(sub_dependency_cache)
         if sub_errors:
             errors.extend(sub_errors)

--- a/tests/test_repeated_cookie_headers.py
+++ b/tests/test_repeated_cookie_headers.py
@@ -1,12 +1,11 @@
-from fastapi import Depends, FastAPI, Cookie, status, Response
+from fastapi import Depends, FastAPI, Response
 from fastapi.testclient import TestClient
-
 
 app = FastAPI()
 
 
 def set_cookie(*, response: Response):
-    response.set_cookie('cookie-name', 'cookie-value')
+    response.set_cookie("cookie-name", "cookie-value")
     return {}
 
 
@@ -30,4 +29,6 @@ client = TestClient(app)
 def test_cookie_is_set_once():
     direct_response = client.get("/directCookie")
     indirect_response = client.get("/indirectCookie")
-    assert direct_response.headers['set-cookie'] == indirect_response.headers['set-cookie']
+    assert (
+        direct_response.headers["set-cookie"] == indirect_response.headers["set-cookie"]
+    )

--- a/tests/test_repeated_cookie_headers.py
+++ b/tests/test_repeated_cookie_headers.py
@@ -1,0 +1,33 @@
+from fastapi import Depends, FastAPI, Cookie, status, Response
+from fastapi.testclient import TestClient
+
+
+app = FastAPI()
+
+
+def set_cookie(*, response: Response):
+    response.set_cookie('cookie-name', 'cookie-value')
+    return {}
+
+
+def set_indirect_cookie(*, dep: str = Depends(set_cookie)):
+    return dep
+
+
+@app.get("/directCookie")
+def get_direct_cookie(dep: str = Depends(set_cookie)):
+    return {"dep": dep}
+
+
+@app.get("/indirectCookie")
+def get_indirect_cookie(dep: str = Depends(set_indirect_cookie)):
+    return {"dep": dep}
+
+
+client = TestClient(app)
+
+
+def test_cookie_is_set_once():
+    direct_response = client.get("/directCookie")
+    indirect_response = client.get("/indirectCookie")
+    assert direct_response.headers['set-cookie'] == indirect_response.headers['set-cookie']


### PR DESCRIPTION
addresses the issue discovered by @scottsmith2gmail in #1385 and adds the test he proposed

> It seems every additional layer of redirection doubles the cookies in the header.