### PR TITLE
Join dependency execution paths before executing

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,7 +1,17 @@
-from typing import Any, Callable
+import contextvars
+import functools
+from typing import (
+    Any,
+    AsyncContextManager,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    ContextManager,
+    TypeVar,
+)
 
+import anyio
 from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
-from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa
 from starlette.concurrency import (  # noqa
     run_until_first_complete as run_until_first_complete,
 )
@@ -22,7 +32,7 @@ def _fake_asynccontextmanager(func: Callable[..., Any]) -> Callable[..., Any]:
 
 try:
     from contextlib import asynccontextmanager as asynccontextmanager  # type: ignore
-except ImportError:
+except ImportError:  # pragma: no cover
     try:
         from async_generator import (  # type: ignore  # isort: skip
             asynccontextmanager as asynccontextmanager,
@@ -32,20 +42,63 @@ except ImportError:
 
 try:
     from contextlib import AsyncExitStack as AsyncExitStack  # type: ignore
-except ImportError:
+except ImportError:  # pragma: no cover
     try:
         from async_exit_stack import AsyncExitStack as AsyncExitStack  # type: ignore
     except ImportError:  # pragma: no cover
         AsyncExitStack = None  # type: ignore
 
 
+T = TypeVar("T")
+
+
+def bind_callable_to_threadpool(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
+    async def inner(*args: Any, **kwargs: Any) -> T:
+        if contextvars is not None:  # pragma: no cover
+            # Ensure we run in the same context
+            child = functools.partial(func, *args, **kwargs)
+            context = contextvars.copy_context()
+            call = context.run
+            args = (child,)
+        elif kwargs:  # pragma: no cover
+            # run_sync doesn't accept 'kwargs', so bind them in here
+            call = functools.partial(func, **kwargs)
+        return await anyio.to_thread.run_sync(call, *args)
+
+    return inner
+
+
+def bind_context_manager_to_threadpool(
+    call: Callable[..., ContextManager[T]]
+) -> Callable[..., AsyncContextManager[T]]:
+    @asynccontextmanager
+    async def inner(*args: Any, **kwds: Any) -> AsyncGenerator[T, None]:
+        cm = call(*args, **kwds)
+        try:
+            yield await bind_callable_to_threadpool(cm.__enter__)()
+        except Exception as e:
+            ok = await bind_callable_to_threadpool(cm.__exit__)(type(e), e, None)
+            if not ok:
+                raise e
+        else:
+            await bind_callable_to_threadpool(cm.__exit__)(None, None, None)
+
+    return inner
+
+
+def bind_async_context_manager_to_stack(
+    cm: Callable[..., AsyncContextManager[T]], stack: AsyncExitStack
+) -> Callable[..., Awaitable[T]]:
+    async def inner(*args: Any, **kwargs: Any) -> T:
+        return await stack.enter_async_context(cm(*args, **kwargs))
+
+    return inner
+
+
 @asynccontextmanager  # type: ignore
 async def contextmanager_in_threadpool(cm: Any) -> Any:
-    try:
-        yield await run_in_threadpool(cm.__enter__)
-    except Exception as e:
-        ok = await run_in_threadpool(cm.__exit__, type(e), e, None)
-        if not ok:
-            raise e
-    else:
-        await run_in_threadpool(cm.__exit__, None, None, None)
+    def wrap():
+        return cm
+
+    async with bind_context_manager_to_threadpool(wrap)() as val:
+        yield val

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,18 @@
+from contextlib import contextmanager
+
+import pytest
+from fastapi.concurrency import contextmanager_in_threadpool
+
+
+@pytest.mark.asyncio
+async def test_cm_in_threadpool():
+    state = {}
+
+    @contextmanager
+    def cm():
+        yield 1234
+        state["cleanup"] = "run"
+
+    async with contextmanager_in_threadpool(cm()) as val:
+        assert val == 1234
+    assert state == {"cleanup": "run"}


### PR DESCRIPTION
This goes hand in hand with https://github.com/encode/starlette/pull/1260

The idea is to defer all execution and binding of arguments to dependencies to a central place using a series of closures/wrappers.

This provides better separation of the responsibilities of the DI system (executing the dependency w/ it's values) from concurrency management (binding sync deps to a thread pool, managing contexts, etc). I think evidence to this is that this system _can_ be annotated to carry dependency return type information through all of the wrapping (see [here](https://github.com/adriangb/anydep/blob/b18d45ade01d8993d348e72284dde43b8eb612c2/anydep/concurrency.py#L66-L93)).

This change should be 100% backwards compatible (unless we remove the now unused `contextmanager_in_threadpool` method, in which case this would not be backwards compatible, but it would be an easy fix for users).