### PR TITLE
🙈 Add more environment related files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ env3.*
 env
 docs_build
 venv
+.venv
 docs.zip
 archive.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ env
 docs_build
 venv
 .venv
+.env
+ENV/
 docs.zip
 archive.zip
 


### PR DESCRIPTION
We should add `.venv` to `.gitignore`, because it would be contributor friendly cause `.venv` is a common name for python virtualenvs (it is also used by poetry) and many devs configured there dev tools to use `.venv` as a default.