### PR TITLE
Raise form early

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,5 +1,8 @@
 import asyncio
+import importlib
 import inspect
+import logging
+
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import (
@@ -776,6 +779,10 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         ]
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
+
+    if BodyFieldInfo == params.Form and importlib.util.find_spec("multipart") is None:
+        logging.error("Must import python-multipart.")
+
     return create_response_field(
         name="body",
         type_=BodyModel,

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import importlib
 import inspect
 import logging
-import pkgutil
 
 from contextlib import contextmanager
 from copy import deepcopy

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -798,8 +798,6 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
                 "[multipart] is installed and not compatible with [python-multipart]. "
                 "Uninstall [multipart] and then install [python-multipart]."
             )
-            [multipart] is installed and not compatible with [python-multipart]. 
-            Uninstall [multipart] and then install [python-multipart]."""
             logger.error(error)
             raise RuntimeError(error)
     return create_response_field(

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -740,7 +740,7 @@ def get_schema_compatible_field(*, field: ModelField) -> ModelField:
 
 
 def is_form_data(BodyFieldInfo):
-    return BodyFieldInfo == params.Form or BodyFieldInfo == params.UploadFile or BodyFieldInfo == bytes
+    return BodyFieldInfo == params.Form or BodyFieldInfo == params.File or BodyFieldInfo == bytes
 
 
 def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
@@ -783,9 +783,18 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         ]
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
-
-    if is_form_data(BodyFieldInfo) and importlib.util.find_spec("multipart") is None:
-        logging.error("Must import python-multipart.")
+    
+    if is_form_data(BodyFieldInfo):
+            if importlib.util.find_spec("multipart") is None:
+                logging.error("Import python-multipart.")
+                return
+            else:
+                import multipart as mp
+                if len(mp.__package__) == 0:
+                    logging.error("Wrong multipart import. pip3 uninstall multipart --> pip3 install python-multipart.")
+                    return
+                else:
+                    print('You have the right multipart!')
 
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -785,16 +785,18 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
     
     if is_form_data(BodyFieldInfo):
         try:
-            import multipart
-            multipart.QuerystringParser({})
-        except AttributeError:  # raised if multipart.QuerystringParser({}) errors out
-            error = """Form data requires [python-multipart] to be installed. Currently
+            import multipart  # check to see if there's an import
+            multipart.QuerystringParser({})  # check to see if correct import using a python-multipart function
+        except AttributeError:
+            error = """Form data requires [python-multipart] to be installed. Currently 
             [multipart] is installed and not compatible with [python-multipart]. 
             Uninstall [multipart] and then install [python-multipart]."""
             logging.error(error)
-            raise ImportError(error)
+            raise RuntimeError(error)
         except ModuleNotFoundError:
-            logging.error("multipart not installed")
+            error = "Form data requires [python-multipart] to be installed."
+            logging.error(error)
+            raise RuntimeError(error)
 
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -783,9 +783,18 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         ]
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
-
-    if is_form_data(BodyFieldInfo) and importlib.util.find_spec("multipart") is None:
-        logging.error("Must import python-multipart.")
+    
+    if is_form_data(BodyFieldInfo):
+            if importlib.util.find_spec("multipart") is None:
+                logging.error("Import python-multipart.")
+                return
+            else:
+                import multipart as mp
+                if len(mp.__package__) == 0:
+                    logging.error("Wrong multipart import. pip3 uninstall multipart --> pip3 install python-multipart.")
+                    return
+                else:
+                    print('You have the right multipart!')
 
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -785,16 +785,14 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
     
     if is_form_data(BodyFieldInfo):
-            if importlib.util.find_spec("multipart") is None:
-                logging.error("Import python-multipart.")
-                return
-            else:
-                import multipart as mp
-                if len(mp.__package__) == 0:
-                    logging.error("Wrong multipart import. pip3 uninstall multipart --> pip3 install python-multipart.")
-                    return
-                else:
-                    print('You have the right multipart!')
+        if importlib.util.find_spec("multipart") is None:
+            logging.error("Import python-multipart.")
+            return
+        try:
+            import multipart
+            multipart.QuerystringParser({})
+        except ImportError:
+            logging.error("kys")
 
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import logging
-
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import (
@@ -738,8 +737,8 @@ def get_schema_compatible_field(*, field: ModelField) -> ModelField:
     return out_field
 
 
-def is_form_data(BodyFieldInfo):
-    return BodyFieldInfo == params.Form or BodyFieldInfo == params.File or BodyFieldInfo == bytes
+def is_form_data(field: Type[params.Body]) -> bool:
+    return field == params.Form or field == params.File or field == bytes
 
 
 def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
@@ -782,11 +781,14 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         ]
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
-    
+
     if is_form_data(BodyFieldInfo):
         try:
             import multipart  # check to see if there's an import
-            multipart.QuerystringParser({})  # check to see if correct import using a python-multipart function
+
+            multipart.QuerystringParser(
+                {}
+            )  # check to see if correct import using a python-multipart function
         except AttributeError:
             error = """Form data requires [python-multipart] to be installed. Currently 
             [multipart] is installed and not compatible with [python-multipart]. 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -788,14 +788,14 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             QuerystringParser(  # check if correct import using python-multipart function
                 {}
             )
+        except ModuleNotFoundError:
+            error = "Form data requires [python-multipart] to be installed."
+            logger.error(error)
+            raise RuntimeError(error)
         except ImportError:
             error = """Form data requires [python-multipart] to be installed. Currently 
             [multipart] is installed and not compatible with [python-multipart]. 
             Uninstall [multipart] and then install [python-multipart]."""
-            logger.error(error)
-            raise RuntimeError(error)
-        except ModuleNotFoundError:
-            error = "Form data requires [python-multipart] to be installed."
             logger.error(error)
             raise RuntimeError(error)
     return create_response_field(

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import inspect
-import logging
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import (
@@ -25,6 +24,7 @@ from fastapi.concurrency import (
     contextmanager_in_threadpool,
 )
 from fastapi.dependencies.models import Dependant, SecurityRequirement
+from fastapi.logger import logger
 from fastapi.security.base import SecurityBase
 from fastapi.security.oauth2 import OAuth2, SecurityScopes
 from fastapi.security.open_id_connect_url import OpenIdConnect
@@ -792,11 +792,11 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             error = """Form data requires [python-multipart] to be installed. Currently 
             [multipart] is installed and not compatible with [python-multipart]. 
             Uninstall [multipart] and then install [python-multipart]."""
-            logging.error(error)
+            logger.error(error)
             raise RuntimeError(error)
         except ModuleNotFoundError:
             error = "Form data requires [python-multipart] to be installed."
-            logging.error(error)
+            logger.error(error)
             raise RuntimeError(error)
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -788,7 +788,7 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             QuerystringParser(  # check if correct import using python-multipart function
                 {}
             )
-        except AttributeError:
+        except ImportError:
             error = """Form data requires [python-multipart] to be installed. Currently 
             [multipart] is installed and not compatible with [python-multipart]. 
             Uninstall [multipart] and then install [python-multipart]."""

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -785,16 +785,13 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
     
     if is_form_data(BodyFieldInfo):
-            if importlib.util.find_spec("multipart") is None:
-                logging.error("Import python-multipart.")
-                return
-            else:
-                import multipart as mp
-                if len(mp.__package__) == 0:
-                    logging.error("Wrong multipart import. pip3 uninstall multipart --> pip3 install python-multipart.")
-                    return
-                else:
-                    print('You have the right multipart!')
+        try:
+            import multipart
+            multipart.QuerystringParser({})
+        except AttributeError:
+            logging.error("incorrect multipart installed")
+        except ModuleNotFoundError:
+            logging.error("multipart straight up not installed")
 
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,5 +1,9 @@
 import asyncio
+import importlib
 import inspect
+import logging
+import pkgutil
+
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import (
@@ -776,6 +780,10 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         ]
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
+
+    if BodyFieldInfo == params.Form and importlib.util.find_spec("multipart") is None:
+        logging.error("Must import python-multipart.")
+
     return create_response_field(
         name="body",
         type_=BodyModel,

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -786,13 +786,19 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
     
     if is_form_data(BodyFieldInfo):
         if importlib.util.find_spec("multipart") is None:
-            logging.error("Import python-multipart.")
+            error = """Form data requires [python-multipart] to be installed."""
+            logging.error(error)
+            raise ImportError(error)
             return
         try:
             import multipart
             multipart.QuerystringParser({})
-        except ImportError:
-            logging.error("kys")
+        except AttributeError:
+            error = """Form data requires [python-multipart] to be installed.
+            [multipart] is installed, and not compatible with [python-multipart]. 
+            Uninstall [multipart] and install [python-multipart]."""
+            logging.error(error)
+            raise ImportError(error)
 
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -781,12 +781,13 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         ]
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
-
     if is_form_data(BodyFieldInfo):
         try:
-            from multipart import QuerystringParser  # check to see if there's an import
+            from multipart import QuerystringParser  # check if there's an import
 
-            QuerystringParser({})  # check to see if correct import using a python-multipart function
+            QuerystringParser(  # check if correct import using python-multipart function
+                {}
+            )
         except AttributeError:
             error = """Form data requires [python-multipart] to be installed. Currently 
             [multipart] is installed and not compatible with [python-multipart]. 
@@ -797,7 +798,6 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             error = "Form data requires [python-multipart] to be installed."
             logging.error(error)
             raise RuntimeError(error)
-
     return create_response_field(
         name="body",
         type_=BodyModel,

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import importlib
 import inspect
 import logging
 
@@ -785,16 +784,17 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
     
     if is_form_data(BodyFieldInfo):
-            if importlib.util.find_spec("multipart") is None:
-                logging.error("Import python-multipart.")
-                return
-            else:
-                import multipart as mp
-                if len(mp.__package__) == 0:
-                    logging.error("Wrong multipart import. pip3 uninstall multipart --> pip3 install python-multipart.")
-                    return
-                else:
-                    print('You have the right multipart!')
+        try:
+            import multipart
+            multipart.QuerystringParser({})
+        except AttributeError:  # raised if multipart.QuerystringParser({}) errors out
+            error = """Form data requires [python-multipart] to be installed. Currently
+            [multipart] is installed and not compatible with [python-multipart]. 
+            Uninstall [multipart] and then install [python-multipart]."""
+            logging.error(error)
+            raise ImportError(error)
+        except ModuleNotFoundError:
+            logging.error("multipart not installed")
 
     return create_response_field(
         name="body",

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -793,7 +793,11 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
             logger.error(error)
             raise RuntimeError(error)
         except ImportError:
-            error = """Form data requires [python-multipart] to be installed. Currently 
+            error = (
+                "Form data requires [python-multipart] to be installed. Currently "
+                "[multipart] is installed and not compatible with [python-multipart]. "
+                "Uninstall [multipart] and then install [python-multipart]."
+            )
             [multipart] is installed and not compatible with [python-multipart]. 
             Uninstall [multipart] and then install [python-multipart]."""
             logger.error(error)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -738,7 +738,7 @@ def get_schema_compatible_field(*, field: ModelField) -> ModelField:
 
 
 def is_form_data(field: Type[params.Body]) -> bool:
-    return field == params.Form or field == params.File or field == bytes
+    return field in (params.Form, params.File, bytes)
 
 
 def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -740,7 +740,7 @@ def get_schema_compatible_field(*, field: ModelField) -> ModelField:
 
 
 def is_form_data(BodyFieldInfo):
-    return BodyFieldInfo == params.Form or BodyFieldInfo == params.UploadFile or BodyFieldInfo == bytes
+    return BodyFieldInfo == params.Form or BodyFieldInfo == params.File or BodyFieldInfo == bytes
 
 
 def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -739,6 +739,10 @@ def get_schema_compatible_field(*, field: ModelField) -> ModelField:
     return out_field
 
 
+def is_form_data(BodyFieldInfo):
+    return BodyFieldInfo == params.Form or BodyFieldInfo == params.UploadFile or BodyFieldInfo == bytes
+
+
 def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
     flat_dependant = get_flat_dependant(dependant)
     if not flat_dependant.body_params:
@@ -780,7 +784,7 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
 
-    if BodyFieldInfo == params.Form and importlib.util.find_spec("multipart") is None:
+    if is_form_data(BodyFieldInfo) and importlib.util.find_spec("multipart") is None:
         logging.error("Must import python-multipart.")
 
     return create_response_field(

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -784,9 +784,9 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
 
     if is_form_data(BodyFieldInfo):
         try:
-            import multipart  # check to see if there's an import
+            from multipart import QuerystringParser  # check to see if there's an import
 
-            multipart.QuerystringParser(
+            QuerystringParser(
                 {}
             )  # check to see if correct import using a python-multipart function
         except AttributeError:

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -13,7 +13,7 @@ def test_incorrect_multipart_installed(monkeypatch):
         app = FastAPI()
 
         @app.post("/login")
-        async def login(username: str = Form(...), password: str = Form(...)):
+        async def login(username: str = Form(...)):
             return {"username": username}  # pragma: nocover
 
 
@@ -28,5 +28,5 @@ def test_no_multipart_installed(monkeypatch):
         app = FastAPI()
 
         @app.post("/login")
-        async def login(username: str = Form(...), password: str = Form(...)):
+        async def login(username: str = Form(...)):
             return {"username": username}  # pragma: nocover

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -19,7 +19,7 @@ def test_incorrect_multipart_installed(monkeypatch):
 
 def test_no_multipart_installed(monkeypatch):
     def raise_attribute_error(*args):
-        raise AttributeError
+        raise ImportError
 
     monkeypatch.setattr(
         "multipart.QuerystringParser", raise_attribute_error, raising=False

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi import FastAPI, Form
+
+
+def test_incorrect_multipart_installed(monkeypatch):
+    def raise_attribute_error(*args):
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(
+        "multipart.QuerystringParser", raise_attribute_error, raising=False
+    )
+    with pytest.raises(RuntimeError):
+        app = FastAPI()
+
+        @app.post("/login")
+        async def login(username: str = Form(...), password: str = Form(...)):
+            return {"username": username}  # pragma: nocover
+
+
+def test_no_multipart_installed(monkeypatch):
+    def raise_attribute_error(*args):
+        raise AttributeError
+
+    monkeypatch.setattr(
+        "multipart.QuerystringParser", raise_attribute_error, raising=False
+    )
+    with pytest.raises(RuntimeError):
+        app = FastAPI()
+
+        @app.post("/login")
+        async def login(username: str = Form(...), password: str = Form(...)):
+            return {"username": username}  # pragma: nocover


### PR DESCRIPTION
Addresses #1599.

We'll be leveraging the `[import].__package__` field as a way to determine if the CORRECT multipart import was used or not.

Oddly enough, the incorrect `multipart` import will have a `.__package__` field value of "" (empty string). The correct import, `python-multipart`, will have a `.__package__` field value of "multipart".

We'll check to see if the user will be using forms or not with `is_form_data(BodyFieldInfo)`. If this evaluates to true, then we can check to see there is a `multipart` import at all by using `importlib.util.find_spec("multipart")`. If that again evaluates to true, we can check the `.__package__` value to see if it is an empty string or not.

Alternative solution:

Instead of testing the imports' `.__package__` field, we could try to wrap a try / catch with a method exclusive to `python-multipart` that is not in `multipart` instead. If an exception was caught we know it's also the wrong import.

`parser = multipart.QuerystringParser()` might be a good method to try out.