### PR TITLE
added missing info to install 'aiofiles' when using 'FileResponse'

### DIFF
--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -190,6 +190,13 @@ This includes many libraries to interact with cloud storage, video processing, a
 
 Asynchronously streams a file as the response.
 
+!!! info
+    To serve files, first install <a href="https://github.com/Tinche/aiofiles" class="external-link" target="_blank">`aiofiles`</a>.
+
+    E.g. `pip install aiofiles`.
+
+    This is because Starlette has an optional dependency on `aiofiles` and uses it in `FileResponse`.
+
 Takes a different set of arguments to instantiate than the other response types:
 
 * `path` - The filepath to the file to stream.


### PR DESCRIPTION
Just noticed that using `FileResponse` needs `aiofiles` to be installed: https://github.com/encode/starlette/blob/master/starlette/responses.py#L247
Added a hint in the docs in the PR.