### PR TITLE
Allow Refreshes to OpenAPI schema for function registered post-startup

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -125,17 +125,21 @@ class FastAPI(Starlette):
         self.openapi_schema: Optional[Dict[str, Any]] = None
         self.setup()
 
+    def refresh_openapi(self) -> None:
+        self.openapi_schema = get_openapi(
+            title=self.title,
+            version=self.version,
+            openapi_version=self.openapi_version,
+            description=self.description,
+            routes=self.routes,
+            tags=self.openapi_tags,
+            servers=self.servers,
+        )
+
     def openapi(self) -> Dict[str, Any]:
         if not self.openapi_schema:
-            self.openapi_schema = get_openapi(
-                title=self.title,
-                version=self.version,
-                openapi_version=self.openapi_version,
-                description=self.description,
-                routes=self.routes,
-                tags=self.openapi_tags,
-                servers=self.servers,
-            )
+            self.refresh_openapi()
+            
         return self.openapi_schema
 
     def setup(self) -> None:


### PR DESCRIPTION
Commit: added refresh_openapi to allow for openapi schema refreshes to the /docs GUI for endpoints registered after startup

My easyjobs application registers new routes to endpoint worker functions after the main application has already started, and needs the ability to refresh the openapi schema to view newly registered functions. If the /docs page has already been visited after the application has started, only the startup schema / or last viewed schema is returned. 

I can work around this by setting:
```
 app.openapi_schema = None
 ```
 
The next visit to docs will show the correctly updated list of endpoints. 

So I believe this simple addition this simple may help others solve the same problem. 