### PR TITLE
⬆️ Upgrade OpenAPI from 3.0.2 to 3.1.0

### DIFF
--- a/docs/en/docs/advanced/additional-responses.md
+++ b/docs/en/docs/advanced/additional-responses.md
@@ -36,7 +36,7 @@ For example, to declare another response with a status code `404` and a Pydantic
     **FastAPI** will take the Pydantic model from there, generate the `JSON Schema`, and put it in the correct place.
 
     The correct place is:
-    
+
     * In the key `content`, that has as value another JSON object (`dict`) that contains:
         * A key with the media type, e.g. `application/json`, that contains as value another JSON object, that contains:
             * A key `schema`, that has as the value the JSON Schema from the model, here's the correct place.
@@ -236,5 +236,5 @@ For example:
 
 To see what exactly you can include in the responses, you can check these sections in the OpenAPI specification:
 
-* <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responsesObject" class="external-link" target="_blank">OpenAPI Responses Object</a>, it includes the `Response Object`.
-* <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject" class="external-link" target="_blank">OpenAPI Response Object</a>, you can include anything from this directly in each response inside your `responses` parameter. Including `description`, `headers`, `content` (inside of this is that you declare different media types and JSON Schemas), and `links`.
+* <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#responsesObject" class="external-link" target="_blank">OpenAPI Responses Object</a>, it includes the `Response Object`.
+* <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#responseObject" class="external-link" target="_blank">OpenAPI Response Object</a>, you can include anything from this directly in each response inside your `responses` parameter. Including `description`, `headers`, `content` (inside of this is that you declare different media types and JSON Schemas), and `links`.

--- a/docs/en/docs/advanced/behind-a-proxy.md
+++ b/docs/en/docs/advanced/behind-a-proxy.md
@@ -46,7 +46,7 @@ The docs UI would also need the OpenAPI schema to declare that this API `server`
 
 ```JSON hl_lines="4-8"
 {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     // More stuff here
     "servers": [
         {
@@ -298,7 +298,7 @@ Will generate an OpenAPI schema like:
 
 ```JSON hl_lines="5-7"
 {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     // More stuff here
     "servers": [
         {

--- a/docs/en/docs/advanced/extending-openapi.md
+++ b/docs/en/docs/advanced/extending-openapi.md
@@ -29,7 +29,7 @@ And that function `get_openapi()` receives as parameters:
 
 * `title`: The OpenAPI title, shown in the docs.
 * `version`: The version of your API, e.g. `2.5.0`.
-* `openapi_version`: The version of the OpenAPI specification used. By default, the latest: `3.0.2`.
+* `openapi_version`: The version of the OpenAPI specification used. By default, the latest: `3.1.0`.
 * `description`: The description of your API.
 * `routes`: A list of routes, these are each of the registered *path operations*. They are taken from `app.routes`.
 

--- a/docs/en/docs/advanced/openapi-callbacks.md
+++ b/docs/en/docs/advanced/openapi-callbacks.md
@@ -103,11 +103,11 @@ It should look just like a normal FastAPI *path operation*:
 There are 2 main differences from a normal *path operation*:
 
 * It doesn't need to have any actual code, because your app will never call this code. It's only used to document the *external API*. So, the function could just have `pass`.
-* The *path* can contain an <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#key-expression" class="external-link" target="_blank">OpenAPI 3 expression</a> (see more below) where it can use variables with parameters and parts of the original request sent to *your API*.
+* The *path* can contain an <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression" class="external-link" target="_blank">OpenAPI 3 expression</a> (see more below) where it can use variables with parameters and parts of the original request sent to *your API*.
 
 ### The callback path expression
 
-The callback *path* can have an <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#key-expression" class="external-link" target="_blank">OpenAPI 3 expression</a> that can contain parts of the original request sent to *your API*.
+The callback *path* can have an <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression" class="external-link" target="_blank">OpenAPI 3 expression</a> that can contain parts of the original request sent to *your API*.
 
 In this case, it's the `str`:
 

--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -99,7 +99,7 @@ It will show a JSON starting with something like:
 
 ```JSON
 {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {
         "title": "FastAPI",
         "version": "0.1.0"

--- a/docs/en/docs/tutorial/path-params.md
+++ b/docs/en/docs/tutorial/path-params.md
@@ -83,7 +83,7 @@ And when you open your browser at <a href="http://127.0.0.1:8000/docs" class="ex
 
 ## Standards-based benefits, alternative documentation
 
-And because the generated schema is from the <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md" class="external-link" target="_blank">OpenAPI</a> standard, there are many compatible tools.
+And because the generated schema is from the <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> standard, there are many compatible tools.
 
 Because of this, **FastAPI** itself provides an alternative API documentation (using ReDoc), which you can access at <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>:
 

--- a/docs/ja/docs/tutorial/first-steps.md
+++ b/docs/ja/docs/tutorial/first-steps.md
@@ -99,7 +99,7 @@ OpenAPIはAPIのためのAPIスキーマを定義します。そして、その�
 
 ```JSON
 {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {
         "title": "FastAPI",
         "version": "0.1.0"

--- a/docs/ja/docs/tutorial/path-params.md
+++ b/docs/ja/docs/tutorial/path-params.md
@@ -83,7 +83,7 @@ Pythonのformat文字列と同様のシンタックスで「パスパラメー�
 
 ## 標準であることのメリット、ドキュメンテーションの代替物
 
-また、生成されたスキーマが <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md" class="external-link" target="_blank">OpenAPI</a> 標準に従っているので、互換性のあるツールが多数あります。
+また、生成されたスキーマが <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> 標準に従っているので、互換性のあるツールが多数あります。
 
 このため、**FastAPI**自体が代替のAPIドキュメントを提供します（ReDocを使用）。これは、 <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a> にアクセスすると確認できます。
 
@@ -139,7 +139,7 @@ Pythonのformat文字列と同様のシンタックスで「パスパラメー�
 
 ### *パスパラメータ*の宣言
 
-次に、作成したenumクラスである`ModelName`を使用した型アノテーションをもつ*パスパラメータ*を作成します: 
+次に、作成したenumクラスである`ModelName`を使用した型アノテーションをもつ*パスパラメータ*を作成します:
 
 ```Python hl_lines="16"
 {!../../../docs_src/path_params/tutorial005.py!}

--- a/docs/pt/docs/tutorial/first-steps.md
+++ b/docs/pt/docs/tutorial/first-steps.md
@@ -2,17 +2,17 @@
 
 O arquivo FastAPI mais simples pode se parecer com:
 
-```Python
+``` Python
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-Copie o conteúdo para um arquivo `main.py`.
+Copie o conteúdo para um arquivo `main.py` .
 
 Execute o servidor:
 
 <div class="termy">
 
-```console
+``` console
 $ uvicorn main:app --reload
 
 <span style="color: green;">INFO</span>:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
@@ -25,17 +25,19 @@ $ uvicorn main:app --reload
 </div>
 
 !!! nota
+
     O comando `uvicorn main:app` se refere a:
 
-    * `main`: o arquivo `main.py` (o "módulo" Python).
-    * `app`: o objeto criado no arquivo `main.py` com a linha `app = FastAPI()`.
-    * `--reload`: faz o servidor reiniciar após mudanças de código. Use apenas para desenvolvimento.
+    - `main`: o arquivo `main.py` (o "módulo" Python).
+    - `app`: o objeto criado no arquivo `main.py` com a linha `app = FastAPI()`.
+    - `--reload`: faz o servidor reiniciar após mudanças de código. Use apenas para desenvolvimento.
 
 Na saída, temos:
 
 ```hl_lines="4"
 INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
-```
+
+``` 
 
 Essa linha mostra a URL onde a sua aplicação está sendo servida, que nesse caso é a sua máquina local.
 
@@ -97,9 +99,9 @@ Você pode ver isso diretamente em: <a href="http://127.0.0.1:8000/openapi.json"
 
 Ele mostrará um JSON começando com algo como:
 
-```JSON
+``` JSON
 {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {
         "title": "FastAPI",
         "version": "0.1.0"
@@ -112,8 +114,6 @@ Ele mostrará um JSON começando com algo como:
                         "description": "Successful Response",
                         "content": {
                             "application/json": {
-
-
 
 ...
 ```
@@ -132,7 +132,8 @@ Você também pode usá-lo para gerar código automaticamente para clientes que 
 
 ```Python hl_lines="1"
 {!../../../docs_src/first_steps/tutorial001.py!}
-```
+
+``` 
 
 `FastAPI` é uma classe Python que fornece todas as funcionalidades para sua API.
 
@@ -147,7 +148,7 @@ Você também pode usá-lo para gerar código automaticamente para clientes que 
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-Aqui, a variável `app` será uma "instância" da classe `FastAPI`.
+Aqui, a variável `app` será uma "instância" da classe `FastAPI` .
 
 Este será o principal ponto de interação para criar toda a sua API.
 
@@ -155,7 +156,7 @@ Este `app` é o mesmo referenciado por `uvicorn` no comando:
 
 <div class="termy">
 
-```console
+``` console
 $ uvicorn main:app --reload
 
 <span style="color: green;">INFO</span>:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
@@ -167,7 +168,8 @@ Se você criar a sua aplicação como:
 
 ```Python hl_lines="3"
 {!../../../docs_src/first_steps/tutorial002.py!}
-```
+
+``` 
 
 E colocar em um arquivo `main.py`, você iria chamar o `uvicorn` assim:
 
@@ -185,21 +187,22 @@ $ uvicorn main:my_awesome_api --reload
 
 #### Rota
 
-"Rota" aqui se refere à última parte da URL, começando do primeiro `/`.
+"Rota" aqui se refere à última parte da URL, começando do primeiro `/` .
 
 Então, em uma URL como:
 
-```
+``` 
 https://example.com/items/foo
 ```
 
 ...a rota seria:
 
-```
+``` 
 /items/foo
 ```
 
 !!! info "Informação"
+
     Uma "rota" também é comumente chamada de "endpoint".
 
 Ao construir uma API, a "rota" é a principal forma de separar "preocupações" e "recursos".
@@ -243,7 +246,8 @@ Vamos chamá-los de "**operações**" também.
 
 ```Python hl_lines="6"
 {!../../../docs_src/first_steps/tutorial001.py!}
-```
+
+``` 
 
 O `@app.get("/")` diz ao **FastAPI** que a função logo abaixo é responsável por tratar as requisições que vão para:
 
@@ -297,17 +301,18 @@ Esta é a nossa "**função de rota**":
 
 Esta é uma função Python.
 
-Ela será chamada pelo **FastAPI** sempre que receber uma requisição para a URL "`/ `" usando uma operação `GET`.
+Ela será chamada pelo **FastAPI** sempre que receber uma requisição para a URL " `/ ` " usando uma operação `GET` .
 
-Neste caso, é uma função `assíncrona`.
+Neste caso, é uma função `assíncrona` .
 
 ---
 
-Você também pode defini-la como uma função normal em vez de `async def`:
+Você também pode defini-la como uma função normal em vez de `async def` :
 
 ```Python hl_lines="7"
 {!../../../docs_src/first_steps/tutorial003.py!}
-```
+
+``` 
 
 !!! nota
     Se você não sabe a diferença, verifique o [Async: *"Com pressa?"*](../async.md#com-pressa){.internal-link target=_blank}.
@@ -318,7 +323,7 @@ Você também pode defini-la como uma função normal em vez de `async def`:
 {!../../../docs_src/first_steps/tutorial001.py!}
 ```
 
-Você pode retornar um `dict`, `list` e valores singulares como `str`, `int`, etc.
+Você pode retornar um `dict` , `list` e valores singulares como `str` , `int` , etc.
 
 Você também pode devolver modelos Pydantic (você verá mais sobre isso mais tarde).
 

--- a/docs/zh/docs/tutorial/first-steps.md
+++ b/docs/zh/docs/tutorial/first-steps.md
@@ -30,7 +30,7 @@ $ uvicorn main:app --reload
     * `main`：`main.py` 文件（一个 Python「模块」）。
     * `app`：在 `main.py` 文件中通过 `app = FastAPI()` 创建的对象。
     * `--reload`：让服务器在更新代码后重新启动。仅在开发时使用该选项。
-    
+
 
 在输出中，会有一行信息像下面这样：
 
@@ -101,7 +101,7 @@ OpenAPI 为你的 API 定义 API 模式。该模式中包含了你的 API 发送
 
 ```JSON
 {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {
         "title": "FastAPI",
         "version": "0.1.0"

--- a/docs/zh/docs/tutorial/path-params.md
+++ b/docs/zh/docs/tutorial/path-params.md
@@ -4,7 +4,8 @@
 
 ```Python hl_lines="6-7"
 {!../../../docs_src/path_params/tutorial001.py!}
-```
+
+``` 
 
 路径参数 `item_id` 的值将作为参数 `item_id` 传递给你的函数。
 
@@ -20,7 +21,8 @@
 
 ```Python hl_lines="7"
 {!../../../docs_src/path_params/tutorial002.py!}
-```
+
+``` 
 
 在这个例子中，`item_id` 被声明为 `int` 类型。
 
@@ -36,7 +38,8 @@
 ```
 
 !!! check
-    注意函数接收（并返回）的值为 3，是一个 Python `int` 值，而不是字符串 `"3"`。
+
+    注意函数接收（并返回）的值为 3，是一个 Python `int` 值，而不是字符串 `"3"` 。
 
     所以，**FastAPI** 通过上面的类型声明提供了对请求的自动<abbr title="将来自 HTTP 请求中的字符串转换为 Python 数据类型">"解析"</abbr>。
 
@@ -44,7 +47,7 @@
 
 但如果你通过浏览器访问 <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a>，你会看到一个清晰可读的 HTTP 错误：
 
-```JSON
+``` JSON
 {
     "detail": [
         {
@@ -59,11 +62,12 @@
 }
 ```
 
-因为路径参数 `item_id` 传入的值为 `"foo"`，它不是一个 `int`。
+因为路径参数 `item_id` 传入的值为 `"foo"` ，它不是一个 `int` 。
 
 如果你提供的是 `float` 而非整数也会出现同样的错误，比如： <a href="http://127.0.0.1:8000/items/4.2" class="external-link" target="_blank">http://127.0.0.1:8000/items/4.2</a>
 
 !!! check
+
     所以，通过同样的 Python 类型声明，**FastAPI** 提供了数据校验功能。
 
     注意上面的错误同样清楚地指出了校验未通过的具体原因。
@@ -77,13 +81,14 @@
 <img src="https://fastapi.tiangolo.com/img/tutorial/path-params/image01.png">
 
 !!! check
+
     再一次，还是通过相同的 Python 类型声明，**FastAPI** 为你提供了自动生成的交互式文档（集成 Swagger UI）。
 
     注意这里的路径参数被声明为一个整数。
 
 ## 基于标准的好处：可选文档
 
-由于生成的 API 模式来自于 <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md" class="external-link" target="_blank">OpenAPI</a> 标准，所以有很多工具与其兼容。
+由于生成的 API 模式来自于 <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> 标准，所以有很多工具与其兼容。
 
 正因如此，**FastAPI** 内置了一个可选的 API 文档（使用 Redoc）：
 
@@ -95,7 +100,7 @@
 
 所有的数据校验都由 <a href="https://pydantic-docs.helpmanual.io/" class="external-link" target="_blank">Pydantic</a> 在幕后完成，所以你可以从它所有的优点中受益。并且你知道它在这方面非常胜任。
 
-你可以使用同样的类型声明来声明 `str`、`float`、`bool` 以及许多其他的复合数据类型。
+你可以使用同样的类型声明来声明 `str` 、 `float` 、 `bool` 以及许多其他的复合数据类型。
 
 本教程的下一章节将探讨其中的一些内容。
 
@@ -103,14 +108,15 @@
 
 在创建*路径操作*时，你会发现有些情况下路径是固定的。
 
-比如 `/users/me`，我们假设它用来获取关于当前用户的数据.
+比如 `/users/me` ，我们假设它用来获取关于当前用户的数据.
 
 然后，你还可以使用路径 `/users/{user_id}` 来通过用户 ID 获取关于特定用户的数据。
 
-由于*路径操作*是按顺序依次运行的，你需要确保路径 `/users/me` 声明在路径 `/users/{user_id}`之前：
+由于*路径操作*是按顺序依次运行的，你需要确保路径 `/users/me` 声明在路径 `/users/{user_id}` 之前：
 ```Python hl_lines="6  11"
 {!../../../docs_src/path_params/tutorial003.py!}
-```
+
+``` 
 
 否则，`/users/{user_id}` 的路径还将与 `/users/me` 相匹配，"认为"自己正在接收一个值为 `"me"` 的 `user_id` 参数。
 
@@ -131,18 +137,21 @@
 ```
 
 !!! info
+
     <a href="https://docs.python.org/3/library/enum.html" class="external-link" target="_blank">枚举（或 enums）</a>从 3.4 版本起在 Python 中可用。
 
 !!! tip
+
     如果你想知道，"AlexNet"、"ResNet" 和 "LeNet" 只是机器学习中的<abbr title="技术上来说是深度学习模型架构">模型</abbr>名称。
 
 ### 声明*路径参数*
 
-然后使用你定义的枚举类（`ModelName`）创建一个带有类型标注的*路径参数*：
+然后使用你定义的枚举类（ `ModelName` ）创建一个带有类型标注的*路径参数*：
 
 ```Python hl_lines="16"
 {!../../../docs_src/path_params/tutorial005.py!}
-```
+
+``` 
 
 ### 查看文档
 
@@ -164,11 +173,12 @@
 
 #### 获取*枚举值*
 
-你可以使用 `model_name.value` 或通常来说 `your_enum_member.value` 来获取实际的值（在这个例子中为 `str`）：
+你可以使用 `model_name.value` 或通常来说 `your_enum_member.value` 来获取实际的值（在这个例子中为 `str` ）：
 
 ```Python hl_lines="19"
 {!../../../docs_src/path_params/tutorial005.py!}
-```
+
+``` 
 
 !!! tip
     你也可以通过 `ModelName.lenet.value` 来获取值 `"lenet"`。
@@ -185,11 +195,11 @@
 
 ## 包含路径的路径参数
 
-假设你有一个*路径操作*，它的路径为 `/files/{file_path}`。
+假设你有一个*路径操作*，它的路径为 `/files/{file_path}` 。
 
-但是你需要 `file_path` 自身也包含*路径*，比如 `home/johndoe/myfile.txt`。
+但是你需要 `file_path` 自身也包含*路径*，比如 `home/johndoe/myfile.txt` 。
 
-因此，该文件的URL将类似于这样：`/files/home/johndoe/myfile.txt`。
+因此，该文件的URL将类似于这样： `/files/home/johndoe/myfile.txt` 。
 
 ### OpenAPI 支持
 
@@ -203,11 +213,11 @@ OpenAPI 不支持任何方式去声明*路径参数*以在其内部包含*路径
 
 你可以使用直接来自 Starlette 的选项来声明一个包含*路径*的*路径参数*：
 
-```
+``` 
 /files/{file_path:path}
 ```
 
-在这种情况下，参数的名称为 `file_path`，结尾部分的 `:path` 说明该参数应匹配任意的*路径*。
+在这种情况下，参数的名称为 `file_path` ，结尾部分的 `:path` 说明该参数应匹配任意的*路径*。
 
 因此，你可以这样使用它：
 
@@ -216,9 +226,10 @@ OpenAPI 不支持任何方式去声明*路径参数*以在其内部包含*路径
 ```
 
 !!! tip
-    你可能会需要参数包含 `/home/johndoe/myfile.txt`，以斜杠（`/`）开头。
 
-    在这种情况下，URL 将会是 `/files//home/johndoe/myfile.txt`，在`files` 和 `home` 之间有一个双斜杠（`//`）。
+    你可能会需要参数包含 `/home/johndoe/myfile.txt` ，以斜杠（ `/` ）开头。
+
+    在这种情况下，URL 将会是 `/files//home/johndoe/myfile.txt` ，在 `files` 和 `home` 之间有一个双斜杠（ `//` ）。
 
 ## 总结
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -117,7 +117,7 @@ class FastAPI(Starlette):
         self.extra = extra
         self.dependency_overrides: Dict[Callable[..., Any], Callable[..., Any]] = {}
 
-        self.openapi_version = "3.0.2"
+        self.openapi_version = "3.1.0"
 
         if self.openapi_url:
             assert self.title, "A title must be provided for OpenAPI, e.g.: 'My API'"

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -115,6 +115,7 @@ class SchemaBase(BaseModel):
     xml: Optional[XML] = None
     externalDocs: Optional[ExternalDocumentation] = None
     example: Optional[Any] = None
+    examples: Optional[List[Any]] = None
     deprecated: Optional[bool] = None
 
 

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -335,7 +335,7 @@ def get_openapi(
     *,
     title: str,
     version: str,
-    openapi_version: str = "3.0.2",
+    openapi_version: str = "3.1.0",
     description: Optional[str] = None,
     routes: Sequence[BaseRoute],
     tags: Optional[List[Dict[str, Any]]] = None,

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-# mypy fastapi
+mypy fastapi
 flake8 fastapi tests
 black fastapi tests --check
 isort fastapi tests docs_src scripts --check-only

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-mypy fastapi
+# mypy fastapi
 flake8 fastapi tests
 black fastapi tests --check
 isort fastapi tests docs_src scripts --check-only

--- a/tests/test_additional_properties.py
+++ b/tests/test_additional_properties.py
@@ -20,7 +20,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/foo": {

--- a/tests/test_additional_response_extra.py
+++ b/tests/test_additional_response_extra.py
@@ -19,7 +19,7 @@ app.include_router(router)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_additional_responses_bad.py
+++ b/tests/test_additional_responses_bad.py
@@ -11,7 +11,7 @@ async def a():
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a": {

--- a/tests/test_additional_responses_custom_model_in_callback.py
+++ b/tests/test_additional_responses_custom_model_in_callback.py
@@ -26,7 +26,7 @@ def main_route(callback_url: HttpUrl):
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/": {

--- a/tests/test_additional_responses_custom_validationerror.py
+++ b/tests/test_additional_responses_custom_validationerror.py
@@ -31,7 +31,7 @@ async def a(id):
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a/{id}": {

--- a/tests/test_additional_responses_default_validationerror.py
+++ b/tests/test_additional_responses_default_validationerror.py
@@ -10,7 +10,7 @@ async def a(id):
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a/{id}": {

--- a/tests/test_additional_responses_response_class.py
+++ b/tests/test_additional_responses_response_class.py
@@ -36,7 +36,7 @@ async def b():
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a": {

--- a/tests/test_additional_responses_router.py
+++ b/tests/test_additional_responses_router.py
@@ -36,7 +36,7 @@ async def c():
 app.include_router(router)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a": {

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -6,7 +6,7 @@ from .main import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/api_route": {

--- a/tests/test_custom_route_class.py
+++ b/tests/test_custom_route_class.py
@@ -47,7 +47,7 @@ app.include_router(router=router_a, prefix="/a")
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a/": {

--- a/tests/test_dependency_duplicates.py
+++ b/tests/test_dependency_duplicates.py
@@ -45,7 +45,7 @@ async def no_duplicates_sub(
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/with-duplicates": {

--- a/tests/test_deprecated_openapi_prefix.py
+++ b/tests/test_deprecated_openapi_prefix.py
@@ -12,7 +12,7 @@ def read_main(request: Request):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/app": {

--- a/tests/test_duplicate_models_openapi.py
+++ b/tests/test_duplicate_models_openapi.py
@@ -24,7 +24,7 @@ def f():
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/": {

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -53,7 +53,7 @@ def trace_item(item_id: str):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_filter_pydantic_sub_model.py
+++ b/tests/test_filter_pydantic_sub_model.py
@@ -41,7 +41,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/model/{name}": {

--- a/tests/test_get_request_body.py
+++ b/tests/test_get_request_body.py
@@ -20,7 +20,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/product": {

--- a/tests/test_include_router_defaults_overrides.py
+++ b/tests/test_include_router_defaults_overrides.py
@@ -440,7 +440,7 @@ def test_paths_level5(override1, override2, override3, override4, override5):
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/override1": {

--- a/tests/test_modules_same_name_body/test_main.py
+++ b/tests/test_modules_same_name_body/test_main.py
@@ -5,7 +5,7 @@ from .app.main import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a/compute": {

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -22,7 +22,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_multi_query_errors.py
+++ b/tests/test_multi_query_errors.py
@@ -15,7 +15,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_openapi_servers.py
+++ b/tests/test_openapi_servers.py
@@ -22,7 +22,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "servers": [
         {"url": "/", "description": "Default, relative server"},

--- a/tests/test_param_in_path_and_dependency.py
+++ b/tests/test_param_in_path_and_dependency.py
@@ -16,7 +16,7 @@ async def read_users(user_id: int):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/{user_id}": {

--- a/tests/test_put_no_body.py
+++ b/tests/test_put_no_body.py
@@ -13,7 +13,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_repeated_dependency_schema.py
+++ b/tests/test_repeated_dependency_schema.py
@@ -50,7 +50,7 @@ schema = {
         }
     },
     "info": {"title": "FastAPI", "version": "0.1.0"},
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "paths": {
         "/": {
             "get": {

--- a/tests/test_response_by_alias.py
+++ b/tests/test_response_by_alias.py
@@ -69,7 +69,7 @@ def no_alias_list():
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/dict": {

--- a/tests/test_response_class_no_mediatype.py
+++ b/tests/test_response_class_no_mediatype.py
@@ -36,7 +36,7 @@ async def b():
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a": {

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -37,7 +37,7 @@ async def b():
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/a": {

--- a/tests/test_response_model_sub_types.py
+++ b/tests/test_response_model_sub_types.py
@@ -33,7 +33,7 @@ def valid4():
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/valid1": {

--- a/tests/test_security_api_key_cookie.py
+++ b/tests/test_security_api_key_cookie.py
@@ -25,7 +25,7 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_api_key_cookie_optional.py
+++ b/tests/test_security_api_key_cookie_optional.py
@@ -32,7 +32,7 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_api_key_header.py
+++ b/tests/test_security_api_key_header.py
@@ -25,7 +25,7 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_api_key_header_optional.py
+++ b/tests/test_security_api_key_header_optional.py
@@ -31,7 +31,7 @@ def read_current_user(current_user: Optional[User] = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_api_key_query.py
+++ b/tests/test_security_api_key_query.py
@@ -25,7 +25,7 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_api_key_query_optional.py
+++ b/tests/test_security_api_key_query_optional.py
@@ -31,7 +31,7 @@ def read_current_user(current_user: Optional[User] = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_base.py
+++ b/tests/test_security_http_base.py
@@ -15,7 +15,7 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_base_optional.py
+++ b/tests/test_security_http_base_optional.py
@@ -21,7 +21,7 @@ def read_current_user(
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_basic_optional.py
+++ b/tests/test_security_http_basic_optional.py
@@ -21,7 +21,7 @@ def read_current_user(credentials: Optional[HTTPBasicCredentials] = Security(sec
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_basic_realm.py
+++ b/tests/test_security_http_basic_realm.py
@@ -18,7 +18,7 @@ def read_current_user(credentials: HTTPBasicCredentials = Security(security)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_bearer.py
+++ b/tests/test_security_http_bearer.py
@@ -15,7 +15,7 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_bearer_optional.py
+++ b/tests/test_security_http_bearer_optional.py
@@ -21,7 +21,7 @@ def read_current_user(
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_digest.py
+++ b/tests/test_security_http_digest.py
@@ -15,7 +15,7 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_http_digest_optional.py
+++ b/tests/test_security_http_digest_optional.py
@@ -21,7 +21,7 @@ def read_current_user(
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -41,7 +41,7 @@ def read_current_user(current_user: "User" = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/login": {

--- a/tests/test_security_oauth2_authorization_code_bearer.py
+++ b/tests/test_security_oauth2_authorization_code_bearer.py
@@ -19,7 +19,7 @@ async def read_items(token: Optional[str] = Security(oauth2_scheme)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -45,7 +45,7 @@ def read_users_me(current_user: Optional[User] = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/login": {

--- a/tests/test_security_oauth2_password_bearer_optional.py
+++ b/tests/test_security_oauth2_password_bearer_optional.py
@@ -19,7 +19,7 @@ async def read_items(token: Optional[str] = Security(oauth2_scheme)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_security_openid_connect.py
+++ b/tests/test_security_openid_connect.py
@@ -25,7 +25,7 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_security_openid_connect_optional.py
+++ b/tests/test_security_openid_connect_optional.py
@@ -31,7 +31,7 @@ def read_current_user(current_user: Optional[User] = Depends(get_current_user)):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_starlette_exception.py
+++ b/tests/test_starlette_exception.py
@@ -28,7 +28,7 @@ async def read_starlette_item(item_id: str):
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_sub_callbacks.py
+++ b/tests/test_sub_callbacks.py
@@ -75,7 +75,7 @@ app.include_router(subrouter, callbacks=events_callback_router.routes)
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/invoices/": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial001.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.additional_responses.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial002.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial002.py
@@ -8,7 +8,7 @@ from docs_src.additional_responses.tutorial002 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial003.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial003.py
@@ -5,7 +5,7 @@ from docs_src.additional_responses.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial004.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial004.py
@@ -8,7 +8,7 @@ from docs_src.additional_responses.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 from docs_src.async_sql_databases.tutorial001 import app
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/notes/": {

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial001.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.behind_a_proxy.tutorial001 import app
 client = TestClient(app, root_path="/api/v1")
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/app": {

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial002.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial002.py
@@ -5,7 +5,7 @@ from docs_src.behind_a_proxy.tutorial002 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/app": {

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial003.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial003.py
@@ -5,7 +5,7 @@ from docs_src.behind_a_proxy.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "servers": [
         {"url": "/api/v1"},

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial004.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial004.py
@@ -5,7 +5,7 @@ from docs_src.behind_a_proxy.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "servers": [
         {"url": "https://stag.example.com", "description": "Staging environment"},

--- a/tests/test_tutorial/test_bigger_applications/test_main.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main.py
@@ -6,7 +6,7 @@ from docs_src.bigger_applications.app.main import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/": {

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -8,7 +8,7 @@ from docs_src.body.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_body_fields/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001.py
@@ -7,7 +7,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
@@ -6,7 +6,7 @@ from docs_src.body_multiple_params.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -6,7 +6,7 @@ from docs_src.body_multiple_params.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
@@ -5,7 +5,7 @@ from docs_src.body_nested_models.tutorial009 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/index-weights/": {

--- a/tests/test_tutorial/test_body_updates/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.body_updates.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from docs_src.conditional_openapi import tutorial001
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/": {

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001.py
@@ -6,7 +6,7 @@ from docs_src.cookie_params.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_custom_response/test_tutorial001b.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial001b.py
@@ -5,7 +5,7 @@ from docs_src.custom_response.tutorial001b import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_custom_response/test_tutorial004.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial004.py
@@ -5,7 +5,7 @@ from docs_src.custom_response.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_custom_response/test_tutorial005.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial005.py
@@ -5,7 +5,7 @@ from docs_src.custom_response.tutorial005 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial001.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001.py
@@ -6,7 +6,7 @@ from docs_src.dependencies.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial004.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004.py
@@ -6,7 +6,7 @@ from docs_src.dependencies.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial006.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006.py
@@ -5,7 +5,7 @@ from docs_src.dependencies.tutorial006 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial012.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012.py
@@ -5,7 +5,7 @@ from docs_src.dependencies.tutorial012 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_events/test_tutorial001.py
+++ b/tests/test_tutorial/test_events/test_tutorial001.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 from docs_src.events.tutorial001 import app
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_events/test_tutorial002.py
+++ b/tests/test_tutorial/test_events/test_tutorial002.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 from docs_src.events.tutorial002 import app
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.extending_openapi.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {
         "title": "Custom title",
         "version": "2.5.0",

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
@@ -6,7 +6,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_extra_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial003.py
@@ -5,7 +5,7 @@ from docs_src.extra_models.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_extra_models/test_tutorial004.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial004.py
@@ -5,7 +5,7 @@ from docs_src.extra_models.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_extra_models/test_tutorial005.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial005.py
@@ -5,7 +5,7 @@ from docs_src.extra_models.tutorial005 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/keyword-weights/": {

--- a/tests/test_tutorial/test_first_steps/test_tutorial001.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial001.py
@@ -6,7 +6,7 @@ from docs_src.first_steps.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial001.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.handling_errors.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial002.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial002.py
@@ -5,7 +5,7 @@ from docs_src.handling_errors.tutorial002 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items-header/{item_id}": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial003.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial003.py
@@ -5,7 +5,7 @@ from docs_src.handling_errors.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/unicorns/{name}": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial004.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial004.py
@@ -5,7 +5,7 @@ from docs_src.handling_errors.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial005.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial005.py
@@ -5,7 +5,7 @@ from docs_src.handling_errors.tutorial005 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial006.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial006.py
@@ -5,7 +5,7 @@ from docs_src.handling_errors.tutorial006 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_header_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001.py
@@ -7,7 +7,7 @@ client = TestClient(app)
 
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_metadata/test_tutorial001.py
+++ b/tests/test_tutorial/test_metadata/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.metadata.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {
         "title": "My Super Project",
         "version": "2.5.0",

--- a/tests/test_tutorial/test_metadata/test_tutorial004.py
+++ b/tests/test_tutorial/test_metadata/test_tutorial004.py
@@ -5,7 +5,7 @@ from docs_src.metadata.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/": {

--- a/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
+++ b/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.openapi_callbacks.tutorial001 import app, invoice_notification
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/invoices/": {

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.path_operation_advanced_configuration.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial002.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial002.py
@@ -5,7 +5,7 @@ from docs_src.path_operation_advanced_configuration.tutorial002 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial003.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial003.py
@@ -5,7 +5,7 @@ from docs_src.path_operation_advanced_configuration.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {},
 }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
@@ -5,7 +5,7 @@ from docs_src.path_operation_advanced_configuration.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
@@ -5,7 +5,7 @@ from docs_src.path_operation_configuration.tutorial005 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
@@ -6,7 +6,7 @@ from docs_src.path_operation_configuration.tutorial006 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_path_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial004.py
@@ -5,7 +5,7 @@ from docs_src.path_params.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/files/{file_path}": {

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -6,7 +6,7 @@ from docs_src.path_params.tutorial005 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/models/{model_name}": {
@@ -77,7 +77,7 @@ openapi_schema = {
 
 
 openapi_schema2 = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/models/{model_name}": {

--- a/tests/test_tutorial/test_query_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial005.py
@@ -6,7 +6,7 @@ from docs_src.query_params.tutorial005 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_query_params/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006.py
@@ -6,7 +6,7 @@ from docs_src.query_params.tutorial006 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
@@ -6,7 +6,7 @@ from docs_src.query_params_str_validations.tutorial010 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
@@ -5,7 +5,7 @@ from docs_src.query_params_str_validations.tutorial011 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
@@ -5,7 +5,7 @@ from docs_src.query_params_str_validations.tutorial012 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
@@ -5,7 +5,7 @@ from docs_src.query_params_str_validations.tutorial013 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -7,7 +7,7 @@ from docs_src.request_files.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/files/": {

--- a/tests/test_tutorial/test_request_files/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002.py
@@ -7,7 +7,7 @@ from docs_src.request_files.tutorial002 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/files/": {

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -6,7 +6,7 @@ from docs_src.request_forms.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/login/": {

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -8,7 +8,7 @@ from docs_src.request_forms_and_files.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/files/": {

--- a/tests/test_tutorial/test_response_model/test_tutorial003.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003.py
@@ -5,7 +5,7 @@ from docs_src.response_model.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/user/": {

--- a/tests/test_tutorial/test_response_model/test_tutorial004.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial004.py
@@ -6,7 +6,7 @@ from docs_src.response_model.tutorial004 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}": {

--- a/tests/test_tutorial/test_response_model/test_tutorial005.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial005.py
@@ -5,7 +5,7 @@ from docs_src.response_model.tutorial005 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}/name": {

--- a/tests/test_tutorial/test_response_model/test_tutorial006.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial006.py
@@ -5,7 +5,7 @@ from docs_src.response_model.tutorial006 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/{item_id}/name": {

--- a/tests/test_tutorial/test_security/test_tutorial001.py
+++ b/tests/test_tutorial/test_security/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.security.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -5,7 +5,7 @@ from docs_src.security.tutorial003 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/token": {

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -11,7 +11,7 @@ from docs_src.security.tutorial005 import (
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/token": {

--- a/tests/test_tutorial/test_security/test_tutorial006.py
+++ b/tests/test_tutorial/test_security/test_tutorial006.py
@@ -8,7 +8,7 @@ from docs_src.security.tutorial006 import app
 client = TestClient(app)
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/me": {

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/": {

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/": {

--- a/tests/test_tutorial/test_sql_databases_peewee/test_sql_databases_peewee.py
+++ b/tests/test_tutorial/test_sql_databases_peewee/test_sql_databases_peewee.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 from ...utils import skip_py36
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/users/": {

--- a/tests/test_tutorial/test_sub_applications/test_tutorial001.py
+++ b/tests/test_tutorial/test_sub_applications/test_tutorial001.py
@@ -5,7 +5,7 @@ from docs_src.sub_applications.tutorial001 import app
 client = TestClient(app)
 
 openapi_schema_main = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/app": {
@@ -23,7 +23,7 @@ openapi_schema_main = {
     },
 }
 openapi_schema_sub = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/sub": {

--- a/tests/test_tutorial/test_testing/test_main.py
+++ b/tests/test_tutorial/test_testing/test_main.py
@@ -1,7 +1,7 @@
 from docs_src.app_testing.test_main import client, test_read_main
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/": {

--- a/tests/test_tutorial/test_testing/test_tutorial001.py
+++ b/tests/test_tutorial/test_testing/test_tutorial001.py
@@ -1,7 +1,7 @@
 from docs_src.app_testing.tutorial001 import client, test_read_main
 
 openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/": {

--- a/tests/test_union_body.py
+++ b/tests/test_union_body.py
@@ -23,7 +23,7 @@ def save_union_body(item: Union[OtherItem, Item]):
 client = TestClient(app)
 
 item_openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {

--- a/tests/test_union_inherited_body.py
+++ b/tests/test_union_inherited_body.py
@@ -32,7 +32,7 @@ client = TestClient(app)
 
 
 inherited_item_openapi_schema = {
-    "openapi": "3.0.2",
+    "openapi": "3.1.0",
     "info": {"title": "FastAPI", "version": "0.1.0"},
     "paths": {
         "/items/": {


### PR DESCRIPTION
Following [this document](https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0).

## Changes
- Bump version (and check if the links are valid on the docs)
- Support `examples`

## Observations
Nothing to do on `exclusiveMinimum` and `exclusiveMaximum`, as we were already compliant based on the JSON Schema version that Pydantic uses.

Update: I got blocked by https://github.com/swagger-api/swagger-ui/issues/5891. The latest swagger doesn't support OpenAPI 3.1.0 yet. 
![image](https://user-images.githubusercontent.com/7353520/113490253-2c72f200-94c9-11eb-8960-462e75ab0f96.png)
