### PR TITLE
Upgrade Starlette to version 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 requires = [
-    "starlette ==0.14.2",
+    "starlette == 0.16.0",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0"
 ]
 description-file = "README.md"

--- a/tests/test_tutorial/test_websockets/test_tutorial002.py
+++ b/tests/test_tutorial/test_websockets/test_tutorial002.py
@@ -72,9 +72,11 @@ def test_websocket_with_header_and_query():
 
 def test_websocket_no_credentials():
     with pytest.raises(WebSocketDisconnect):
-        client.websocket_connect("/items/foo/ws")
+        with client.websocket_connect("/items/foo/ws"):
+            pass
 
 
 def test_websocket_invalid_data():
     with pytest.raises(WebSocketDisconnect):
-        client.websocket_connect("/items/foo/ws?q=bar&token=some-token")
+        with client.websocket_connect("/items/foo/ws?q=bar&token=some-token"):
+            pass


### PR DESCRIPTION
## Overview

This small change upgrades FastAPI's internal dependency on Startlette to version 0.16.0, which incorporates several important bugfixes (see release notes for [0.15.0](https://github.com/encode/starlette/releases/tag/0.15.0) and [0.16.0](https://github.com/encode/starlette/releases/tag/0.16.0)) that would be relevant for FastAPI users.

## Testing done

- [x] Run unit tests per the [contribution docs](https://fastapi.tiangolo.com/contributing/#tests)
- [x] Run a few examples from the FastAPI docs locally to ensure some "real-world" examples still work as expected

## Other notes

- During the upgrade, there were only a couple of unit tests that failed due to upstream breakage relating to websocket connections, which were pretty straightforward to resolve
- It's worth noting that Starlette now requires [AnyIO](https://anyio.readthedocs.io/) as of version 0.15.0; I don't claim to fully understand 100% of the reasons behind this switch, but from the commits I've read in Starlette, it seems to provide upstream support for different async runtimes (e.g. [Trio](https://trio-asyncio.readthedocs.io/)) along with other nice async I/O primitives such as [task groups](https://anyio.readthedocs.io/en/stable/tasks.html)

Apologies in advance if version upgrades aren't a typical part of outside contribution, but I figured this would be one way to get my feet wet!