### PR TITLE
WIP: ✨ Add probes endpoints

### DIFF
--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI, Request
+
+app = FastAPI(liveness_probe_url="/health/liveness")
+
+
+@app.get("/")
+def change_state(request: Request):
+    request.app.probes_state.alive = not request.app.probes_state.alive


### PR DESCRIPTION
## Summary

More like a prototype of `/liveness` and `/readiness` endpoints supported natively. 

### Proposed Solution :sunglasses: 

This solution proposes storing the `probes_state`. In that state, we define two attributes: `alive` and `ready`. Based on those two attributes, we're able to change the response of the `liveness` and `readiness` probes. 

Those two attributes can be changed at any moment using the `request.app.probes_state.<alive|ready>` for **now**. This is obviously a solution that @tiangolo will not accept, neither I think is a good one. :sweat_smile: I think we should have a duck typed solution here. That being said, some ideas:
- Global variable imported instead of storing the state inside the FastAPI class (which doesn't look that good and it will be exceptional way to do something in FastAPI), for instance:
```python
from fastapi import probes_state
``` 
- Provide a new object the same way BackgroundTasks and Request is inserted, for instance:
```python
from fastapi import FastAPI, LivenessState, ReadinessState

app = FastAPI()

@app.get("/")
async def potato(liveness_state: LivenessState, readiness_state: ReadinessState):
    liveness_state.broken() # Turn alive to False
    liveness_state.correct() # Turn alive to True
    readiness_state.accepting_traffic() # Turn ready to True
    readiness_state.refusing_traffic() # Turn ready to False  
```

### Pros :heavy_check_mark: 
- Looks like people want this feature (check related issue thumbs up).

### Cons :x: 
- Easy to implement i.e. doesn't need to be on FastAPI natively.

### Related issues :nerd_face: 
- https://github.com/tiangolo/fastapi/issues/1907

### References
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
- https://spring.io/blog/2020/03/25/liveness-and-readiness-probes-with-spring-boot
- https://www.baeldung.com/spring-liveness-readiness-probes

### Personal note for curious readers
Let your like here if you want this feature, but don't assume this will be merged, please.  