### PR TITLE
Fix using websockets with prefixed routers

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -606,7 +606,7 @@ class APIRouter(routing.Router):
         self, path: str, endpoint: Callable[..., Any], name: Optional[str] = None
     ) -> None:
         route = APIWebSocketRoute(
-            path,
+            self.prefix + path,
             endpoint=endpoint,
             name=name,
             dependency_overrides_provider=self.dependency_overrides_provider,
@@ -621,6 +621,11 @@ class APIRouter(routing.Router):
             return func
 
         return decorator
+
+    def websocket_route(
+        self, path: str, name: Optional[str] = None
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return super().websocket_route(self.prefix + path, name=name)  # type: ignore # in Starlette
 
     def include_router(
         self,

--- a/tests/test_ws_router.py
+++ b/tests/test_ws_router.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 router = APIRouter()
 prefix_router = APIRouter()
+prefix_router2 = APIRouter(prefix="/prefix2")
 app = FastAPI()
 
 
@@ -27,6 +28,13 @@ async def routerprefixindex(websocket: WebSocket):
     await websocket.close()
 
 
+@prefix_router2.websocket_route("/ws")
+async def routerprefixws(websocket: WebSocket):
+    await websocket.accept()
+    await websocket.send_text("Hello, router with prefix and name!")
+    await websocket.close()
+
+
 @router.websocket("/router2")
 async def routerindex2(websocket: WebSocket):
     await websocket.accept()
@@ -47,8 +55,18 @@ async def router_ws_decorator_depends(
     await websocket.close()
 
 
+@prefix_router2.websocket("/router-ws-depends/")
+async def router_prefix_ws_decorator_depends(
+    websocket: WebSocket, data=Depends(ws_dependency)
+):
+    await websocket.accept()
+    await websocket.send_text(data)
+    await websocket.close()
+
+
 app.include_router(router)
 app.include_router(prefix_router, prefix="/prefix")
+app.include_router(prefix_router2)
 
 
 def test_app():
@@ -72,6 +90,13 @@ def test_prefix_router():
         assert data == "Hello, router with prefix!"
 
 
+def test_prefix_router2():
+    client = TestClient(app)
+    with client.websocket_connect("/prefix2/ws") as websocket:
+        data = websocket.receive_text()
+        assert data == "Hello, router with prefix and name!"
+
+
 def test_router2():
     client = TestClient(app)
     with client.websocket_connect("/router2") as websocket:
@@ -88,5 +113,24 @@ def test_router_ws_depends():
 def test_router_ws_depends_with_override():
     client = TestClient(app)
     app.dependency_overrides[ws_dependency] = lambda: "Override"
-    with client.websocket_connect("/router-ws-depends/") as websocket:
-        assert websocket.receive_text() == "Override"
+    try:
+        with client.websocket_connect("/router-ws-depends/") as websocket:
+            assert websocket.receive_text() == "Override"
+    finally:
+        del app.dependency_overrides[ws_dependency]
+
+
+def test_router_prefix_ws_depends():
+    client = TestClient(app)
+    with client.websocket_connect("/prefix2/router-ws-depends/") as websocket:
+        assert websocket.receive_text() == "Socket Dependency"
+
+
+def test_router_prefix_ws_depends_with_override():
+    client = TestClient(app)
+    app.dependency_overrides[ws_dependency] = lambda: "Override"
+    try:
+        with client.websocket_connect("/prefix2/router-ws-depends/") as websocket:
+            assert websocket.receive_text() == "Override"
+    finally:
+        del app.dependency_overrides[ws_dependency]


### PR DESCRIPTION
Fixes the newly reported issues in #98 with router prefixes being ignored and improves the tests to explicitly check for this.