### PR TITLE
⬆ Upgrade docs development dependency on `typer-cli` to >=0.0.12 to fix conflicts

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -26,7 +26,7 @@ jobs:
         run: python3.7 -m pip install flit
       - name: Install docs extras
         if: steps.cache.outputs.cache-hit != 'true'
-        run: python3.7 -m flit install --extras doc
+        run: python3.7 -m flit install --deps production --extras doc
       - name: Install Material for MkDocs Insiders
         if: github.event.pull_request.head.repo.fork == false && steps.cache.outputs.cache-hit != 'true'
         run: pip install git+https://${{ secrets.ACTIONS_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,10 @@ test = [
 ]
 doc = [
     "mkdocs >=1.1.2,<2.0.0",
-    "mkdocs-material >=6.1.4,<7.0.0",
-    "markdown-include >=0.5.1,<0.6.0",
+    "mkdocs-material >=7.1.9,<8.0.0",
+    "markdown-include >=0.6.0,<0.7.0",
     "mkdocs-markdownextradata-plugin >=0.1.7,<0.2.0",
-    # TODO: enable typer-cli once it supports Click 8.x, as other dependencies require it
-    # "typer-cli >=0.0.9,<0.0.10",
+    "typer-cli >=0.0.9,<0.0.10",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ doc = [
     "mkdocs-material >=7.1.9,<8.0.0",
     "markdown-include >=0.6.0,<0.7.0",
     "mkdocs-markdownextradata-plugin >=0.1.7,<0.2.0",
-    "typer-cli >=0.0.9,<0.0.10",
+    "typer-cli >=0.0.12,<0.0.13",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,8 @@ doc = [
     "mkdocs-material >=6.1.4,<7.0.0",
     "markdown-include >=0.5.1,<0.6.0",
     "mkdocs-markdownextradata-plugin >=0.1.7,<0.2.0",
-    "typer-cli >=0.0.9,<0.0.10",
+    # TODO: enable typer-cli once it supports Click 8.x, as other dependencies require it
+    # "typer-cli >=0.0.9,<0.0.10",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [


### PR DESCRIPTION
⬆ Upgrade docs development dependency on `typer-cli` to >=0.0.12 to fix conflicts with MkDocs.

Also, update build command for docs in CI to minimize the number of installed packages.