### PR TITLE
♻ Assume request bodies contain JSON when no Content-Type header is provided

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -184,7 +184,9 @@ def get_request_handler(
                     if body_bytes:
                         json_body: Any = Undefined
                         content_type_value = request.headers.get("content-type")
-                        if content_type_value:
+                        if not content_type_value:
+                            json_body = await request.json()
+                        else:
                             message = email.message.Message()
                             message["content-type"] = content_type_value
                             if message.get_content_maintype() == "application":

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -229,6 +229,20 @@ def test_geo_json():
     assert response.status_code == 200, response.text
 
 
+def test_no_content_type_is_json():
+    response = client.post(
+        "/items/",
+        data='{"name": "Foo", "price": 50.5}',
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "name": "Foo",
+        "description": None,
+        "price": 50.5,
+        "tax": None,
+    }
+
+
 def test_wrong_headers():
     data = '{"name": "Foo", "price": 50.5}'
     invalid_dict = {


### PR DESCRIPTION
♻ Assume request bodies contain JSON when no Content-Type header is provided

This is related to https://github.com/tiangolo/fastapi/pull/2118 and the CVE https://github.com/tiangolo/fastapi/security/advisories/GHSA-8h2j-cgx8-6xv7 about CSRF.

Some clients already assume that request bodies are read as JSON, even when no content-type header is set: https://github.com/tiangolo/fastapi/pull/2118#issuecomment-858155064

And the risk of CSRF only applies for specific Content-Type headers, so, no Content-Type header is already protected from CORS preflights: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests