### PR TITLE
📝 Add External Link: Deploy FastAPI on Ubuntu and Serve using Caddy 2 Web Server

### DIFF
--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -148,6 +148,10 @@ articles:
       title: How to monitor your FastAPI service
       author_link: https://twitter.com/louis_guitton
       author: Louis Guitton
+    - link: https://www.tutlinks.com/deploy-fastapi-on-ubuntu-gunicorn-caddy-2/
+      title: Deploy FastAPI on Ubuntu and Serve using Caddy 2 Web Server
+      author_link: https://www.linkedin.com/in/navule/
+      author: Navule Pavan Kumar Rao
   japanese:
     - link: https://qiita.com/mtitg/items/47770e9a562dd150631d
       title: FastAPI｜DB接続してCRUDするPython製APIサーバーを構築


### PR DESCRIPTION
A detailed video tutorial https://www.youtube.com/watch?v=Dh5lzOwyVAY along with step by step article on How to Deploy FastAPI on Ubuntu and Serve using Caddy 2 Web Server.

Hope this will be helpful for our FastAPI community!