### PR TITLE
👷 Update GitHub Action latest-changes

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -11,15 +11,27 @@ on:
       number:
         description: PR number
         required: true
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        required: false
+        default: false
 
 jobs:
   latest-changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Allow debugging with tmate
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
+          token: ${{ secrets.ACTIONS_TOKEN }}
+          standard_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker://tiangolo/latest-changes:0.0.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ACTION_TOKEN }}
           latest_changes_file: docs/en/docs/release-notes.md
           latest_changes_header: '## Latest Changes\n\n'
           debug_logs: true


### PR DESCRIPTION
👷 Update GitHub Action latest-changes.

Add custom action token to try to allow it to commit while keeping branch protections for PRs.