### PR TITLE
🔧 Sort external links in docs to have the most recent at the top

### DIFF
--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -1,258 +1,258 @@
 articles:
   english:
-    - link: https://medium.com/@williamhayes/fastapi-starlette-debug-vs-prod-5f7561db3a59
-      title: FastAPI/Starlette debug vs prod
-      author_link: https://medium.com/@williamhayes
-      author: William Hayes
-    - link: https://medium.com/data-rebels/fastapi-google-as-an-external-authentication-provider-3a527672cf33
-      title: FastAPI — Google as an external authentication provider
-      author_link: https://medium.com/@nilsdebruin
-      author: Nils de Bruin
-    - link: https://medium.com/data-rebels/fastapi-how-to-add-basic-and-cookie-authentication-a45c85ef47d3
-      title: FastAPI — How to add basic and cookie authentication
-      author_link: https://medium.com/@nilsdebruin
-      author: Nils de Bruin
-    - link: https://dev.to/errietta/introduction-to-the-fastapi-python-framework-2n10
-      title: Introduction to the fastapi python framework
-      author_link: https://dev.to/errietta
-      author: Errieta Kostala
-    - link: https://nickc1.github.io/api,/scikit-learn/2019/01/10/scikit-fastapi.html
-      title: "FastAPI and Scikit-Learn: Easily Deploy Models"
-      author_link: https://nickc1.github.io/
-      author: Nick Cortale
-    - link: https://medium.com/data-rebels/fastapi-authentication-revisited-enabling-api-key-authentication-122dc5975680
-      title: "FastAPI authentication revisited: Enabling API key authentication"
-      author_link: https://medium.com/@nilsdebruin
-      author: Nils de Bruin
-    - link: https://medium.com/@nico.axtmann95/deploying-a-scikit-learn-model-with-onnx-und-fastapi-1af398268915
-      title: Deploying a scikit-learn model with ONNX and FastAPI
-      author_link: https://www.linkedin.com/in/nico-axtmann
-      author: Nico Axtmann
-    - link: https://geekflare.com/python-asynchronous-web-frameworks/
-      title: Top 5 Asynchronous Web Frameworks for Python
-      author_link: https://geekflare.com/author/ankush/
-      author: Ankush Thakur
-    - link: https://medium.com/@gntrm/jwt-authentication-with-fastapi-and-aws-cognito-1333f7f2729e
-      title: JWT Authentication with FastAPI and AWS Cognito
-      author_link: https://twitter.com/gntrm
-      author: Johannes Gontrum
-    - link: https://towardsdatascience.com/how-to-deploy-a-machine-learning-model-dc51200fe8cf
-      title: How to Deploy a Machine Learning Model
-      author_link: https://www.linkedin.com/in/mgrootendorst/
-      author: Maarten Grootendorst
-    - link: https://eng.uber.com/ludwig-v0-2/
-      title: "Uber: Ludwig v0.2 Adds New Features and Other Improvements to its Deep Learning Toolbox [including a FastAPI server]"
-      author_link: https://eng.uber.com
-      author: Uber Engineering
-    - link: https://gitlab.com/euri10/fastapi_cheatsheet
-      title: A FastAPI and Swagger UI visual cheatsheet
-      author_link: https://gitlab.com/euri10
-      author: "@euri10"
-    - link: https://medium.com/@mike.p.moritz/using-docker-compose-to-deploy-a-lightweight-python-rest-api-with-a-job-queue-37e6072a209b
-      title: Using Docker Compose to deploy a lightweight Python REST API with a job queue
-      author_link: https://medium.com/@mike.p.moritz
-      author: Mike Moritz
-    - link: https://robwagner.dev/tortoise-fastapi-setup/
-      title: Setting up Tortoise ORM with FastAPI
-      author_link: https://robwagner.dev/
-      author: Rob Wagner
-    - link: https://dev.to/dbanty/why-i-m-leaving-flask-3ki6
-      title: Why I'm Leaving Flask
-      author_link: https://dev.to/dbanty
-      author: Dylan Anthony
-    - link: https://medium.com/python-data/how-to-deploy-tensorflow-2-0-models-as-an-api-service-with-fastapi-docker-128b177e81f3
-      title: How To Deploy Tensorflow 2.0 Models As An API Service With FastAPI & Docker
-      author_link: https://medium.com/@bbrenyah
-      author: Bernard Brenyah
-    - link: https://testdriven.io/blog/fastapi-crud/
-      title: "TestDriven.io: Developing and Testing an Asynchronous API with FastAPI and Pytest"
-      author_link: https://testdriven.io/authors/herman
-      author: Michael Herman
-    - link: https://towardsdatascience.com/deploying-iris-classifications-with-fastapi-and-docker-7c9b83fdec3a
-      title: "Towards Data Science: Deploying Iris Classifications with FastAPI and Docker"
-      author_link: https://towardsdatascience.com/@mandygu
-      author: Mandy Gu
-    - link: https://medium.com/analytics-vidhya/deploy-machine-learning-models-with-keras-fastapi-redis-and-docker-4940df614ece
-      title: Deploy Machine Learning Models with Keras, FastAPI, Redis and Docker
-      author_link: https://medium.com/@shane.soh
-      author: Shane Soh
-    - link: https://medium.com/@arthur393/another-boilerplate-to-fastapi-azure-pipeline-ci-pytest-3c8d9a4be0bb
-      title: "Another Boilerplate to FastAPI: Azure Pipeline CI + Pytest"
-      author_link: https://twitter.com/arthurheinrique
-      author: Arthur Henrique
-    - link: https://iwpnd.pw/articles/2020-01/deploy-fastapi-to-aws-lambda
-      title: How to continuously deploy a FastAPI to AWS Lambda with AWS SAM
-      author_link: https://iwpnd.pw
-      author: Benjamin Ramser
-    - link: https://www.tutlinks.com/create-and-deploy-fastapi-app-to-heroku/
-      title: Create and Deploy FastAPI app to Heroku without using Docker
-      author_link: https://www.linkedin.com/in/navule/
-      author: Navule Pavan Kumar Rao
-    - link: https://iwpnd.pw/articles/2020-03/apache-kafka-fastapi-geostream
-      title: Apache Kafka producer and consumer with FastAPI and aiokafka
-      author_link: https://iwpnd.pw
-      author: Benjamin Ramser
-    - link: https://wuilly.com/2019/10/real-time-notifications-with-python-and-postgres/
-      title: Real-time Notifications with Python and Postgres
-      author_link: https://wuilly.com/
-      author: Guillermo Cruz
-    - link: https://dev.to/paurakhsharma/microservice-in-python-using-fastapi-24cc
-      title: Microservice in Python using FastAPI
-      author_link: https://twitter.com/PaurakhSharma
-      author: Paurakh Sharma Humagain
-    - link: https://dev.to/cuongld2/build-simple-api-service-with-python-fastapi-part-1-581o
-      title: Build simple API service with Python FastAPI — Part 1
-      author_link: https://dev.to/cuongld2
-      author: cuongld2
-    - link: https://paulsec.github.io/posts/fastapi_plus_zeit_serverless_fu/
-      title: FastAPI + Zeit.co = 🚀
-      author_link: https://twitter.com/PaulWebSec
-      author: Paul Sec
-    - link: https://dev.to/tiangolo/build-a-web-api-from-scratch-with-fastapi-the-workshop-2ehe
-      title: Build a web API from scratch with FastAPI - the workshop
-      author_link: https://twitter.com/tiangolo
-      author: Sebastián Ramírez (tiangolo)
-    - link: https://www.twilio.com/blog/build-secure-twilio-webhook-python-fastapi
-      title: Build a Secure Twilio Webhook with Python and FastAPI
-      author_link: https://www.twilio.com
-      author: Twilio
-    - link: https://www.stavros.io/posts/fastapi-with-django/
-      title: Using FastAPI with Django
-      author_link: https://twitter.com/Stavros
-      author: Stavros Korokithakis
-    - link: https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072
-      title: Introducing Dispatch
-      author_link: https://netflixtechblog.com/
-      author: Netflix
-    - link: https://davidefiocco.github.io/streamlit-fastapi-ml-serving/
-      title: Machine learning model serving in Python using FastAPI and streamlit
-      author_link: https://github.com/davidefiocco
-      author: Davide Fiocco
-    - link: https://www.tutlinks.com/deploy-fastapi-on-azure/
-      title: Deploy FastAPI on Azure App Service
-      author_link: https://www.linkedin.com/in/navule/
-      author: Navule Pavan Kumar Rao
-    - link: https://towardsdatascience.com/build-and-host-fast-data-science-applications-using-fastapi-823be8a1d6a0
-      title: Build And Host Fast Data Science Applications Using FastAPI
-      author_link: https://medium.com/@farhadmalik
-      author: Farhad Malik
-    - link: https://medium.com/@gabbyprecious2000/creating-a-crud-app-with-fastapi-part-one-7c049292ad37
-      title: Creating a CRUD App with FastAPI (Part one)
-      author_link: https://medium.com/@gabbyprecious2000
-      author: Precious Ndubueze
-    - link: https://julienharbulot.com/notification-server.html
-      title: HTTP server to display desktop notifications
-      author_link: https://julienharbulot.com/
-      author: Julien Harbulot
-    - link: https://guitton.co/posts/fastapi-monitoring/
-      title: How to monitor your FastAPI service
-      author_link: https://twitter.com/louis_guitton
-      author: Louis Guitton
-    - link: https://amitness.com/2020/06/fastapi-vs-flask/
-      title: FastAPI for Flask Users
-      author_link: https://twitter.com/amitness
-      author: Amit Chaudhary
-    - link: https://valonjanuzaj.medium.com/deploy-a-dockerized-fastapi-application-to-aws-cc757830ba1b
-      title: Deploy a dockerized FastAPI application to AWS
-      author_link: https://www.linkedin.com/in/valon-januzaj-b02692187/
-      author: Valon Januzaj
-    - link: https://dompatmore.com/blog/authenticate-your-fastapi-app-with-auth0
-      title: Authenticate Your FastAPI App with auth0
-      author_link: https://twitter.com/dompatmore
-      author: Dom Patmore
-  japanese:
-    - link: https://qiita.com/mtitg/items/47770e9a562dd150631d
-      title: FastAPI｜DB接続してCRUDするPython製APIサーバーを構築
-      author_link: https://qiita.com/mtitg
-      author: "@mtitg"
-    - link: https://qiita.com/ryoryomaru/items/59958ed385b3571d50de
-      title: python製の最新APIフレームワーク FastAPI を触ってみた
-      author_link: https://qiita.com/ryoryomaru
-      author: "@ryoryomaru"
-    - link: https://qiita.com/angel_katayoku/items/0e1f5dbbe62efc612a78
-      title: FastAPIでCORSを回避
-      author_link: https://qiita.com/angel_katayoku
-      author: "@angel_katayoku"
-    - link: https://qiita.com/angel_katayoku/items/4fbc1a4e2b33fa2237d2
-      title: FastAPIをMySQLと接続してDockerで管理してみる
-      author_link: https://qiita.com/angel_katayoku
-      author: "@angel_katayoku"
-    - link: https://qiita.com/angel_katayoku/items/8a458a8952f50b73f420
-      title: FastAPIでPOSTされたJSONのレスポンスbodyを受け取る
-      author_link: https://qiita.com/angel_katayoku
-      author: "@angel_katayoku"
-    - link: https://qiita.com/hikarut/items/b178af2e2440c67c6ac4
-      title: フロントエンド開発者向けのDockerによるPython開発環境構築
-      author_link: https://qiita.com/hikarut
-      author: Hikaru Takahashi
-    - link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-environment
-      title: "【第1回】FastAPIチュートリアル: ToDoアプリを作ってみよう【環境構築編】"
-      author_link: https://rightcode.co.jp/author/jun
-      author: ライトコードメディア編集部
-    - link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-model-building
-      title: "【第2回】FastAPIチュートリアル: ToDoアプリを作ってみよう【モデル構築編】"
-      author_link: https://rightcode.co.jp/author/jun
-      author: ライトコードメディア編集部
-    - link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-authentication-user-registration
-      title: "【第3回】FastAPIチュートリアル: toDoアプリを作ってみよう【認証・ユーザ登録編】"
-      author_link: https://rightcode.co.jp/author/jun
-      author: ライトコードメディア編集部
-    - link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-admin-page-improvement
-      title: "【第4回】FastAPIチュートリアル: toDoアプリを作ってみよう【管理者ページ改良編】"
-      author_link: https://rightcode.co.jp/author/jun
-      author: ライトコードメディア編集部
-    - link: https://qiita.com/bee2/items/0ad260ab9835a2087dae
-      title: PythonのWeb frameworkのパフォーマンス比較 (Django, Flask, responder, FastAPI, japronto)
-      author_link: https://qiita.com/bee2
-      author: "@bee2"
-    - link: https://qiita.com/bee2/items/75d9c0d7ba20e7a4a0e9
-      title: "[FastAPI] Python製のASGI Web フレームワーク FastAPIに入門する"
-      author_link: https://qiita.com/bee2
-      author: "@bee2"
-  vietnamese:
-    - link: https://fullstackstation.com/fastapi-trien-khai-bang-docker/
-      title: "FASTAPI: TRIỂN KHAI BẰNG DOCKER"
-      author_link: https://fullstackstation.com/author/figonking/
-      author: Nguyễn Nhân
-  russian:
-    - link: https://habr.com/ru/post/454440/
-      title: "Мелкая питонячая радость #2: Starlette - Солидная примочка – FastAPI"
-      author_link: https://habr.com/ru/users/57uff3r/
-      author: Andrey Korchak
-    - link: https://habr.com/ru/post/478620/
-      title: Почему Вы должны попробовать FastAPI?
-      author_link: https://github.com/prostomarkeloff
-      author: prostomarkeloff
-    - link: https://trkohler.com/fast-api-introduction-to-framework
-      title: "FastAPI: знакомимся с фреймворком"
-      author_link: https://www.linkedin.com/in/trkohler/
-      author: Troy Köhler
+  - author: Dom Patmore
+    author_link: https://twitter.com/dompatmore
+    link: https://dompatmore.com/blog/authenticate-your-fastapi-app-with-auth0
+    title: Authenticate Your FastAPI App with auth0
+  - author: Valon Januzaj
+    author_link: https://www.linkedin.com/in/valon-januzaj-b02692187/
+    link: https://valonjanuzaj.medium.com/deploy-a-dockerized-fastapi-application-to-aws-cc757830ba1b
+    title: Deploy a dockerized FastAPI application to AWS
+  - author: Amit Chaudhary
+    author_link: https://twitter.com/amitness
+    link: https://amitness.com/2020/06/fastapi-vs-flask/
+    title: FastAPI for Flask Users
+  - author: Louis Guitton
+    author_link: https://twitter.com/louis_guitton
+    link: https://guitton.co/posts/fastapi-monitoring/
+    title: How to monitor your FastAPI service
+  - author: Julien Harbulot
+    author_link: https://julienharbulot.com/
+    link: https://julienharbulot.com/notification-server.html
+    title: HTTP server to display desktop notifications
+  - author: Precious Ndubueze
+    author_link: https://medium.com/@gabbyprecious2000
+    link: https://medium.com/@gabbyprecious2000/creating-a-crud-app-with-fastapi-part-one-7c049292ad37
+    title: Creating a CRUD App with FastAPI (Part one)
+  - author: Farhad Malik
+    author_link: https://medium.com/@farhadmalik
+    link: https://towardsdatascience.com/build-and-host-fast-data-science-applications-using-fastapi-823be8a1d6a0
+    title: Build And Host Fast Data Science Applications Using FastAPI
+  - author: Navule Pavan Kumar Rao
+    author_link: https://www.linkedin.com/in/navule/
+    link: https://www.tutlinks.com/deploy-fastapi-on-azure/
+    title: Deploy FastAPI on Azure App Service
+  - author: Davide Fiocco
+    author_link: https://github.com/davidefiocco
+    link: https://davidefiocco.github.io/streamlit-fastapi-ml-serving/
+    title: Machine learning model serving in Python using FastAPI and streamlit
+  - author: Netflix
+    author_link: https://netflixtechblog.com/
+    link: https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072
+    title: Introducing Dispatch
+  - author: Stavros Korokithakis
+    author_link: https://twitter.com/Stavros
+    link: https://www.stavros.io/posts/fastapi-with-django/
+    title: Using FastAPI with Django
+  - author: Twilio
+    author_link: https://www.twilio.com
+    link: https://www.twilio.com/blog/build-secure-twilio-webhook-python-fastapi
+    title: Build a Secure Twilio Webhook with Python and FastAPI
+  - author: Sebastián Ramírez (tiangolo)
+    author_link: https://twitter.com/tiangolo
+    link: https://dev.to/tiangolo/build-a-web-api-from-scratch-with-fastapi-the-workshop-2ehe
+    title: Build a web API from scratch with FastAPI - the workshop
+  - author: Paul Sec
+    author_link: https://twitter.com/PaulWebSec
+    link: https://paulsec.github.io/posts/fastapi_plus_zeit_serverless_fu/
+    title: FastAPI + Zeit.co = 🚀
+  - author: cuongld2
+    author_link: https://dev.to/cuongld2
+    link: https://dev.to/cuongld2/build-simple-api-service-with-python-fastapi-part-1-581o
+    title: Build simple API service with Python FastAPI — Part 1
+  - author: Paurakh Sharma Humagain
+    author_link: https://twitter.com/PaurakhSharma
+    link: https://dev.to/paurakhsharma/microservice-in-python-using-fastapi-24cc
+    title: Microservice in Python using FastAPI
+  - author: Guillermo Cruz
+    author_link: https://wuilly.com/
+    link: https://wuilly.com/2019/10/real-time-notifications-with-python-and-postgres/
+    title: Real-time Notifications with Python and Postgres
+  - author: Benjamin Ramser
+    author_link: https://iwpnd.pw
+    link: https://iwpnd.pw/articles/2020-03/apache-kafka-fastapi-geostream
+    title: Apache Kafka producer and consumer with FastAPI and aiokafka
+  - author: Navule Pavan Kumar Rao
+    author_link: https://www.linkedin.com/in/navule/
+    link: https://www.tutlinks.com/create-and-deploy-fastapi-app-to-heroku/
+    title: Create and Deploy FastAPI app to Heroku without using Docker
+  - author: Benjamin Ramser
+    author_link: https://iwpnd.pw
+    link: https://iwpnd.pw/articles/2020-01/deploy-fastapi-to-aws-lambda
+    title: How to continuously deploy a FastAPI to AWS Lambda with AWS SAM
+  - author: Arthur Henrique
+    author_link: https://twitter.com/arthurheinrique
+    link: https://medium.com/@arthur393/another-boilerplate-to-fastapi-azure-pipeline-ci-pytest-3c8d9a4be0bb
+    title: 'Another Boilerplate to FastAPI: Azure Pipeline CI + Pytest'
+  - author: Shane Soh
+    author_link: https://medium.com/@shane.soh
+    link: https://medium.com/analytics-vidhya/deploy-machine-learning-models-with-keras-fastapi-redis-and-docker-4940df614ece
+    title: Deploy Machine Learning Models with Keras, FastAPI, Redis and Docker
+  - author: Mandy Gu
+    author_link: https://towardsdatascience.com/@mandygu
+    link: https://towardsdatascience.com/deploying-iris-classifications-with-fastapi-and-docker-7c9b83fdec3a
+    title: 'Towards Data Science: Deploying Iris Classifications with FastAPI and Docker'
+  - author: Michael Herman
+    author_link: https://testdriven.io/authors/herman
+    link: https://testdriven.io/blog/fastapi-crud/
+    title: 'TestDriven.io: Developing and Testing an Asynchronous API with FastAPI and Pytest'
+  - author: Bernard Brenyah
+    author_link: https://medium.com/@bbrenyah
+    link: https://medium.com/python-data/how-to-deploy-tensorflow-2-0-models-as-an-api-service-with-fastapi-docker-128b177e81f3
+    title: How To Deploy Tensorflow 2.0 Models As An API Service With FastAPI & Docker
+  - author: Dylan Anthony
+    author_link: https://dev.to/dbanty
+    link: https://dev.to/dbanty/why-i-m-leaving-flask-3ki6
+    title: Why I'm Leaving Flask
+  - author: Rob Wagner
+    author_link: https://robwagner.dev/
+    link: https://robwagner.dev/tortoise-fastapi-setup/
+    title: Setting up Tortoise ORM with FastAPI
+  - author: Mike Moritz
+    author_link: https://medium.com/@mike.p.moritz
+    link: https://medium.com/@mike.p.moritz/using-docker-compose-to-deploy-a-lightweight-python-rest-api-with-a-job-queue-37e6072a209b
+    title: Using Docker Compose to deploy a lightweight Python REST API with a job queue
+  - author: '@euri10'
+    author_link: https://gitlab.com/euri10
+    link: https://gitlab.com/euri10/fastapi_cheatsheet
+    title: A FastAPI and Swagger UI visual cheatsheet
+  - author: Uber Engineering
+    author_link: https://eng.uber.com
+    link: https://eng.uber.com/ludwig-v0-2/
+    title: 'Uber: Ludwig v0.2 Adds New Features and Other Improvements to its Deep Learning Toolbox [including a FastAPI server]'
+  - author: Maarten Grootendorst
+    author_link: https://www.linkedin.com/in/mgrootendorst/
+    link: https://towardsdatascience.com/how-to-deploy-a-machine-learning-model-dc51200fe8cf
+    title: How to Deploy a Machine Learning Model
+  - author: Johannes Gontrum
+    author_link: https://twitter.com/gntrm
+    link: https://medium.com/@gntrm/jwt-authentication-with-fastapi-and-aws-cognito-1333f7f2729e
+    title: JWT Authentication with FastAPI and AWS Cognito
+  - author: Ankush Thakur
+    author_link: https://geekflare.com/author/ankush/
+    link: https://geekflare.com/python-asynchronous-web-frameworks/
+    title: Top 5 Asynchronous Web Frameworks for Python
+  - author: Nico Axtmann
+    author_link: https://www.linkedin.com/in/nico-axtmann
+    link: https://medium.com/@nico.axtmann95/deploying-a-scikit-learn-model-with-onnx-und-fastapi-1af398268915
+    title: Deploying a scikit-learn model with ONNX and FastAPI
+  - author: Nils de Bruin
+    author_link: https://medium.com/@nilsdebruin
+    link: https://medium.com/data-rebels/fastapi-authentication-revisited-enabling-api-key-authentication-122dc5975680
+    title: 'FastAPI authentication revisited: Enabling API key authentication'
+  - author: Nick Cortale
+    author_link: https://nickc1.github.io/
+    link: https://nickc1.github.io/api,/scikit-learn/2019/01/10/scikit-fastapi.html
+    title: 'FastAPI and Scikit-Learn: Easily Deploy Models'
+  - author: Errieta Kostala
+    author_link: https://dev.to/errietta
+    link: https://dev.to/errietta/introduction-to-the-fastapi-python-framework-2n10
+    title: Introduction to the fastapi python framework
+  - author: Nils de Bruin
+    author_link: https://medium.com/@nilsdebruin
+    link: https://medium.com/data-rebels/fastapi-how-to-add-basic-and-cookie-authentication-a45c85ef47d3
+    title: FastAPI — How to add basic and cookie authentication
+  - author: Nils de Bruin
+    author_link: https://medium.com/@nilsdebruin
+    link: https://medium.com/data-rebels/fastapi-google-as-an-external-authentication-provider-3a527672cf33
+    title: FastAPI — Google as an external authentication provider
+  - author: William Hayes
+    author_link: https://medium.com/@williamhayes
+    link: https://medium.com/@williamhayes/fastapi-starlette-debug-vs-prod-5f7561db3a59
+    title: FastAPI/Starlette debug vs prod
   german:
-    - link: https://blog.codecentric.de/2019/08/inbetriebnahme-eines-scikit-learn-modells-mit-onnx-und-fastapi/
-      title: Inbetriebnahme eines scikit-learn-Modells mit ONNX und FastAPI
-      author_link: https://twitter.com/_nicoax
-      author: Nico Axtmann
+  - author: Nico Axtmann
+    author_link: https://twitter.com/_nicoax
+    link: https://blog.codecentric.de/2019/08/inbetriebnahme-eines-scikit-learn-modells-mit-onnx-und-fastapi/
+    title: Inbetriebnahme eines scikit-learn-Modells mit ONNX und FastAPI
+  japanese:
+  - author: '@bee2'
+    author_link: https://qiita.com/bee2
+    link: https://qiita.com/bee2/items/75d9c0d7ba20e7a4a0e9
+    title: '[FastAPI] Python製のASGI Web フレームワーク FastAPIに入門する'
+  - author: '@bee2'
+    author_link: https://qiita.com/bee2
+    link: https://qiita.com/bee2/items/0ad260ab9835a2087dae
+    title: PythonのWeb frameworkのパフォーマンス比較 (Django, Flask, responder, FastAPI, japronto)
+  - author: ライトコードメディア編集部
+    author_link: https://rightcode.co.jp/author/jun
+    link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-admin-page-improvement
+    title: '【第4回】FastAPIチュートリアル: toDoアプリを作ってみよう【管理者ページ改良編】'
+  - author: ライトコードメディア編集部
+    author_link: https://rightcode.co.jp/author/jun
+    link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-authentication-user-registration
+    title: '【第3回】FastAPIチュートリアル: toDoアプリを作ってみよう【認証・ユーザ登録編】'
+  - author: ライトコードメディア編集部
+    author_link: https://rightcode.co.jp/author/jun
+    link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-model-building
+    title: '【第2回】FastAPIチュートリアル: ToDoアプリを作ってみよう【モデル構築編】'
+  - author: ライトコードメディア編集部
+    author_link: https://rightcode.co.jp/author/jun
+    link: https://rightcode.co.jp/blog/information-technology/fastapi-tutorial-todo-apps-environment
+    title: '【第1回】FastAPIチュートリアル: ToDoアプリを作ってみよう【環境構築編】'
+  - author: Hikaru Takahashi
+    author_link: https://qiita.com/hikarut
+    link: https://qiita.com/hikarut/items/b178af2e2440c67c6ac4
+    title: フロントエンド開発者向けのDockerによるPython開発環境構築
+  - author: '@angel_katayoku'
+    author_link: https://qiita.com/angel_katayoku
+    link: https://qiita.com/angel_katayoku/items/8a458a8952f50b73f420
+    title: FastAPIでPOSTされたJSONのレスポンスbodyを受け取る
+  - author: '@angel_katayoku'
+    author_link: https://qiita.com/angel_katayoku
+    link: https://qiita.com/angel_katayoku/items/4fbc1a4e2b33fa2237d2
+    title: FastAPIをMySQLと接続してDockerで管理してみる
+  - author: '@angel_katayoku'
+    author_link: https://qiita.com/angel_katayoku
+    link: https://qiita.com/angel_katayoku/items/0e1f5dbbe62efc612a78
+    title: FastAPIでCORSを回避
+  - author: '@ryoryomaru'
+    author_link: https://qiita.com/ryoryomaru
+    link: https://qiita.com/ryoryomaru/items/59958ed385b3571d50de
+    title: python製の最新APIフレームワーク FastAPI を触ってみた
+  - author: '@mtitg'
+    author_link: https://qiita.com/mtitg
+    link: https://qiita.com/mtitg/items/47770e9a562dd150631d
+    title: FastAPI｜DB接続してCRUDするPython製APIサーバーを構築
+  russian:
+  - author: Troy Köhler
+    author_link: https://www.linkedin.com/in/trkohler/
+    link: https://trkohler.com/fast-api-introduction-to-framework
+    title: 'FastAPI: знакомимся с фреймворком'
+  - author: prostomarkeloff
+    author_link: https://github.com/prostomarkeloff
+    link: https://habr.com/ru/post/478620/
+    title: Почему Вы должны попробовать FastAPI?
+  - author: Andrey Korchak
+    author_link: https://habr.com/ru/users/57uff3r/
+    link: https://habr.com/ru/post/454440/
+    title: 'Мелкая питонячая радость #2: Starlette - Солидная примочка – FastAPI'
+  vietnamese:
+  - author: Nguyễn Nhân
+    author_link: https://fullstackstation.com/author/figonking/
+    link: https://fullstackstation.com/fastapi-trien-khai-bang-docker/
+    title: 'FASTAPI: TRIỂN KHAI BẰNG DOCKER'
 podcasts:
   english:
-    - link: https://pythonbytes.fm/episodes/show/123/time-to-right-the-py-wrongs?time_in_sec=855
-      title: FastAPI on PythonBytes
-      author_link: https://pythonbytes.fm/
-      author: Python Bytes FM
-    - link: https://www.pythonpodcast.com/fastapi-web-application-framework-episode-259/
-      title: "Build The Next Generation Of Python Web Applications With FastAPI - Episode 259 - interview to Sebastían Ramírez (tiangolo)"
-      author_link: https://www.pythonpodcast.com/
-      author: Podcast.`__init__`
+  - author: Podcast.`__init__`
+    author_link: https://www.pythonpodcast.com/
+    link: https://www.pythonpodcast.com/fastapi-web-application-framework-episode-259/
+    title: Build The Next Generation Of Python Web Applications With FastAPI - Episode 259 - interview to Sebastían Ramírez (tiangolo)
+  - author: Python Bytes FM
+    author_link: https://pythonbytes.fm/
+    link: https://pythonbytes.fm/episodes/show/123/time-to-right-the-py-wrongs?time_in_sec=855
+    title: FastAPI on PythonBytes
 talks:
   english:
-    - link: https://www.youtube.com/watch?v=3DLwPcrE5mA
-      title: "PyCon UK 2019: FastAPI from the ground up"
-      author_link: https://twitter.com/chriswithers13
-      author: Chris Withers
-    - link: https://www.youtube.com/watch?v=z9K5pwb0rt8
-      title: "PyConBY 2020: Serve ML models easily with FastAPI"
-      author_link: https://twitter.com/tiangolo
-      author: "Sebastián Ramírez (tiangolo)"
-    - link: https://www.youtube.com/watch?v=PnpTY1f4k2U
-      title: "[VIRTUAL] Py.Amsterdam's flying Software Circus: Intro to FastAPI"
-      author_link: https://twitter.com/tiangolo
-      author: "Sebastián Ramírez (tiangolo)"
+  - author: Sebastián Ramírez (tiangolo)
+    author_link: https://twitter.com/tiangolo
+    link: https://www.youtube.com/watch?v=PnpTY1f4k2U
+    title: '[VIRTUAL] Py.Amsterdam''s flying Software Circus: Intro to FastAPI'
+  - author: Sebastián Ramírez (tiangolo)
+    author_link: https://twitter.com/tiangolo
+    link: https://www.youtube.com/watch?v=z9K5pwb0rt8
+    title: 'PyConBY 2020: Serve ML models easily with FastAPI'
+  - author: Chris Withers
+    author_link: https://twitter.com/chriswithers13
+    link: https://www.youtube.com/watch?v=3DLwPcrE5mA
+    title: 'PyCon UK 2019: FastAPI from the ground up'

--- a/docs/en/docs/help-fastapi.md
+++ b/docs/en/docs/help-fastapi.md
@@ -92,7 +92,7 @@ You can [contribute](contributing.md){.internal-link target=_blank} to the sourc
 
 * To fix a typo you found on the documentation.
 * To share an article, video, or podcast you created or found about FastAPI by <a href="https://github.com/tiangolo/fastapi/edit/master/docs/en/data/external_links.yml" class="external-link" target="_blank">editing this file</a>.
-    * Make sure you add your link to the end of the corresponding section.
+    * Make sure you add your link to the start of the corresponding section.
 * To help [translate the documentation](contributing.md#translations){.internal-link target=_blank} to your language.
     * You can also help reviewing the translations created by others.
 * To propose new documentation sections.


### PR DESCRIPTION
🔧 Sort external links in docs to have the most recent at the top.

The re-sorting script was:

```Python
from pathlib import Path
import yaml

external_links_path = Path("./docs/en/data/external_links.yml")
external_links_path2 = Path("./docs/en/data/external_links2.yml")

data = yaml.safe_load(external_links_path.read_text(encoding="utf-8"))

new_data = {}

for section in data:
    new_data[section] = {}
    for language in data[section]:
        new_data[section][language] = list(reversed(data[section][language]))

external_links_path2.write_text(
    yaml.safe_dump(new_data, allow_unicode=True, width=3000), encoding="utf-8"
)
```