### PR TITLE
✏ Fix typos and add rewording in docs

### DIFF
--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -131,7 +131,7 @@ Inside of the function, you can access all the attributes of the model object di
 
 ## Request body + path parameters
 
-You can declare path parameters and body requests at the same time.
+You can declare path parameters and request body at the same time.
 
 **FastAPI** will recognize that the function parameters that match path parameters should be **taken from the path**, and that function parameters that are declared to be Pydantic models should be **taken from the request body**.
 

--- a/docs/en/docs/tutorial/path-params-numeric-validations.md
+++ b/docs/en/docs/tutorial/path-params-numeric-validations.md
@@ -106,7 +106,7 @@ And you can also declare numeric validations:
 * `le`: `l`ess than or `e`qual
 
 !!! info
-    `Query`, `Path` and others you will see later subclasses of a common `Param` class (that you don't need to use).
+    `Query`, `Path`, and others you will see later are subclasses of a common `Param` class (that you don't need to use).
 
     And all of them share the same all these same parameters of additional validation and metadata you have seen.
 

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -17,7 +17,7 @@ The query parameter `q` is of type `Optional[str]`, that means that it's of type
 
 ## Additional validation
 
-We are going to enforce that even though `q` is optional, whenever it is provided, it **doesn't exceed a length of 50 characters**.
+We are going to enforce that even though `q` is optional, whenever it is provided, **its length doesn't exceed 50 characters**.
 
 ### Import `Query`
 


### PR DESCRIPTION
Fix typos in docs.

## target

- "Tutorial - User Guide"
  - "Request Body"
  - "Query Parameters and String Validations"
  - "Path Parameters and Numeric Validations"