### PR TITLE
📝 Simplify intro to Python Types, all currently supported Python versions include type hints 🎉

### DIFF
--- a/docs/en/docs/python-types.md
+++ b/docs/en/docs/python-types.md
@@ -1,8 +1,8 @@
 # Python Types Intro
 
-**Python 3.6+** has support for optional "type hints".
+**Python 3.5+** has support for optional "type hints".
 
-These **"type hints"** are a new syntax (since Python 3.6+) that allow declaring the <abbr title="for example: str, int, float, bool">type</abbr> of a variable.
+These **"type hints"** are a new syntax (since Python 3.0+) that allow declaring the <abbr title="for example: str, int, float, bool">type</abbr> of a variable.
 
 By declaring types for your variables, editors and tools can give you better support.
 

--- a/docs/en/docs/python-types.md
+++ b/docs/en/docs/python-types.md
@@ -1,8 +1,8 @@
 # Python Types Intro
 
-**Python 3.5+** has support for optional "type hints".
+Python has support for optional "type hints".
 
-These **"type hints"** are a new syntax (since Python 3.0+) that allow declaring the <abbr title="for example: str, int, float, bool">type</abbr> of a variable.
+These **"type hints"** are a special syntax that allow declaring the <abbr title="for example: str, int, float, bool">type</abbr> of a variable.
 
 By declaring types for your variables, editors and tools can give you better support.
 


### PR DESCRIPTION
Function annotation syntax was proposed in [pep 3107](https://www.python.org/dev/peps/pep-3107/) in 2006 and was a feature of Python 3.0. Type annotations were already a proposed usecase at this time. Mypy supports Python 3.2 and newer. A standard vocabulary for type hints (and the typing module itself) based on conventions used in Mypy and other sources was added in 3.5 with [pep 484](https://www.python.org/dev/peps/pep-0484/).

The only thing new for type hints in 3.6 is _variable annotations_, which allows types to be specified outside of function signatures. [pep 526](https://www.python.org/dev/peps/pep-0526/)