### PR TITLE
fix jsonable_encoder exclude include encode model obj invalid

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -56,6 +56,8 @@ def jsonable_encoder(
             obj_dict = obj_dict["__root__"]
         return jsonable_encoder(
             obj_dict,
+            include=include,
+            exclude=exclude,
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             custom_encoder=encoder,
@@ -81,6 +83,8 @@ def jsonable_encoder(
             ):
                 encoded_key = jsonable_encoder(
                     key,
+                    include=include,
+                    exclude=exclude,
                     by_alias=by_alias,
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
@@ -89,6 +93,8 @@ def jsonable_encoder(
                 )
                 encoded_value = jsonable_encoder(
                     value,
+                    include=include,
+                    exclude=exclude,
                     by_alias=by_alias,
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
@@ -141,6 +147,8 @@ def jsonable_encoder(
             raise ValueError(errors)
     return jsonable_encoder(
         data,
+        include=include,
+        exclude=exclude,
         by_alias=by_alias,
         exclude_unset=exclude_unset,
         exclude_defaults=exclude_defaults,

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -172,3 +172,15 @@ def test_encode_model_with_path(model_with_path):
 def test_encode_root():
     model = ModelWithRoot(__root__="Foo")
     assert jsonable_encoder(model) == "Foo"
+
+
+def test_encode_model_with_include():
+    model = ModelWithDefault(foo="foo", bar="bar")
+    assert jsonable_encoder(model) == {"foo": "foo", "bar": "bar", "bla": "bla"}
+    assert jsonable_encoder(model, include={"foo"}) == {"foo": "foo"}
+
+
+def test_encode_model_with_exclude():
+    model = ModelWithDefault(foo="foo", bar="bar")
+    assert jsonable_encoder(model) == {"foo": "foo", "bar": "bar", "bla": "bla"}
+    assert jsonable_encoder(model, exclude={"foo"}) == {"bar": "bar", "bla": "bla"}


### PR DESCRIPTION
Hi, When i use the `jsonable_encoder` expect covert model to dict obj，use the `exclude` or `include` options  was invalid

```
data = jsonable_encoder(queryset, exclude={'id'})
```

or

```
data = jsonable_encoder(queryset, include={'name'})
```

The `id` always in the data

So i created this  pr to solve this problem, Maybe there are better ways to solve this problem