### PR TITLE
Remove unnecesarry branch for default empty list

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -460,7 +460,7 @@ class APIRouter(routing.Router):
             ), "A path prefix must not end with '/', as the routes will start with '/'"
         self.prefix = prefix
         self.tags: List[str] = tags or []
-        self.dependencies = list(dependencies or []) or []
+        self.dependencies = list(dependencies or [])
         self.deprecated = deprecated
         self.include_in_schema = include_in_schema
         self.responses = responses or {}


### PR DESCRIPTION
```python
list(dependencies or [])
```

is identical behaviour to

```python
list(dependencies or []) or []
```

Is it not?