### PR TITLE
Add HttpException to avoid overriding 

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -210,6 +210,8 @@ def get_request_handler(
                             body = body_bytes
         except json.JSONDecodeError as e:
             raise RequestValidationError([ErrorWrapper(e, ("body", e.pos))], body=e.doc)
+        except HTTPException as e:
+            raise e
         except Exception as e:
             raise HTTPException(
                 status_code=400, detail="There was an error parsing the body"


### PR DESCRIPTION
This change will allow middlewares interacting with the body parsing
process to raise appropriate HTTPExceptions.