### PR TITLE
Docs for `default_response_class`

### DIFF
--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -205,7 +205,9 @@ File responses will include appropriate `Content-Length`, `Last-Modified` and `E
 
 ## Default response class
 
-When creating a **FastAPI** class instance, you can specify a Response class type using `default_response_class`.
+When creating a **FastAPI** class instance, you can specify which response type to use by default. 
+
+The parameter that defines this is `default_response_class`.
 
 In the example below, **FastAPI** in all routes will use `ORJSONResponse` by default instead of `JSONResponse`.
 

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -207,11 +207,14 @@ File responses will include appropriate `Content-Length`, `Last-Modified` and `E
 
 When creating a **FastAPI** class instance, you can specify a Response class type using `default_response_class`.
 
-In the example below, **FastAPI** will use `ORJSONResponse` by default instead of `JSONResponse`.
+In the example below, **FastAPI** in all routes will use `ORJSONResponse` by default instead of `JSONResponse`.
 
 ```Python hl_lines="2 4"
 {!../../../docs_src/custom_response/tutorial010.py!}
 ```
+
+!!! tip
+    You can still override response_class in routes as before.
 
 ## Additional documentation
 

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -203,6 +203,16 @@ File responses will include appropriate `Content-Length`, `Last-Modified` and `E
 {!../../../docs_src/custom_response/tutorial009.py!}
 ```
 
+## Default response class
+
+When creating a **FastAPI** class instance, you can specify a Response class type using `default_response_class`.
+
+In the example below, **FastAPI** will use `ORJSONResponse` by default instead of `JSONResponse`.
+
+```Python hl_lines="2 4"
+{!../../../docs_src/custom_response/tutorial010.py!}
+```
+
 ## Additional documentation
 
 You can also declare the media type and many other details in OpenAPI using `responses`: [Additional Responses in OpenAPI](additional-responses.md){.internal-link target=_blank}.

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -205,18 +205,18 @@ File responses will include appropriate `Content-Length`, `Last-Modified` and `E
 
 ## Default response class
 
-When creating a **FastAPI** class instance, you can specify which response type to use by default. 
+When creating a **FastAPI** class instance or an `APIRouter` you can specify which response class to use by default.
 
 The parameter that defines this is `default_response_class`.
 
-In the example below, **FastAPI** in all routes will use `ORJSONResponse` by default instead of `JSONResponse`.
+In the example below, **FastAPI** will use `ORJSONResponse` by default, in all *path operations*, instead of `JSONResponse`.
 
 ```Python hl_lines="2 4"
 {!../../../docs_src/custom_response/tutorial010.py!}
 ```
 
 !!! tip
-    You can still override `response_class` in routes as before.
+    You can still override `response_class` in *path operations* as before.
 
 ## Additional documentation
 

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -214,7 +214,7 @@ In the example below, **FastAPI** in all routes will use `ORJSONResponse` by def
 ```
 
 !!! tip
-    You can still override response_class in routes as before.
+    You can still override `response_class` in routes as before.
 
 ## Additional documentation
 

--- a/docs_src/custom_response/tutorial010.py
+++ b/docs_src/custom_response/tutorial010.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+from fastapi.responses import ORJSONResponse
+
+app = FastAPI(default_response_class=ORJSONResponse)
+
+
+@app.get("/items/")
+async def read_items():
+    return [{"item_id": "Foo"}]


### PR DESCRIPTION
Added short documentation on how to use `default_response_class` in Advanced docs

This is helpful for #467