### PR TITLE
🔥 Remove old/unused parameter sqlalchemy_safe from jsonable_encoder

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -32,7 +32,6 @@ def jsonable_encoder(
     exclude_defaults: bool = False,
     exclude_none: bool = False,
     custom_encoder: dict = {},
-    sqlalchemy_safe: bool = True,
 ) -> Any:
     if include is not None and not isinstance(include, set):
         include = set(include)
@@ -57,7 +56,6 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             custom_encoder=encoder,
-            sqlalchemy_safe=sqlalchemy_safe,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -68,14 +66,8 @@ def jsonable_encoder(
     if isinstance(obj, dict):
         encoded_dict = {}
         for key, value in obj.items():
-            if (
-                (
-                    not sqlalchemy_safe
-                    or (not isinstance(key, str))
-                    or (not key.startswith("_sa"))
-                )
-                and (value is not None or not exclude_none)
-                and ((include and key in include) or not exclude or key not in exclude)
+            if (value is not None or not exclude_none) and (
+                (include and key in include) or not exclude or key not in exclude
             ):
                 encoded_key = jsonable_encoder(
                     key,
@@ -83,7 +75,6 @@ def jsonable_encoder(
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
-                    sqlalchemy_safe=sqlalchemy_safe,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -91,7 +82,6 @@ def jsonable_encoder(
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
-                    sqlalchemy_safe=sqlalchemy_safe,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -108,7 +98,6 @@ def jsonable_encoder(
                     exclude_defaults=exclude_defaults,
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
-                    sqlalchemy_safe=sqlalchemy_safe,
                 )
             )
         return encoded_list
@@ -144,5 +133,4 @@ def jsonable_encoder(
         exclude_defaults=exclude_defaults,
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
-        sqlalchemy_safe=sqlalchemy_safe,
     )


### PR DESCRIPTION
🔥 Remove old/unused parameter `sqlalchemy_safe` from `jsonable_encoder`.

It was an early hack to allow returning SQLAlchemy models, but it was never documented, and the recommended way is using Pydantic's `orm_mode` as described in: https://fastapi.tiangolo.com/tutorial/sql-databases/