### PR TITLE
Enable the use of nested structures in peewee

### DIFF
--- a/docs_src/sql_databases_peewee/sql_app/schemas.py
+++ b/docs_src/sql_databases_peewee/sql_app/schemas.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Optional
 
 import peewee
+from playhouse.shortcuts import model_to_dict
 from pydantic import BaseModel
 from pydantic.utils import GetterDict
 
@@ -10,6 +11,8 @@ class PeeweeGetterDict(GetterDict):
         res = getattr(self._obj, key, default)
         if isinstance(res, peewee.ModelSelect):
             return list(res)
+        elif isinstance(res, peewee.Model):
+            return model_to_dict(res)
         return res
 
 


### PR DESCRIPTION
Hello, 

I love your lib, it is such a produtivity booster to me!

Another lib that I love is Peewee. One little problem that I have is the conversion from peewee to Pydantic models. When you have a nested model, the proposed getter on the documentation fails to convert it. With the proposed path, it convert the nested reference to model to json, and Pydantic take care of the right conversion. 