### PR TITLE
Allow parameterized router subclasses in applications.

### DIFF
--- a/docs/en/docs/advanced/custom-request-and-route.md
+++ b/docs/en/docs/advanced/custom-request-and-route.md
@@ -1,6 +1,6 @@
-# Custom Request and APIRoute class
+# Custom Request, APIRoute, and APIRouter class
 
-In some cases, you may want to override the logic used by the `Request` and `APIRoute` classes.
+In some cases, you may want to override the logic used by the `Request`, `APIRoute`, and `APIRouter` classes.
 
 In particular, this may be a good alternative to logic in a middleware.
 
@@ -18,6 +18,7 @@ Some use cases include:
 * Converting non-JSON request bodies to JSON (e.g. <a href="https://msgpack.org/index.html" class="external-link" target="_blank">`msgpack`</a>).
 * Decompressing gzip-compressed request bodies.
 * Automatically logging all request bodies.
+* Automatically generating extra routes.
 
 ## Handling custom request body encodings
 
@@ -96,7 +97,7 @@ If an exception occurs, the`Request` instance will still be in scope, so we can 
 
 ## Custom `APIRoute` class in a router
 
-You can also set the `route_class` parameter of an `APIRouter`:
+You can set the `route_class` parameter of an `APIRouter`:
 
 ```Python hl_lines="26"
 {!../../../docs_src/custom_request_and_route/tutorial003.py!}
@@ -106,4 +107,38 @@ In this example, the *path operations* under the `router` will use the custom `T
 
 ```Python hl_lines="13-20"
 {!../../../docs_src/custom_request_and_route/tutorial003.py!}
+```
+
+## Custom `APIRouter` class in an application
+
+You can also set the `router_class` parameter of a `FastAPI` application:
+
+```Python hl_lines="15"
+{!../../../docs_src/custom_request_and_route/tutorial004.py!}
+```
+
+This allows you to set a custom router with special route generation logic at the top level of your application.
+
+In this example, we have defined a custom router to generate `HEAD` variants of all our `GET` request handlers automatically:
+
+```Python hl_lines="8-12"
+{!../../../docs_src/custom_request_and_route/tutorial004.py!}
+```
+
+This router applies to all routes directly added to our application. For example, our `via_router_class` handler:
+
+```Python hl_lines="18-20"
+{!../../../docs_src/custom_request_and_route/tutorial004.py!}
+```
+
+will now happily respond to requests such as:
+
+```sh
+curl -IHEAD localhost:8000/via-router-class
+```
+
+The alternative is instantiating and including a router instance directly, which is more verbose (but useful for adding custom route generation for just subsections of your application):
+
+```Python hl_lines="23-31"
+{!../../../docs_src/custom_request_and_route/tutorial004.py!}
 ```

--- a/docs_src/custom_request_and_route/tutorial004.py
+++ b/docs_src/custom_request_and_route/tutorial004.py
@@ -1,0 +1,31 @@
+import time
+from typing import Callable
+
+from fastapi import FastAPI
+from fastapi.routing import APIRouter
+
+
+class GetsGenerateHeadsRouter(APIRouter):
+    def add_api_route(self, path, endpoint, *args, methods=None, **kwargs):
+        if methods and "GET" in methods:
+            super().add_api_route(path, endpoint, *args, methods=["HEAD"], **kwargs)
+        super().add_api_route(path, endpoint, *args, methods=methods, **kwargs)
+
+
+app = FastAPI(router_class=GetsGenerateHeadsRouter)
+
+
+@app.get("/via-router-class")
+async def via_router_class():
+    return {"message": "Welcome to FastAPI!"}
+
+
+included_router = GetsGenerateHeadsRouter()
+
+
+@included_router.get("/via-include")
+async def via_include():
+    return {"message": "Welcome to FastAPI!"}
+
+
+app.include_router(included_router)

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -58,6 +58,7 @@ class FastAPI(Starlette):
         openapi_prefix: str = "",
         root_path: str = "",
         root_path_in_servers: bool = True,
+        router_class: Type[routing.APIRouter] = routing.APIRouter,
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
         callbacks: Optional[List[BaseRoute]] = None,
         deprecated: Optional[bool] = None,
@@ -66,7 +67,7 @@ class FastAPI(Starlette):
     ) -> None:
         self._debug: bool = debug
         self.state: State = State()
-        self.router: routing.APIRouter = routing.APIRouter(
+        self.router: routing.APIRouter = router_class(
             routes=routes,
             dependency_overrides_provider=self,
             on_startup=on_startup,

--- a/tests/test_application_router_subclass.py
+++ b/tests/test_application_router_subclass.py
@@ -1,0 +1,72 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRouter
+from fastapi.testclient import TestClient
+
+
+class SubclassedRouter(APIRouter):
+    def add_api_route(self, path, endpoint, *args, methods=None, **kwargs):
+        if methods and "GET" in methods:
+            super().add_api_route(path, endpoint, *args, methods=["HEAD"], **kwargs)
+        super().add_api_route(path, endpoint, *args, methods=methods, **kwargs)
+
+
+vanilla_app = FastAPI()
+
+
+@vanilla_app.get("/")
+def vanilla_root():
+    return {"welcome": "Welcome to vanilla FastAPI!"}
+
+
+vanilla_client = TestClient(vanilla_app)
+
+customized_app = FastAPI(router_class=SubclassedRouter)
+
+
+@customized_app.get("/")
+def customized_root():
+    return {"welcome": "Welcome to customized FastAPI!"}
+
+
+customized_client = TestClient(customized_app)
+
+
+@pytest.mark.parametrize(
+    "path,expected_status,expected_response",
+    [("/", 200, {"welcome": "Welcome to vanilla FastAPI!"})],
+)
+def test_vanilla_router_get(path, expected_status, expected_response):
+    response = vanilla_client.get(path)
+    assert response.status_code == expected_status
+    assert response.json() == {"welcome": "Welcome to vanilla FastAPI!"}
+
+
+@pytest.mark.parametrize(
+    "path,expected_status,expected_response",
+    [("/", 405, None)],
+)
+def test_vanilla_router_head(path, expected_status, expected_response):
+    response = vanilla_client.head(path)
+    assert response.status_code == expected_status
+    assert not response.content
+
+
+@pytest.mark.parametrize(
+    "path,expected_status,expected_response",
+    [("/", 200, {"welcome": "Welcome to customized FastAPI!"})],
+)
+def test_customized_router_get(path, expected_status, expected_response):
+    response = customized_client.get(path)
+    assert response.status_code == expected_status
+    assert response.json() == {"welcome": "Welcome to customized FastAPI!"}
+
+
+@pytest.mark.parametrize(
+    "path,expected_status,expected_response",
+    [("/", 200, None)],
+)
+def test_customized_router_head(path, expected_status, expected_response):
+    response = customized_client.head(path)
+    assert response.status_code == expected_status
+    assert not response.content

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial004.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial004.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from docs_src.custom_request_and_route.tutorial004 import app
+
+client = TestClient(app)
+
+
+def test_router_class_get():
+    response = client.get("/via-router-class")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Welcome to FastAPI!"}
+
+
+def test_router_class_head():
+    response = client.head("/via-router-class")
+    assert response.status_code == 200
+    assert not response.content
+
+
+def test_included_router_get():
+    response = client.get("/via-include")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Welcome to FastAPI!"}
+
+
+def test_included_router_head():
+    response = client.head("/via-include")
+    assert response.status_code == 200
+    assert not response.content


### PR DESCRIPTION
This allows developers to to provide custom router subclasses to their FastAPI applications for further customization.

Documentation for this feature added [here](https://6075131e18fa27238205260c--fastapi.netlify.app/advanced/custom-request-and-route/#custom-apirouter-class-in-an-application).

Closes #3079.