### PR TITLE
Fix: websocket route path not inherited  prefix value

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -49,6 +49,7 @@ from starlette.routing import (
     get_name,
     request_response,
     websocket_session,
+    WebSocketRoute,
 )
 from starlette.status import WS_1008_POLICY_VIOLATION
 from starlette.types import ASGIApp
@@ -586,6 +587,12 @@ class APIRouter(routing.Router):
             name=name,
             dependency_overrides_provider=self.dependency_overrides_provider,
         )
+        self.routes.append(route)
+
+    def add_websocket_route(
+        self, path: str, endpoint: Callable, name: str = None
+    ) -> None:
+        route = WebSocketRoute(self.prefix + path, endpoint=endpoint, name=name)
         self.routes.append(route)
 
     def websocket(


### PR DESCRIPTION
websocket route path not inherited  prefix value

In my case:
```
router = APIRouter(prefix = '/asset')
@router.websocket_route("/ws")
async def ws_func(ws: WebSocket):
    ....
app.include_router(router)
```
`ws_func` path should be  `/asset/ws` .
but `ws_func` path is `/ws` .
I found starlette WebSocketRoute not have prefix  attribute.

we need override add_websocket_route method for add router prefix .
