### PR TITLE
Update isort script to match changes in the new release, isort v5.0.2

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,8 +1,0 @@
-[settings]
-multi_line_output=3
-include_trailing_comma=True
-combine_as_imports=True
-line_length=88
-known_third_party=fastapi,pydantic,starlette
-skip_glob=tests/test_tutorial/**,docs_src/**,env/**,venv/**
-

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+combine_as_imports=True
+line_length=88
+known_third_party=fastapi,pydantic,starlette
+skip_glob=tests/test_tutorial/**,docs_src/**,env/**,venv/**
+

--- a/docs/en/docs/advanced/nosql-databases.md
+++ b/docs/en/docs/advanced/nosql-databases.md
@@ -19,7 +19,7 @@ You can adapt it to any other NoSQL database like:
 
 For now, don't pay attention to the rest, only the imports:
 
-```Python hl_lines="6 7 8"
+```Python hl_lines="3 4 5"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 
@@ -29,7 +29,7 @@ We will use it later as a fixed field `type` in our documents.
 
 This is not required by Couchbase, but is a good practice that will help you afterwards.
 
-```Python hl_lines="10"
+```Python hl_lines="9"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 
@@ -54,7 +54,7 @@ This utility function will:
     * Set defaults for timeouts.
 * Return it.
 
-```Python hl_lines="13 14 15 16 17 18 19 20 21 22"
+```Python hl_lines="12 13 14 15 16 17 18 19 20 21"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 
@@ -66,7 +66,7 @@ As **Couchbase** "documents" are actually just "JSON objects", we can model them
 
 First, let's create a `User` model:
 
-```Python hl_lines="25 26 27 28 29"
+```Python hl_lines="24 25 26 27 28"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 
@@ -80,7 +80,7 @@ This will have the data that is actually stored in the database.
 
 We don't create it as a subclass of Pydantic's `BaseModel` but as a subclass of our own `User`, because it will have all the attributes in `User` plus a couple more:
 
-```Python hl_lines="32 33 34"
+```Python hl_lines="31 32 33"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 
@@ -100,7 +100,7 @@ Now create a function that will:
 
 By creating a function that is only dedicated to getting your user from a `username` (or any other parameter) independent of your *path operation function*, you can more easily re-use it in multiple parts and also add <abbr title="Automated test, written in code, that checks if another piece of code is working correctly.">unit tests</abbr> for it:
 
-```Python hl_lines="37 38 39 40 41 42 43"
+```Python hl_lines="36 37 38 39 40 41 42"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 
@@ -135,7 +135,7 @@ UserInDB(username="johndoe", hashed_password="some_hash")
 
 ### Create the `FastAPI` app
 
-```Python hl_lines="47"
+```Python hl_lines="46"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 
@@ -145,7 +145,7 @@ As our code is calling Couchbase and we are not using the <a href="https://docs.
 
 Also, Couchbase recommends not using a single `Bucket` object in multiple "<abbr title="A sequence of code being executed by the program, while at the same time, or at intervals, there can be others being executed too.">thread</abbr>s", so, we can get just get the bucket directly and pass it to our utility functions:
 
-```Python hl_lines="50 51 52 53 54"
+```Python hl_lines="49 50 51 52 53"
 {!../../../docs_src/nosql_databases/tutorial001.py!}
 ```
 

--- a/docs_src/nosql_databases/tutorial001.py
+++ b/docs_src/nosql_databases/tutorial001.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
-from fastapi import FastAPI
-from pydantic import BaseModel
-
 from couchbase import LOCKMODE_WAIT
 from couchbase.bucket import Bucket
 from couchbase.cluster import Cluster, PasswordAuthenticator
+from fastapi import FastAPI
+from pydantic import BaseModel
 
 USERPROFILE_DOC_TYPE = "userprofile"
 

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,6 +1,7 @@
 """FastAPI framework, high performance, easy to learn, fast to code, ready for production"""
 
 __version__ = "0.58.1"
+
 from starlette import status
 
 from .applications import FastAPI

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,7 +1,6 @@
 """FastAPI framework, high performance, easy to learn, fast to code, ready for production"""
 
 __version__ = "0.58.1"
-
 from starlette import status
 
 from .applications import FastAPI

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -61,7 +61,8 @@ try:
 except ImportError:  # pragma: nocover
     # TODO: remove when removing support for Pydantic < 1.0.0
     from pydantic import Schema as FieldInfo  # type: ignore
-    from pydantic.fields import Field as ModelField, Required, Shape  # type: ignore
+    from pydantic.fields import Field as ModelField  # type: ignore
+    from pydantic.fields import Required, Shape  # type: ignore
     from pydantic.schema import get_annotation_from_schema  # type: ignore
     from pydantic.utils import ForwardRef, evaluate_forwardref  # type: ignore
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -60,11 +60,11 @@ try:
     from pydantic.typing import ForwardRef, evaluate_forwardref
 except ImportError:  # pragma: nocover
     # TODO: remove when removing support for Pydantic < 1.0.0
-    from pydantic.fields import Field as ModelField  # type: ignore
-    from pydantic.fields import Required, Shape  # type: ignore
     from pydantic import Schema as FieldInfo  # type: ignore
+    from pydantic.fields import Field as ModelField, Required, Shape  # type: ignore
     from pydantic.schema import get_annotation_from_schema  # type: ignore
-    from pydantic.utils import ForwardRef, evaluate_forwardref  # type: ignore
+    from pydantic.utils import ForwardRef  # type: ignore
+    from pydantic.utils import evaluate_forwardref  # type: ignore
 
     SHAPE_LIST = Shape.LIST
     SHAPE_SEQUENCE = Shape.SEQUENCE

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -63,8 +63,7 @@ except ImportError:  # pragma: nocover
     from pydantic import Schema as FieldInfo  # type: ignore
     from pydantic.fields import Field as ModelField, Required, Shape  # type: ignore
     from pydantic.schema import get_annotation_from_schema  # type: ignore
-    from pydantic.utils import ForwardRef  # type: ignore
-    from pydantic.utils import evaluate_forwardref  # type: ignore
+    from pydantic.utils import ForwardRef, evaluate_forwardref  # type: ignore
 
     SHAPE_LIST = Shape.LIST
     SHAPE_SEQUENCE = Shape.SEQUENCE

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -8,8 +8,7 @@ try:
     from pydantic import AnyUrl, Field
 except ImportError:  # pragma: nocover
     # TODO: remove when removing support for Pydantic < 1.0.0
-    from pydantic import Schema as Field  # type: ignore
-    from pydantic import UrlStr as AnyUrl  # type: ignore
+    from pydantic import Schema as Field, UrlStr as AnyUrl  # type: ignore
 
 try:
     import email_validator

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -8,7 +8,8 @@ try:
     from pydantic import AnyUrl, Field
 except ImportError:  # pragma: nocover
     # TODO: remove when removing support for Pydantic < 1.0.0
-    from pydantic import Schema as Field, UrlStr as AnyUrl  # type: ignore
+    from pydantic import Schema as Field  # type: ignore
+    from pydantic import UrlStr as AnyUrl  # type: ignore
 
 try:
     import email_validator

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -3,10 +3,8 @@ from base64 import b64decode
 from typing import Optional
 
 from fastapi.exceptions import HTTPException
-from fastapi.openapi.models import (
-    HTTPBase as HTTPBaseModel,
-    HTTPBearer as HTTPBearerModel,
-)
+from fastapi.openapi.models import HTTPBase as HTTPBaseModel
+from fastapi.openapi.models import HTTPBearer as HTTPBearerModel
 from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
 from fastapi.exceptions import HTTPException
-from fastapi.openapi.models import OAuth2 as OAuth2Model, OAuthFlows as OAuthFlowsModel
+from fastapi.openapi.models import OAuth2 as OAuth2Model
+from fastapi.openapi.models import OAuthFlows as OAuthFlowsModel
 from fastapi.param_functions import Form
 from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -18,8 +18,8 @@ try:
     PYDANTIC_1 = True
 except ImportError:  # pragma: nocover
     # TODO: remove when removing support for Pydantic < 1.0.0
-    from pydantic.fields import Field as ModelField  # type: ignore
     from pydantic import Schema as FieldInfo  # type: ignore
+    from pydantic.fields import Field as ModelField  # type: ignore
 
     class UndefinedType:  # type: ignore
         def __repr__(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,7 @@ all = [
     "async_exit_stack",
     "async_generator"
 ]
+
+[tool.isort]
+profile = "black"
+known_third_party = ["fastapi", "pydantic", "starlette"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "pytest-cov==2.10.0",
     "mypy",
     "black",
-    "isort",
+    "isort==4.3.21",
     "requests",
     "email_validator",
     "sqlalchemy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "pytest-cov==2.10.0",
     "mypy",
     "black",
-    "isort==4.3.21",
+    "isort",
     "requests",
     "email_validator",
     "sqlalchemy",

--- a/scripts/format-imports.sh
+++ b/scripts/format-imports.sh
@@ -2,5 +2,5 @@
 set -x
 
 # Sort imports one per line, so autoflake can remove unused imports
-isort --fas --force-single-line-imports --thirdparty fastapi --apply fastapi tests docs_src scripts
+isort --recursive --force-single-line-imports --thirdparty fastapi --apply fastapi tests docs_src scripts
 sh ./scripts/format.sh

--- a/scripts/format-imports.sh
+++ b/scripts/format-imports.sh
@@ -2,5 +2,5 @@
 set -x
 
 # Sort imports one per line, so autoflake can remove unused imports
-isort --force-single-line-imports --thirdparty fastapi fastapi tests docs_src scripts
+isort . --force-single-line-imports
 sh ./scripts/format.sh

--- a/scripts/format-imports.sh
+++ b/scripts/format-imports.sh
@@ -2,5 +2,5 @@
 set -x
 
 # Sort imports one per line, so autoflake can remove unused imports
-isort . --force-single-line-imports
+isort fastapi tests docs_src scripts --force-single-line-imports
 sh ./scripts/format.sh

--- a/scripts/format-imports.sh
+++ b/scripts/format-imports.sh
@@ -2,5 +2,5 @@
 set -x
 
 # Sort imports one per line, so autoflake can remove unused imports
-isort --recursive --force-single-line-imports --thirdparty fastapi --apply fastapi tests docs_src scripts
+isort --force-single-line-imports --thirdparty fastapi fastapi tests docs_src scripts
 sh ./scripts/format.sh

--- a/scripts/format-imports.sh
+++ b/scripts/format-imports.sh
@@ -2,5 +2,5 @@
 set -x
 
 # Sort imports one per line, so autoflake can remove unused imports
-isort --recursive  --force-single-line-imports --thirdparty fastapi --apply fastapi tests docs_src scripts
+isort --fas --force-single-line-imports --thirdparty fastapi --apply fastapi tests docs_src scripts
 sh ./scripts/format.sh

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,4 +3,4 @@ set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place docs_src fastapi tests scripts --exclude=__init__.py
 black fastapi tests docs_src scripts
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests docs_src scripts

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,4 +3,4 @@ set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place docs_src fastapi tests scripts --exclude=__init__.py
 black fastapi tests docs_src scripts
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --fas --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,4 +3,4 @@ set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place docs_src fastapi tests scripts --exclude=__init__.py
 black fastapi tests docs_src scripts
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --fas --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,4 +3,4 @@ set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place docs_src fastapi tests scripts --exclude=__init__.py
 black fastapi tests docs_src scripts
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests docs_src scripts
+isort . --force-grid-wrap=0 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,4 +3,4 @@ set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place docs_src fastapi tests scripts --exclude=__init__.py
 black fastapi tests docs_src scripts
-isort . --force-grid-wrap=0 
+isort fastapi tests docs_src scripts

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ set -x
 
 mypy fastapi
 black fastapi tests --check
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --fas --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ set -x
 
 mypy fastapi
 black fastapi tests --check
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ set -x
 
 mypy fastapi
 black fastapi tests --check
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --fas --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ set -x
 
 mypy fastapi
 black fastapi tests --check
-isort . --check-only 
+isort fastapi tests docs_src scripts --check-only 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ set -x
 
 mypy fastapi
 black fastapi tests --check
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests
+isort . --check-only 

--- a/tests/test_tutorial/test_additional_responses/test_tutorial001.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from additional_responses.tutorial001 import app
+from docs_src.additional_responses.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_additional_responses/test_tutorial002.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial002.py
@@ -3,7 +3,7 @@ import shutil
 
 from fastapi.testclient import TestClient
 
-from additional_responses.tutorial002 import app
+from docs_src.additional_responses.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_additional_responses/test_tutorial003.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial003.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from additional_responses.tutorial003 import app
+from docs_src.additional_responses.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_additional_responses/test_tutorial004.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial004.py
@@ -3,7 +3,7 @@ import shutil
 
 from fastapi.testclient import TestClient
 
-from additional_responses.tutorial004 import app
+from docs_src.additional_responses.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_additional_status_codes/test_tutorial001.py
+++ b/tests/test_tutorial/test_additional_status_codes/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from additional_status_codes.tutorial001 import app
+from docs_src.additional_status_codes.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_advanced_middleware/test_tutorial001.py
+++ b/tests/test_tutorial/test_advanced_middleware/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from advanced_middleware.tutorial001 import app
+from docs_src.advanced_middleware.tutorial001 import app
 
 
 def test_middleware():

--- a/tests/test_tutorial/test_advanced_middleware/test_tutorial002.py
+++ b/tests/test_tutorial/test_advanced_middleware/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from advanced_middleware.tutorial002 import app
+from docs_src.advanced_middleware.tutorial002 import app
 
 
 def test_middleware():

--- a/tests/test_tutorial/test_advanced_middleware/test_tutorial003.py
+++ b/tests/test_tutorial/test_advanced_middleware/test_tutorial003.py
@@ -1,7 +1,7 @@
 from fastapi.responses import PlainTextResponse
 from fastapi.testclient import TestClient
 
-from advanced_middleware.tutorial003 import app
+from docs_src.advanced_middleware.tutorial003 import app
 
 
 @app.get("/large")

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from async_sql_databases.tutorial001 import app
+from docs_src.async_sql_databases.tutorial001 import app
 
 openapi_schema = {
     "openapi": "3.0.2",

--- a/tests/test_tutorial/test_background_tasks/test_tutorial001.py
+++ b/tests/test_tutorial/test_background_tasks/test_tutorial001.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from background_tasks.tutorial001 import app
+from docs_src.background_tasks.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_background_tasks/test_tutorial002.py
+++ b/tests/test_tutorial/test_background_tasks/test_tutorial002.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from background_tasks.tutorial002 import app
+from docs_src.background_tasks.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial001.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from behind_a_proxy.tutorial001 import app
+from docs_src.behind_a_proxy.tutorial001 import app
 
 client = TestClient(app, root_path="/api/v1")
 

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial002.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from behind_a_proxy.tutorial002 import app
+from docs_src.behind_a_proxy.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_bigger_applications/test_main.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from bigger_applications.app.main import app
+from docs_src.bigger_applications.app.main import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from body.tutorial001 import app
+from docs_src.body.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_body_fields/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from body_fields.tutorial001 import app
+from docs_src.body_fields.tutorial001 import app
 
 # TODO: remove when removing support for Pydantic < 1.0.0
 try:

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from body_multiple_params.tutorial001 import app
+from docs_src.body_multiple_params.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from body_multiple_params.tutorial003 import app
+from docs_src.body_multiple_params.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from body_nested_models.tutorial009 import app
+from docs_src.body_nested_models.tutorial009 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_body_updates/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from body_updates.tutorial001 import app
+from docs_src.body_updates.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
@@ -2,7 +2,7 @@ import importlib
 
 from fastapi.testclient import TestClient
 
-from conditional_openapi import tutorial001
+from docs_src.conditional_openapi import tutorial001
 
 openapi_schema = {
     "openapi": "3.0.2",

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from cookie_params.tutorial001 import app
+from docs_src.cookie_params.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_cors/test_tutorial001.py
+++ b/tests/test_tutorial/test_cors/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from cors.tutorial001 import app
+from docs_src.cors.tutorial001 import app
 
 
 def test_cors():

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial001.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial001.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import Request
 from fastapi.testclient import TestClient
 
-from custom_request_and_route.tutorial001 import app
+from docs_src.custom_request_and_route.tutorial001 import app
 
 
 @app.get("/check-class")

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from custom_request_and_route.tutorial002 import app
+from docs_src.custom_request_and_route.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial003.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial003.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from custom_request_and_route.tutorial003 import app
+from docs_src.custom_request_and_route.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial001b.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial001b.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from custom_response.tutorial001b import app
+from docs_src.custom_response.tutorial001b import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial004.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial004.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from custom_response.tutorial004 import app
+from docs_src.custom_response.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial005.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial005.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from custom_response.tutorial005 import app
+from docs_src.custom_response.tutorial005 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial006.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from custom_response.tutorial006 import app
+from docs_src.custom_response.tutorial006 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial007.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial007.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from custom_response.tutorial007 import app
+from docs_src.custom_response.tutorial007 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial008.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial008.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from custom_response import tutorial008
-from custom_response.tutorial008 import app
+from docs_src.custom_response import tutorial008
+from docs_src.custom_response.tutorial008 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_dependencies/test_tutorial001.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from dependencies.tutorial001 import app
+from docs_src.dependencies.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_dependencies/test_tutorial004.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from dependencies.tutorial004 import app
+from docs_src.dependencies.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_dependencies/test_tutorial006.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from dependencies.tutorial006 import app
+from docs_src.dependencies.tutorial006 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_events/test_tutorial001.py
+++ b/tests/test_tutorial/test_events/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from events.tutorial001 import app
+from docs_src.events.tutorial001 import app
 
 openapi_schema = {
     "openapi": "3.0.2",

--- a/tests/test_tutorial/test_events/test_tutorial002.py
+++ b/tests/test_tutorial/test_events/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from events.tutorial002 import app
+from docs_src.events.tutorial002 import app
 
 openapi_schema = {
     "openapi": "3.0.2",

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from extending_openapi.tutorial001 import app
+from docs_src.extending_openapi.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from extra_data_types.tutorial001 import app
+from docs_src.extra_data_types.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_extra_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial003.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from extra_models.tutorial003 import app
+from docs_src.extra_models.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_extra_models/test_tutorial004.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial004.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from extra_models.tutorial004 import app
+from docs_src.extra_models.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_extra_models/test_tutorial005.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial005.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from extra_models.tutorial005 import app
+from docs_src.extra_models.tutorial005 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_first_steps/test_tutorial001.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from first_steps.tutorial001 import app
+from docs_src.first_steps.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_handling_errors/test_tutorial001.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from handling_errors.tutorial001 import app
+from docs_src.handling_errors.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_handling_errors/test_tutorial002.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from handling_errors.tutorial002 import app
+from docs_src.handling_errors.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_handling_errors/test_tutorial003.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial003.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from handling_errors.tutorial003 import app
+from docs_src.handling_errors.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_handling_errors/test_tutorial004.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial004.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from handling_errors.tutorial004 import app
+from docs_src.handling_errors.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_handling_errors/test_tutorial005.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial005.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from handling_errors.tutorial005 import app
+from docs_src.handling_errors.tutorial005 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_handling_errors/test_tutorial006.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial006.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from handling_errors.tutorial006 import app
+from docs_src.handling_errors.tutorial006 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_header_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from header_params.tutorial001 import app
+from docs_src.header_params.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_metadata/test_tutorial001.py
+++ b/tests/test_tutorial/test_metadata/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from metadata.tutorial001 import app
+from docs_src.metadata.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_metadata/test_tutorial004.py
+++ b/tests/test_tutorial/test_metadata/test_tutorial004.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from metadata.tutorial004 import app
+from docs_src.metadata.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
+++ b/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from openapi_callbacks.tutorial001 import app, invoice_notification
+from docs_src.openapi_callbacks.tutorial001 import app, invoice_notification
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from path_operation_advanced_configuration.tutorial001 import app
+from docs_src.path_operation_advanced_configuration.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial002.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from path_operation_advanced_configuration.tutorial002 import app
+from docs_src.path_operation_advanced_configuration.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial003.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial003.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from path_operation_advanced_configuration.tutorial003 import app
+from docs_src.path_operation_advanced_configuration.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from path_operation_advanced_configuration.tutorial004 import app
+from docs_src.path_operation_advanced_configuration.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from path_operation_configuration.tutorial005 import app
+from docs_src.path_operation_configuration.tutorial005 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from path_operation_configuration.tutorial006 import app
+from docs_src.path_operation_configuration.tutorial006 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial004.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from path_params.tutorial004 import app
+from docs_src.path_params.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from path_params.tutorial005 import app
+from docs_src.path_params.tutorial005 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_query_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial005.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from query_params.tutorial005 import app
+from docs_src.query_params.tutorial005 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_query_params/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from query_params.tutorial006 import app
+from docs_src.query_params.tutorial006 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from query_params_str_validations.tutorial010 import app
+from docs_src.query_params_str_validations.tutorial010 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from query_params_str_validations.tutorial011 import app
+from docs_src.query_params_str_validations.tutorial011 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from query_params_str_validations.tutorial012 import app
+from docs_src.query_params_str_validations.tutorial012 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from query_params_str_validations.tutorial013 import app
+from docs_src.query_params_str_validations.tutorial013 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -2,7 +2,7 @@ import os
 
 from fastapi.testclient import TestClient
 
-from request_files.tutorial001 import app
+from docs_src.request_files.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_request_files/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002.py
@@ -2,7 +2,7 @@ import os
 
 from fastapi.testclient import TestClient
 
-from request_files.tutorial002 import app
+from docs_src.request_files.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from request_forms.tutorial001 import app
+from docs_src.request_forms.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from request_forms_and_files.tutorial001 import app
+from docs_src.request_forms_and_files.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_change_status_code/test_tutorial001.py
+++ b/tests/test_tutorial/test_response_change_status_code/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_change_status_code.tutorial001 import app
+from docs_src.response_change_status_code.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_cookies/test_tutorial001.py
+++ b/tests/test_tutorial/test_response_cookies/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_cookies.tutorial001 import app
+from docs_src.response_cookies.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_cookies/test_tutorial002.py
+++ b/tests/test_tutorial/test_response_cookies/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_cookies.tutorial002 import app
+from docs_src.response_cookies.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_headers/test_tutorial001.py
+++ b/tests/test_tutorial/test_response_headers/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_headers.tutorial001 import app
+from docs_src.response_headers.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_headers/test_tutorial002.py
+++ b/tests/test_tutorial/test_response_headers/test_tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_headers.tutorial002 import app
+from docs_src.response_headers.tutorial002 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_model/test_tutorial003.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_model.tutorial003 import app
+from docs_src.response_model.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_model/test_tutorial004.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial004.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from response_model.tutorial004 import app
+from docs_src.response_model.tutorial004 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_model/test_tutorial005.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial005.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_model.tutorial005 import app
+from docs_src.response_model.tutorial005 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_response_model/test_tutorial006.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial006.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from response_model.tutorial006 import app
+from docs_src.response_model.tutorial006 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_security/test_tutorial001.py
+++ b/tests/test_tutorial/test_security/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from security.tutorial001 import app
+from docs_src.security.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from security.tutorial003 import app
+from docs_src.security.tutorial003 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from security.tutorial005 import (
+from docs_src.security.tutorial005 import (
     app,
     create_access_token,
     fake_users_db,

--- a/tests/test_tutorial/test_security/test_tutorial006.py
+++ b/tests/test_tutorial/test_security/test_tutorial006.py
@@ -3,7 +3,7 @@ from base64 import b64encode
 from fastapi.testclient import TestClient
 from requests.auth import HTTPBasicAuth
 
-from security.tutorial006 import app
+from docs_src.security.tutorial006 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_settings/test_app02.py
+++ b/tests/test_tutorial/test_settings/test_app02.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from settings.app02 import main, test_main
+from docs_src.settings.app02 import main, test_main
 
 client = TestClient(main.app)
 

--- a/tests/test_tutorial/test_sub_applications/test_tutorial001.py
+++ b/tests/test_tutorial/test_sub_applications/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from sub_applications.tutorial001 import app
+from docs_src.sub_applications.tutorial001 import app
 
 client = TestClient(app)
 

--- a/tests/test_tutorial/test_wsgi/test_tutorial001.py
+++ b/tests/test_tutorial/test_wsgi/test_tutorial001.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from wsgi.tutorial001 import app
+from docs_src.wsgi.tutorial001 import app
 
 client = TestClient(app)
 


### PR DESCRIPTION
Apparently, isort latest release ```isort v5.0.2``` is missing the ```--recursive or -rc``` flag and since the project uses the flag in it's script, it causes the tests to fail. An alternative to this is a dot, as in ```isort .```.

#### Missing flags
```
--apply
--recursive
```
#### Replacement
```
isort .
```

For more information on these changes see:
https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020

With this change, the build should be okay.