### PR TITLE
Fix python/mypy#8338 - Add __all__ support for re-exported type defin…

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -23,3 +23,26 @@ from .requests import Request
 from .responses import Response
 from .routing import APIRouter
 from .websockets import WebSocket, WebSocketDisconnect
+
+__all__ = [
+    "__version__",
+    "status",
+    "FastAPI",
+    "BackgroundTasks",
+    "UploadFile",
+    "HTTPException",
+    "Body",
+    "Cookie",
+    "Depends",
+    "File",
+    "Form",
+    "Header",
+    "Path",
+    "Query",
+    "Security",
+    "Request",
+    "Response",
+    "APIRouter",
+    "WebSocket",
+    "WebSocketDisconnect",
+]

--- a/fastapi/middleware/__init__.py
+++ b/fastapi/middleware/__init__.py
@@ -1,1 +1,3 @@
 from starlette.middleware import Middleware
+
+__all__ = ["Middleware"]

--- a/fastapi/security/__init__.py
+++ b/fastapi/security/__init__.py
@@ -28,7 +28,8 @@ __all__ = [
     "OAuth2",
     "OAuth2AuthorizationCodeBearer",
     "OAuth2PasswordBearer",
-    "OAuth2PasswordRequestForm" "OAuth2PasswordRequestFormStrict",
+    "OAuth2PasswordRequestForm",
+    "OAuth2PasswordRequestFormStrict",
     "SecurityScopes",
     "OpenIdConnect",
 ]

--- a/fastapi/security/__init__.py
+++ b/fastapi/security/__init__.py
@@ -15,3 +15,20 @@ from .oauth2 import (
     SecurityScopes,
 )
 from .open_id_connect_url import OpenIdConnect
+
+__all__ = [
+    "APIKeyCookie",
+    "APIKeyHeader",
+    "APIKeyQuery",
+    "HTTPAuthorizationCredentials",
+    "HTTPBasic",
+    "HTTPBasicCredentials",
+    "HTTPBearer",
+    "HTTPDigest",
+    "OAuth2",
+    "OAuth2AuthorizationCodeBearer",
+    "OAuth2PasswordBearer",
+    "OAuth2PasswordRequestForm" "OAuth2PasswordRequestFormStrict",
+    "SecurityScopes",
+    "OpenIdConnect",
+]


### PR DESCRIPTION
Fix python/mypy#8338

Declares the type definitions in `__all__` to indicate they are re-exported.

Suggestion per:
https://github.com/python/mypy/issues/8338#issuecomment-585135210