### PR TITLE
fix breaking openapi contract in ValidationError

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -34,7 +34,11 @@ validation_error_definition = {
     "title": "ValidationError",
     "type": "object",
     "properties": {
-        "loc": {"title": "Location", "type": "array", "items": {"type": "string"}},
+        "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+        },
         "msg": {"title": "Message", "type": "string"},
         "type": {"title": "Error Type", "type": "string"},
     },
@@ -191,7 +195,7 @@ def get_openapi_path(
             if route.callbacks:
                 callbacks = {}
                 for callback in route.callbacks:
-                    cb_path, cb_security_schemes, cb_definitions, = get_openapi_path(
+                    (cb_path, cb_security_schemes, cb_definitions,) = get_openapi_path(
                         route=callback, model_name_map=model_name_map
                     )
                     callbacks[callback.name] = {callback.path: cb_path}


### PR DESCRIPTION
The raised ValidationError breaks the openapi ValidationError contract, because the schema does not match.