### PR TITLE
✏️ Fix typo on dependencies utils and cleanup unused variable

### DIFF
--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -3,8 +3,6 @@ from typing import Callable, List, Optional, Sequence
 from fastapi.security.base import SecurityBase
 from pydantic.fields import ModelField
 
-param_supported_types = (str, int, float, bool)
-
 
 class SecurityRequirement:
     def __init__(

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -94,7 +94,7 @@ def check_file_field(field: ModelField) -> None:
 
             assert __version__
             try:
-                # parse_options_header is only available in the right multlipart
+                # parse_options_header is only available in the right multipart
                 from multipart.multipart import parse_options_header
 
                 assert parse_options_header


### PR DESCRIPTION
Small PR.

**Changes**:
- Removed unused `param_supported_types = (str, int, float, bool)`
- Fix typo on `multlipart` -> `multipart`