### PR TITLE
Add default for `default` argument in Path

### DIFF
--- a/docs/en/docs/tutorial/path-params-numeric-validations.md
+++ b/docs/en/docs/tutorial/path-params-numeric-validations.md
@@ -12,19 +12,15 @@ First, import `Path` from `fastapi`:
 
 ## Declare metadata
 
-You can declare all the same parameters as for `Query`.
+You can declare all the same parameters as for `Query` except for the default. A path parameter is always required as it has to be part of the path. You should declare it with `...` to correctly mark it as required, for convenience FastAPI already does this if you leave it out.
 
-For example, to declare a `title` metadata value for the path parameter `item_id` you can type:
+As an example of what you can pass to `Path`, to declare a `title` metadata value for the path parameter `item_id` you can type:
 
 ```Python hl_lines="10"
 {!../../../docs_src/path_params_numeric_validations/tutorial001.py!}
 ```
 
 !!! note
-    A path parameter is always required as it has to be part of the path.
-    
-    So, you should declare it with `...` to mark it as required.
-
     Nevertheless, even if you declared it with `None` or set a default value, it would not affect anything, it would still be always required.
 
 ## Order the parameters as you need

--- a/docs_src/path_params_numeric_validations/tutorial001.py
+++ b/docs_src/path_params_numeric_validations/tutorial001.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/{item_id}")
 async def read_items(
-    item_id: int = Path(..., title="The ID of the item to get"),
+    item_id: int = Path(title="The ID of the item to get"),
     q: Optional[str] = Query(None, alias="item-query"),
 ):
     results = {"item_id": item_id}

--- a/docs_src/path_params_numeric_validations/tutorial002.py
+++ b/docs_src/path_params_numeric_validations/tutorial002.py
@@ -5,7 +5,7 @@ app = FastAPI()
 
 @app.get("/items/{item_id}")
 async def read_items(
-    q: str, item_id: int = Path(..., title="The ID of the item to get")
+    q: str, item_id: int = Path(title="The ID of the item to get")
 ):
     results = {"item_id": item_id}
     if q:

--- a/docs_src/path_params_numeric_validations/tutorial003.py
+++ b/docs_src/path_params_numeric_validations/tutorial003.py
@@ -5,7 +5,7 @@ app = FastAPI()
 
 @app.get("/items/{item_id}")
 async def read_items(
-    *, item_id: int = Path(..., title="The ID of the item to get"), q: str
+    *, item_id: int = Path(title="The ID of the item to get"), q: str
 ):
     results = {"item_id": item_id}
     if q:

--- a/docs_src/path_params_numeric_validations/tutorial004.py
+++ b/docs_src/path_params_numeric_validations/tutorial004.py
@@ -5,7 +5,7 @@ app = FastAPI()
 
 @app.get("/items/{item_id}")
 async def read_items(
-    *, item_id: int = Path(..., title="The ID of the item to get", ge=1), q: str
+    *, item_id: int = Path(title="The ID of the item to get", ge=1), q: str
 ):
     results = {"item_id": item_id}
     if q:

--- a/docs_src/path_params_numeric_validations/tutorial005.py
+++ b/docs_src/path_params_numeric_validations/tutorial005.py
@@ -6,7 +6,7 @@ app = FastAPI()
 @app.get("/items/{item_id}")
 async def read_items(
     *,
-    item_id: int = Path(..., title="The ID of the item to get", gt=0, le=1000),
+    item_id: int = Path(title="The ID of the item to get", gt=0, le=1000),
     q: str,
 ):
     results = {"item_id": item_id}

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -5,7 +5,7 @@ from pydantic.fields import Undefined
 
 
 def Path(  # noqa: N802
-    default: Any,
+    default: Any = ...,
     *,
     alias: Optional[str] = None,
     title: Optional[str] = None,

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -60,7 +60,7 @@ class Path(Param):
 
     def __init__(
         self,
-        default: Any,
+        default: Any = ...,
         *,
         alias: Optional[str] = None,
         title: Optional[str] = None,


### PR DESCRIPTION
This pull request means that the following the code from [Path Parameters and Numeric Validations - FastAPI](https://fastapi.tiangolo.com/tutorial/path-params-numeric-validations/#declare-metadata) can omit its pointless default argument:
```py
from typing import Optional

from fastapi import FastAPI, Path, Query

app = FastAPI()


@app.get("/items/{item_id}")
async def read_items(
    # item_id: int = Path(..., title="The ID of the item to get"),
    item_id: int = Path(title="The ID of the item to get"),
    q: Optional[str] = Query(None, alias="item-query"),
):
    results = {"item_id": item_id}
    if q:
        results.update({"q": q})
    return results
```

As explained by the note under it, and by looking at the source, we can make out that this argument never had any meaning.
> A path parameter is always required as it has to be part of the path.
> 
> So, you should declare it with `...` to mark it as required.
> 
> Nevertheless, even if you declared it with None or set a default value, it would not affect anything, it would still be always required.

Looking at the source (simplified as to not take up too much space):
```py
class Path(Param):
    def __init__(
        self,
        default: Any,
        *,
        **extra: Any,
    ):
        super().__init__(
            ...,
            **extra,
        )
```