### PR TITLE
Add fine grained dependency support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" targe
 
 ### Recap
 
-In summary, you declare **once** the types of parameters, body, etc. as function parameters. 
+In summary, you declare **once** the types of parameters, body, etc. as function parameters.
 
 You do that with standard modern Python types.
 
@@ -371,7 +371,7 @@ Coming back to the previous code example, **FastAPI** will:
     * As the `q` parameter is declared with `= None`, it is optional.
     * Without the `None` it would be required (as is the body in the case with `PUT`).
 * For `PUT` requests to `/items/{item_id}`, Read the body as JSON:
-    * Check that it has a required attribute `name` that should be a `str`. 
+    * Check that it has a required attribute `name` that should be a `str`.
     * Check that it has a required attribute `price` that has to be a `float`.
     * Check that it has an optional attribute `is_offer`, that should be a `bool`, if present.
     * All this would also work for deeply nested JSON objects.
@@ -453,7 +453,7 @@ Used by FastAPI / Starlette:
 * <a href="https://www.uvicorn.org" target="_blank"><code>uvicorn</code></a> - for the server that loads and serves your application.
 * <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
 
-You can install all of these with `pip install fastapi[all]`.
+You can install all of these with `pip install fastapi[all]`. If you need a subset of dependencies from this list, you can also request them by name with `pip install fastapi[request,aiofiles,pyyaml]`. This will ensure that dependence installed will conform to the rages FastAPI expects.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,19 @@ all = [
     "async_exit_stack >=1.0.1,<2.0.0",
     "async_generator >=1.10,<2.0.0"
 ]
+requests = ["requests >=2.24.0,<3.0.0"]
+aiofiles = ["aiofiles >=0.5.0,<0.6.0"]
+jinja2 = ["jinja2 >=2.11.2,<3.0.0"]
+python-multipart = ["python-multipart >=0.0.5,<0.0.6"]
+itsdangerous = ["itsdangerous >=1.1.0,<2.0.0"]
+pyyaml = ["pyyaml >=5.3.1,<6.0.0"]
+graphene = ["graphene >=2.1.8,<3.0.0"]
+ujson = ["ujson >=4.0.1,<5.0.0"]
+orjson = ["orjson >=3.2.1,<4.0.0"]
+email_validator = ["email_validator >=1.1.1,<2.0.0"]
+uvicorn = ["uvicorn[standard] >=0.12.0,<0.14.0"]
+async_exit_stack = ["async_exit_stack >=1.0.1,<2.0.0"]
+async_generator = ["async_generator >=1.10,<2.0.0"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
FastAPI has a number of optional dependencies that need to be installed
based on the use case. This change will create a extras-require for each
for of them. This will allow for users to install everything they need
for their service while keeping the requirements as slim as possible.

For example if a user need form parsing and the test client they can
install with `pip install fastapi[requests,python-multipart]`.

This will also help ensure the packages FastAPI depends on are in the
desired range.