### PR TITLE
Update URI for deprecation openapi_prefix message

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -80,7 +80,7 @@ class FastAPI(Starlette):
                 '"openapi_prefix" has been deprecated in favor of "root_path", which '
                 "follows more closely the ASGI standard, is simpler, and more "
                 "automatic. Check the docs at "
-                "https://fastapi.tiangolo.com/advanced/sub-applications-proxy/"
+                "https://fastapi.tiangolo.com/advanced/sub-applications/"
             )
         self.root_path = root_path or openapi_prefix
         self.docs_url = docs_url


### PR DESCRIPTION
Looks like documentation has been updated and previous link [(/sub-applications-proxy/)](https://fastapi.tiangolo.com/advanced/sub-applications-proxy/) is returning 404