### PR TITLE
squash __root__ in BaseModel json encoding

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -71,6 +71,8 @@ def jsonable_encoder(
                 by_alias=by_alias,
                 skip_defaults=bool(exclude_unset or skip_defaults),
             )
+        if "__root__" in obj_dict:
+            obj_dict = obj_dict["__root__"]
         return jsonable_encoder(
             obj_dict,
             exclude_none=exclude_none,

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -76,6 +76,10 @@ class ModelWithDefault(BaseModel):
     bla: str = "bla"
 
 
+class ModelWithRoot(BaseModel):
+    __root__: str
+
+
 @pytest.fixture(
     name="model_with_path", params=[PurePath, PurePosixPath, PureWindowsPath]
 )
@@ -158,3 +162,8 @@ def test_encode_model_with_path(model_with_path):
     else:
         expected = "/foo/bar"
     assert jsonable_encoder(model_with_path) == {"path": expected}
+
+
+def test_encode_root():
+    model = ModelWithRoot(__root__="Foo")
+    assert jsonable_encoder(model) == "Foo"


### PR DESCRIPTION
Fixes #911.

This corrects the specific problem described by @peku33, where the response is received by the client as `{"__root__": foo}`. This change simply converts to `foo` during json encoding.

Note that these `__root__` structures may still exist internally, e.g. `{"foo": {"__root__": foo}}`. That is a pydantic bug (https://github.com/samuelcolvin/pydantic/issues/1414) with an open PR.