### PR TITLE
📝 Fix renamed parameter `content_type` typo

### DIFF
--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -40,7 +40,7 @@ Import the `Response` class (sub-class) you want to use and declare it in the *p
 To return a response with HTML directly from **FastAPI**, use `HTMLResponse`.
 
 * Import `HTMLResponse`.
-* Pass `HTMLResponse` as the parameter `content_type` of your *path operation*.
+* Pass `HTMLResponse` as the parameter `response_class` of your *path operation*.
 
 ```Python hl_lines="2  7"
 {!../../../docs_src/custom_response/tutorial002.py!}

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -40,7 +40,7 @@ Import the `Response` class (sub-class) you want to use and declare it in the *p
 To return a response with HTML directly from **FastAPI**, use `HTMLResponse`.
 
 * Import `HTMLResponse`.
-* Pass `HTMLResponse` as the parameter `response_class` of your *path operation*.
+* Pass `HTMLResponse` as the parameter `response_class` of your *path operation decorator*.
 
 ```Python hl_lines="2  7"
 {!../../../docs_src/custom_response/tutorial002.py!}


### PR DESCRIPTION
The `content_type` parameter was renamed to `response_class` in release `0.19.0`

### Tangential question to maintainers:

This is the 3rd documentation-related PR I've opened this week. They all fall into different categories, but all have fairly small changes. 
- Is this disruptive? 
- Would it be better to condense any near-future PRs into a single "documentation" PR? 

Thanks in advance!