### PR TITLE
Feature: Support custom response types that handle the raw response format.

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -224,17 +224,20 @@ def get_request_handler(
                 if raw_response.background is None:
                     raw_response.background = background_tasks
                 return raw_response
-            response_data = await serialize_response(
-                field=response_field,
-                response_content=raw_response,
-                include=response_model_include,
-                exclude=response_model_exclude,
-                by_alias=response_model_by_alias,
-                exclude_unset=response_model_exclude_unset,
-                exclude_defaults=response_model_exclude_defaults,
-                exclude_none=response_model_exclude_none,
-                is_coroutine=is_coroutine,
-            )
+            elif hasattr(actual_response_class, "__handles_raw_response__"):
+                response_data = raw_response
+            else:
+                response_data = await serialize_response(
+                    field=response_field,
+                    response_content=raw_response,
+                    include=response_model_include,
+                    exclude=response_model_exclude,
+                    by_alias=response_model_by_alias,
+                    exclude_unset=response_model_exclude_unset,
+                    exclude_defaults=response_model_exclude_defaults,
+                    exclude_none=response_model_exclude_none,
+                    is_coroutine=is_coroutine,
+                )
             response_args: Dict[str, Any] = {"background": background_tasks}
             # If status_code was set, use it, otherwise use the default from the
             # response class, in the case of redirect it's 307

--- a/tests/test_raw_response_class.py
+++ b/tests/test_raw_response_class.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from fastapi.testclient import TestClient
+
+
+class Hotdog:
+    ...
+
+
+class RawResponse(PlainTextResponse):
+    __handles_raw_response__ = True
+
+    def render(self, content: Any) -> bytes:
+        if isinstance(content, Hotdog):
+            return "hotdog".encode("utf-8")
+        else:
+            return "not-hotdog".encode("utf-8")
+
+
+app = FastAPI(default_response_class=RawResponse)
+
+
+@app.get("/")
+def get_root(want_dog: bool):
+    if want_dog:
+        return Hotdog()
+    else:
+        return "Hello World"
+
+
+client = TestClient(app)
+
+
+def test_uses_raw_response():
+    with client:
+        response = client.get("/?want_dog=True")
+    assert response.text == "hotdog"
+    with client:
+        response = client.get("/?want_dog=False")
+    assert response.text == "not-hotdog"


### PR DESCRIPTION
Currently the serialization process is first to use jsonable_encoder, followed then by passing to the custom response class. This is problematic where custom JSON encoding is desired, for example adding support for new types.

Extend the response class support to have a per-class configuration option indicating they are capable of handling the raw response from the method - this permits them to do arbitrary logic on the raw Python types (inc. if desired calling jsonable_encoder).

I think this is a fairly minimal change to achieve this effect, but also potentially unblocks other use-cases that may want access to the raw Python objects.