### PR TITLE
🐛 Fix issues introduced by removing SQLAlchemy safeguard in jsonable_encoder

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -32,6 +32,7 @@ def jsonable_encoder(
     exclude_defaults: bool = False,
     exclude_none: bool = False,
     custom_encoder: dict = {},
+    sqlalchemy_safe: bool = True,
 ) -> Any:
     if include is not None and not isinstance(include, set):
         include = set(include)
@@ -56,6 +57,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             custom_encoder=encoder,
+            sqlalchemy_safe=sqlalchemy_safe,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -66,8 +68,14 @@ def jsonable_encoder(
     if isinstance(obj, dict):
         encoded_dict = {}
         for key, value in obj.items():
-            if (value is not None or not exclude_none) and (
-                (include and key in include) or not exclude or key not in exclude
+            if (
+                (
+                    not sqlalchemy_safe
+                    or (not isinstance(key, str))
+                    or (not key.startswith("_sa"))
+                )
+                and (value is not None or not exclude_none)
+                and ((include and key in include) or not exclude or key not in exclude)
             ):
                 encoded_key = jsonable_encoder(
                     key,
@@ -75,6 +83,7 @@ def jsonable_encoder(
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -82,6 +91,7 @@ def jsonable_encoder(
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -98,6 +108,7 @@ def jsonable_encoder(
                     exclude_defaults=exclude_defaults,
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
                 )
             )
         return encoded_list
@@ -133,4 +144,5 @@ def jsonable_encoder(
         exclude_defaults=exclude_defaults,
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
+        sqlalchemy_safe=sqlalchemy_safe,
     )


### PR DESCRIPTION
🐛 Fix issues introduced by removing SQLAlchemy safeguard in `jsonable_encoder`.

The `jsonable_encoder` originally had a `sqlalchemy_safe=True` parameter that would avoid trying to encode any object attribute starting with `_sa`, as SQLAlchemy creates several attributes with that prefix in the models.

It was there as a quick and early workaround/hack to allow working with SQLAlchemy easily. But I didn't really want to have ORM-specific logic in FastAPI, as FastAPI is independent of ORM (or DB, you could just use MongoDB or ElasticSearch as well).

The main workflow for using any type of ORM with FastAPI is with [Pydantic's ORM mode](https://pydantic-docs.helpmanual.io/usage/models/#orm-mode-aka-arbitrary-class-instances), as described in [Tutorial: SQL (Relational) Databases](https://fastapi.tiangolo.com/tutorial/sql-databases/) that feature has been there for a long while. So I expected the `jsonable_encoder` to no longer need that workaround. But I had used the same workaround in e.g. the project generator: https://github.com/tiangolo/full-stack-fastapi-postgresql/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/backend/app/app/crud/base.py#L35 :facepalm: 

So, for now, I'm reverting it, for the cases that depended on it, as noticed by @shawnwall on https://github.com/tiangolo/fastapi/pull/1864#issuecomment-675026492 

---

Later I would like to remove the SQLAlchemy-specific logic.

But I think it would have to be something like discarding arbitrary object attributes that start with `_` (but this would include, e.g. a MongoDB ORM object with an `_id` attribute). Although this would only apply to objects, not dictionaries. And only in the case where it's an arbitrary object, not a Pydantic model.