### PR TITLE
➖ Remove Typer as a docs building dependency (covered by typer-cli) to fix pip resolver conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ doc = [
     "mkdocs-material >=6.1.4,<7.0.0",
     "markdown-include >=0.5.1,<0.6.0",
     "mkdocs-markdownextradata-plugin >=0.1.7,<0.2.0",
-    "typer >=0.3.0,<0.4.0",
     "typer-cli >=0.0.9,<0.0.10",
     "pyyaml >=5.3.1,<6.0.0"
 ]


### PR DESCRIPTION
➖ Remove Typer as a docs building dependency (covered by typer-cli) to fix pip resolver conflicts