### PR TITLE
Add default parameter for Router path parameter

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -62,6 +62,7 @@ class FastAPI(Starlette):
             dependency_overrides_provider=self,
             on_startup=on_startup,
             on_shutdown=on_shutdown,
+            default_path="/",
         )
         self.exception_handlers = (
             {} if exception_handlers is None else dict(exception_handlers)
@@ -319,7 +320,7 @@ class FastAPI(Starlette):
 
     def get(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -368,7 +369,7 @@ class FastAPI(Starlette):
 
     def put(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -417,7 +418,7 @@ class FastAPI(Starlette):
 
     def post(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -466,7 +467,7 @@ class FastAPI(Starlette):
 
     def delete(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -515,7 +516,7 @@ class FastAPI(Starlette):
 
     def options(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -564,7 +565,7 @@ class FastAPI(Starlette):
 
     def head(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -613,7 +614,7 @@ class FastAPI(Starlette):
 
     def patch(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -662,7 +663,7 @@ class FastAPI(Starlette):
 
     def trace(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -390,6 +390,7 @@ class APIRouter(routing.Router):
         routes: Optional[List[routing.BaseRoute]] = None,
         redirect_slashes: bool = True,
         default: Optional[ASGIApp] = None,
+        default_path: str = "",
         dependency_overrides_provider: Optional[Any] = None,
         route_class: Type[APIRoute] = APIRoute,
         default_response_class: Optional[Type[Response]] = None,
@@ -403,6 +404,7 @@ class APIRouter(routing.Router):
             on_startup=on_startup,
             on_shutdown=on_shutdown,
         )
+        self.default_path = default_path
         self.dependency_overrides_provider = dependency_overrides_provider
         self.route_class = route_class
         self.default_response_class = default_response_class
@@ -466,7 +468,7 @@ class APIRouter(routing.Router):
 
     def api_route(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -492,7 +494,7 @@ class APIRouter(routing.Router):
     ) -> Callable:
         def decorator(func: Callable) -> Callable:
             self.add_api_route(
-                path,
+                path if path is not None else self.default_path,
                 func,
                 response_model=response_model,
                 status_code=status_code,
@@ -517,6 +519,11 @@ class APIRouter(routing.Router):
                 callbacks=callbacks,
             )
             return func
+
+        # Add route was called as decorator without parameters
+        if callable(path):
+            func, path = path, self.default_path
+            return decorator(func)
 
         return decorator
 
@@ -616,7 +623,7 @@ class APIRouter(routing.Router):
 
     def get(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -666,7 +673,7 @@ class APIRouter(routing.Router):
 
     def put(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -716,7 +723,7 @@ class APIRouter(routing.Router):
 
     def post(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -766,7 +773,7 @@ class APIRouter(routing.Router):
 
     def delete(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -816,7 +823,7 @@ class APIRouter(routing.Router):
 
     def options(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -866,7 +873,7 @@ class APIRouter(routing.Router):
 
     def head(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -916,7 +923,7 @@ class APIRouter(routing.Router):
 
     def patch(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,
@@ -966,7 +973,7 @@ class APIRouter(routing.Router):
 
     def trace(
         self,
-        path: str,
+        path: Optional[str] = None,
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: int = 200,

--- a/tests/test_router_default_path.py
+++ b/tests/test_router_default_path.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from pytest import mark
+
+app = FastAPI()
+client = TestClient(app)
+
+sub_router = APIRouter()
+another_sub_router = APIRouter()
+
+METHODS = ["get", "post", "put", "patch", "delete", "trace"]
+
+for method in METHODS:
+
+    @getattr(app, method)
+    def route(m=method):
+        return {"result": f"root-{m}"}
+
+    @getattr(sub_router, method)
+    def sub_route(m=method):
+        return {"result": f"sub-no-params-{m}"}
+
+    decorator = getattr(another_sub_router, method)
+
+    @decorator()
+    def another_sub_route(m=method):
+        return {"result": f"sub-with-params-{m}"}
+
+
+app.include_router(sub_router, prefix="/sub")
+app.include_router(another_sub_router, prefix="/another-sub")
+
+
+@mark.parametrize("method", METHODS)
+def test_root_router(method):
+    response = client.request(method, "/")
+    assert response.json() == {"result": f"root-{method}"}
+
+
+@mark.parametrize("method", METHODS)
+def test_sub_router(method):
+    response = client.request(method, "/sub")
+    assert response.json() == {"result": f"sub-no-params-{method}"}
+
+
+@mark.parametrize("method", METHODS)
+def test_another_sub_router(method):
+    response = client.request(method, "/another-sub")
+    assert response.json() == {"result": f"sub-with-params-{method}"}


### PR DESCRIPTION
Add default parameter to the Router `path` parameter.

Code like this:
```python
@router.get("", response_model=Item)
def route():
    ...
```
Can be rewritten to:
```python
@router.get(response_model=Item)
def route():
    ...
```

In case when call to `router` method doesn't have any arguments than a parenthesis can be skipped:
```python
@router.get
def route():
    ...
```


