### PR TITLE
WIP: Populate summary and description of an endpoint from its docstring

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -336,8 +336,13 @@ class APIRoute(routing.Route):
             self.dependencies = list(dependencies)
         else:
             self.dependencies = []
-        self.summary = summary
-        self.description = description or inspect.cleandoc(self.endpoint.__doc__ or "")
+        if summary:
+            self.summary = summary
+            self.description = description or inspect.cleandoc(self.endpoint.__doc__ or "")
+        else:
+            doc_parts = inspect.cleandoc(self.endpoint.__doc__ or "").split("\n\n", 1)
+            self.summary = doc_parts[0]
+            self.description = description or (doc_parts[1] if len(doc_parts) > 1 else "")
         # if a "form feed" character (page break) is found in the description text,
         # truncate description text to the content preceding the first "form feed"
         self.description = self.description.split("\f")[0]

--- a/tests/test_sub_callbacks.py
+++ b/tests/test_sub_callbacks.py
@@ -68,8 +68,8 @@ openapi_schema = {
     "paths": {
         "/invoices/": {
             "post": {
-                "summary": "Create Invoice",
-                "description": 'Create an invoice.\n\nThis will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
+                "summary": "Create an invoice.",
+                "description": 'This will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
                 "operationId": "create_invoice_invoices__post",
                 "parameters": [
                     {

--- a/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
+++ b/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
@@ -10,8 +10,8 @@ openapi_schema = {
     "paths": {
         "/invoices/": {
             "post": {
-                "summary": "Create Invoice",
-                "description": 'Create an invoice.\n\nThis will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
+                "summary": "Create an invoice.",
+                "description": 'This will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
                 "operationId": "create_invoice_invoices__post",
                 "parameters": [
                     {


### PR DESCRIPTION
**Note!** Please see https://github.com/tiangolo/fastapi/issues/1633 for context why I think this is a good idea.

**Note!** This is still work in progress and missing, among other things:

- Documentation
- Unit testing the new changes
- I'll need to make the way to "parse" the summary and description lines from the docstring cover all cases, like badly formatted docstrings and different line ending styles.

I'm sharing this PR to gather feedback if the maintainers agree it is a good idea and I should proceed with cleaning up this patch.

--

This commit changes how the OpenAPI summary and description for an endpoint are populated from the docstring of the function implementing the endpoint.

Old behavior: Only the description is populated from the docstring

New behavior: Both the summary and the description are populated from
the docstring unless explicitly provided as decorator arguments

The new behavior is more aligned with PEP 257 specifying that a docstring consists of summary line and an extended description, neatly mapping to the corresponding fields in OpenAPI specification.