### PR TITLE
Fixed incorrect default value for type Set

### DIFF
--- a/docs_src/body_nested_models/tutorial004.py
+++ b/docs_src/body_nested_models/tutorial004.py
@@ -16,7 +16,7 @@ class Item(BaseModel):
     description: Optional[str] = None
     price: float
     tax: Optional[float] = None
-    tags: Set[str] = []
+    tags: Set[str] = set()
     image: Optional[Image] = None
 
 


### PR DESCRIPTION
Fixed incorrect default value for the `tags` of type `Set` from the list `[]` to the actual set `set()` according to initial type.
