### PR TITLE
✨ Add support for custom attributes on custom APIRoute

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -205,6 +205,7 @@ class FastAPI(Starlette):
         include_in_schema: bool = True,
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
+        **kwargs: Dict[str, Any],
     ) -> None:
         self.router.add_api_route(
             path,
@@ -229,6 +230,7 @@ class FastAPI(Starlette):
             include_in_schema=include_in_schema,
             response_class=response_class or self.default_response_class,
             name=name,
+            **kwargs,  # type: ignore
         )
 
     def api_route(
@@ -255,6 +257,7 @@ class FastAPI(Starlette):
         include_in_schema: bool = True,
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         def decorator(func: Callable) -> Callable:
             self.router.add_api_route(
@@ -280,6 +283,7 @@ class FastAPI(Starlette):
                 include_in_schema=include_in_schema,
                 response_class=response_class or self.default_response_class,
                 name=name,
+                **kwargs,  # type: ignore
             )
             return func
 
@@ -341,6 +345,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.get(
             path,
@@ -364,6 +369,7 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )
 
     def put(
@@ -390,6 +396,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.put(
             path,
@@ -413,6 +420,7 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )
 
     def post(
@@ -439,6 +447,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.post(
             path,
@@ -462,6 +471,7 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )
 
     def delete(
@@ -488,6 +498,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.delete(
             path,
@@ -511,6 +522,7 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )
 
     def options(
@@ -537,6 +549,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.options(
             path,
@@ -560,6 +573,7 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )
 
     def head(
@@ -586,6 +600,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.head(
             path,
@@ -609,6 +624,7 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )
 
     def patch(
@@ -635,6 +651,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.patch(
             path,
@@ -658,6 +675,7 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )
 
     def trace(
@@ -684,6 +702,7 @@ class FastAPI(Starlette):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[routing.APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.router.trace(
             path,
@@ -707,4 +726,5 @@ class FastAPI(Starlette):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,  # type: ignore
         )

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -568,7 +568,6 @@ class APIRouter(routing.Router):
                     )
         if responses is None:
             responses = {}
-        print(len(router.routes))
         for route in router.routes:
             if isinstance(route, APIRoute):
                 combined_responses = {**responses, **route.responses}

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -494,6 +494,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         def decorator(func: Callable) -> Callable:
             self.add_api_route(
@@ -520,6 +521,8 @@ class APIRouter(routing.Router):
                 response_class=response_class or self.default_response_class,
                 name=name,
                 callbacks=callbacks,
+                # Below ignore is a MyPY issue: https://github.com/python/mypy/issues/1969
+                **kwargs,  # type: ignore
             )
             return func
 
@@ -648,6 +651,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.api_route(
             path=path,
@@ -672,6 +676,7 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )
 
     def put(
@@ -698,6 +703,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.api_route(
             path=path,
@@ -722,6 +728,7 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )
 
     def post(
@@ -748,6 +755,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.api_route(
             path=path,
@@ -772,6 +780,7 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )
 
     def delete(
@@ -798,6 +807,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.api_route(
             path=path,
@@ -822,6 +832,7 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )
 
     def options(
@@ -848,6 +859,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.api_route(
             path=path,
@@ -872,6 +884,7 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )
 
     def head(
@@ -898,6 +911,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.api_route(
             path=path,
@@ -922,6 +936,7 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )
 
     def patch(
@@ -948,6 +963,7 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
         return self.api_route(
             path=path,
@@ -972,6 +988,7 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )
 
     def trace(
@@ -998,8 +1015,8 @@ class APIRouter(routing.Router):
         response_class: Optional[Type[Response]] = None,
         name: Optional[str] = None,
         callbacks: Optional[List[APIRoute]] = None,
+        **kwargs: Dict[str, Any],
     ) -> Callable:
-
         return self.api_route(
             path=path,
             response_model=response_model,
@@ -1023,4 +1040,5 @@ class APIRouter(routing.Router):
             response_class=response_class or self.default_response_class,
             name=name,
             callbacks=callbacks,
+            **kwargs,
         )

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -521,7 +521,6 @@ class APIRouter(routing.Router):
                 response_class=response_class or self.default_response_class,
                 name=name,
                 callbacks=callbacks,
-                # Below ignore is a MyPY issue: https://github.com/python/mypy/issues/1969
                 **kwargs,  # type: ignore
             )
             return func
@@ -603,7 +602,7 @@ class APIRouter(routing.Router):
                     **{
                         attr: getattr(route, attr)
                         for attr in set(dir(route))
-                        - set(dir(APIRoute(path="/", endpoint=lambda x: x)))
+                        - set(dir(self.route_class(path="/", endpoint=lambda x: x)))
                     },
                 )
             elif isinstance(route, routing.Route):

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -280,7 +280,7 @@ class APIRoute(routing.Route):
         response_class: Optional[Type[Response]] = None,
         dependency_overrides_provider: Optional[Any] = None,
         callbacks: Optional[List["APIRoute"]] = None,
-        **kwargs: dict,
+        **kwargs: Dict[str, Any],
     ) -> None:
         # normalise enums e.g. http.HTTPStatus
         if isinstance(status_code, enum.IntEnum):
@@ -437,7 +437,7 @@ class APIRouter(routing.Router):
         name: Optional[str] = None,
         route_class_override: Optional[Type[APIRoute]] = None,
         callbacks: Optional[List[APIRoute]] = None,
-        **kwargs: dict,
+        **kwargs: Dict[str, Any],
     ) -> None:
         route_class = route_class_override or self.route_class
         route = route_class(
@@ -570,11 +570,6 @@ class APIRouter(routing.Router):
             responses = {}
         print(len(router.routes))
         for route in router.routes:
-            print("permissions" in dir(route))
-            print(dir(route))
-            print()
-            print(dir(APIRoute(path="/", endpoint=lambda x: x)))
-            print()
             if isinstance(route, APIRoute):
                 combined_responses = {**responses, **route.responses}
                 self.add_api_route(

--- a/tests/test_custom_route_class_with_attributes.py
+++ b/tests/test_custom_route_class_with_attributes.py
@@ -1,5 +1,6 @@
 from typing import Callable, Iterable, Optional
 
+import pytest
 from fastapi import APIRouter, FastAPI, Request, Response
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
@@ -7,45 +8,90 @@ from fastapi.testclient import TestClient
 app = FastAPI()
 
 
-class CustomAPIRoute(APIRoute):
-    def __init__(
-        self,
-        path: str,
-        endpoint: Callable,
-        *,
-        permissions: Optional[Iterable[str]] = None,
-        **kwargs
-    ) -> None:
-        super().__init__(path, endpoint, **kwargs)
-        self.permissions = permissions
-
+class APIRouteWithoutConstructor(APIRoute):
     def get_route_handler(self) -> Callable:
         original_route_handler = super().get_route_handler()
 
         async def custom_route_handler(request: Request) -> Response:
-            request.state.permissions = self.permissions
+            request.state.params = self.params
             response = await original_route_handler(request)
             return response
 
         return custom_route_handler
 
 
-router = APIRouter(route_class=CustomAPIRoute)
+class APIRouteWithConstructor(APIRoute):
+    def __init__(
+        self,
+        path: str,
+        endpoint: Callable,
+        *,
+        params: Optional[Iterable[str]] = None,
+        **kwargs
+    ) -> None:
+        super().__init__(path, endpoint, **kwargs)
+        self.params = params
 
-_permissions = ["Foo", "Bar"]
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            request.state.params = self.params
+            response = await original_route_handler(request)
+            return response
+
+        return custom_route_handler
 
 
-@router.get("/", permissions=_permissions)
-def home(request: Request):
-    return request.state.permissions
+router_with_constructor = APIRouter(route_class=APIRouteWithConstructor)
+router_without_constructor = APIRouter(route_class=APIRouteWithoutConstructor)
 
 
-app.include_router(router)
+params = ["Foo", "Bar"]
+
+
+@router_without_constructor.get("/use_params", params=params)
+@router_with_constructor.get("/use_params", params=params)
+def get_use_params(request: Request):
+    return request.state.params
+
+
+@router_without_constructor.get("/without_params")
+@router_with_constructor.get("/without_params")
+def get_without_params(request: Request):
+    return request.state.params
+
+
+@router_without_constructor.get("/unused_params", not_used_params=None)
+@router_with_constructor.get("/unused_params", not_used_param=None)
+def get_unused_params():
+    return None
+
+
+app.include_router(router_with_constructor, prefix="/with")
+app.include_router(router_without_constructor, prefix="/without")
 
 client = TestClient(app)
 
 
-def test_route_class():
-    response = client.get("/")
-    assert response.status_code == 200
-    assert response.json() == _permissions
+@pytest.mark.parametrize(
+    "endpoint,status_code,expected",
+    [
+        ("/with/use_params", 200, params),
+        ("/with/without_params", 200, None),
+        ("/with/unused_params", 200, None),
+        ("/without/use_params", 200, params),
+    ],
+)
+def test_valid_custom_api_route(endpoint, status_code, expected):
+    response = client.get(endpoint)
+    assert response.status_code == status_code
+    assert response.json() == expected
+
+
+@pytest.mark.parametrize(
+    "endpoint", ["/without/without_params", "/without/unused_params"],
+)
+def test_invalid_custom_api_route(endpoint):
+    with pytest.raises(AttributeError):
+        client.get(endpoint)

--- a/tests/test_custom_route_class_with_attributes.py
+++ b/tests/test_custom_route_class_with_attributes.py
@@ -1,0 +1,85 @@
+from typing import Callable, Iterable, Optional
+
+from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+
+class CustomAPIRoute(APIRoute):
+    def __init__(
+        self,
+        path: str,
+        endpoint: Callable,
+        *,
+        permissions: Optional[Iterable[str]] = None,
+        **kwargs
+    ) -> None:
+        super().__init__(path, endpoint, **kwargs)
+        self.permissions = permissions
+
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            request.state.permissions = self.permissions
+            response = await original_route_handler(request)
+            return response
+
+        return custom_route_handler
+
+
+class CustomAPIRouter(APIRouter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.route_class = CustomAPIRoute
+
+    def add_api_route(
+        self,
+        path: str,
+        endpoint: Callable,
+        *,
+        permissions: Optional[Iterable[str]] = None,
+        **kwargs
+    ) -> None:
+        route = self.route_class(
+            path=path, endpoint=endpoint, permissions=permissions, **kwargs
+        )
+        print("permissions" in dir(route))
+        self.routes.append(route)
+
+    def api_route(
+        self, path: str, *, permissions: Optional[Iterable[str]] = None, **kwargs
+    ) -> Callable:
+        def decorator(func: Callable) -> Callable:
+            self.add_api_route(path, func, permissions=permissions, **kwargs)
+            return func
+
+        return decorator
+
+    def get(
+        self, path: str, *, permissions: Optional[Iterable[str]] = None, **kwargs
+    ) -> Callable:
+        return self.api_route(path, permissions=permissions, **kwargs)
+
+
+router = CustomAPIRouter()
+
+_permissions = ["Foo", "Bar"]
+
+
+@router.get("/", permissions=_permissions)
+def home(request: Request):
+    return request.state.permissions
+
+
+app.include_router(router)
+
+client = TestClient(app)
+
+
+def test_route_class():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == _permissions

--- a/tests/test_custom_route_class_with_attributes.py
+++ b/tests/test_custom_route_class_with_attributes.py
@@ -30,41 +30,7 @@ class CustomAPIRoute(APIRoute):
         return custom_route_handler
 
 
-class CustomAPIRouter(APIRouter):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.route_class = CustomAPIRoute
-
-    def add_api_route(
-        self,
-        path: str,
-        endpoint: Callable,
-        *,
-        permissions: Optional[Iterable[str]] = None,
-        **kwargs
-    ) -> None:
-        route = self.route_class(
-            path=path, endpoint=endpoint, permissions=permissions, **kwargs
-        )
-        print("permissions" in dir(route))
-        self.routes.append(route)
-
-    def api_route(
-        self, path: str, *, permissions: Optional[Iterable[str]] = None, **kwargs
-    ) -> Callable:
-        def decorator(func: Callable) -> Callable:
-            self.add_api_route(path, func, permissions=permissions, **kwargs)
-            return func
-
-        return decorator
-
-    def get(
-        self, path: str, *, permissions: Optional[Iterable[str]] = None, **kwargs
-    ) -> Callable:
-        return self.api_route(path, permissions=permissions, **kwargs)
-
-
-router = CustomAPIRouter()
+router = APIRouter(route_class=CustomAPIRoute)
 
 _permissions = ["Foo", "Bar"]
 


### PR DESCRIPTION
I'm not sure if this PR will be accepted. :cry:
Because I've implemented without waiting @tiangolo 's answer about "if it's a good feature". :eyes: 

If you're reading this, and you think is a nice feature, please leave a :+1: 

**Changes:**
- `APIRoute` setup now withstand custom attributes. It makes possible the following code:
```python
@router.get("/", permissions=["Potato", "Tomato"])
def home(request: Request):
    return request.state.permissions
```

Issue: https://github.com/tiangolo/fastapi/issues/1879

Notes:
- If needed, I can add docs about it. :book: 
- If needed, I can add more tests. :white_check_mark: 

Edit (Aug 19): 
- Commit https://github.com/tiangolo/fastapi/pull/1917/commits/753330344a13d448e03a07f223cc9d2866ce5a71 changes slightly the idea, as you don't need to override the `http method` methods anymore. 
- MyPy ignores were added due to known MyPy issue: https://github.com/python/mypy/issues/1969
