### PR TITLE
Add alias parameters to Form Data tutorial

### DIFF
--- a/docs/en/docs/tutorial/request-forms.md
+++ b/docs/en/docs/tutorial/request-forms.md
@@ -35,6 +35,22 @@ With `Form` you can declare the same metadata and validation as with `Body` (and
 !!! tip
     To declare form bodies, you need to use `Form` explicitly, because without it the parameters would be interpreted as query parameters or body (JSON) parameters.
 
+## Alias parameters
+
+Imagine that you want the parameter to be `user-name`.
+
+But `user-name` is not a valid Python variable name.
+
+The closest would be `user_name`.
+
+But you still need it to be exactly `user-name`...
+
+Then you can declare an `alias`, and that alias is what will be used to find the parameter value:
+
+```Python hl_lines="8"
+{!../../../docs_src/request_forms/tutorial002.py!}
+```
+
 ## About "Form Fields"
 
 The way HTML forms (`<form></form>`) sends the data to the server normally uses a "special" encoding for that data, it's different from JSON.

--- a/docs_src/request_forms/tutorial002.py
+++ b/docs_src/request_forms/tutorial002.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI, Form
+
+app = FastAPI()
+
+
+@app.post("/login/")
+async def login(
+    username: str = Form(..., alias="user-name"), password: str = Form(...)
+):
+    return {"user-name": username}

--- a/tests/test_tutorial/test_request_forms/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial002.py
@@ -1,0 +1,150 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from docs_src.request_forms.tutorial002 import app
+
+client = TestClient(app)
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "FastAPI", "version": "0.1.0"},
+    "paths": {
+        "/login/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+                "summary": "Login",
+                "operationId": "login_login__post",
+                "requestBody": {
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_login_login__post"
+                            }
+                        }
+                    },
+                    "required": True,
+                },
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Body_login_login__post": {
+                "title": "Body_login_login__post",
+                "required": ["user-name", "password"],
+                "type": "object",
+                "properties": {
+                    "user-name": {"title": "User-Name", "type": "string"},
+                    "password": {"title": "Password", "type": "string"},
+                },
+            },
+            "ValidationError": {
+                "title": "ValidationError",
+                "required": ["loc", "msg", "type"],
+                "type": "object",
+                "properties": {
+                    "loc": {
+                        "title": "Location",
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "msg": {"title": "Message", "type": "string"},
+                    "type": {"title": "Error Type", "type": "string"},
+                },
+            },
+            "HTTPValidationError": {
+                "title": "HTTPValidationError",
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "title": "Detail",
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/ValidationError"},
+                    }
+                },
+            },
+        }
+    },
+}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == openapi_schema
+
+
+password_required = {
+    "detail": [
+        {
+            "loc": ["body", "password"],
+            "msg": "field required",
+            "type": "value_error.missing",
+        }
+    ]
+}
+username_required = {
+    "detail": [
+        {
+            "loc": ["body", "user-name"],
+            "msg": "field required",
+            "type": "value_error.missing",
+        }
+    ]
+}
+username_and_password_required = {
+    "detail": [
+        {
+            "loc": ["body", "user-name"],
+            "msg": "field required",
+            "type": "value_error.missing",
+        },
+        {
+            "loc": ["body", "password"],
+            "msg": "field required",
+            "type": "value_error.missing",
+        },
+    ]
+}
+
+
+@pytest.mark.parametrize(
+    "path,body,expected_status,expected_response",
+    [
+        (
+            "/login/",
+            {"user-name": "Foo", "password": "secret"},
+            200,
+            {"user-name": "Foo"},
+        ),
+        ("/login/", {"username": "Foo", "password": "secret"}, 422, username_required),
+        ("/login/", {"user-name": "Foo"}, 422, password_required),
+        ("/login/", {"password": "secret"}, 422, username_required),
+        ("/login/", None, 422, username_and_password_required),
+    ],
+)
+def test_post_body_form(path, body, expected_status, expected_response):
+    response = client.post(path, data=body)
+    assert response.status_code == expected_status
+    assert response.json() == expected_response
+
+
+def test_post_body_json():
+    response = client.post("/login/", json={"user-name": "Foo", "password": "secret"})
+    assert response.status_code == 422, response.text
+    assert response.json() == username_and_password_required


### PR DESCRIPTION
This is more or less the same documentation that appears at https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#alias-parameters

However this may make it easier for people to find in the context of using Form Data.

This PR was brought about by https://github.com/tiangolo/fastapi/issues/2705