### PR TITLE
add defaultModelsExpandDepth to config show depth or not show schema …

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -14,7 +14,7 @@ def get_swagger_ui_html(
     swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
     oauth2_redirect_url: Optional[str] = None,
     init_oauth: Optional[Dict[str, Any]] = None,
-    defaultModelsExpandDepth: int = 1,
+    default_models_expand_depth: int = 1,
 ) -> HTMLResponse:
 
     html = f"""

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -33,7 +33,7 @@ def get_swagger_ui_html(
     <script>
     const ui = SwaggerUIBundle({{
         url: '{openapi_url}',
-        defaultModelsExpandDepth: {defaultModelsExpandDepth},
+        defaultModelsExpandDepth: {default_models_expand_depth},
     """
 
     if oauth2_redirect_url:

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -14,6 +14,7 @@ def get_swagger_ui_html(
     swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
     oauth2_redirect_url: Optional[str] = None,
     init_oauth: Optional[Dict[str, Any]] = None,
+    defaultModelsExpandDepth: int = 1,
 ) -> HTMLResponse:
 
     html = f"""
@@ -32,6 +33,7 @@ def get_swagger_ui_html(
     <script>
     const ui = SwaggerUIBundle({{
         url: '{openapi_url}',
+        defaultModelsExpandDepth: {defaultModelsExpandDepth},
     """
 
     if oauth2_redirect_url:


### PR DESCRIPTION
I add defaultModelsExpandDepth to provide config defaultModelsExpandDepth, cause in some case, I need to hide schema models and only show the endpoint. I set the default value to defaultModelsExpandDepth like on [swaggers documentation](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/).