### PR TITLE
Allow None as a valid JSON value

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -97,6 +97,7 @@ sequence_shape_to_type = {
 
 _sentinel = object()
 
+
 def get_param_sub_dependant(
     *, param: inspect.Parameter, path: str, security_scopes: List[str] = None
 ) -> Dependant:


### PR DESCRIPTION
ATM, if you receive a post with the following json: `{data: null}`

And you have the following definition:
```
@app.post("/")
def post_data(data: Optional[str]):
  pass
```

FastAPI will say `data` was not passed. That's because it internally uses `None` as a placeholder for non-existing fields, instead of a sentinel value.