### PR TITLE
Fix: Override successful response

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -225,9 +225,19 @@ def get_openapi_path(
                         status_code_key = "default"
                     operation.setdefault("responses", {})[status_code_key] = response
             status_code = str(route.status_code)
+            description = route.response_description
+            try:
+                success = operation["responses"][status_code]
+            except KeyError:
+                pass
+            else:
+                success_desc = success["description"]
+                if not success_desc == "OK":
+                    description = success_desc
+
             operation.setdefault("responses", {}).setdefault(status_code, {})[
                 "description"
-            ] = route.response_description
+            ] = description
             if (
                 route_response_media_type
                 and route.status_code not in STATUS_CODES_WITH_NO_BODY

--- a/tests/test_tutorial/test_additional_responses/test_tutorial002.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial002.py
@@ -15,7 +15,7 @@ openapi_schema = {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Successful Response",
+                        "description": "Return the JSON item or an image.",
                         "content": {
                             "image/png": {},
                             "application/json": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial003.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial003.py
@@ -20,7 +20,7 @@ openapi_schema = {
                         },
                     },
                     "200": {
-                        "description": "Successful Response",
+                        "description": "Item requested by ID",
                         "content": {
                             "application/json": {
                                 "schema": {"$ref": "#/components/schemas/Item"},


### PR DESCRIPTION
first PR to fix bug #1528. shows overriden success description if specified else falls back to default response