### PR TITLE
✨ Support HEAD method when GET is supported [1]

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -171,6 +171,8 @@ def get_openapi_path(
     route_response_media_type: Optional[str] = current_response_class.media_type
     if route.include_in_schema:
         for method in route.methods:
+            if method == "HEAD" and "GET" in route.methods:
+                continue
             operation = get_openapi_operation_metadata(route=route, method=method)
             parameters: List[Dict[str, Any]] = []
             flat_dependant = get_flat_dependant(route.dependant, skip_repeats=True)
@@ -359,6 +361,7 @@ def get_openapi(
             result = get_openapi_path(route=route, model_name_map=model_name_map)
             if result:
                 path, security_schemes, path_definitions = result
+                print(path)
                 if path:
                     paths.setdefault(route.path_format, {}).update(path)
                 if security_schemes:

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -361,7 +361,6 @@ def get_openapi(
             result = get_openapi_path(route=route, model_name_map=model_name_map)
             if result:
                 path, security_schemes, path_definitions = result
-                print(path)
                 if path:
                     paths.setdefault(route.path_format, {}).update(path)
                 if security_schemes:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -310,7 +310,10 @@ class APIRoute(routing.Route):
         self.name = get_name(endpoint) if name is None else name
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
         if methods is None:
-            methods = ["GET"]
+            methods = ["GET", "HEAD"]
+        elif "GET" in methods:
+            methods = list(methods)
+            methods.append("HEAD")
         self.methods: Set[str] = set([method.upper() for method in methods])
         self.unique_id = generate_operation_id_for_path(
             name=self.name, path=self.path_format, method=list(methods)[0]
@@ -735,7 +738,7 @@ class APIRouter(routing.Router):
             response_description=response_description,
             responses=responses,
             deprecated=deprecated,
-            methods=["GET"],
+            methods=["GET", "HEAD"],
             operation_id=operation_id,
             response_model_include=response_model_include,
             response_model_exclude=response_model_exclude,

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -13,6 +13,11 @@ class Item(BaseModel):
     price: Optional[float] = None
 
 
+@app.head("/items/{item_id}")
+def head_item(item_id: str):
+    return JSONResponse(headers={"x-fastapi-item-id": item_id})
+
+
 @app.api_route("/items/{item_id}", methods=["GET"])
 def get_items(item_id: str):
     return {"item_id": item_id}
@@ -28,11 +33,6 @@ app.add_api_route("/items-not-decorated/{item_id}", get_not_decorated)
 @app.delete("/items/{item_id}")
 def delete_item(item_id: str, item: Item):
     return {"item_id": item_id, "item": item}
-
-
-@app.head("/items/{item_id}")
-def head_item(item_id: str):
-    return JSONResponse(headers={"x-fastapi-item-id": item_id})
 
 
 @app.options("/items/{item_id}")


### PR DESCRIPTION
First approach towards closing https://github.com/tiangolo/fastapi/issues/1773.

Considerations:
- This approach has the problem of "order matters" between `get()` and `head()` methods, meaning that if the `get()` is implemented first, the `head()` is ignored.  
- It does not make it optional adding the `HEAD` to OpenAPI, it just doesn't include it. If we want to make it optional we can add a `include_head_schema` on the _HTTP method_ methods.

TO DO:
- [X] Implement logic around `APIRouter` methods.
- [ ] Implement logic around `FastAPI` methods.
- [ ] Add tests.