### PR TITLE
add tags and path sorting, add related docs

### DIFF
--- a/docs/en/docs/advanced/extending-openapi.md
+++ b/docs/en/docs/advanced/extending-openapi.md
@@ -250,25 +250,22 @@ Now, you should be able to disconnect your WiFi, go to your docs at <a href="htt
 And even without Internet, you would be able to see the docs for your API and interact with it.
 
 
-### Add Tags
-
-You can group path by tags in both docs and redoc by using tags, tags also allows you to put descriptions and links. Tags description suppports markdown.
-
-```Python hl_lines="9-22 56"
-{!../../../docs_src/extending_openapi/tutorial003.py!}
-```
-
 ### Change the *path operation* order
 
 It is good to have a documentation, but a sorted one is better, you can use tags_sorter and operations_sorter to sort your docs.
-See this thread for the underlying logic (Swagger UI 3.17.6 required, Redoc not affected) :
-<a href="https://github.com/swagger-api/swagger-ui/issues/2990" class="external-link" target="_blank">https://github.com/swagger-api/swagger-ui/issues/2990</a>
 
+Possible values are "aplha" or a custom build *sort* function for the tags, and "alpha", "method" or a custom build *sort* function for the operations as defined in the <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">Swagger UI doc</a>.
 
-```Python hl_lines="37-38"
+!!! note "Technical Details"
+    Swagger UI 3.17.6 required, Redoc not affected
+    See this thread for the underlying logic
+    <a href="https://github.com/swagger-api/swagger-ui/issues/2990" class="external-link" target="_blank">https://github.com/swagger-api/swagger-ui/issues/2990</a>
+
+The custom function provided in this exemple create a length order, more examples can be found in the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort" class="external-link" target="_blank">MDN Array.prototype.sort() documentation</a>
+
+```Python hl_lines="37-42"
 {!../../../docs_src/extending_openapi/tutorial003.py!}
 ```
 
 !!! tip
-    Possible values are "aplha" or a custom build *sort* function for the tags,
-    and "alpha", "method" or a custom build *sort* function for the operations.
+    Follow <a href="https://fastapi.tiangolo.com/tutorial/metadata/#metadata-for-tags" target="_blank">https://fastapi.tiangolo.com/tutorial/metadata/#metadata-for-tags</a> to see how to define tags.

--- a/docs/en/docs/advanced/extending-openapi.md
+++ b/docs/en/docs/advanced/extending-openapi.md
@@ -248,3 +248,27 @@ Now, to be able to test that everything works, create a *path operation*:
 Now, you should be able to disconnect your WiFi, go to your docs at <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>, and reload the page.
 
 And even without Internet, you would be able to see the docs for your API and interact with it.
+
+
+### Add Tags
+
+You can group path by tags in both docs and redoc by using tags, tags also allows you to put descriptions and links. Tags description suppports markdown.
+
+```Python hl_lines="9-22 56"
+{!../../../docs_src/extending_openapi/tutorial003.py!}
+```
+
+### Change the *path operation* order
+
+It is good to have a documentation, but a sorted one is better, you can use tags_sorter and operations_sorter to sort your docs.
+See this thread for the underlying logic (Swagger UI 3.17.6 required, Redoc not affected) :
+<a href="https://github.com/swagger-api/swagger-ui/issues/2990" class="external-link" target="_blank">https://github.com/swagger-api/swagger-ui/issues/2990</a>
+
+
+```Python hl_lines="37-38"
+{!../../../docs_src/extending_openapi/tutorial003.py!}
+```
+
+!!! tip
+    Possible values are "aplha" or a custom build *sort* function for the tags,
+    and "alpha", "method" or a custom build *sort* function for the operations.

--- a/docs/en/docs/tutorial/metadata.md
+++ b/docs/en/docs/tutorial/metadata.md
@@ -73,6 +73,8 @@ The order of each tag metadata dictionary also defines the order shown in the do
 
 For example, even though `users` would go after `items` in alphabetical order, it is shown before them, because we added their metadata as the first dictionary in the list.
 
+If you use SwaggerUI, you can also modify the display order by using the "tags_sorter" option, see <a href="https://fastapi.tiangolo.com/advanced/extending-openapi/?h=exten#Change-the-path-operation-order" target="_blank">extending OpenAPi</a> for the details.
+
 ## OpenAPI URL
 
 By default, the OpenAPI schema is served at `/openapi.json`.

--- a/docs_src/extending_openapi/tutorial003.py
+++ b/docs_src/extending_openapi/tutorial003.py
@@ -34,8 +34,12 @@ async def custom_swagger_ui_html():
         oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
         swagger_js_url="/static/swagger-ui-bundle.js",
         swagger_css_url="/static/swagger-ui.css",
-        tags_sorter="alpha",
-        operations_sorter="method",
+        tags_sorter='"alpha"',
+        operations_sorter='function(e,t) {\
+            if (e.get("path").length < t.get("path").length) {return -1;}\
+            if (e.get("path").length > t.get("path").length) {return 1;}\
+            return 0;\
+            }',
     )
 
 

--- a/docs_src/extending_openapi/tutorial003.py
+++ b/docs_src/extending_openapi/tutorial003.py
@@ -1,0 +1,63 @@
+from fastapi import FastAPI
+from fastapi.openapi.docs import (
+    get_redoc_html,
+    get_swagger_ui_html,
+    get_swagger_ui_oauth2_redirect_html,
+)
+from fastapi.staticfiles import StaticFiles
+
+tags_metadata = [
+    {
+        "name": "Users",
+        "description": "Operations with Users",
+        "externalDocs": {
+            "description": "Users documentation",
+            "url": "https://fastapi.tiangolo.com",
+        },
+    },
+    {
+        "name": "Pets",
+        "description": "Operations with *Pets*",
+    },
+]
+
+app = FastAPI(docs_url=None, openapi_tags=tags_metadata, redoc_url=None)
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.get("/docs", include_in_schema=False)
+async def custom_swagger_ui_html():
+    return get_swagger_ui_html(
+        openapi_url=app.openapi_url,
+        title=app.title + " - Swagger UI",
+        oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
+        swagger_js_url="/static/swagger-ui-bundle.js",
+        swagger_css_url="/static/swagger-ui.css",
+        tags_sorter="alpha",
+        operations_sorter="method",
+    )
+
+
+@app.get(app.swagger_ui_oauth2_redirect_url, include_in_schema=False)
+async def swagger_ui_redirect():
+    return get_swagger_ui_oauth2_redirect_html()
+
+
+@app.get("/redoc", include_in_schema=False)
+async def redoc_html():
+    return get_redoc_html(
+        openapi_url=app.openapi_url,
+        title=app.title + " - ReDoc",
+        redoc_js_url="/static/redoc.standalone.js",
+    )
+
+
+@app.get("/users/{username}", tags=["Users"])
+async def read_user(username: str):
+    return {"message": f"Hello {username}"}
+
+
+@app.get("/pets/{name}", tags=["Pets"])
+async def read_pets(name: str):
+    return {"message": f"A new pet : {name}"}

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -14,6 +14,8 @@ def get_swagger_ui_html(
     swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
     oauth2_redirect_url: Optional[str] = None,
     init_oauth: Optional[Dict[str, Any]] = None,
+    tags_sorter: str = None,
+    operations_sorter: str = None,
 ) -> HTMLResponse:
 
     html = f"""
@@ -36,6 +38,12 @@ def get_swagger_ui_html(
 
     if oauth2_redirect_url:
         html += f"oauth2RedirectUrl: window.location.origin + '{oauth2_redirect_url}',"
+
+    if tags_sorter:
+        html += (f"tagsSorter: '{tags_sorter}',",)
+
+    if operations_sorter:
+        html += (f"operationsSorter : '{operations_sorter}',",)
 
     html += """
         dom_id: '#swagger-ui',

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -40,10 +40,10 @@ def get_swagger_ui_html(
         html += f"oauth2RedirectUrl: window.location.origin + '{oauth2_redirect_url}',"
 
     if tags_sorter:
-        html += (f"tagsSorter: '{tags_sorter}',",)
+        html += (f"tagsSorter: {tags_sorter},",)
 
     if operations_sorter:
-        html += (f"operationsSorter : '{operations_sorter}',",)
+        html += (f"operationsSorter : {operations_sorter},",)
 
     html += """
         dom_id: '#swagger-ui',


### PR DESCRIPTION
Hi, having the need to sort the swagger documentation, I made a quick changes that resolves : https://github.com/tiangolo/fastapi/issues/1000
It relies on https://github.com/swagger-api/swagger-ui/issues/2990 for the underlying sort operation.
It might be a duplicate functionality regarding https://github.com/tiangolo/fastapi/pull/2337 but the way it works is way simpler as it relies heavily on swagger to do the work.
I also checked for Redoc ordering but reading https://github.com/Redocly/redoc/issues/98 it seems it is not done yet.
Please let me know if some changes are needed before you can merge, thanks for your work @tiangolo 