### PR TITLE
Removed redundant variable assignments; replaced with direct return

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -252,8 +252,7 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
         )
         for param in signature.parameters.values()
     ]
-    typed_signature = inspect.Signature(typed_params)
-    return typed_signature
+    return inspect.Signature(typed_params)
 
 
 def get_typed_annotation(param: inspect.Parameter, globalns: Dict[str, Any]) -> Any:
@@ -711,8 +710,7 @@ async def request_body_to_args(
 
 
 def get_missing_field_error(loc: Tuple[str, ...]) -> ErrorWrapper:
-    missing_field_error = ErrorWrapper(MissingError(), loc=loc)
-    return missing_field_error
+    return ErrorWrapper(MissingError(), loc=loc)
 
 
 def get_schema_compatible_field(*, field: ModelField) -> ModelField:


### PR DESCRIPTION
The anti-pattern spotted as returning variable after assignment, which is just redundant.
Instead, return it directly.