### PR TITLE
Fix app.extra annotation

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -51,7 +51,7 @@ class FastAPI(Starlette):
         openapi_prefix: str = "",
         root_path: str = "",
         root_path_in_servers: bool = True,
-        **extra: Dict[str, Any],
+        **extra: Any,
     ) -> None:
         self.default_response_class = default_response_class
         self._debug = debug


### PR DESCRIPTION
`**kwargs` annotation is based on the value.
ATM extra is annotated like `Dict[str, Dict[str, Any]]` which causes issues with type-checkers.