### PR TITLE
Encoding subclass of a model with json_encoders

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -50,7 +50,7 @@ def jsonable_encoder(
     if exclude is not None and not isinstance(exclude, set):
         exclude = set(exclude)
     if isinstance(obj, BaseModel):
-        encoder = getattr(obj.Config, "json_encoders", {})
+        encoder = getattr(obj.__config__, "json_encoders", {})
         if custom_encoder:
             encoder.update(custom_encoder)
         if PYDANTIC_1:

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -55,6 +55,11 @@ class ModelWithCustomEncoder(BaseModel):
         }
 
 
+class ModelWithCustomEncoderSubclass(ModelWithCustomEncoder):
+    class Config:
+        pass
+
+
 class RoleEnum(Enum):
     admin = "admin"
     normal = "normal"
@@ -114,6 +119,11 @@ def test_encode_unsupported():
 
 def test_encode_custom_json_encoders_model():
     model = ModelWithCustomEncoder(dt_field=datetime(2019, 1, 1, 8))
+    assert jsonable_encoder(model) == {"dt_field": "2019-01-01T08:00:00+00:00"}
+
+
+def test_encode_custom_json_encoders_model_subclass():
+    model = ModelWithCustomEncoderSubclass(dt_field=datetime(2019, 1, 1, 8))
     assert jsonable_encoder(model) == {"dt_field": "2019-01-01T08:00:00+00:00"}
 
 


### PR DESCRIPTION
Currently when encoding a model, the `json_encoders` property is ignored if it is defined in a superclass of the model. For example;

```python
from pydantic import BaseModel
from datetime import datetime, timezone
from fastapi.encoders import jsonable_encoder


class ModelWithCustomEncoder(BaseModel):
    class Config:
        json_encoders = {
            datetime: lambda dt: dt.replace(
                microsecond=0, tzinfo=timezone.utc
            ).isoformat()
        }


class ModelWithCustomEncoderSubclass(ModelWithCustomEncoder):
    dt_field: datetime

    class Config:
        pass


model = ModelWithCustomEncoderSubclass(dt_field=datetime(2019, 1, 1, 8))

print(model.json())
# {"dt_field": "2019-01-01T08:00:00+00:00"}

print(jsonable_encoder(model))
# {'dt_field': '2019-01-01T08:00:00'}

```

To fix this, I modified `jsonable_encoder` to get the config using the `.__config__` property.