### PR TITLE
Allow aiofiles 0.6.x.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ test = [
     "async_exit_stack >=1.0.1,<2.0.0",
     "async_generator >=1.10,<2.0.0",
     "python-multipart >=0.0.5,<0.0.6",
-    "aiofiles >=0.5.0,<0.6.0",
+    "aiofiles >=0.5.0,<0.7.0",
     "flask >=1.1.2,<2.0.0"
 ]
 doc = [


### PR DESCRIPTION
Release notes for 0.6.0 (https://pypi.org/project/aiofiles/) show one
API change:
“Added name and mode properties to async file objects.”
(https://github.com/Tinche/aiofiles/pull/82)