### PR TITLE
Update isort command to use the new releases of isort v5.0.2

### DIFF
--- a/scripts/format-imports.sh
+++ b/scripts/format-imports.sh
@@ -2,5 +2,5 @@
 set -x
 
 # Sort imports one per line, so autoflake can remove unused imports
-isort --recursive  --force-single-line-imports --thirdparty fastapi --apply fastapi tests docs_src scripts
+isort --force-single-line-imports --thirdparty fastapi --apply fastapi tests docs_src scripts
 sh ./scripts/format.sh

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,4 +3,4 @@ set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place docs_src fastapi tests scripts --exclude=__init__.py
 black fastapi tests docs_src scripts
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --thirdparty fastapi --thirdparty pydantic --thirdparty starlette --apply fastapi tests docs_src scripts

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,4 @@ set -x
 
 mypy fastapi
 black fastapi tests --check
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests
+isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --check-only --thirdparty fastapi --thirdparty fastapi --thirdparty pydantic --thirdparty starlette fastapi tests


### PR DESCRIPTION
Apparently, isort latest release ```isort v5.0.2``` is missing the ```--recursive or -rc``` flag and since the project uses the flag in it's script, it causes the tests to fail. An alternative to this is a dot, as in ```isort .```.

#### Missing flags
```
--apply
--recursive
```
#### Replacement
```
isort .
```

For more information on these changes see:
https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020

With this change, the build should be okay.