### PR TITLE
Cannot import ''OAuth2PasswordRequestFormStrict''

### DIFF
--- a/fastapi/security/__init__.py
+++ b/fastapi/security/__init__.py
@@ -11,6 +11,7 @@ from .oauth2 import (
     OAuth2AuthorizationCodeBearer,
     OAuth2PasswordBearer,
     OAuth2PasswordRequestForm,
+    OAuth2PasswordRequestFormStrict,
     SecurityScopes,
 )
 from .open_id_connect_url import OpenIdConnect

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -1,7 +1,6 @@
 import pytest
 from fastapi import Depends, FastAPI, Security
-from fastapi.security import OAuth2
-from fastapi.security.oauth2 import OAuth2PasswordRequestFormStrict
+from fastapi.security import OAuth2, OAuth2PasswordRequestFormStrict
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -2,8 +2,7 @@ from typing import Optional
 
 import pytest
 from fastapi import Depends, FastAPI, Security
-from fastapi.security import OAuth2
-from fastapi.security.oauth2 import OAuth2PasswordRequestFormStrict
+from fastapi.security import OAuth2, OAuth2PasswordRequestFormStrict
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 


### PR DESCRIPTION
Fixes an import error:     

from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestFormStrict
ImportError: cannot import name 'OAuth2PasswordRequestFormStrict'


Currently using the workaround:
from fastapi.security.oauth2 import OAuth2PasswordRequestFormStrict

Not sure whether the maintainers intended for the import to be different from the rest of the security imports. I assume this is a simple oversight.