### PR TITLE
docs/zh: update path-params and fix typo in deployment

### DIFF
--- a/docs/zh/docs/deployment.md
+++ b/docs/zh/docs/deployment.md
@@ -272,7 +272,7 @@ $ docker run -d --name mycontainer -p 80:80 myimage
 * 默认情况下，一个 IP 地址仅有一个 HTTPS 证书。
     * 无论你的服务器大小，都是如此。
     * 但是对此有解决办法。
-* TSL 协议（在 TCP 层处理加密的协议，发生在 HTTP 之前）有一个扩展，叫 <a href="https://en.wikipedia.org/wiki/Server_Name_Indication" class="external-link" target="_blank"><abbr title="Server Name Indication">SNI</abbr></a>。
+* TLS 协议（在 TCP 层处理加密的协议，发生在 HTTP 之前）有一个扩展，叫 <a href="https://en.wikipedia.org/wiki/Server_Name_Indication" class="external-link" target="_blank"><abbr title="Server Name Indication">SNI</abbr></a>。
     * SNI 扩展允许一个服务器（一个 IP 地址）有多个 HTTPS 证书，为多个 HTTPS 域名/应用 提供服务。
     * 要使其工作，服务器运行的单一组件（程序）监听公网 IP 地址，所有 HTTPS 证书必须都在该服务器上。
 * 在获得一个安全连接之后，通讯协议仍然是 HTTP。

--- a/docs/zh/docs/tutorial/path-params.md
+++ b/docs/zh/docs/tutorial/path-params.md
@@ -166,7 +166,7 @@
 
 你可以使用 `model_name.value` 或通常来说 `your_enum_member.value` 来获取实际的值（在这个例子中为 `str`）：
 
-```Python hl_lines="19"
+```Python hl_lines="20"
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 

--- a/docs/zh/docs/tutorial/path-params.md
+++ b/docs/zh/docs/tutorial/path-params.md
@@ -179,8 +179,17 @@
 
 在返回给客户端之前，它们将被转换为对应的值：
 
-```Python hl_lines="18-21"
+```Python hl_lines="18  21  23"
 {!../../../docs_src/path_params/tutorial005.py!}
+```
+
+在你的客户端会得到这样的 JSON 响应：
+
+```JSON
+{
+  "model_name": "alexnet",
+  "message": "Deep Learning FTW!"
+}
 ```
 
 ## 包含路径的路径参数


### PR DESCRIPTION
https://github.com/tiangolo/fastapi/raw/master/docs/en/docs/tutorial/path-params.md

````
#### Get the *enumeration value*

You can get the actual value (a `str` in this case) using `model_name.value`, or in general, `your_enum_member.value`:

```Python hl_lines="20"
{!../../../docs_src/path_params/tutorial005.py!}
```
````