### PR TITLE
✏️ Add descriptive error message when model that has no json encoders gets encoded

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -118,7 +118,10 @@ def jsonable_encoder(
 
     errors: List[Exception] = []
     try:
-        data = dict(obj)
+        try:
+            data = dict(obj)
+        except TypeError:
+            raise TypeError(f"'{type(obj).__name__}' object has no json encoder")
     except Exception as e:
         errors.append(e)
         try:


### PR DESCRIPTION
It took me hours of debugging to realize my error was not including `json_encoders` in the `Config` class of my Model.
Twice.

Changed:
* The error `TypeError: 'MyModel' object is not iterable` becomes `TypeError: 'MyModel' object has no json encoder`