### PR TITLE
Used default value if empty string in request

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -69,6 +69,7 @@ sequence_shape_to_type = {
     SHAPE_TUPLE_ELLIPSIS: list,
 }
 
+EmptyString = ""
 
 multipart_not_installed_error = (
     'Form data requires "python-multipart" to be installed. \n'
@@ -614,7 +615,7 @@ def request_params_to_args(
         assert isinstance(
             field_info, params.Param
         ), "Params must be subclasses of Param"
-        if value is None:
+        if value is None or value == EmptyString:
             if field.required:
                 errors.append(
                     ErrorWrapper(


### PR DESCRIPTION
Some problems with default value

For example, we have route like this

```python
@router.get("/all")
async def get_all(
    itemId: Optional[int] = Query(None),
    page: int = Query(1),
    size: int = Query(10),
):
    return {"itemId": itemId, "page": page, "size": size}
```

and I try to send request with empty value `GET /all?itemId`. I hope, I'll get default value from `Query(None)`, but in `starlette` into request empty value always is empty string. If I send this request `GET /all?itemId`, I'll get validation error, because we compare string with int.

I decided the best way equate empty string to empty value.