### PR TITLE
Cleanup of duplicate codes

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -401,7 +401,7 @@ def get_param_field(
         required=required,
         field_info=field_info,
     )
-    field.required = required
+
     if not had_schema and not is_scalar_field(field=field):
         field.field_info = params.Body(field_info.default)
 


### PR DESCRIPTION
I found a line of duplicate code, the required attribute has already been assigned in the create_response_field function, so I'll clean it up.