### PR TITLE
add pydantic pycharm plugin in document

### DIFF
--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -108,6 +108,8 @@ But you would get the same editor support with <a href="https://www.jetbrains.co
 
 <img src="/img/tutorial/body/image05.png">
 
+In PyCharm, There is <a href="https://github.com/koxudaxi/pydantic-pycharm-plugin/" class="external-link" target="_blank">Pydantic PyCharm Plugin</a>. It improves features that are auto-completion, type-checking, refactoring, searching, inspections for Pydantic.
+
 ## Use the model
 
 Inside of the function, you can access all the attributes of the model object directly:

--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -108,7 +108,16 @@ But you would get the same editor support with <a href="https://www.jetbrains.co
 
 <img src="/img/tutorial/body/image05.png">
 
-In PyCharm, There is <a href="https://github.com/koxudaxi/pydantic-pycharm-plugin/" class="external-link" target="_blank">Pydantic PyCharm Plugin</a>. It improves features that are auto-completion, type-checking, refactoring, searching, inspections for Pydantic.
+!!! tip
+    If you use <a href="https://www.jetbrains.com/pycharm/" class="external-link" target="_blank">PyCharm</a> as your editor, you can use the <a href="https://github.com/koxudaxi/pydantic-pycharm-plugin/" class="external-link" target="_blank">Pydantic PyCharm Plugin</a>.
+
+    It improves editor support for Pydantic models, with:
+    
+    * auto-completion
+    * type checks
+    * refactoring
+    * searching
+    * inspections
 
 ## Use the model
 


### PR DESCRIPTION
@tiangolo 
Thank you for writing excellent documents.

I'm developing PyCharm Plugin for pydantic.
The plugin provides features that are auto-completion, type-checking, refactoring, searching, inspections for pydantic.
The PR adds the link of the plugin in FastAPI's document.

Also, the link is in pydantic documents.
https://pydantic-docs.helpmanual.io/pycharm_plugin/

