### PR TITLE
Tiny doc change to improve clarity of Optional type hint note in tutorial

### DIFF
--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -156,9 +156,11 @@ The function parameters will be recognized as follows:
 * If the parameter is declared to be of the type of a **Pydantic model**, it will be interpreted as a request **body**.
 
 !!! note
-    FastAPI will know that the value of `q` is not required because of the default value `= None`.
+    The `Optional` type hint included above is purely for type-checking and editor support, it does not impact **FastAPI**.
 
-    The `Optional` in `Optional[str]` is not used by FastAPI, but will allow your editor to give you better support and detect errors.
+    **FastAPI** knows that `q` should be a string, due to the `str` in `Optional[str]`, and it knows it is not *required* because it has a default value set by `= None`.
+
+    See the [Required Query Parameters](query-params.md#required-query-parameters) section for more details.
 
 ## Without Pydantic
 

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -11,9 +11,11 @@ Let's take this application as example:
 The query parameter `q` is of type `Optional[str]`, that means that it's of type `str` but could also be `None`, and indeed, the default value is `None`, so FastAPI will know it's not required.
 
 !!! note
-    FastAPI will know that the value of `q` is not required because of the default value `= None`.
+    The `Optional` type hint included above is purely for type-checking and editor support, it does not impact **FastAPI**.
 
-    The `Optional` in `Optional[str]` is not used by FastAPI, but will allow your editor to give you better support and detect errors.
+    **FastAPI** knows that `q` should be a string, due to the `str` in `Optional[str]`, and it knows it is not *required* because it has a default value set by `= None`.
+
+    See the [Required Query Parameters](query-params.md#required-query-parameters) section for more details.
 
 ## Additional validation
 

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -45,16 +45,16 @@ So:
 q: Optional[str] = Query(None)
 ```
 
-...makes the parameter optional, the same as:
+...sets the default value to None, the same as:
 
 ```Python
 q: Optional[str] = None
 ```
 
-But it declares it explicitly as being a query parameter.
+but it also declares it explicitly as being a query parameter.
 
 !!! info
-    Have in mind that FastAPI cares about the part:
+    Remember that FastAPI only cares about the part:
 
     ```Python
     = None
@@ -66,9 +66,9 @@ But it declares it explicitly as being a query parameter.
     = Query(None)
     ```
 
-    and will use that `None` to detect that the query parameter is not required.
+    In either case, the fact that the parameter is assigned a default value signals to FastAPI that it is not required.
 
-    The `Optional` part is only to allow your editor to provide better support.
+    The `Optional` type hint is only to allow your editor to provide better support.
 
 Then, we can pass more parameters to `Query`. In this case, the `max_length` parameter that applies to strings:
 

--- a/docs/en/docs/tutorial/query-params.md
+++ b/docs/en/docs/tutorial/query-params.md
@@ -73,9 +73,10 @@ In this case, the function parameter `q` will be optional, and will be `None` by
     Also notice that **FastAPI** is smart enough to notice that the path parameter `item_id` is a path parameter and `q` is not, so, it's a query parameter.
 
 !!! note
-    FastAPI will know that `q` is optional because of the `= None`.
+    Note that the `Optional` type hint does not impact **FastAPI**, nor should it.
 
-    The `Optional` in `Optional[str]` is not used by FastAPI (FastAPI will only use the `str` part), but the `Optional[str]` will let your editor help you finding errors in your code.
+    **FastAPI** knows that `q` should be a string, due to the `str` in `Optional[str]`, and it knows it is not *required* because it has a default value set by `= None`. Including the `Optional` type hint allows your editor / type-checking software to know this variable can be `None`.
+
 
 ## Query parameter type conversion
 

--- a/docs/en/docs/tutorial/query-params.md
+++ b/docs/en/docs/tutorial/query-params.md
@@ -73,9 +73,12 @@ In this case, the function parameter `q` will be optional, and will be `None` by
     Also notice that **FastAPI** is smart enough to notice that the path parameter `item_id` is a path parameter and `q` is not, so, it's a query parameter.
 
 !!! note
-    Note that the `Optional` type hint does not impact **FastAPI**, nor should it.
+    The `Optional` type hint included above is purely for type-checking and editor support, it does not impact **FastAPI**.
 
-    **FastAPI** knows that `q` should be a string, due to the `str` in `Optional[str]`, and it knows it is not *required* because it has a default value set by `= None`. Including the `Optional` type hint allows your editor / type-checking software to know this variable can be `None`.
+    **FastAPI** knows that `q` should be a string, due to the `str` in `Optional[str]`, and it knows it is not *required* because it has a default value set by `= None`.
+
+    See the [Required Query Parameters](#required-query-parameters) section for more details.
+
 
 
 ## Query parameter type conversion


### PR DESCRIPTION
When reading the documentation, the note regarding Optional type hints was somewhat confusing to me - it made it seem like FastAPI was ignoring relevant type information, which goes against all the rest of the beautiful type awareness. This is my attempt to clarify that note.

(Somewhat related to #1561, which seems as though it can be closed.)