### PR TITLE
Relax hard-pinning of starlette

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 requires = [
-    "starlette ==0.13.2",
+    "starlette ~=0.13.2",
     "pydantic >=0.32.2,<2.0.0"
 ]
 description-file = "README.md"


### PR DESCRIPTION
[`starlette`](https://github.com/encode/starlette/releases) is up to `0.13.4` now.

Unless a specific patch release is actually a hard requirement it's more user-friendly to pin to a [compatible release](https://www.python.org/dev/peps/pep-0440/#compatible-release) so as to *automatically* benefit from bug/security fixes.