### PR TITLE
Access by_alias from FastAPI to control OpenAPI spec

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -62,6 +62,7 @@ class FastAPI(Starlette):
         callbacks: Optional[List[BaseRoute]] = None,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
+        schema_by_alias: bool = True,
         **extra: Any,
     ) -> None:
         self._debug: bool = debug
@@ -116,6 +117,7 @@ class FastAPI(Starlette):
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
         self.extra = extra
         self.dependency_overrides: Dict[Callable[..., Any], Callable[..., Any]] = {}
+        self.schema_by_alias = schema_by_alias
 
         self.openapi_version = "3.0.2"
 
@@ -135,6 +137,7 @@ class FastAPI(Starlette):
                 routes=self.routes,
                 tags=self.openapi_tags,
                 servers=self.servers,
+                schema_by_alias=self.schema_by_alias,
             )
         return self.openapi_schema
 

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -340,6 +340,7 @@ def get_openapi(
     routes: Sequence[BaseRoute],
     tags: Optional[List[Dict[str, Any]]] = None,
     servers: Optional[List[Dict[str, Union[str, Any]]]] = None,
+    schema_by_alias: bool = True,
 ) -> Dict[str, Any]:
     info = {"title": title, "version": version}
     if description:
@@ -352,7 +353,9 @@ def get_openapi(
     flat_models = get_flat_models_from_routes(routes)
     model_name_map = get_model_name_map(flat_models)
     definitions = get_model_definitions(
-        flat_models=flat_models, model_name_map=model_name_map
+        flat_models=flat_models,
+        model_name_map=model_name_map,
+        schema_by_alias=schema_by_alias,
     )
     for route in routes:
         if isinstance(route, routing.APIRoute):

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -18,11 +18,15 @@ def get_model_definitions(
     *,
     flat_models: Set[Union[Type[BaseModel], Type[Enum]]],
     model_name_map: Dict[Union[Type[BaseModel], Type[Enum]], str],
+    schema_by_alias: bool = True,
 ) -> Dict[str, Any]:
     definitions: Dict[str, Dict[str, Any]] = {}
     for model in flat_models:
         m_schema, m_definitions, m_nested_models = model_process_schema(
-            model, model_name_map=model_name_map, ref_prefix=REF_PREFIX
+            model,
+            model_name_map=model_name_map,
+            ref_prefix=REF_PREFIX,
+            by_alias=schema_by_alias,
         )
         definitions.update(m_definitions)
         model_name = model_name_map[model]


### PR DESCRIPTION
FastAPI seems to assume that the OpenAPI schema definition should always use Pydantic's default `by_alias = True` without providing a way to control whether or not this is the correct parameter.

This is an effort to get access to the `by_alias` parameter of Pydantic's `model_process_schema` function which is used by FastAPI in `fastapi.utils.get_model_definitions()`.

These changes would open up the possibility for FastAPI to build the OpenAPI schema based on a Pydantic model's `attribute` instead of it's `alias` which would be desirable in the case of working with aliases having the `_key` syntax while hiding this from the API specs.

For instance, MongoDB uses `_id` to store a document's `ObjectId`. Pydantic handles this by allowing an alias like so:

```python
class MongoId:
  
      @classmethod
      def __get_validators__(cls):
          yield cls.validate
  
      @classmethod
      def __modify_schema__(cls, field_schema: Dict):
          field_schema.update(type='string')
  
      @classmethod
      def validate(cls, value):
          try:
              return bson.ObjectId(str(value))
          except bson.errors.InvalidId:
              raise ValueError('Invalid ObjetId')
  
  
  class Schema(BaseModel):
  
     id: MongoId = Field(..., alias='_id')
  
      class Config:
          json_encoders = { 
              bson.ObjectId: lambda oid: str(oid),
          }
```

This works just fine for creating a Pydantic model from Mongo's query results and can even be sent over the wire correctly via the `response_model_by_alias = False` flag in the route decorator. 

However, the API spec then indicates that the schema's response would include a `_id` instead of the `id` that it would actually receive. This is likely to cause confusion for the consumers of the API docs and makes the docs inconsistent with the actual response payload (seen in the image below).

<img width="1464" alt="OpenAPIdiscrepancy" src="https://user-images.githubusercontent.com/13722050/116755774-8b486000-a9d0-11eb-8ce0-75fef6ec7d89.png">

The proposed remedy to this problem would then suggest that by passing a simple flag to the FastAPI object like:

```python

app = FastAPI(schema_by_alias=False)

@app.get('/', response_model=Schema, response_model_by_alias=False)
def pull_request():
    return Schema(**{'_id': ObjectId('608c2c8e320b7f09dd80d189')})
```

The results would be consistent between the response the the API docs.

<img width="1444" alt="OpenAPIfixed" src="https://user-images.githubusercontent.com/13722050/116755805-99967c00-a9d0-11eb-900c-91c12c23966a.png">

Hopefully, the maintainers will consider this issue and that my efforts, at very least, provide a talking point as to a possible resolution. Please feel free to provide feedback if this is not the prefer way to handle this and I can take another look at finding an alternative solution.