### PR TITLE
✨ Support HEAD method when GET is supported [2]

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -171,6 +171,8 @@ def get_openapi_path(
     route_response_media_type: Optional[str] = current_response_class.media_type
     if route.include_in_schema:
         for method in route.methods:
+            if method == "HEAD" and "GET" in route.methods:
+                continue
             operation = get_openapi_operation_metadata(route=route, method=method)
             parameters: List[Dict[str, Any]] = []
             flat_dependant = get_flat_dependant(route.dependant, skip_repeats=True)

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,6 +1,7 @@
 import asyncio
 import enum
 import inspect
+import itertools
 import json
 from typing import (
     Any,
@@ -627,6 +628,16 @@ class APIRouter(routing.Router):
             responses = {}
         for route in router.routes:
             if isinstance(route, APIRoute):
+                if "GET" in route.methods and "HEAD" not in route.methods:
+                    routes_in_path = [
+                        r
+                        for r in router.routes
+                        if isinstance(r, APIRoute) and r.path == route.path
+                    ]
+                    methods_in_path = [route.methods for route in routes_in_path]
+                    all_methods = set(itertools.chain.from_iterable(methods_in_path))
+                    if "HEAD" not in all_methods:
+                        route.methods.add("HEAD")
                 combined_responses = {**responses, **route.responses}
                 use_response_class = get_value_or_default(
                     route.response_class,


### PR DESCRIPTION
This is the second approach towards closing #1773.

Slower performance compared to #2762 at startup. 

TO DO:
- [X] Support `HEAD` on `GET` methods by default.
- [ ] Modularize the core logic of this PR.
- [ ] Add tests.