### PR TITLE
Allow OpenAPI extensions

### DIFF
--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 from fastapi.logger import logger
-from pydantic import AnyUrl, BaseModel, Field
+from pydantic import AnyUrl, BaseModel, Extra, Field
 
 try:
     import email_validator  # type: ignore
@@ -126,6 +126,9 @@ class Schema(SchemaBase):
     items: Optional[SchemaBase] = None
     properties: Optional[Dict[str, SchemaBase]] = None
     additionalProperties: Optional[Union[Dict[str, Any], bool]] = None
+
+    class Config:
+        extra = Extra.allow
 
 
 class Example(BaseModel):


### PR DESCRIPTION
The fastapi documentation describes how you can provide additional open api config: https://fastapi.tiangolo.com/tutorial/schema-extra-example/#pydantic-schema_extra

However, it does not work openapi extensions: https://swagger.io/docs/specification/openapi-extensions/

