### PR TITLE
✨ Add support for `option` argument in ORJsonResponse

### DIFF
--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
@@ -18,6 +18,13 @@ except ImportError:  # pragma: nocover
 class ORJSONResponse(JSONResponse):
     media_type = "application/json"
 
+    def __init__(self, *args, option: Optional[int] = None, **kwargs) -> None:  # type: ignore
+        self.option = option
+        super().__init__(*args, **kwargs)
+
     def render(self, content: Any) -> bytes:
         assert orjson is not None, "orjson must be installed to use ORJSONResponse"
-        return orjson.dumps(content)
+        if self.option is not None:
+            return orjson.dumps(content, option=self.option)
+        else:
+            return orjson.dumps(content)

--- a/tests/test_default_response_class.py
+++ b/tests/test_default_response_class.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 import orjson
 from fastapi import APIRouter, FastAPI
@@ -9,8 +9,16 @@ from fastapi.testclient import TestClient
 class ORJSONResponse(JSONResponse):
     media_type = "application/x-orjson"
 
+    def __init__(self, *args, option: Optional[int] = None, **kwargs) -> None:  # type: ignore
+        self.option = option
+        super().__init__(*args, **kwargs)
+
     def render(self, content: Any) -> bytes:
-        return orjson.dumps(content)
+        assert orjson is not None, "orjson must be installed to use ORJSONResponse"
+        if self.option is not None:
+            return orjson.dumps(content, option=self.option)
+        else:
+            return orjson.dumps(content)
 
 
 class OverrideResponse(JSONResponse):

--- a/tests/test_orjson_custom_encoder.py
+++ b/tests/test_orjson_custom_encoder.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+import orjson
+from fastapi import FastAPI
+from fastapi.responses import ORJSONResponse
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class ModelWithDatetimeField(BaseModel):
+    dt_field: datetime
+
+
+app = FastAPI()
+model = ModelWithDatetimeField(dt_field=datetime(2019, 1, 1, 8))
+
+
+@app.get("/model", response_model=ModelWithDatetimeField)
+def get_model():
+    return ORJSONResponse(model.dict())
+
+
+@app.get("/model_with_option", response_model=ModelWithDatetimeField)
+def get_model_with_option():
+    return ORJSONResponse(model.dict(), option=orjson.OPT_NAIVE_UTC)
+
+
+client = TestClient(app)
+
+
+def test_dt():
+    with client:
+        response = client.get("/model")
+        response_with_option = client.get("/model_with_option")
+
+    assert response.json() == {"dt_field": "2019-01-01T08:00:00"}
+    assert response_with_option.json() == {"dt_field": "2019-01-01T08:00:00+00:00"}


### PR DESCRIPTION
✨ Add support for the `option` argument of orjson when building an ORJsonResponse. 

The `orjson.dumps()` function supports an `option` argument [1] where flags can be specified. 
This PR makes it available when creating am `ORJSONResponse`.

For example, to support serializing numpy arrays
```python
return ORJSONResponse(content, option=orjson.OPT_SERIALIZE_NUMPY)
```

[1][ https://github.com/ijl/orjson#option]( https://github.com/ijl/orjson#option)