### PR TITLE
OpenAPI docs for scopes defined on a single route

### DIFF
--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -50,7 +50,7 @@ class Dependant:
         self.websocket_param_name = websocket_param_name
         self.response_param_name = response_param_name
         self.background_tasks_param_name = background_tasks_param_name
-        self.security_scopes = security_scopes
+        self.security_scopes = security_scopes or []
         self.security_scopes_param_name = security_scopes_param_name
         self.name = name
         self.call = call

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -170,6 +170,7 @@ def get_flat_dependant(
         cookie_params=dependant.cookie_params.copy(),
         body_params=dependant.body_params.copy(),
         security_schemes=dependant.security_requirements.copy(),
+        security_scopes=dependant.security_scopes.copy(),
         use_cache=dependant.use_cache,
         path=dependant.path,
     )
@@ -185,6 +186,7 @@ def get_flat_dependant(
         flat_dependant.cookie_params.extend(flat_sub.cookie_params)
         flat_dependant.body_params.extend(flat_sub.body_params)
         flat_dependant.security_requirements.extend(flat_sub.security_requirements)
+        flat_dependant.security_scopes.extend(flat_sub.security_scopes)
     return flat_dependant
 
 

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -38,6 +38,13 @@ def read_current_user(current_user: "User" = Depends(get_current_user)):
     return current_user
 
 
+@app.get("/users/")
+def list_users(
+    current_user: "User" = Security(get_current_user, scopes=["read:users"])
+):
+    return [User(username="first"), User(username="second")]
+
+
 client = TestClient(app)
 
 openapi_schema = {
@@ -87,6 +94,19 @@ openapi_schema = {
                 "summary": "Read Current User",
                 "operationId": "read_current_user_users_me_get",
                 "security": [{"OAuth2": []}],
+            }
+        },
+        "/users/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    }
+                },
+                "summary": "List Users",
+                "operationId": "list_users_users__get",
+                "security": [{"OAuth2": ["read:users"]}],
             }
         },
     },

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -197,7 +197,7 @@ def test_security_oauth2_password_bearer_no_header():
     assert response.json() == {"detail": "Not authenticated"}
 
 
-def test_security_oauth2():
+def test_security_oauth2_scopes():
     response = client.get("/users/", headers={"Authorization": "Bearer footokenbar"})
     assert response.status_code == 200, response.text
     assert response.json() == [{"username": "first"}, {"username": "second"}]

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -197,6 +197,12 @@ def test_security_oauth2_password_bearer_no_header():
     assert response.json() == {"detail": "Not authenticated"}
 
 
+def test_security_oauth2():
+    response = client.get("/users/", headers={"Authorization": "Bearer footokenbar"})
+    assert response.status_code == 200, response.text
+    assert response.json() == [{"username": "first"}, {"username": "second"}]
+
+
 required_params = {
     "detail": [
         {


### PR DESCRIPTION
Scopes that are defined on an individual route as part of a `Security` Dependency were not being returned on the OpenAPI JSON that is generated.

This seems to be because when the dependencies are flattened the `security_scopes` are not being flattened (unlike `security_requirements` and others which are). This sets the default scopes to an empty list and flattens the scopes of sub dependencies. I've added a test which confirms this in the OAuth2 test.

I'm brand new to the FastAPI code base so I am unsure if there are any unintended consequences with this approach - but all the tests seem to pass and the new behaviour makes sense in my understanding of what the code should do.