### PR TITLE
🔧 Update GitHub Action Label Approved, run at 12:00

### DIFF
--- a/.github/workflows/label-approved.yml
+++ b/.github/workflows/label-approved.yml
@@ -2,7 +2,7 @@ name: Label Approved
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 12 * * *"
 
 jobs:
   label-approved:


### PR DESCRIPTION
🔧 Update GitHub Action Label Approved, run at 12:00.

It is currently having GitHub API rate limit errors, most probably because the Issue Manager that makes a lot of calls runs at the same time (at 00:00). So run this at 12:00.