### PR TITLE
📝 Update Uvicorn installation instructions to use uvicorn[standard] (includes uvloop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/en/docs/deployment/manually.md
+++ b/docs/en/docs/deployment/manually.md
@@ -11,12 +11,17 @@ You just need to install an ASGI compatible server like:
     <div class="termy">
 
     ```console
-    $ pip install uvicorn
+    $ pip install uvicorn[standard]
 
     ---> 100%
     ```
 
     </div>
+
+    !!! tip
+        By adding the `standard`, Uvicorn will install and use some recommended extra dependencies.
+        
+        That including `uvloop`, the high-performance drop-in replacement for `asyncio`, that provides the big concurrency performance boost.
 
 === "Hypercorn"
 

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -128,7 +128,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/en/docs/tutorial/index.md
+++ b/docs/en/docs/tutorial/index.md
@@ -64,7 +64,7 @@ $ pip install fastapi[all]
     Also install `uvicorn` to work as the server:
 
     ```
-    pip install uvicorn
+    pip install uvicorn[standard]
     ```
 
     And the same for each of the optional dependencies that you want to use.

--- a/docs/es/docs/index.md
+++ b/docs/es/docs/index.md
@@ -127,7 +127,7 @@ También vas a necesitar un servidor ASGI para producción cómo <a href="https:
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/es/docs/tutorial/index.md
+++ b/docs/es/docs/tutorial/index.md
@@ -64,7 +64,7 @@ $ pip install fastapi[all]
     También debes instalar `uvicorn` para que funcione como tu servidor:
 
     ```
-    pip install uvicorn
+    pip install uvicorn[standard]
     ```
 
     Y lo mismo para cada una de las dependencias opcionales que quieras utilizar.

--- a/docs/fr/docs/index.md
+++ b/docs/fr/docs/index.md
@@ -132,7 +132,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/it/docs/index.md
+++ b/docs/it/docs/index.md
@@ -132,7 +132,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/ja/docs/index.md
+++ b/docs/ja/docs/index.md
@@ -128,7 +128,7 @@ $ pip install fastapi
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/ja/docs/tutorial/index.md
+++ b/docs/ja/docs/tutorial/index.md
@@ -64,7 +64,7 @@ $ pip install fastapi[all]
     また、サーバーとして動作するように`uvicorn` をインストールします:
 
     ```
-    pip install uvicorn
+    pip install uvicorn[standard]
     ```
 
     そして、使用したい依存関係をそれぞれ同様にインストールします。

--- a/docs/ko/docs/index.md
+++ b/docs/ko/docs/index.md
@@ -128,7 +128,7 @@ $ pip install fastapi
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/pt/docs/deployment.md
+++ b/docs/pt/docs/deployment.md
@@ -336,7 +336,7 @@ Você apenas precisa instalar um servidor ASGI compatível como:
     <div class="termy">
 
     ```console
-    $ pip install uvicorn
+    $ pip install uvicorn[standard]
 
     ---> 100%
     ```

--- a/docs/pt/docs/index.md
+++ b/docs/pt/docs/index.md
@@ -121,7 +121,7 @@ Você também precisará de um servidor ASGI para produção, tal como <a href="
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/pt/docs/tutorial/index.md
+++ b/docs/pt/docs/tutorial/index.md
@@ -64,7 +64,7 @@ $ pip install fastapi[all]
     Também instale o `uvicorn` para funcionar como servidor:
 
     ```
-    pip install uvicorn
+    pip install uvicorn[standard]
     ```
 
     E o mesmo para cada dependência opcional que você quiser usar.

--- a/docs/ru/docs/index.md
+++ b/docs/ru/docs/index.md
@@ -132,7 +132,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/sq/docs/index.md
+++ b/docs/sq/docs/index.md
@@ -132,7 +132,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/tr/docs/index.md
+++ b/docs/tr/docs/index.md
@@ -132,7 +132,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/uk/docs/index.md
+++ b/docs/uk/docs/index.md
@@ -132,7 +132,7 @@ You will also need an ASGI server, for production such as <a href="https://www.u
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/zh/docs/deployment.md
+++ b/docs/zh/docs/deployment.md
@@ -338,7 +338,7 @@ Traefik 也集成了 Docker，所以你也可以在每个应用的配置中声�
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/zh/docs/index.md
+++ b/docs/zh/docs/index.md
@@ -128,7 +128,7 @@ $ pip install fastapi
 <div class="termy">
 
 ```console
-$ pip install uvicorn
+$ pip install uvicorn[standard]
 
 ---> 100%
 ```

--- a/docs/zh/docs/tutorial/index.md
+++ b/docs/zh/docs/tutorial/index.md
@@ -64,7 +64,7 @@ $ pip install fastapi[all]
     并且安装`uvicorn`来作为服务器：
 
     ```
-    pip install uvicorn
+    pip install uvicorn[standard]
     ```
 
     然后对你想使用的每个可选依赖项也执行相同的操作。


### PR DESCRIPTION
📝 Update Uvicorn installation instructions to use `uvicorn[standard]` (includes `uvloop`)

This was a recent change in Uvicorn, so plain `uvicorn` is now the minimal version, and `uvicorn[standard]` is the standard, high-performance, version.