### PR TITLE
Update tutorial003.py, fixed bad import in websockets docs

### DIFF
--- a/docs_src/websockets/tutorial003.py
+++ b/docs_src/websockets/tutorial003.py
@@ -1,8 +1,8 @@
 from typing import List
 
 from fastapi import FastAPI, WebSocket
-from fastapi.websockets import WebSocketDisconnect
 from fastapi.responses import HTMLResponse
+from fastapi.websockets import WebSocketDisconnect
 
 app = FastAPI()
 

--- a/docs_src/websockets/tutorial003.py
+++ b/docs_src/websockets/tutorial003.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket
+from fastapi.websockets import WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 
 app = FastAPI()


### PR DESCRIPTION
Fixed ImportError: cannot import name 'WebSocketDisconnect' from 'fastapi' in websockets example