### PR TITLE
Translated `index.md` and `first-steps.md` from Tutorial - User Guide to Italian

### DIFF
--- a/docs/it/docs/tutorial/first-steps.md
+++ b/docs/it/docs/tutorial/first-steps.md
@@ -1,14 +1,14 @@
 # Primi Passi
 
-The simplest FastAPI file could look like this:
+Il più semplice script con FastAPI potrebbe essere questo:
 
 ```Python
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-Copy that to a file `main.py`.
+Copialo in un file chiamato `main.py`.
 
-Run the live server:
+Carica il programma su un server:
 
 <div class="termy">
 
@@ -24,78 +24,78 @@ $ uvicorn main:app --reload
 
 </div>
 
-!!! note
-    The command `uvicorn main:app` refers to:
+!!! nota
+    Vediamo in dettaglio il comando `uvicorn main:app`:
 
-    * `main`: the file `main.py` (the Python "module").
-    * `app`: the object created inside of `main.py` with the line `app = FastAPI()`.
-    * `--reload`: make the server restart after code changes. Only use for development.
+    * `main`: il file `main.py` (il "modulo" Python).
+    * `app`: l'oggetto creato all'interno di `main.py` con la riga `app = FastAPI()`.
+    * `--reload`: riavvia il server automaticamente ad ogni modifica del codice. Usalo solo durante il sviluppo.
 
-In the output, there's a line with something like:
+Nell'output c'è questa riga:
 
 ```hl_lines="4"
 INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```
 
-That line shows the URL where your app is being served, in your local machine.
+La riga mostra l'URL dove è disponibile la tua app sulla tua macchina.
 
-### Check it
+### Testalo
 
-Open your browser at <a href="http://127.0.0.1:8000" class="external-link" target="_blank">http://127.0.0.1:8000</a>.
+Apri il browser all'indirizzo <a href="http://127.0.0.1:8000" class="external-link" target="_blank">http://127.0.0.1:8000</a>.
 
-You will see the JSON response as:
+Vedrai la seguente risposta JSON:
 
 ```JSON
 {"message": "Hello World"}
 ```
 
-### Interactive API docs
+### Documentazione API interattiva
 
-Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Adesso vai su <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
 
-You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+Vedrai la documentazione dell'API interattiva generata automaticamente (offerta da <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
-### Alternative API docs
+### Documentazione API interattiva alternativa
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+Adesso vai su <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
 
-You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
+Vedrai una documentazione dell'API alternativa (offerta da <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
 ### OpenAPI
 
-**FastAPI** generates a "schema" with all your API using the **OpenAPI** standard for defining APIs.
+**FastAPI** genera uno "schema" con la tua API usando lo standard **OpenAPI** standard per definire le API.
 
 #### "Schema"
 
-A "schema" is a definition or description of something. Not the code that implements it, but just an abstract description.
+Uno "schema" è la definizione o descrizione di qualcosa. Non si tratta della descrizione del codice, è qualcosa di più astratto.
 
-#### API "schema"
+####"Schema" dell'API
 
-In this case, <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> is a specification that dictates how to define a schema of your API.
+In questo caso, <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> è la specifica che stabilisce come definire lo schema della tua API.
 
-This schema definition includes your API paths, the possible parameters they take, etc.
+La definizione di questo schema riguarda anche i percorsi dell'API, i possibili parametri che possono accettare, e così via.
 
-#### Data "schema"
+#### Lo "schema" dei dati
 
-The term "schema" might also refer to the shape of some data, like a JSON content.
+Il termine "schema" potrebbe anche riguardare la struttura di certi dati, come i contenuti JSON.
 
-In that case, it would mean the JSON attributes, and data types they have, etc.
+In quel caso, potrebbe riguardare gli attributi JSON, e i loro tipi di valori, ecc.
 
-#### OpenAPI and JSON Schema
+#### Schema OpenAPI e JSON
 
-OpenAPI defines an API schema for your API. And that schema includes definitions (or "schemas") of the data sent and received by your API using **JSON Schema**, the standard for JSON data schemas.
+OpenAPI definisce uno schema per la tua API. E quello schema include le definizioni (o "schemas") dei dati inviati e ricevuti dalla tua API usando lo **Schema JSON**, lo standard per gli schemi JSON.
 
-#### Check the `openapi.json`
+#### Controlla `openapi.json`
 
-If you are curious about how the raw OpenAPI schema looks like, FastAPI automatically generates a JSON (schema) with the descriptions of all your API.
+Se sei curioso dello schema OpenAPI, FastAPI genera automaticamente un file JSON (lo "schema") con una descrizione di tutte le tue API.
 
-You can see it directly at: <a href="http://127.0.0.1:8000/openapi.json" class="external-link" target="_blank">http://127.0.0.1:8000/openapi.json</a>.
+Lo puoi vedere al seguente indirizzo: <a href="http://127.0.0.1:8000/openapi.json" class="external-link" target="_blank">http://127.0.0.1:8000/openapi.json</a>.
 
-It will show a JSON starting with something like:
+Vedrai un file JSON che inizia circa così:
 
 ```JSON
 {
@@ -118,40 +118,40 @@ It will show a JSON starting with something like:
 ...
 ```
 
-#### What is OpenAPI for
+#### A cosa serve OpenAPI
 
-The OpenAPI schema is what powers the two interactive documentation systems included.
+Lo schema OpenAPI è ciò su cui sono basati i due sistemi di documentazione interattiva inclusi.
 
-And there are dozens of alternatives, all based on OpenAPI. You could easily add any of those alternatives to your application built with **FastAPI**.
+E ci sono dozzine di alternative, tutte basate su OpenAPI. È facile adattare una qualsiasi alternativa alla tua applicazione con **FastAPI**.
 
-You could also use it to generate code automatically, for clients that communicate with your API. For example, frontend, mobile or IoT applications.
+Puoi anche usare lo schema OpenAPI per generare il codice automaticamente per i client che comunicano con la tua API. Per esempio, le applicazioni web, mobile o IoT.
 
-## Recap, step by step
+## Riassumendo, passo a passo
 
-### Step 1: import `FastAPI`
+### Passo 1: import `FastAPI`
 
 ```Python hl_lines="1"
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-`FastAPI` is a Python class that provides all the functionality for your API.
+`FastAPI` è una classe in Python che ti fornisce tutto quello che serve per progettare la tua API.
 
-!!! note "Technical Details"
-    `FastAPI` is a class that inherits directly from `Starlette`.
+!!! note "Dettagli Tecnici"
+    `FastAPI` è una classe che eredita direttamente da `Starlette`.
 
-    You can use all the <a href="https://www.starlette.io/" class="external-link" target="_blank">Starlette</a> functionality with `FastAPI` too.
+    Puoi usare tutte le funzionalità di <a href="https://www.starlette.io/" class="external-link" target="_blank">Starlette</a> anche con `FastAPI`.
 
-### Step 2: create a `FastAPI` "instance"
+### Passo 2: crea una "istanza" di `FastAPI`
 
 ```Python hl_lines="3"
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-Here the `app` variable will be an "instance" of the class `FastAPI`.
+Qui la variabile `app` è una "istanza" della classe `FastAPI`.
 
-This will be the main point of interaction to create all your API.
+Useremo questa variabile per creare l'API.
 
-This `app` is the same one referred by `uvicorn` in the command:
+Questa `app` è la stessa che abbiamo specificato con il comando `uvicorn`:
 
 <div class="termy">
 
@@ -163,13 +163,13 @@ $ uvicorn main:app --reload
 
 </div>
 
-If you create your app like:
+Se crei un'app in questo modo:
 
 ```Python hl_lines="3"
 {!../../../docs_src/first_steps/tutorial002.py!}
 ```
 
-And put it in a file `main.py`, then you would call `uvicorn` like:
+E aggiori il file `main.py`, allora dovresti chiamare `uvicorn` così:
 
 <div class="termy">
 
@@ -181,73 +181,73 @@ $ uvicorn main:my_awesome_api --reload
 
 </div>
 
-### Step 3: create a *path operation*
+### Passo 3: crea un *path operation*
 
 #### Path
 
-"Path" here refers to the last part of the URL starting from the first `/`.
+Qui <abbr title="in italiano: percorso">"path"</abbr> si riferisce all'ultima parte di un URL che inizia con `/`.
 
-So, in a URL like:
+Quindi, in questo URL:
 
 ```
 https://example.com/items/foo
 ```
 
-...the path would be:
+...il path è:
 
 ```
 /items/foo
 ```
 
 !!! info
-    A "path" is also commonly called an "endpoint" or a "route".
+    Un "path" è anche comunemente chiamato "endpoint" o "route".
 
-While building an API, the "path" is the main way to separate "concerns" and "resources".
+Quando progetti una API, il "path" è il modo principale per separare "concerns" e "resources".
 
 #### Operation
 
-"Operation" here refers to one of the HTTP "methods".
+Qui "operation" si riferisce a uno dei <abbr title="in italiano: metodi HTTP">"HTTP methods"</abbr>.
 
-One of:
+Per esempio:
 
 * `POST`
 * `GET`
 * `PUT`
 * `DELETE`
 
-...and the more exotic ones:
+...ma anche:
 
 * `OPTIONS`
 * `HEAD`
 * `PATCH`
 * `TRACE`
 
-In the HTTP protocol, you can communicate to each path using one (or more) of these "methods".
+Con il protocollo HTTP, puoi comunicare a ogni path usando uno (o più) di questi "methods".
 
 ---
 
-When building APIs, you normally use these specific HTTP methods to perform a specific action.
+Quando progetti API, normalmente puoi usare uno dei HTTP methods per compiere una certa azione.
 
-Normally you use:
+Normalmente si usa:
 
-* `POST`: to create data.
-* `GET`: to read data.
-* `PUT`: to update data.
-* `DELETE`: to delete data.
+* `POST`: per creare dati.
+* `GET`: per leggere dati.
+* `PUT`: per aggiornare dati.
+* `DELETE`: per eliminare dati.
 
-So, in OpenAPI, each of the HTTP methods is called an "operation".
+Quindi, in OpenAPI, ogni metodo HTTP è chiamato "operation".
 
-We are going to call them "**operations**" too.
+Li andremo a chiamare "**operations**".
 
-#### Define a *path operation decorator*
+#### Definisci un *path operation decorator*
 
 ```Python hl_lines="6"
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-The `@app.get("/")` tells **FastAPI** that the function right below is in charge of handling requests that go to:
+`@app.get("/")` dice a **FastAPI** that the function right below is in charge of handling requests that go to:
 
-* the path `/`
+* il percorso `/`
 * using a <abbr title="an HTTP GET method"><code>get</code> operation</abbr>
 
 !!! info "`@decorator` Info"
@@ -295,11 +295,11 @@ This is our "**path operation function**":
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-This is a Python function.
+Questa è una funzione Python.
 
 It will be called by **FastAPI** whenever it receives a request to the URL "`/`" using a `GET` operation.
 
-In this case, it is an `async` function.
+In questo caso, è una funzione `async`.
 
 ---
 
@@ -309,10 +309,10 @@ You could also define it as a normal function instead of `async def`:
 {!../../../docs_src/first_steps/tutorial003.py!}
 ```
 
-!!! note
-    If you don't know the difference, check the [Async: *"In a hurry?"*](../async.md#in-a-hurry){.internal-link target=_blank}.
+!!! Suggerimento
+    Se non sai quale sia la differenza, consulta [Async: *"In a hurry?"*](../async.md#in-a-hurry){.internal-link target=_blank}.
 
-### Step 5: return the content
+### Passo 5: return the content
 
 ```Python hl_lines="8"
 {!../../../docs_src/first_steps/tutorial001.py!}
@@ -324,10 +324,10 @@ You can also return Pydantic models (you'll see more about that later).
 
 There are many other objects and models that will be automatically converted to JSON (including ORMs, etc). Try using your favorite ones, it's highly probable that they are already supported.
 
-## Recap
+## Riassumendo
 
-* Import `FastAPI`.
-* Create an `app` instance.
-* Write a **path operation decorator** (like `@app.get("/")`).
-* Write a **path operation function** (like `def root(): ...` above).
-* Run the development server (like `uvicorn main:app --reload`).
+* Importa `FastAPI`.
+* Crea un'istanza `app`.
+* Scrivi un **path operation decorator** (come `@app.get("/")`).
+* Scrivi una **path operation function** (come `def root(): ...` sopra).
+* Esegui il server di sviluppo (per esempio con `uvicorn main:app --reload`).

--- a/docs/it/docs/tutorial/first-steps.md
+++ b/docs/it/docs/tutorial/first-steps.md
@@ -1,6 +1,6 @@
 # Primi Passi
 
-Il più semplice script con FastAPI potrebbe essere questo:
+Il più semplice file con FastAPI potrebbe essere questo:
 
 ```Python
 {!../../../docs_src/first_steps/tutorial001.py!}
@@ -29,7 +29,7 @@ $ uvicorn main:app --reload
 
     * `main`: il file `main.py` (il "modulo" Python).
     * `app`: l'oggetto creato all'interno di `main.py` con la riga `app = FastAPI()`.
-    * `--reload`: riavvia il server automaticamente ad ogni modifica del codice. Usalo solo durante il sviluppo.
+    * `--reload`: riavvia il server automaticamente ad ogni modifica del codice. Usalo solo durante la fase di sviluppo.
 
 Nell'output c'è questa riga:
 
@@ -37,7 +37,7 @@ Nell'output c'è questa riga:
 INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```
 
-La riga mostra l'URL dove è disponibile la tua app sulla tua macchina.
+La riga mostra l'URL dove è ospitata localmente la tua app sulla tua macchina.
 
 ### Testalo
 
@@ -67,7 +67,7 @@ Vedrai una documentazione dell'API alternativa (offerta da <a href="https://gith
 
 ### OpenAPI
 
-**FastAPI** genera uno "schema" con la tua API usando lo standard **OpenAPI** standard per definire le API.
+**FastAPI** genera uno "schema" della tua API usando **OpenAPI**, standard per definire le API.
 
 #### "Schema"
 
@@ -83,17 +83,17 @@ La definizione di questo schema riguarda anche i percorsi dell'API, i possibili 
 
 Il termine "schema" potrebbe anche riguardare la struttura di certi dati, come i contenuti JSON.
 
-In quel caso, potrebbe riguardare gli attributi JSON, e i loro tipi di valori, ecc.
+In quel caso, potrebbe riguardare gli attributi JSON, e i tipi dei loro valori, ecc.
 
 #### Schema OpenAPI e JSON
 
-OpenAPI definisce uno schema per la tua API. E quello schema include le definizioni (o "schemas") dei dati inviati e ricevuti dalla tua API usando lo **Schema JSON**, lo standard per gli schemi JSON.
+OpenAPI definisce uno schema per la tua API. E questo schema include le definizioni (o "schemas") dei dati inviati e ricevuti dalla tua API usando lo **Schema JSON**, lo standard per gli schemi JSON.
 
 #### Controlla `openapi.json`
 
 Se sei curioso dello schema OpenAPI, FastAPI genera automaticamente un file JSON (lo "schema") con una descrizione di tutte le tue API.
 
-Lo puoi vedere al seguente indirizzo: <a href="http://127.0.0.1:8000/openapi.json" class="external-link" target="_blank">http://127.0.0.1:8000/openapi.json</a>.
+Lo puoi trovare al seguente indirizzo: <a href="http://127.0.0.1:8000/openapi.json" class="external-link" target="_blank">http://127.0.0.1:8000/openapi.json</a>.
 
 Vedrai un file JSON che inizia circa così:
 
@@ -120,13 +120,13 @@ Vedrai un file JSON che inizia circa così:
 
 #### A cosa serve OpenAPI
 
-Lo schema OpenAPI è ciò su cui sono basati i due sistemi di documentazione interattiva inclusi.
+Lo schema OpenAPI è ciò su cui sono basati i due sistemi di documentazione interattiva adottati dal framework.
 
 E ci sono dozzine di alternative, tutte basate su OpenAPI. È facile adattare una qualsiasi alternativa alla tua applicazione con **FastAPI**.
 
 Puoi anche usare lo schema OpenAPI per generare il codice automaticamente per i client che comunicano con la tua API. Per esempio, le applicazioni web, mobile o IoT.
 
-## Riassumendo, passo a passo
+## Ricapitolando, passo dopo passo
 
 ### Passo 1: import `FastAPI`
 
@@ -139,7 +139,7 @@ Puoi anche usare lo schema OpenAPI per generare il codice automaticamente per i 
 !!! note "Dettagli Tecnici"
     `FastAPI` è una classe che eredita direttamente da `Starlette`.
 
-    Puoi usare tutte le funzionalità di <a href="https://www.starlette.io/" class="external-link" target="_blank">Starlette</a> anche con `FastAPI`.
+    Puoi quindi usare tutte le funzionalità di <a href="https://www.starlette.io/" class="external-link" target="_blank">Starlette</a> anche con `FastAPI`.
 
 ### Passo 2: crea una "istanza" di `FastAPI`
 
@@ -163,13 +163,13 @@ $ uvicorn main:app --reload
 
 </div>
 
-Se crei un'app in questo modo:
+Quindi, se crei un'app così:
 
 ```Python hl_lines="3"
 {!../../../docs_src/first_steps/tutorial002.py!}
 ```
 
-E aggiori il file `main.py`, allora dovresti chiamare `uvicorn` così:
+E aggiori il file `main.py`, allora dovresti chiamare `uvicorn` in questo modo:
 
 <div class="termy">
 
@@ -222,11 +222,11 @@ Per esempio:
 * `PATCH`
 * `TRACE`
 
-Con il protocollo HTTP, puoi comunicare a ogni path usando uno (o più) di questi "methods".
+Con il protocollo HTTP puoi comunicare con ogni path usando uno (o più) di questi "methods".
 
 ---
 
-Quando progetti API, normalmente puoi usare uno dei HTTP methods per compiere una certa azione.
+Quando progetti API, normalmente puoi usare uno dei metodi HTTP per portare a termine una determinata azione.
 
 Normalmente si usa:
 
@@ -235,7 +235,7 @@ Normalmente si usa:
 * `PUT`: per aggiornare dati.
 * `DELETE`: per eliminare dati.
 
-Quindi, in OpenAPI, ogni metodo HTTP è chiamato "operation".
+Quindi, all'interno di OpenAPI, ogni metodo HTTP è chiamato "operation".
 
 Li andremo a chiamare "**operations**".
 
@@ -245,29 +245,29 @@ Li andremo a chiamare "**operations**".
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-`@app.get("/")` dice a **FastAPI** that the function right below is in charge of handling requests that go to:
+`@app.get("/")` dice a **FastAPI** che la funzione sottostante è resposabile delle richieste che:
 
-* il percorso `/`
-* using a <abbr title="an HTTP GET method"><code>get</code> operation</abbr>
+* specificano il percorso `/`
+* usano una <abbr title="un metodo HTTP GET"><code>get</code> operation</abbr>
 
 !!! info "`@decorator` Info"
-    That `@something` syntax in Python is called a "decorator".
+    La sintassi `@something` in Python è chiamata <abbr title="in italiano: decoratore">"decorator"</abbr>.
 
-    You put it on top of a function. Like a pretty decorative hat (I guess that's where the term came from).
+    La metti sopra una funzione. Come se fosse un bel cappellino di decorazione (forse è da lì che proviene il nome).
 
-    A "decorator" takes the function below and does something with it.
+    Un "decorator" prende la funzione sottostante e la usa per farci qualcosa.
 
-    In our case, this decorator tells **FastAPI** that the function below corresponds to the **path** `/` with an **operation** `get`.
+    Nel nostor caso, questo decoratore dice a **FastAPI** che la funzione sottostante corrisponde al path **path** `/` con una **operation** `get`.
 
-    It is the "**path operation decorator**".
+    È quindi il "**path operation decorator**".
 
-You can also use the other operations:
+Puoi anche usare altre operazioni:
 
 * `@app.post()`
 * `@app.put()`
 * `@app.delete()`
 
-And the more exotic ones:
+E anche queste meno comuni:
 
 * `@app.options()`
 * `@app.head()`
@@ -275,17 +275,17 @@ And the more exotic ones:
 * `@app.trace()`
 
 !!! tip
-    You are free to use each operation (HTTP method) as you wish.
+    Sei libero di una usare qualsiasi operazione (metodo HTTP).
 
     **FastAPI** doesn't enforce any specific meaning.
 
-    The information here is presented as a guideline, not a requirement.
+    Le informazioni qui sono presentate come linee guida, non come requisiti specifici.
 
-    For example, when using GraphQL you normally perform all the actions using only `POST` operations.
+    Per esempio, quando usi GraphQL normalmente esegue tutte le azioni usando solo operazioni `POST`.
 
-### Step 4: define the **path operation function**
+### Passo 4: definisci la **path operation function**
 
-This is our "**path operation function**":
+Questa è la nostra "**path operation function**":
 
 * **path**: is `/`.
 * **operation**: is `get`.
@@ -297,13 +297,13 @@ This is our "**path operation function**":
 
 Questa è una funzione Python.
 
-It will be called by **FastAPI** whenever it receives a request to the URL "`/`" using a `GET` operation.
+Sarà chiamata da **FastAPI** ogni volta che riceverà la richiesta all'URL "`/`" usando un'operazione `GET`.
 
 In questo caso, è una funzione `async`.
 
 ---
 
-You could also define it as a normal function instead of `async def`:
+Puoi anche definirla come una funzione normale usando `async def`:
 
 ```Python hl_lines="7"
 {!../../../docs_src/first_steps/tutorial003.py!}
@@ -318,13 +318,13 @@ You could also define it as a normal function instead of `async def`:
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-You can return a `dict`, `list`, singular values as `str`, `int`, etc.
+Puoi restituire un `dict`, `list`, valori singoli come `str`, `int`, ecc.
 
-You can also return Pydantic models (you'll see more about that later).
+Puoi anche restituire i modelli Pydantic (li vedremo tra poco).
 
-There are many other objects and models that will be automatically converted to JSON (including ORMs, etc). Try using your favorite ones, it's highly probable that they are already supported.
+Ci sono anche tanti altri oggetti e modelli che saranno automaticamente convertiti in JSON (inclusi gli ORM, ecc). Prova a usare i tuoi oggetti preferiti, è molto probabile che saranno supportati.
 
-## Riassumendo
+## Ricapitolando
 
 * Importa `FastAPI`.
 * Crea un'istanza `app`.

--- a/docs/it/docs/tutorial/first-steps.md
+++ b/docs/it/docs/tutorial/first-steps.md
@@ -1,0 +1,333 @@
+# Primi Passi
+
+The simplest FastAPI file could look like this:
+
+```Python
+{!../../../docs_src/first_steps/tutorial001.py!}
+```
+
+Copy that to a file `main.py`.
+
+Run the live server:
+
+<div class="termy">
+
+```console
+$ uvicorn main:app --reload
+
+<span style="color: green;">INFO</span>:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+<span style="color: green;">INFO</span>:     Started reloader process [28720]
+<span style="color: green;">INFO</span>:     Started server process [28722]
+<span style="color: green;">INFO</span>:     Waiting for application startup.
+<span style="color: green;">INFO</span>:     Application startup complete.
+```
+
+</div>
+
+!!! note
+    The command `uvicorn main:app` refers to:
+
+    * `main`: the file `main.py` (the Python "module").
+    * `app`: the object created inside of `main.py` with the line `app = FastAPI()`.
+    * `--reload`: make the server restart after code changes. Only use for development.
+
+In the output, there's a line with something like:
+
+```hl_lines="4"
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+That line shows the URL where your app is being served, in your local machine.
+
+### Check it
+
+Open your browser at <a href="http://127.0.0.1:8000" class="external-link" target="_blank">http://127.0.0.1:8000</a>.
+
+You will see the JSON response as:
+
+```JSON
+{"message": "Hello World"}
+```
+
+### Interactive API docs
+
+Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+
+You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+
+![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
+
+### Alternative API docs
+
+And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+
+You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
+
+![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
+
+### OpenAPI
+
+**FastAPI** generates a "schema" with all your API using the **OpenAPI** standard for defining APIs.
+
+#### "Schema"
+
+A "schema" is a definition or description of something. Not the code that implements it, but just an abstract description.
+
+#### API "schema"
+
+In this case, <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> is a specification that dictates how to define a schema of your API.
+
+This schema definition includes your API paths, the possible parameters they take, etc.
+
+#### Data "schema"
+
+The term "schema" might also refer to the shape of some data, like a JSON content.
+
+In that case, it would mean the JSON attributes, and data types they have, etc.
+
+#### OpenAPI and JSON Schema
+
+OpenAPI defines an API schema for your API. And that schema includes definitions (or "schemas") of the data sent and received by your API using **JSON Schema**, the standard for JSON data schemas.
+
+#### Check the `openapi.json`
+
+If you are curious about how the raw OpenAPI schema looks like, FastAPI automatically generates a JSON (schema) with the descriptions of all your API.
+
+You can see it directly at: <a href="http://127.0.0.1:8000/openapi.json" class="external-link" target="_blank">http://127.0.0.1:8000/openapi.json</a>.
+
+It will show a JSON starting with something like:
+
+```JSON
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "FastAPI",
+        "version": "0.1.0"
+    },
+    "paths": {
+        "/items/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+
+
+
+...
+```
+
+#### What is OpenAPI for
+
+The OpenAPI schema is what powers the two interactive documentation systems included.
+
+And there are dozens of alternatives, all based on OpenAPI. You could easily add any of those alternatives to your application built with **FastAPI**.
+
+You could also use it to generate code automatically, for clients that communicate with your API. For example, frontend, mobile or IoT applications.
+
+## Recap, step by step
+
+### Step 1: import `FastAPI`
+
+```Python hl_lines="1"
+{!../../../docs_src/first_steps/tutorial001.py!}
+```
+
+`FastAPI` is a Python class that provides all the functionality for your API.
+
+!!! note "Technical Details"
+    `FastAPI` is a class that inherits directly from `Starlette`.
+
+    You can use all the <a href="https://www.starlette.io/" class="external-link" target="_blank">Starlette</a> functionality with `FastAPI` too.
+
+### Step 2: create a `FastAPI` "instance"
+
+```Python hl_lines="3"
+{!../../../docs_src/first_steps/tutorial001.py!}
+```
+
+Here the `app` variable will be an "instance" of the class `FastAPI`.
+
+This will be the main point of interaction to create all your API.
+
+This `app` is the same one referred by `uvicorn` in the command:
+
+<div class="termy">
+
+```console
+$ uvicorn main:app --reload
+
+<span style="color: green;">INFO</span>:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+</div>
+
+If you create your app like:
+
+```Python hl_lines="3"
+{!../../../docs_src/first_steps/tutorial002.py!}
+```
+
+And put it in a file `main.py`, then you would call `uvicorn` like:
+
+<div class="termy">
+
+```console
+$ uvicorn main:my_awesome_api --reload
+
+<span style="color: green;">INFO</span>:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+</div>
+
+### Step 3: create a *path operation*
+
+#### Path
+
+"Path" here refers to the last part of the URL starting from the first `/`.
+
+So, in a URL like:
+
+```
+https://example.com/items/foo
+```
+
+...the path would be:
+
+```
+/items/foo
+```
+
+!!! info
+    A "path" is also commonly called an "endpoint" or a "route".
+
+While building an API, the "path" is the main way to separate "concerns" and "resources".
+
+#### Operation
+
+"Operation" here refers to one of the HTTP "methods".
+
+One of:
+
+* `POST`
+* `GET`
+* `PUT`
+* `DELETE`
+
+...and the more exotic ones:
+
+* `OPTIONS`
+* `HEAD`
+* `PATCH`
+* `TRACE`
+
+In the HTTP protocol, you can communicate to each path using one (or more) of these "methods".
+
+---
+
+When building APIs, you normally use these specific HTTP methods to perform a specific action.
+
+Normally you use:
+
+* `POST`: to create data.
+* `GET`: to read data.
+* `PUT`: to update data.
+* `DELETE`: to delete data.
+
+So, in OpenAPI, each of the HTTP methods is called an "operation".
+
+We are going to call them "**operations**" too.
+
+#### Define a *path operation decorator*
+
+```Python hl_lines="6"
+{!../../../docs_src/first_steps/tutorial001.py!}
+```
+
+The `@app.get("/")` tells **FastAPI** that the function right below is in charge of handling requests that go to:
+
+* the path `/`
+* using a <abbr title="an HTTP GET method"><code>get</code> operation</abbr>
+
+!!! info "`@decorator` Info"
+    That `@something` syntax in Python is called a "decorator".
+
+    You put it on top of a function. Like a pretty decorative hat (I guess that's where the term came from).
+
+    A "decorator" takes the function below and does something with it.
+
+    In our case, this decorator tells **FastAPI** that the function below corresponds to the **path** `/` with an **operation** `get`.
+
+    It is the "**path operation decorator**".
+
+You can also use the other operations:
+
+* `@app.post()`
+* `@app.put()`
+* `@app.delete()`
+
+And the more exotic ones:
+
+* `@app.options()`
+* `@app.head()`
+* `@app.patch()`
+* `@app.trace()`
+
+!!! tip
+    You are free to use each operation (HTTP method) as you wish.
+
+    **FastAPI** doesn't enforce any specific meaning.
+
+    The information here is presented as a guideline, not a requirement.
+
+    For example, when using GraphQL you normally perform all the actions using only `POST` operations.
+
+### Step 4: define the **path operation function**
+
+This is our "**path operation function**":
+
+* **path**: is `/`.
+* **operation**: is `get`.
+* **function**: is the function below the "decorator" (below `@app.get("/")`).
+
+```Python hl_lines="7"
+{!../../../docs_src/first_steps/tutorial001.py!}
+```
+
+This is a Python function.
+
+It will be called by **FastAPI** whenever it receives a request to the URL "`/`" using a `GET` operation.
+
+In this case, it is an `async` function.
+
+---
+
+You could also define it as a normal function instead of `async def`:
+
+```Python hl_lines="7"
+{!../../../docs_src/first_steps/tutorial003.py!}
+```
+
+!!! note
+    If you don't know the difference, check the [Async: *"In a hurry?"*](../async.md#in-a-hurry){.internal-link target=_blank}.
+
+### Step 5: return the content
+
+```Python hl_lines="8"
+{!../../../docs_src/first_steps/tutorial001.py!}
+```
+
+You can return a `dict`, `list`, singular values as `str`, `int`, etc.
+
+You can also return Pydantic models (you'll see more about that later).
+
+There are many other objects and models that will be automatically converted to JSON (including ORMs, etc). Try using your favorite ones, it's highly probable that they are already supported.
+
+## Recap
+
+* Import `FastAPI`.
+* Create an `app` instance.
+* Write a **path operation decorator** (like `@app.get("/")`).
+* Write a **path operation function** (like `def root(): ...` above).
+* Run the development server (like `uvicorn main:app --reload`).

--- a/docs/it/docs/tutorial/index.md
+++ b/docs/it/docs/tutorial/index.md
@@ -1,0 +1,80 @@
+# Tutorial - Guida Utente - Introduzione
+
+Questo tutorial ti spiega come usare **FastAPI** e le sue funzionalità, passo per passo.
+
+Ogni sezione sviluppa sugli argomenti trattati nella sezione precedente, ma la guida è strutturata in modo tale ciascuna sezione possa essere consultata singolarmente.
+
+In questo modo potrai usare il tutorial anche come referenza.
+
+Così potrai tornare indietro e rivedere solo i concetti che ti servono.
+
+## Esegui il codice
+
+Tutti i blocchi di codice che vedrai nella guida possono essere copiati e usati direttamente (fanno parte dei test interni).
+
+Per provare gli esempi, copia il codice in un file chiamato `main.py`, e avvia `uvicorn` con il seguente comando:
+
+<div class="termy">
+
+```console
+$ uvicorn main:app --reload
+
+<span style="color: green;">INFO</span>:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+<span style="color: green;">INFO</span>:     Started reloader process [28720]
+<span style="color: green;">INFO</span>:     Started server process [28722]
+<span style="color: green;">INFO</span>:     Waiting for application startup.
+<span style="color: green;">INFO</span>:     Application startup complete.
+```
+
+</div>
+
+È **ALTAMENTE consigliato** scrivere o copiare il codice, modificarlo ed eseguirlo localmente.
+
+Quando proverai gli esempi direttamente all'interno dell'editor di testo noterai immediatamente i vantaggi di FastAPI, quanto poco codice serva, i controlli sulle annotazioni di tipo, l'autocompletamento, ecc.
+
+---
+
+## Installa FastAPI
+
+Il primo passo è quello di installare FastAPI.
+
+Per questo tutorial è consigliato installarlo insieme alle dipendenze e funzionalità opzionali:
+
+<div class="termy">
+
+```console
+$ pip install fastapi[all]
+
+---> 100%
+```
+
+</div>
+
+...il che include `uvicorn`, che puoi usare come server per eseguire il tuo codice.
+
+!!! nota
+    Puoi anche installare le dipendenze singolarmente, una per una.
+
+    Il che è consigliato quando vorrai rilasciare la tua applicazione in produzione:
+
+    ```
+    pip install fastapi
+    ```
+
+    Puoi installare `uvicorn`, il server che esegue il codice:
+
+    ```
+    pip install uvicorn
+    ```
+
+    Puoi seguire lo stesso procedimento per ciascuna dipendenza opzionale che vorrai usare.
+
+## Guida Utente Avanzata
+
+È disponibile anche una **Guida Utente Avanzata** che potrai consultare dopo il **Tutorial - Guida Utente**.
+
+La **Guida Utente Avanzata**, che è la successione e che usa gli stessi concetti di questo Tutorial, ti mostra alcune funzionalità aggiuntive.
+
+Ti consigliamo però di completare il **Tutorial - Guida Utente** (che stai leggendo in questo momento).
+
+Il **Tutorial - Guida Utente** ti mostra come sviluppare un'applicazione completa, che potrai migliorare a seconda delle tue esigenze usando alcuni dei concetti più avanzati della **Guida Avanzata Utente**.

--- a/docs/it/docs/tutorial/index.md
+++ b/docs/it/docs/tutorial/index.md
@@ -1,8 +1,8 @@
 # Tutorial - Guida Utente - Introduzione
 
-Questo tutorial ti spiega come usare **FastAPI** e le sue funzionalità, passo per passo.
+Questo tutorial ti spiega come usare **FastAPI** e le sue funzionalità, passo dopo passo.
 
-Ogni sezione sviluppa sugli argomenti trattati nella sezione precedente, ma la guida è strutturata in modo tale ciascuna sezione possa essere consultata singolarmente.
+Ogni sezione sviluppa gli argomenti trattati nella sezione precedente, ma la guida è strutturata in modo tale che ciascuna sezione possa essere consultata singolarmente.
 
 In questo modo potrai usare il tutorial anche come referenza.
 
@@ -10,7 +10,7 @@ Così potrai tornare indietro e rivedere solo i concetti che ti servono.
 
 ## Esegui il codice
 
-Tutti i blocchi di codice che vedrai nella guida possono essere copiati e usati direttamente (fanno parte dei test interni).
+Tutti i blocchi di codice che vedrai nella guida possono essere copiati e usati direttamente (fanno parte della suite di test del framework).
 
 Per provare gli esempi, copia il codice in un file chiamato `main.py`, e avvia `uvicorn` con il seguente comando:
 
@@ -30,7 +30,7 @@ $ uvicorn main:app --reload
 
 È **ALTAMENTE consigliato** scrivere o copiare il codice, modificarlo ed eseguirlo localmente.
 
-Quando proverai gli esempi direttamente all'interno dell'editor di testo noterai immediatamente i vantaggi di FastAPI, quanto poco codice serva, i controlli sulle annotazioni di tipo, l'autocompletamento, ecc.
+Quando proverai gli esempi direttamente all'interno dell'editor di testo ti accorgerai subito dei vantaggi di FastAPI, quanto poco codice serva scrivere, i controlli sulle annotazioni di tipo, l'autocompletamento, ecc.
 
 ---
 
@@ -38,7 +38,7 @@ Quando proverai gli esempi direttamente all'interno dell'editor di testo noterai
 
 Il primo passo è quello di installare FastAPI.
 
-Per questo tutorial è consigliato installarlo insieme alle dipendenze e funzionalità opzionali:
+Per questo tutorial è consigliato installarlo insieme alle dipendenze e funzionalità opzionali con il seguente comando:
 
 <div class="termy">
 
@@ -61,7 +61,7 @@ $ pip install fastapi[all]
     pip install fastapi
     ```
 
-    Puoi installare `uvicorn`, il server che esegue il codice:
+    Per installare `uvicorn`, il server che esegue il codice, usa:
 
     ```
     pip install uvicorn
@@ -73,8 +73,8 @@ $ pip install fastapi[all]
 
 È disponibile anche una **Guida Utente Avanzata** che potrai consultare dopo il **Tutorial - Guida Utente**.
 
-La **Guida Utente Avanzata**, che è la successione e che usa gli stessi concetti di questo Tutorial, ti mostra alcune funzionalità aggiuntive.
+La **Guida Utente Avanzata**, che usa gli stessi concetti di questo Tutorial e ne è il suo proseguimento, ti mostra alcune funzionalità aggiuntive.
 
-Ti consigliamo però di completare il **Tutorial - Guida Utente** (che stai leggendo in questo momento).
+Ti consigliamo però di completare prima il **Tutorial - Guida Utente** (che stai leggendo in questo momento).
 
 Il **Tutorial - Guida Utente** ti mostra come sviluppare un'applicazione completa, che potrai migliorare a seconda delle tue esigenze usando alcuni dei concetti più avanzati della **Guida Avanzata Utente**.

--- a/docs/it/mkdocs.yml
+++ b/docs/it/mkdocs.yml
@@ -26,6 +26,9 @@ nav:
   - pt: /pt/
   - ru: /ru/
   - zh: /zh/
+- Tutorial - User Guide:
+  - tutorial/index.md
+  - tutorial/first-steps.md
 markdown_extensions:
 - toc:
     permalink: true


### PR DESCRIPTION
I've translated `index.md` and `first-steps.md` from Tutorial - User Guide to Italian (the first file was so short that I included both in the PR, separate PRs will be created this way forward). `docs/it/mkdocs.yml` was updated accordingly. 