### PR TITLE
fix: async partial function will not awaited in Depends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .mypy_cache
 .vscode
 __pycache__
+.python-version
 .pytest_cache
 htmlcov
 dist

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -546,6 +546,8 @@ async def solve_dependencies(
             )
         elif is_coroutine_callable(call):
             solved = await call(**sub_values)
+        elif asyncio.iscoroutinefunction(call):
+            solved = await call(**sub_values)
         else:
             solved = await run_in_threadpool(call, **sub_values)
         if sub_dependant.name is not None:

--- a/tests/test_callable_endpoint.py
+++ b/tests/test_callable_endpoint.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Optional
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
 
@@ -9,11 +9,26 @@ def main(some_arg, q: Optional[str] = None):
     return {"some_arg": some_arg, "q": q}
 
 
+def partial_func(q: str):
+    async def inner(data):
+        return data
+
+    return partial(inner, q + " extras")
+
+
+def async_partial_deps_func(data: str = Depends(partial_func("test"))):
+    return {"data": data}
+
+
 endpoint = partial(main, "foo")
 
 app = FastAPI()
 
 app.get("/")(endpoint)
+
+async_partial_deps_endpoint = async_partial_deps_func
+
+app.get("/async_partial_dps")(async_partial_deps_endpoint)
 
 
 client = TestClient(app)
@@ -23,3 +38,6 @@ def test_partial():
     response = client.get("/?q=bar")
     data = response.json()
     assert data == {"some_arg": "foo", "q": "bar"}
+    response = client.get("/async_partial_dps")
+    data = response.json()
+    assert data == {"data": "test extras"}


### PR DESCRIPTION
Hi, it seems wrong when using async partial function in Depends. Here's an example code:

```
def partial_func(q: str):
    async def inner(data):
        return data

    return partial(inner, q + " extras")

@app.get("/")
def test(data: str = Depends(partial_func("test"))):
    return {"data": data}
```

In `test` method, data here will be a coroutine object.

I just add `asyncio.iscoroutinefunction` to check if depends function is awaitable in this pr, I have no idea whether this is the right solution. Or maybe I need to change `is_coroutine_callable` method?