### PR TITLE
🐛 Fix Enum handling with their own schema definitions

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -188,6 +188,16 @@ def get_flat_dependant(
     return flat_dependant
 
 
+def get_flat_params(dependant: Dependant) -> List[ModelField]:
+    flat_dependant = get_flat_dependant(dependant, skip_repeats=True)
+    return (
+        flat_dependant.path_params
+        + flat_dependant.query_params
+        + flat_dependant.header_params
+        + flat_dependant.cookie_params
+    )
+
+
 def is_scalar_field(field: ModelField) -> bool:
     field_info = get_field_info(field)
     if not (

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -92,12 +92,13 @@ def get_openapi_operation_parameters(
     for param in all_route_params:
         field_info = get_field_info(param)
         field_info = cast(Param, field_info)
+        # ignore mypy error until enum schemas are released
         parameter = {
             "name": param.alias,
             "in": field_info.in_.value,
             "required": param.required,
             "schema": field_schema(
-                param, model_name_map=model_name_map, ref_prefix=REF_PREFIX
+                param, model_name_map=model_name_map, ref_prefix=REF_PREFIX  # type: ignore
             )[0],
         }
         if field_info.description:
@@ -116,8 +117,9 @@ def get_openapi_operation_request_body(
     if not body_field:
         return None
     assert isinstance(body_field, ModelField)
+    # ignore mypy error until enum schemas are released
     body_schema, _, _ = field_schema(
-        body_field, model_name_map=model_name_map, ref_prefix=REF_PREFIX
+        body_field, model_name_map=model_name_map, ref_prefix=REF_PREFIX  # type: ignore
     )
     field_info = cast(Body, get_field_info(body_field))
     request_media_type = field_info.media_type
@@ -320,9 +322,11 @@ def get_openapi(
     components: Dict[str, Dict] = {}
     paths: Dict[str, Dict] = {}
     flat_models = get_flat_models_from_routes(routes)
-    model_name_map = get_model_name_map(flat_models)
+    # ignore mypy error until enum schemas are released
+    model_name_map = get_model_name_map(flat_models)  # type: ignore
+    # ignore mypy error until enum schemas are released
     definitions = get_model_definitions(
-        flat_models=flat_models, model_name_map=model_name_map
+        flat_models=flat_models, model_name_map=model_name_map  # type: ignore
     )
     for route in routes:
         if isinstance(route, routing.APIRoute):

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -1,5 +1,6 @@
 import http.client
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, cast
+from enum import Enum
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union, cast
 
 from fastapi import routing
 from fastapi.dependencies.models import Dependant
@@ -85,7 +86,7 @@ def get_openapi_security_definitions(flat_dependant: Dependant) -> Tuple[Dict, L
 def get_openapi_operation_parameters(
     *,
     all_route_params: Sequence[ModelField],
-    model_name_map: Dict[Type[BaseModel], str]
+    model_name_map: Dict[Union[Type[BaseModel], Type[Enum]], str]
 ) -> List[Dict[str, Any]]:
     parameters = []
     for param in all_route_params:
@@ -108,7 +109,9 @@ def get_openapi_operation_parameters(
 
 
 def get_openapi_operation_request_body(
-    *, body_field: Optional[ModelField], model_name_map: Dict[Type[BaseModel], str]
+    *,
+    body_field: Optional[ModelField],
+    model_name_map: Dict[Union[Type[BaseModel], Type[Enum]], str]
 ) -> Optional[Dict]:
     if not body_field:
         return None
@@ -269,11 +272,13 @@ def get_openapi_path(
     return path, security_schemes, definitions
 
 
-def get_flat_models_from_routes(routes: Sequence[BaseRoute]) -> Set[Type[BaseModel]]:
+def get_flat_models_from_routes(
+    routes: Sequence[BaseRoute],
+) -> Set[Union[Type[BaseModel], Type[Enum]]]:
     body_fields_from_routes: List[ModelField] = []
     responses_from_routes: List[ModelField] = []
     request_fields_from_routes: List[ModelField] = []
-    callback_flat_models: Set[Type[BaseModel]] = set()
+    callback_flat_models: Set[Union[Type[BaseModel], Type[Enum]]] = set()
     for route in routes:
         if getattr(route, "include_in_schema", None) and isinstance(
             route, routing.APIRoute

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,6 +1,7 @@
 import functools
 import re
 from dataclasses import is_dataclass
+from enum import Enum
 from typing import Any, Dict, Optional, Set, Type, Union, cast
 
 import fastapi
@@ -49,7 +50,9 @@ def warning_response_model_skip_defaults_deprecated() -> None:
 
 
 def get_model_definitions(
-    *, flat_models: Set[Type[BaseModel]], model_name_map: Dict[Type[BaseModel], str]
+    *,
+    flat_models: Set[Union[Type[BaseModel], Type[Enum]]],
+    model_name_map: Dict[Union[Type[BaseModel], Type[Enum]], str],
 ) -> Dict[str, Any]:
     definitions: Dict[str, Dict] = {}
     for model in flat_models:

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -56,8 +56,9 @@ def get_model_definitions(
 ) -> Dict[str, Any]:
     definitions: Dict[str, Dict] = {}
     for model in flat_models:
+        # ignore mypy error until enum schemas are released
         m_schema, m_definitions, m_nested_models = model_process_schema(
-            model, model_name_map=model_name_map, ref_prefix=REF_PREFIX
+            model, model_name_map=model_name_map, ref_prefix=REF_PREFIX  # type: ignore
         )
         definitions.update(m_definitions)
         model_name = model_name_map[model]

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,17 +1,15 @@
 import functools
 import re
 from dataclasses import is_dataclass
-from typing import Any, Dict, List, Optional, Sequence, Set, Type, Union, cast
+from typing import Any, Dict, Optional, Set, Type, Union, cast
 
 import fastapi
-from fastapi import routing
 from fastapi.logger import logger
 from fastapi.openapi.constants import REF_PREFIX
 from pydantic import BaseConfig, BaseModel, create_model
 from pydantic.class_validators import Validator
-from pydantic.schema import get_flat_models_from_fields, model_process_schema
+from pydantic.schema import model_process_schema
 from pydantic.utils import lenient_issubclass
-from starlette.routing import BaseRoute
 
 try:
     from pydantic.fields import FieldInfo, ModelField, UndefinedType
@@ -48,31 +46,6 @@ def warning_response_model_skip_defaults_deprecated() -> None:
         "response_model_exclude_unset to keep in line with Pydantic v1, support for "
         "it will be removed soon."
     )
-
-
-def get_flat_models_from_routes(routes: Sequence[BaseRoute]) -> Set[Type[BaseModel]]:
-    body_fields_from_routes: List[ModelField] = []
-    responses_from_routes: List[ModelField] = []
-    callback_flat_models: Set[Type[BaseModel]] = set()
-    for route in routes:
-        if getattr(route, "include_in_schema", None) and isinstance(
-            route, routing.APIRoute
-        ):
-            if route.body_field:
-                assert isinstance(
-                    route.body_field, ModelField
-                ), "A request body must be a Pydantic Field"
-                body_fields_from_routes.append(route.body_field)
-            if route.response_field:
-                responses_from_routes.append(route.response_field)
-            if route.response_fields:
-                responses_from_routes.extend(route.response_fields.values())
-            if route.callbacks:
-                callback_flat_models |= get_flat_models_from_routes(route.callbacks)
-    flat_models = callback_flat_models | get_flat_models_from_fields(
-        body_fields_from_routes + responses_from_routes, known_models=set()
-    )
-    return flat_models
 
 
 def get_model_definitions(

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,4 +3,4 @@ set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place docs_src fastapi tests scripts --exclude=__init__.py
 black fastapi tests docs_src scripts
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --thirdparty fastapi --apply fastapi tests docs_src scripts
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ set -x
 
 mypy fastapi
 black fastapi tests --check
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only --thirdparty fastapi fastapi tests
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -87,7 +87,7 @@ openapi_schema2 = {
                 "parameters": [
                     {
                         "required": True,
-                        "schema": {"$ref": "#/definitions/ModelName"},
+                        "schema": {"$ref": "#/components/schemas/ModelName"},
                         "name": "model_name",
                         "in": "path",
                     }
@@ -123,6 +123,12 @@ openapi_schema2 = {
                         "items": {"$ref": "#/components/schemas/ValidationError"},
                     }
                 },
+            },
+            "ModelName": {
+                "title": "ModelName",
+                "enum": ["alexnet", "resnet", "lenet"],
+                "type": "string",
+                "description": "An enumeration.",
             },
             "ValidationError": {
                 "title": "ValidationError",


### PR DESCRIPTION
🐛 Fix Enum handling with their own schema definitions.

I missed an error in https://github.com/tiangolo/fastapi/pull/1461 , the story is a bit more complex. This currently breaks Swagger UI when using enums in other parts apart from bodies (e.g. path params).

It's necessary to add enums to the whole handling with OpenAPI of models to include the new definition in the components.

These changes plus a couple of updates in https://github.com/samuelcolvin/pydantic/pull/1432 work correctly in Swagger UI and generate an independent schema for enums (which was the original intention).