### PR TITLE
✨ Enable recent Material for MkDocs Insiders features

### DIFF
--- a/docs/de/mkdocs.yml
+++ b/docs/de/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/de/mkdocs.yml
+++ b/docs/de/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -162,6 +164,9 @@ markdown_extensions:
     permalink: true
 - markdown.extensions.codehilite:
     guess_lang: false
+# Uncomment these 2 lines during development to more easily add highlights
+# - pymdownx.highlight:
+#     linenums: true
 - mdx_include:
     base_path: docs
 - admonition
@@ -171,7 +176,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -224,6 +229,5 @@ extra_css:
 - css/termynal.css
 - css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - js/termynal.js
 - js/custom.js

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/es/mkdocs.yml
+++ b/docs/es/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/es/mkdocs.yml
+++ b/docs/es/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -77,7 +79,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -130,6 +132,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/fr/mkdocs.yml
+++ b/docs/fr/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -75,7 +77,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -128,6 +130,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/fr/mkdocs.yml
+++ b/docs/fr/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/id/mkdocs.yml
+++ b/docs/id/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/id/mkdocs.yml
+++ b/docs/id/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/it/mkdocs.yml
+++ b/docs/it/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/it/mkdocs.yml
+++ b/docs/it/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/ja/mkdocs.yml
+++ b/docs/ja/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -107,7 +109,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -160,6 +162,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/ja/mkdocs.yml
+++ b/docs/ja/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/ko/mkdocs.yml
+++ b/docs/ko/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/ko/mkdocs.yml
+++ b/docs/ko/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -73,7 +75,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -126,6 +128,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/pl/mkdocs.yml
+++ b/docs/pl/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/pl/mkdocs.yml
+++ b/docs/pl/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/pt/mkdocs.yml
+++ b/docs/pt/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -81,7 +83,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -134,6 +136,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/pt/mkdocs.yml
+++ b/docs/pt/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/ru/mkdocs.yml
+++ b/docs/ru/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/ru/mkdocs.yml
+++ b/docs/ru/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/sq/mkdocs.yml
+++ b/docs/sq/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/sq/mkdocs.yml
+++ b/docs/sq/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/tr/mkdocs.yml
+++ b/docs/tr/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/tr/mkdocs.yml
+++ b/docs/tr/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/uk/mkdocs.yml
+++ b/docs/uk/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -67,7 +69,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -120,6 +122,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/uk/mkdocs.yml
+++ b/docs/uk/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data

--- a/docs/zh/mkdocs.yml
+++ b/docs/zh/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.tabs.link
   icon:
     repo: fontawesome/brands/github-alt
   logo: https://fastapi.tiangolo.com/img/icon-white.svg
@@ -32,6 +33,7 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
+- social
 - search
 - markdownextradata:
     data: data
@@ -116,7 +118,7 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_div_format ''
+      format: !!python/name:pymdownx.superfences.fence_code_format ''
 - pymdownx.tabbed
 extra:
   social:
@@ -169,6 +171,5 @@ extra_css:
 - https://fastapi.tiangolo.com/css/termynal.css
 - https://fastapi.tiangolo.com/css/custom.css
 extra_javascript:
-- https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - https://fastapi.tiangolo.com/js/termynal.js
 - https://fastapi.tiangolo.com/js/custom.js

--- a/docs/zh/mkdocs.yml
+++ b/docs/zh/mkdocs.yml
@@ -33,7 +33,6 @@ google_analytics:
 - UA-133183413-1
 - auto
 plugins:
-- social
 - search
 - markdownextradata:
     data: data


### PR DESCRIPTION
✨ Enable recent Material for MkDocs Insiders features. Particularly `content.tabs.link`, that will be used for the tutorials for Python 3.9 and Python 3.10.