### PR TITLE
Fixed issues with docs , particularly extending OpenAPI schema

### DIFF
--- a/docs/en/docs/advanced/extending-openapi.md
+++ b/docs/en/docs/advanced/extending-openapi.md
@@ -79,6 +79,8 @@ That way, your application won't have to generate the schema every time a user o
 
 It will be generated only once, and then the same cached schema will be used for the next requests.
 
+Please note we specify a default prefix as a blank string. This can be changed.
+
 ```Python hl_lines="13 14  25 26"
 {!../../../docs_src/extending_openapi/tutorial001.py!}
 ```

--- a/docs_src/extending_openapi/tutorial001.py
+++ b/docs_src/extending_openapi/tutorial001.py
@@ -9,7 +9,7 @@ async def read_items():
     return [{"name": "Foo"}]
 
 
-def custom_openapi(openapi_prefix: str):
+def custom_openapi(openapi_prefix: str=''):
     if app.openapi_schema:
         return app.openapi_schema
     openapi_schema = get_openapi(


### PR DESCRIPTION
The example in the docs do not work because the defualt prefix is not specified. It may confuse a lot of begginers and thats why I modified both the en docs as well as the python code for the same.