### PR TITLE
Add 'swagger_ui_expansion' option in 'FastAPI()'

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -46,6 +46,7 @@ class FastAPI(Starlette):
         redoc_url: Optional[str] = "/redoc",
         swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
         swagger_ui_init_oauth: Optional[Dict[str, Any]] = None,
+        swagger_ui_expansion: str = "list",
         middleware: Optional[Sequence[Middleware]] = None,
         exception_handlers: Optional[
             Dict[
@@ -114,6 +115,13 @@ class FastAPI(Starlette):
         self.redoc_url = redoc_url
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
+        assert swagger_ui_expansion in (
+            "none",
+            "list",
+            "full",
+        ), f"'swagger_ui_expansion' option must be in: none, list or full, not {swagger_ui_expansion}"
+        self.swagger_ui_expansion = swagger_ui_expansion
+
         self.extra = extra
         self.dependency_overrides: Dict[Callable[..., Any], Callable[..., Any]] = {}
 
@@ -165,6 +173,7 @@ class FastAPI(Starlette):
                     title=self.title + " - Swagger UI",
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
+                    doc_expansion=self.swagger_ui_expansion,
                 )
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -14,6 +14,7 @@ def get_swagger_ui_html(
     swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
     oauth2_redirect_url: Optional[str] = None,
     init_oauth: Optional[Dict[str, Any]] = None,
+    doc_expansion: str = "list",
 ) -> HTMLResponse:
 
     html = f"""
@@ -37,7 +38,7 @@ def get_swagger_ui_html(
     if oauth2_redirect_url:
         html += f"oauth2RedirectUrl: window.location.origin + '{oauth2_redirect_url}',"
 
-    html += """
+    html += f"""
         dom_id: '#swagger-ui',
         presets: [
         SwaggerUIBundle.presets.apis,
@@ -46,8 +47,9 @@ def get_swagger_ui_html(
         layout: "BaseLayout",
         deepLinking: true,
         showExtensions: true,
-        showCommonExtensions: true
-    })"""
+        showCommonExtensions: true,
+        docExpansion: '{doc_expansion}'
+    }})"""
 
     if init_oauth:
         html += f"""


### PR DESCRIPTION
This allows to benefit of the swagger UI option 'docExpansion'. This option accepts 3 values: none, list (default), all.
When you have a lot of endpoints, putting 'none' will collapse all endpoints and only display tags.

docExpansion doc can be found here: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

Note: this PR could be invalidated if this one is accepted: https://github.com/tiangolo/fastapi/pull/2568