### PR TITLE
Fix/incorrect jsonable encoder arguments cast

### DIFF
--- a/docs/en/docs/tutorial/response-model.md
+++ b/docs/en/docs/tutorial/response-model.md
@@ -174,6 +174,9 @@ So, they will be included in the JSON response.
 
 You can also use the *path operation decorator* parameters `response_model_include` and `response_model_exclude`.
 
+!!! info
+    FastAPI passes these parameters to Pydantic <a href="https://pydantic-docs.helpmanual.io/usage/exporting_models/#advanced-include-and-exclude" class="external-link" target="_blank">`include` and `exclude` parameters</a>.
+
 They take a `set` of `str` with the name of the attributes to include (omitting the rest) or to exclude (including the rest).
 
 This can be used as a quick shortcut if you have only one Pydantic model and want to remove some data from the output.
@@ -194,12 +197,24 @@ This can be used as a quick shortcut if you have only one Pydantic model and wan
 
     It is equivalent to `set(["name", "description"])`.
 
-#### Using `list`s instead of `set`s
+#### Nested models
 
-If you forget to use a `set` and use a `list` or `tuple` instead, FastAPI will still convert it to a `set` and it will work correctly:
+For nested models it is possible to use `dict` instead of `set`.
+
+Three dots (`...`) are used to include / exclude all keys of nested model.
+
+When dealing with lists of nested models you can define include / exclude for particular items. To apply rule for all items in collection special `__all__` key should be used. 
+
+```Python hl_lines="40  50  60  70"
+{!../../../docs_src/response_model/tutorial006.py!}
+```
+
+#### Using `list`s instead of `set`s and `dict`s
+
+If you forget to use a `set` or `dict` and use a `list` or `tuple` instead, FastAPI will still convert it to a `set` and it will work correctly:
 
 ```Python hl_lines="31  37"
-{!../../../docs_src/response_model/tutorial006.py!}
+{!../../../docs_src/response_model/tutorial007.py!}
 ```
 
 ## Recap

--- a/docs_src/response_model/tutorial006.py
+++ b/docs_src/response_model/tutorial006.py
@@ -25,10 +25,10 @@ class Item(BaseModel):
 items = {
     "foo": {
         "name": "Foo",
-        "image": {"url": "http://test.com/img.jpg", "name": "Some image"},
+        "image": {"url": "https://example.com/img.jpg", "name": "Some image"},
         "videos": [
-            {"url": "http://test.com/video_1.mp4", "duration": 40},
-            {"url": "http://test.com/video_2.mp4", "duration": 120},
+            {"url": "https://example.com/video_1.mp4", "duration": 40},
+            {"url": "https://example.com/video_2.mp4", "duration": 120},
         ],
     },
 }

--- a/docs_src/response_model/tutorial006.py
+++ b/docs_src/response_model/tutorial006.py
@@ -1,39 +1,74 @@
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl
 
 app = FastAPI()
 
 
+class Image(BaseModel):
+    url: HttpUrl
+    name: str
+
+
+class Video(BaseModel):
+    url: HttpUrl
+    duration: int
+
+
 class Item(BaseModel):
     name: str
-    description: Optional[str] = None
-    price: float
-    tax: float = 10.5
+    image: Optional[Image] = None
+    videos: Optional[List[Video]] = None
 
 
 items = {
-    "foo": {"name": "Foo", "price": 50.2},
-    "bar": {"name": "Bar", "description": "The Bar fighters", "price": 62, "tax": 20.2},
-    "baz": {
-        "name": "Baz",
-        "description": "There goes my baz",
-        "price": 50.2,
-        "tax": 10.5,
+    "foo": {
+        "name": "Foo",
+        "image": {"url": "http://test.com/img.jpg", "name": "Some image"},
+        "videos": [
+            {"url": "http://test.com/video_1.mp4", "duration": 40},
+            {"url": "http://test.com/video_2.mp4", "duration": 120},
+        ],
     },
 }
 
 
 @app.get(
-    "/items/{item_id}/name",
+    "/items/{item_id}/image_name",
     response_model=Item,
-    response_model_include=["name", "description"],
+    response_model_exclude={"image": {"url"}, "videos": ...},
 )
-async def read_item_name(item_id: str):
+async def read_item_image_name(item_id: str):
+    # Returns name of item and name of image
     return items[item_id]
 
 
-@app.get("/items/{item_id}/public", response_model=Item, response_model_exclude=["tax"])
-async def read_item_public_data(item_id: str):
+@app.get(
+    "/items/{item_id}/image",
+    response_model=Item,
+    response_model_include={"name": ..., "image": {"url"}},
+)
+async def read_item_image(item_id: str):
+    # Returns name of item and url of image
+    return items[item_id]
+
+
+@app.get(
+    "/items/{item_id}/first_video",
+    response_model=Item,
+    response_model_include={"name": ..., "videos": {0: ...}},
+)
+async def read_item_first_video(item_id: str):
+    # Returns name of item and full info for first video
+    return items[item_id]
+
+
+@app.get(
+    "/items/{item_id}/videos",
+    response_model=Item,
+    response_model_include={"name": ..., "videos": {"__all__": {"url"}}},
+)
+async def read_item_videos(item_id: str):
+    # Returns name of item and url for all videos
     return items[item_id]

--- a/docs_src/response_model/tutorial007.py
+++ b/docs_src/response_model/tutorial007.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    description: Optional[str] = None
+    price: float
+    tax: float = 10.5
+
+
+items = {
+    "foo": {"name": "Foo", "price": 50.2},
+    "bar": {"name": "Bar", "description": "The Bar fighters", "price": 62, "tax": 20.2},
+    "baz": {
+        "name": "Baz",
+        "description": "There goes my baz",
+        "price": 50.2,
+        "tax": 10.5,
+    },
+}
+
+
+@app.get(
+    "/items/{item_id}/name",
+    response_model=Item,
+    response_model_include=["name", "description"],
+)
+async def read_item_name(item_id: str):
+    return items[item_id]
+
+
+@app.get("/items/{item_id}/public", response_model=Item, response_model_exclude=["tax"])
+async def read_item_public_data(item_id: str):
+    return items[item_id]

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -36,9 +36,9 @@ def jsonable_encoder(
     custom_encoder: Dict[Any, Callable[[Any], Any]] = {},
     sqlalchemy_safe: bool = True,
 ) -> Any:
-    if include is not None and not isinstance(include, set):
+    if include is not None and not isinstance(include, (set, dict)):
         include = set(include)
-    if exclude is not None and not isinstance(exclude, set):
+    if exclude is not None and not isinstance(exclude, (set, dict)):
         exclude = set(exclude)
     if isinstance(obj, BaseModel):
         encoder = getattr(obj.__config__, "json_encoders", {})

--- a/tests/test_tutorial/test_response_model/test_tutorial006.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial006.py
@@ -19,7 +19,7 @@ def test_include_nested():
     assert response.status_code == 200, response.text
     assert response.json() == {
         "name": "Foo",
-        "image": {"url": "http://test.com/img.jpg"},
+        "image": {"url": "https://example.com/img.jpg"},
     }
 
 
@@ -28,7 +28,7 @@ def test_include_nested_index():
     assert response.status_code == 200, response.text
     assert response.json() == {
         "name": "Foo",
-        "videos": [{"url": "http://test.com/video_1.mp4", "duration": 40}],
+        "videos": [{"url": "https://example.com/video_1.mp4", "duration": 40}],
     }
 
 
@@ -38,7 +38,7 @@ def test_include_nested_all():
     assert response.json() == {
         "name": "Foo",
         "videos": [
-            {"url": "http://test.com/video_1.mp4"},
-            {"url": "http://test.com/video_2.mp4"},
+            {"url": "https://example.com/video_1.mp4"},
+            {"url": "https://example.com/video_2.mp4"},
         ],
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial006.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial006.py
@@ -4,139 +4,41 @@ from docs_src.response_model.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}/name": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Name",
-                "operationId": "read_item_name_items__item_id__name_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/items/{item_id}/public": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Public Data",
-                "operationId": "read_item_public_data_items__item_id__public_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"type": "string"},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
 
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_read_item_name():
-    response = client.get("/items/bar/name")
-    assert response.status_code == 200, response.text
-    assert response.json() == {"name": "Bar", "description": "The Bar fighters"}
-
-
-def test_read_item_public_data():
-    response = client.get("/items/bar/public")
+def test_exclude_nested():
+    response = client.get("/items/foo/image_name")
     assert response.status_code == 200, response.text
     assert response.json() == {
-        "name": "Bar",
-        "description": "The Bar fighters",
-        "price": 62,
+        "name": "Foo",
+        "image": {"name": "Some image"},
+    }
+
+
+def test_include_nested():
+    response = client.get("/items/foo/image")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "name": "Foo",
+        "image": {"url": "http://test.com/img.jpg"},
+    }
+
+
+def test_include_nested_index():
+    response = client.get("/items/foo/first_video")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "name": "Foo",
+        "videos": [{"url": "http://test.com/video_1.mp4", "duration": 40}],
+    }
+
+
+def test_include_nested_all():
+    response = client.get("/items/foo/videos")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "name": "Foo",
+        "videos": [
+            {"url": "http://test.com/video_1.mp4"},
+            {"url": "http://test.com/video_2.mp4"},
+        ],
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial007.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial007.py
@@ -1,0 +1,142 @@
+from fastapi.testclient import TestClient
+
+from docs_src.response_model.tutorial007 import app
+
+client = TestClient(app)
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "FastAPI", "version": "0.1.0"},
+    "paths": {
+        "/items/{item_id}/name": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+                "summary": "Read Item Name",
+                "operationId": "read_item_name_items__item_id__name_get",
+                "parameters": [
+                    {
+                        "required": True,
+                        "schema": {"title": "Item Id", "type": "string"},
+                        "name": "item_id",
+                        "in": "path",
+                    }
+                ],
+            }
+        },
+        "/items/{item_id}/public": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+                "summary": "Read Item Public Data",
+                "operationId": "read_item_public_data_items__item_id__public_get",
+                "parameters": [
+                    {
+                        "required": True,
+                        "schema": {"title": "Item Id", "type": "string"},
+                        "name": "item_id",
+                        "in": "path",
+                    }
+                ],
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "Item": {
+                "title": "Item",
+                "required": ["name", "price"],
+                "type": "object",
+                "properties": {
+                    "name": {"title": "Name", "type": "string"},
+                    "price": {"title": "Price", "type": "number"},
+                    "description": {"title": "Description", "type": "string"},
+                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                },
+            },
+            "ValidationError": {
+                "title": "ValidationError",
+                "required": ["loc", "msg", "type"],
+                "type": "object",
+                "properties": {
+                    "loc": {
+                        "title": "Location",
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "msg": {"title": "Message", "type": "string"},
+                    "type": {"title": "Error Type", "type": "string"},
+                },
+            },
+            "HTTPValidationError": {
+                "title": "HTTPValidationError",
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "title": "Detail",
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/ValidationError"},
+                    }
+                },
+            },
+        }
+    },
+}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == openapi_schema
+
+
+def test_read_item_name():
+    response = client.get("/items/bar/name")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"name": "Bar", "description": "The Bar fighters"}
+
+
+def test_read_item_public_data():
+    response = client.get("/items/bar/public")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "name": "Bar",
+        "description": "The Bar fighters",
+        "price": 62,
+    }


### PR DESCRIPTION
Due to https://pydantic-docs.helpmanual.io/usage/exporting_models/#advanced-include-and-exclude it is possible to pass dicts into Pydantic model `dict()` method for `include` and `exclude` params. 
Types in jsonable_encoder were already correct, but the cast inside function supported only sets.

PR includes:

- The fix itself
- Docs for passing dicts into jsonable_encoder with new part of tutorial
- Tests