### PR TITLE
🔧 Add External Link, replaces #1898

### DIFF
--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -1,5 +1,9 @@
 articles:
   english:
+  - author: Patrick Ladon
+    author_link: https://dev.to/factorlive
+    link: https://dev.to/factorlive/python-facebook-messenger-webhook-with-fastapi-on-glitch-4n90
+    title: Python Facebook messenger webhook with FastAPI on Glitch  
   - author: Dom Patmore
     author_link: https://twitter.com/dompatmore
     link: https://dompatmore.com/blog/authenticate-your-fastapi-app-with-auth0


### PR DESCRIPTION
🔧 Add External Link, replaces #1898