### PR TITLE
✏ Fix typos in docs and source examples

### DIFF
--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -210,7 +210,7 @@ Most of the existing popular Python frameworks (including Flask and Django) were
 
 Even though the main specification for asynchronous web Python (ASGI) was developed at Django, to add support for WebSockets.
 
-That kind of asynchronicity is what made NodeJS popular (even though NodeJS is not parallel) and that's the strength of Go as a programing language.
+That kind of asynchronicity is what made NodeJS popular (even though NodeJS is not parallel) and that's the strength of Go as a programming language.
 
 And that's the same level of performance you get with **FastAPI**.
 

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -20,7 +20,7 @@ def _fake_asynccontextmanager(func: Callable) -> Callable:
 
 try:
     from contextlib import asynccontextmanager  # type: ignore
-except ImportError:  # pragma: no cover
+except ImportError:
     try:
         from async_generator import asynccontextmanager  # type: ignore
     except ImportError:  # pragma: no cover

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -20,7 +20,7 @@ def _fake_asynccontextmanager(func: Callable) -> Callable:
 
 try:
     from contextlib import asynccontextmanager  # type: ignore
-except ImportError:
+except ImportError:  # pragma: no cover
     try:
         from async_generator import asynccontextmanager  # type: ignore
     except ImportError:  # pragma: no cover
@@ -28,7 +28,7 @@ except ImportError:
 
 try:
     from contextlib import AsyncExitStack  # type: ignore
-except ImportError:
+except ImportError:  # pragma: no cover
     try:
         from async_exit_stack import AsyncExitStack  # type: ignore
     except ImportError:  # pragma: no cover

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -28,7 +28,7 @@ except ImportError:
 
 try:
     from contextlib import AsyncExitStack  # type: ignore
-except ImportError:  # pragma: no cover
+except ImportError:
     try:
         from async_exit_stack import AsyncExitStack  # type: ignore
     except ImportError:  # pragma: no cover

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -42,7 +42,7 @@ def test_incorrect_multipart_installed_multi_form(monkeypatch):
         app = FastAPI()
 
         @app.post("/")
-        async def root(username: str = Form(...), pasword: str = Form(...)):
+        async def root(username: str = Form(...), password: str = Form(...)):
             return username  # pragma: nocover
 
 


### PR DESCRIPTION
Fixing some typos on `async.md`, `unzip-docs.sh` and `test_multipart_installation.py` that I encountered while checking the source code.