### PR TITLE
📝 Add link to article in Russian "FastAPI: знакомимся с фреймворком"

### DIFF
--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -211,6 +211,10 @@ articles:
       title: Почему Вы должны попробовать FastAPI?
       author_link: https://github.com/prostomarkeloff
       author: prostomarkeloff
+    - link: https://trkohler.com/fast-api-%D0%B7%D0%BD%D0%B0%D0%BA%D0%BE%D0%BC%D0%B8%D0%BC%D1%81%D1%8F-%D1%81-%D1%84%D1%80%D0%B5%D0%B9%D0%BC%D0%B2%D0%BE%D1%80%D0%BA%D0%BE%D0%BC
+      title: "FastAPI: знакомимся с фреймворком"
+      author_link: https://www.linkedin.com/in/trkohler/
+      author: Troy Köhler
   german:
     - link: https://blog.codecentric.de/2019/08/inbetriebnahme-eines-scikit-learn-modells-mit-onnx-und-fastapi/
       title: Inbetriebnahme eines scikit-learn-Modells mit ONNX und FastAPI

--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -211,7 +211,7 @@ articles:
       title: Почему Вы должны попробовать FastAPI?
       author_link: https://github.com/prostomarkeloff
       author: prostomarkeloff
-    - link: https://trkohler.com/fast-api-%D0%B7%D0%BD%D0%B0%D0%BA%D0%BE%D0%BC%D0%B8%D0%BC%D1%81%D1%8F-%D1%81-%D1%84%D1%80%D0%B5%D0%B9%D0%BC%D0%B2%D0%BE%D1%80%D0%BA%D0%BE%D0%BC
+    - link: https://trkohler.com/fast-api-introduction-to-framework
       title: "FastAPI: знакомимся с фреймворком"
       author_link: https://www.linkedin.com/in/trkohler/
       author: Troy Köhler


### PR DESCRIPTION
Hi there! 👋 

Hope it would be considered as useful addition!

In my article in Russian I covered how to:
- get familiar with FastAPI framework
- set up tests
- connect to async Tortoise ORM 
- make async test for the previous feature

Sorry in advance for the ugly link :( Gatsby generates it based on Russian headline and I still hadn't fix this.