### PR TITLE
Add Swagger UI persistAuthorization configuration parameter

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -46,6 +46,7 @@ class FastAPI(Starlette):
         redoc_url: Optional[str] = "/redoc",
         swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
         swagger_ui_init_oauth: Optional[Dict[str, Any]] = None,
+        swagger_ui_persist_auth: bool = False,
         middleware: Optional[Sequence[Middleware]] = None,
         exception_handlers: Optional[
             Dict[
@@ -114,6 +115,7 @@ class FastAPI(Starlette):
         self.redoc_url = redoc_url
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
+        self.swagger_ui_persist_auth = swagger_ui_persist_auth
         self.extra = extra
         self.dependency_overrides: Dict[Callable[..., Any], Callable[..., Any]] = {}
 
@@ -165,6 +167,7 @@ class FastAPI(Starlette):
                     title=self.title + " - Swagger UI",
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
+                    persist_auth=self.swagger_ui_persist_auth,
                 )
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -14,6 +14,7 @@ def get_swagger_ui_html(
     swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
     oauth2_redirect_url: Optional[str] = None,
     init_oauth: Optional[Dict[str, Any]] = None,
+    persist_auth: bool = False,
 ) -> HTMLResponse:
 
     html = f"""
@@ -37,7 +38,7 @@ def get_swagger_ui_html(
     if oauth2_redirect_url:
         html += f"oauth2RedirectUrl: window.location.origin + '{oauth2_redirect_url}',"
 
-    html += """
+    html += f"""
         dom_id: '#swagger-ui',
         presets: [
         SwaggerUIBundle.presets.apis,
@@ -46,8 +47,9 @@ def get_swagger_ui_html(
         layout: "BaseLayout",
         deepLinking: true,
         showExtensions: true,
-        showCommonExtensions: true
-    })"""
+        showCommonExtensions: true,
+        persistAuthorization: {json.dumps(persist_auth)}
+    }})"""
 
     if init_oauth:
         html += f"""


### PR DESCRIPTION
When developing APIs that requires authentication using Swagger UI, if you reload the browser window of Swagger UI to reflect a change in the code, the authentication is lost and you have to log in again, which is troublesome.

Swagger UI has a `persistAuthorization` parameter that, if enabled, will persist the authentication and keep you logged in even if you reload or close the browser.
[Swagger Documentation](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/)

In this PR, an argument `swagger_ui_persist_auth` is added to `FastAPI` constructor to set the `persistAuthorization` parameter. The default value is False, but setting this argument to True will also set the `persistAuthorization` parameter of Swagger UI to true.
