### PR TITLE
💄 Use OS preference theme

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://fastapi.tiangolo.com/
 theme:
   name: material
   palette:
+    scheme: preference
     primary: teal
     accent: amber
   icon:

--- a/docs/es/mkdocs.yml
+++ b/docs/es/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://fastapi.tiangolo.com/es/
 theme:
   name: material
   palette:
+    scheme: preference
     primary: teal
     accent: amber
   icon:

--- a/docs/it/mkdocs.yml
+++ b/docs/it/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://fastapi.tiangolo.com/it/
 theme:
   name: material
   palette:
+    scheme: preference
     primary: teal
     accent: amber
   icon:

--- a/docs/pt/mkdocs.yml
+++ b/docs/pt/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://fastapi.tiangolo.com/pt/
 theme:
   name: material
   palette:
+    scheme: preference
     primary: teal
     accent: amber
   icon:

--- a/docs/ru/mkdocs.yml
+++ b/docs/ru/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://fastapi.tiangolo.com/ru/
 theme:
   name: material
   palette:
+    scheme: preference
     primary: teal
     accent: amber
   icon:

--- a/docs/zh/mkdocs.yml
+++ b/docs/zh/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://fastapi.tiangolo.com/zh/
 theme:
   name: material
   palette:
+    scheme: preference
     primary: teal
     accent: amber
   icon:


### PR DESCRIPTION
Related to #725 

MkDocs [implemented a feature](https://squidfunk.github.io/mkdocs-material/getting-started/#color-scheme) to set the theme based on the user's OS preference.

This is what the website will look like if the user's preferred theme is dark:
![image](https://user-images.githubusercontent.com/19605940/88103492-64d3d980-cba1-11ea-8031-d5d5924720cd.png)

For the light theme users:
![image](https://user-images.githubusercontent.com/19605940/88103632-8cc33d00-cba1-11ea-9208-ae7d464ada17.png)

I placed my cursor on `Languages` so that you can see that the accent is still there.
