### PR TITLE
WIP: [Docs] - Fix OpenAPI version in extending openapi

### DIFF
--- a/docs_src/extending_openapi/tutorial001.py
+++ b/docs_src/extending_openapi/tutorial001.py
@@ -14,7 +14,7 @@ def custom_openapi():
         return app.openapi_schema
     openapi_schema = get_openapi(
         title="Custom title",
-        version="2.5.0",
+        version="3.0.0",
         description="This is a very custom OpenAPI schema",
         routes=app.routes,
     )


### PR DESCRIPTION
Hi,

Here is a small fix on the documentation.
As shown in this issue: tiangolo#1457 if we use openapi `2.5.0` as mentioned in the doc today we have a rendering problem. We need to use at least openapi `3.0.0` in order to get the Swagger UI displayed.

Have a good day.

PS: Thanks again for this framework ! It's just 👌