### PR TITLE
⬆️ Bump mkdocs-material

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
 ]
 doc = [
     "mkdocs >=1.1.2,<2.0.0",
-    "mkdocs-material >=5.4.0,<6.0.0",
+    "mkdocs-material >=5.5.0,<6.0.0",
     "markdown-include >=0.5.1,<0.6.0",
     "mkdocs-markdownextradata-plugin >=0.1.7,<0.2.0",
     "typer >=0.3.0,<0.4.0",


### PR DESCRIPTION
Following #1760, highlighted code color in the dark theme was nearly impossible to read, as @AngliD stated in [#725](https://github.com/tiangolo/fastapi/issues/725#issuecomment-662447763).

Later in that issue, @squidfunk stated that by bumping `mkdocs-material` to `5.5.0`, the colors will be better.

- Light theme before:
![image](https://user-images.githubusercontent.com/19605940/88455944-fd0be000-ce79-11ea-8c2e-ca769571a5eb.png)

- Light theme now:
![image](https://user-images.githubusercontent.com/19605940/88455955-1ca30880-ce7a-11ea-9ae7-1ab1e7510b06.png)

- Dark theme before:
![image](https://user-images.githubusercontent.com/19605940/88455966-393f4080-ce7a-11ea-8933-3c7cc9207890.png)

- Dark theme now:
![image](https://user-images.githubusercontent.com/19605940/88455973-48be8980-ce7a-11ea-8af9-90eb978d712b.png)
