### PR TITLE
Add Stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - help-wanted
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity in the last 90 days. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
The configuration is basically the same like the example config of https://probot.github.io/apps/stale/.
Differences:
- 90 instead of 60 days: for the start of the bot we should allow issues to be stale a little bit longer. This can be decrease in the future.
- exemptLabels:
  - pinned and security: are not part of the project, but could be useful in the future.
  - help-wanted: is probably something which the authors are willing to work on.
- markComment: make it more clear what "recent" means

Fixes #2049.
Additionally stale bot has to be installed into the repository. This can only be done by the maintainers.

Sorry if stale bot is not something which is wanted for this project. I probably should've checked with the maintainers before.