### PR TITLE
Fixes the URL for starlette Request reference documentation

### DIFF
--- a/docs/en/docs/advanced/custom-request-and-route.md
+++ b/docs/en/docs/advanced/custom-request-and-route.md
@@ -63,7 +63,7 @@ Here we use it to create a `GzipRequest` from the original request.
 
     And those two things, `scope` and `receive`, are what is needed to create a new `Request` instance.
 
-    To learn more about the `Request` check <a href="https://www.starlette.io/requests/" class="external-link" target="_blank">Starlette's docs about Requests</a>.
+    To learn more about the `Request` check <a href="https://www.starlette.io/requests.html" class="external-link" target="_blank">Starlette's docs about Requests</a>.
 
 The only thing the function returned by `GzipRequest.get_route_handler` does differently is convert the `Request` to a `GzipRequest`.
 

--- a/docs/en/docs/advanced/using-request-directly.md
+++ b/docs/en/docs/advanced/using-request-directly.md
@@ -15,7 +15,7 @@ But there are situations where you might need to access the `Request` object dir
 
 ## Details about the `Request` object
 
-As **FastAPI** is actually **Starlette** underneath, with a layer of several tools on top, you can use Starlette's <a href="https://www.starlette.io/requests/" class="external-link" target="_blank">`Request`</a> object directly when you need to.
+As **FastAPI** is actually **Starlette** underneath, with a layer of several tools on top, you can use Starlette's <a href="https://www.starlette.io/requests.html" class="external-link" target="_blank">`Request`</a> object directly when you need to.
 
 It would also mean that if you get data from the `Request` object directly (for example, read the body) it won't be validated, converted or documented (with OpenAPI, for the automatic API user interface) by FastAPI.
 
@@ -44,7 +44,7 @@ By declaring a *path operation function* parameter with the type being the `Requ
 
 ## `Request` documentation
 
-You can read more details about the <a href="https://www.starlette.io/requests/" class="external-link" target="_blank">`Request` object in the official Starlette documentation site</a>.
+You can read more details about the <a href="https://www.starlette.io/requests.html" class="external-link" target="_blank">`Request` object in the official Starlette documentation site</a>.
 
 !!! note "Technical Details"
     You could also use `from starlette.requests import Request`.

--- a/docs/en/docs/tutorial/sql-databases.md
+++ b/docs/en/docs/tutorial/sql-databases.md
@@ -653,7 +653,7 @@ The middleware we'll add (just a function) will create a new SQLAlchemy `Session
 
 ### About `request.state`
 
-`request.state` is a property of each `Request` object. It is there to store arbitrary objects attached to the request itself, like the database session in this case. You can read more about it in <a href="https://www.starlette.io/requests/#other-state" class="external-link" target="_blank">Starlette's docs about `Request` state</a>.
+`request.state` is a property of each `Request` object. It is there to store arbitrary objects attached to the request itself, like the database session in this case. You can read more about it in <a href="https://www.starlette.io/requests.html#other-state" class="external-link" target="_blank">Starlette's docs about `Request` state</a>.
 
 For us in this case, it helps us ensure a single database session is used through all the request, and then closed afterwards (in the middleware).
 


### PR DESCRIPTION
Changes Request reference URL from https://www.starlette.io/requests/ to
https://www.starlette.io/requests.html