### PR TITLE
Swap light mode and dark mode toggle tooltip on docs

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to dark mode
+      name: Switch to light mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to light mode
+      name: Switch to dark mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/es/mkdocs.yml
+++ b/docs/es/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/fr/mkdocs.yml
+++ b/docs/fr/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/it/mkdocs.yml
+++ b/docs/it/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/ja/mkdocs.yml
+++ b/docs/ja/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/ko/mkdocs.yml
+++ b/docs/ko/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/pt/mkdocs.yml
+++ b/docs/pt/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/ru/mkdocs.yml
+++ b/docs/ru/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/sq/mkdocs.yml
+++ b/docs/sq/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/tr/mkdocs.yml
+++ b/docs/tr/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/uk/mkdocs.yml
+++ b/docs/uk/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight

--- a/docs/zh/mkdocs.yml
+++ b/docs/zh/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight


### PR DESCRIPTION
The current one shows "switch to light mode" while and light mode and "switch to dark mode" while on dark mode. This commit will correct it.