### PR TITLE
Simplify usage of RedirectResponse/FileResponse

### DIFF
--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -1,10 +1,13 @@
-from typing import Any
+from os import stat_result
+from typing import Any, Union
 
-from starlette.responses import FileResponse  # noqa
+from starlette.background import BackgroundTask
+from starlette.datastructures import URL
+from starlette.responses import FileResponse as StarletteFileResponse  # noqa
 from starlette.responses import HTMLResponse  # noqa
 from starlette.responses import JSONResponse  # noqa
 from starlette.responses import PlainTextResponse  # noqa
-from starlette.responses import RedirectResponse  # noqa
+from starlette.responses import RedirectResponse as StarletteRedirectResponse  # noqa
 from starlette.responses import Response  # noqa
 from starlette.responses import StreamingResponse  # noqa
 from starlette.responses import UJSONResponse  # noqa
@@ -21,3 +24,30 @@ class ORJSONResponse(JSONResponse):
     def render(self, content: Any) -> bytes:
         assert orjson is not None, "orjson must be installed to use ORJSONResponse"
         return orjson.dumps(content)
+
+
+class RedirectResponse(StarletteRedirectResponse):
+    def __init__(
+        self,
+        url: Union[str, URL] = None, status_code: int = 307, headers: dict = None,
+        background: BackgroundTask = None, content: Union[str, URL] = None
+    ) -> None:
+        self.background = background
+        super().__init__(url or content, status_code, headers)
+
+
+class FileResponse(StarletteFileResponse):
+    def __init__(
+        self,
+        path: str = None,
+        status_code: int = 200,
+        headers: dict = None,
+        media_type: str = None,
+        background: BackgroundTask = None,
+        filename: str = None,
+        stat_result: stat_result = None,
+        method: str = None,
+        content: str = None
+    ) -> None:
+        super().__init__(path or content, status_code, headers, media_type,
+                         background, filename, stat_result, method)


### PR DESCRIPTION
A simple solution to #1628:

```python3
from fastapi import FastAPI
from fastapi.responses import RedirectResponse, PlainTextResponse

app = FastAPI()

@app.get('/', response_class=PlainTextResponse)
async def hello():
    return 'Hello world!'

@app.get('/redir', response_class=RedirectResponse, status_code=303)
async def redir():
    return '/'
```

```
$ curl -iL "http://127.0.0.1:8000/redir" -H "accept: */*"
HTTP/1.1 303 See Other
date: Sun, 28 Jun 2020 12:44:30 GMT
server: uvicorn
location: /
transfer-encoding: chunked

HTTP/1.1 200 OK
date: Sun, 28 Jun 2020 12:44:30 GMT
server: uvicorn
content-length: 12
content-type: text/plain; charset=utf-8

Hello world!
```