### PR TITLE
♻ Change a `dict()` for `{}` in `fastapi/utils.py`

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -76,7 +76,7 @@ def create_cloned_field(
 ) -> ModelField:
     # _cloned_types has already cloned types, to support recursive models
     if cloned_types is None:
-        cloned_types = dict()
+        cloned_types = {}
     original_type = field.type_
     if is_dataclass(original_type) and hasattr(original_type, "__pydantic_model__"):
         original_type = original_type.__pydantic_model__


### PR DESCRIPTION
In general `dict()` call is considered slower than direct `{}`.
The internal representations are also different, there is no extra function call while constructing the map with `{}`
```
>>> import dis
>>> dis.dis('{}')
  1           0 BUILD_MAP                0
              2 RETURN_VALUE
>>> dis.dis('dict()')
  1           0 LOAD_NAME                0 (dict)
              2 CALL_FUNCTION            0
              4 RETURN_VALUE
```

There are bunch of similar cases in FastAPI source code, I will send PRs accordingly.