### PR TITLE
Updates starlette dependency to 0.13.6 due to vulnerability in 0.13.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 requires = [
-    "starlette ==0.13.4",
+    "starlette ==0.13.6",
     "pydantic >=0.32.2,<2.0.0"
 ]
 description-file = "README.md"


### PR DESCRIPTION
The project has Starlett dependency of version 0.13.4 which has a directory traversal vulnerability for windows machines. I was made aware of this through: https://snyk.io/vuln/SNYK-PYTHON-STARLETTE-573266

This upgrade would mostly be for the fix to this vulnerability that was introduced in Starlette 0.13.5. This upgrade would be to version 0.13.6 because version 0.13.6 fixes a breaking change related to how 0.13.5 was initially implemented.

Here is a link to the Starlett issue that was fixed for more details: https://github.com/encode/starlette/issues/981