### PR TITLE
📝 Add note in CORS tutorial about allow_origins with ["*"] and allow_credentials

### DIFF
--- a/docs/en/docs/tutorial/cors.md
+++ b/docs/en/docs/tutorial/cors.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 * `allow_origin_regex` - A regex string to match against origins that should be permitted to make cross-origin requests. eg. `'https://.*\.example\.org'`.
 * `allow_methods` - A list of HTTP methods that should be allowed for cross-origin requests. Defaults to `['GET']`. You can use `['*']` to allow all standard methods.
 * `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for CORS requests.
-* `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`.
+* `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`. Also, `allow_origins` cannot be set to `['*']` for credentials to be allowed, origins must be specified.
 * `expose_headers` - Indicate any response headers that should be made accessible to the browser. Defaults to `[]`.
 * `max_age` - Sets a maximum time in seconds for browsers to cache CORS responses. Defaults to `600`.
 


### PR DESCRIPTION
Couldn't get credentials working with `allow_origins` set to `['*']`. Thought this might help others.

I was lucky to find this after a while: https://stackoverflow.com/questions/46288437/set-cookies-for-cross-origin-requests

which explains: "Also, make sure the HTTP header Access-Control-Allow-Origin is set and not with a wildcard *."

Specifying some origins, allows my axios request with `{ withCredentials: true }` set to work.