### PR TITLE
🔒 Match HTTP Digest specs from RFC 7616

### DIFF
--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -127,15 +127,23 @@ class HTTPBearer(HTTPBase):
 
 
 class HTTPDigest(HTTPBase):
-    def __init__(self, *, scheme_name: Optional[str] = None, auto_error: bool = True):
+    def __init__(
+        self,
+        *,
+        scheme_name: Optional[str] = None,
+        realm: Optional[str] = None,
+        auto_error: bool = True,
+    ):
         self.model = HTTPBaseModel(scheme="digest")
         self.scheme_name = scheme_name or self.__class__.__name__
+        self.realm = realm
         self.auto_error = auto_error
 
     async def __call__(
         self, request: Request
     ) -> Optional[HTTPAuthorizationCredentials]:
         authorization: str = request.headers.get("Authorization")
+        algorithm: str = request.headers.get("")
         scheme, credentials = get_authorization_scheme_param(authorization)
         if not (authorization and scheme and credentials):
             if self.auto_error:

--- a/fastapi/security/utils.py
+++ b/fastapi/security/utils.py
@@ -1,4 +1,7 @@
-from typing import Tuple
+import hashlib
+from typing import Callable, Tuple
+
+from _typeshed import ReadableBuffer
 
 
 def get_authorization_scheme_param(authorization_header_value: str) -> Tuple[str, str]:
@@ -6,3 +9,14 @@ def get_authorization_scheme_param(authorization_header_value: str) -> Tuple[str
         return "", ""
     scheme, _, param = authorization_header_value.partition(" ")
     return scheme, param
+
+
+# TODO(Marcelo): Decide the returned value.
+def get_digest_algorithm(algorithm: str):
+    if algorithm in ("MD5", "MD5-sess"):
+        return hashlib.md5
+    if algorithm in ("SHA-256", "SHA-256-sess"):
+        return hashlib.sha256
+    if algorithm in ("SHA-512-256", "SHA-512-256-sess"):
+        return hashlib.sha512
+    raise ValueError("Algorithm is not valid")


### PR DESCRIPTION
Closes #1476

## Changes :sparkles: :
- Add `realm` as specified <sup>[1](#response-headers)</sup>.
- Add optional `algorithm` header. If not present, should use `MD5`, as specified <sup>[1](#response-headers)</sup>. 

## TODO:

- [ ] Implement the changes based on RFC 7616.
- [ ] Documentation.

## Decisions

- I didn't add the `domain` parameter on the `HTTPDigest` class, as it's optional and I've noticed that some implementations ignores its existence. 

### References
- https://docs.python.org/3/library/hashlib.html
- https://en.wikipedia.org/wiki/Digest_access_authentication
- https://tools.ietf.org/html/rfc2617
- https://github.com/miguelgrinberg/Flask-HTTPAuth/blob/master/flask_httpauth.py
- https://stackoverflow.com/questions/9534602/what-is-the-difference-between-digest-and-basic-authentication

### Footnotes:
 <a name="response-headers">1</a>: https://tools.ietf.org/html/rfc7616#section-3.3

#### Updates
- 2021-04-11: Add support to `algorithm` and `realm`. 