### PR TITLE
🎨 Add newly required type annotations for mypy

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -752,7 +752,7 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
     for param in flat_dependant.body_params:
         setattr(param.field_info, "embed", True)
     model_name = "Body_" + name
-    BodyModel = create_model(model_name)
+    BodyModel: Type[BaseModel] = create_model(model_name)
     for f in flat_dependant.body_params:
         BodyModel.__fields__[f.name] = get_schema_compatible_field(field=f)
     required = any(True for f in flat_dependant.body_params if f.required)

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Type
 
-from pydantic import ValidationError, create_model
+from pydantic import BaseModel, ValidationError, create_model
 from pydantic.error_wrappers import ErrorList
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -16,8 +16,8 @@ class HTTPException(StarletteHTTPException):
         self.headers = headers
 
 
-RequestErrorModel = create_model("Request")
-WebSocketErrorModel = create_model("WebSocket")
+RequestErrorModel: Type[BaseModel] = create_model("Request")
+WebSocketErrorModel: Type[BaseModel] = create_model("WebSocket")
 
 
 class FastAPIError(RuntimeError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "pytest ==5.4.3",
     "pytest-cov ==2.10.0",
     "pytest-asyncio >=0.14.0,<0.15.0",
-    "mypy ==0.790",
+    "mypy ==0.812",
     "flake8 >=3.8.3,<4.0.0",
     "black ==20.8b1",
     "isort >=5.0.6,<6.0.0",


### PR DESCRIPTION
🎨 Add newly required type annotations for mypy

And upgrade `mypy` to the latest version.

This is probably related to the recent latest version of Pydantic, 1.8. I don't really see how it could affect, but `mypy` seems to want those extra explicit annotations now. :shrug: 