### PR TITLE
Fix adding prefix from APIRouter for websockets routes

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -568,7 +568,7 @@ class APIRouter(routing.Router):
         self, path: str, endpoint: Callable, name: Optional[str] = None
     ) -> None:
         route = APIWebSocketRoute(
-            path,
+            self.prefix + path,
             endpoint=endpoint,
             name=name,
             dependency_overrides_provider=self.dependency_overrides_provider,

--- a/tests/test_ws_router.py
+++ b/tests/test_ws_router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, FastAPI, WebSocket
 from fastapi.testclient import TestClient
 
 router = APIRouter()
-prefix_router = APIRouter()
+prefix_router = APIRouter(prefix="/router-prefix")
 app = FastAPI()
 
 
@@ -20,7 +20,7 @@ async def routerindex(websocket: WebSocket):
     await websocket.close()
 
 
-@prefix_router.websocket_route("/")
+@prefix_router.websocket("/index-prefix")
 async def routerprefixindex(websocket: WebSocket):
     await websocket.accept()
     await websocket.send_text("Hello, router with prefix!")
@@ -48,7 +48,7 @@ async def router_ws_decorator_depends(
 
 
 app.include_router(router)
-app.include_router(prefix_router, prefix="/prefix")
+app.include_router(prefix_router, prefix="/include-prefix")
 
 
 def test_app():
@@ -67,7 +67,9 @@ def test_router():
 
 def test_prefix_router():
     client = TestClient(app)
-    with client.websocket_connect("/prefix/") as websocket:
+    with client.websocket_connect(
+        "/include-prefix/router-prefix/index-prefix"
+    ) as websocket:
         data = websocket.receive_text()
         assert data == "Hello, router with prefix!"
 


### PR DESCRIPTION
Fix the behavior of prefixes for websockets, which was added for api routers in version [0.62.0](https://github.com/tiangolo/fastapi/releases/tag/0.62.0)