### PR TITLE
add alias for auth code flow for oauth redirect html

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -137,7 +137,8 @@ def get_swagger_ui_oauth2_redirect_html() -> HTMLResponse:
 
             if ((
             oauth2.auth.schema.get("flow") === "accessCode"||
-            oauth2.auth.schema.get("flow") === "authorizationCode"
+            oauth2.auth.schema.get("flow") === "authorizationCode"||
+            oauth2.auth.schema.get("flow") === "authorization_code"
             ) && !oauth2.auth.code) {
                 if (!isValid) {
                     oauth2.errCb({


### PR DESCRIPTION

According to [a merged PR from swagger-ui](https://github.com/swagger-api/swagger-ui/pull/6750#issue-546386258), add support of authorization_code flow similar to other cases: [example](https://github.com/swagger-api/swagger-ui/blob/0807687f9161a3293ff679ac9a1208df24921dd1/src/core/oauth2-authorize.js#L35)

code reference:
https://github.com/swagger-api/swagger-ui/blob/9320e8597af2ceb508a475d930909ea305e1bf7f/dist/oauth2-redirect.html#L34