### PR TITLE
Require async_exit_stack and async_generator only on Python < 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ test = [
     "peewee >=3.13.3,<4.0.0",
     "databases[sqlite] >=0.3.2,<0.4.0",
     "orjson >=3.2.1,<4.0.0",
-    "async_exit_stack >=1.0.1,<2.0.0",
-    "async_generator >=1.10,<2.0.0",
+    "async_exit_stack >=1.0.1,<2.0.0; python_version < '3.7'",
+    "async_generator >=1.10,<2.0.0; python_version < '3.7'",
     "python-multipart >=0.0.5,<0.0.6",
     "aiofiles >=0.5.0,<0.6.0",
     "flask >=1.1.2,<2.0.0"
@@ -91,8 +91,8 @@ all = [
     "orjson >=3.2.1,<4.0.0",
     "email_validator >=1.1.1,<2.0.0",
     "uvicorn[standard] >=0.12.0,<0.14.0",
-    "async_exit_stack >=1.0.1,<2.0.0",
-    "async_generator >=1.10,<2.0.0"
+    "async_exit_stack >=1.0.1,<2.0.0; python_version < '3.7'",
+    "async_generator >=1.10,<2.0.0; python_version < '3.7'"
 ]
 
 [tool.isort]


### PR DESCRIPTION
Backport libraries should not be required where they are not useful. Require them only on Python 3.6 and older.

No code changes should be required; the library already imports these only when they are needed.