### PR TITLE
Typographical Fix: Change Default Title Separator from Hyphen to En Dash

### DIFF
--- a/docs_src/extending_openapi/tutorial002.py
+++ b/docs_src/extending_openapi/tutorial002.py
@@ -15,7 +15,7 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 async def custom_swagger_ui_html():
     return get_swagger_ui_html(
         openapi_url=app.openapi_url,
-        title=app.title + " - Swagger UI",
+        title=app.title + " – Swagger UI",
         oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
         swagger_js_url="/static/swagger-ui-bundle.js",
         swagger_css_url="/static/swagger-ui.css",
@@ -31,7 +31,7 @@ async def swagger_ui_redirect():
 async def redoc_html():
     return get_redoc_html(
         openapi_url=app.openapi_url,
-        title=app.title + " - ReDoc",
+        title=app.title + " – ReDoc",
         redoc_js_url="/static/redoc.standalone.js",
     )
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -162,7 +162,7 @@ class FastAPI(Starlette):
                     oauth2_redirect_url = root_path + oauth2_redirect_url
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
-                    title=self.title + " - Swagger UI",
+                    title=self.title + " – Swagger UI",
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                 )
@@ -185,7 +185,7 @@ class FastAPI(Starlette):
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 return get_redoc_html(
-                    openapi_url=openapi_url, title=self.title + " - ReDoc"
+                    openapi_url=openapi_url, title=self.title + " – ReDoc"
                 )
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)


### PR DESCRIPTION
In usages such as "App Title – Swagger UI", an en dash (–) or an em dash (—) can be used, but never a hyphen (-). So this tiny PR changes the hyphens in these cases to en dashes. The difference between - and – might seem subtle depending on the font used but it's definitely easier on the eye to use the typographically correct dash here.

See also https://en.wikipedia.org/wiki/Dash#Parenthetic_and_other_uses_at_the_sentence_level

This PR doesn't change usages in the docs as this would be a whole nother can of worms.