### PR TITLE
🔧 enable ansi in cmd

### DIFF
--- a/fastapi/logger.py
+++ b/fastapi/logger.py
@@ -1,3 +1,7 @@
 import logging
 
 logger = logging.getLogger("fastapi")
+
+if platform.system() == "Windows":
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)

--- a/fastapi/logger.py
+++ b/fastapi/logger.py
@@ -1,4 +1,6 @@
 import logging
+import ctypes
+import platform
 
 logger = logging.getLogger("fastapi")
 


### PR DESCRIPTION
The Windows Console did not support ANSI escape sequences, nor did Microsoft provide any method to enable them.
But in 2016, Microsoft released the Windows 10 version 1511 update which unexpectedly implemented support for ANSI escape sequences, over two decades after the debut of Windows NT.
Windows Console Host used by Command Prompt support for character escape codes used by terminal-based software for Unix-like systems. This is not the default behavior and must be enabled programmatically with the Win32 API via `SetConsoleMode(handle, ENABLE_VIRTUAL_TERMINAL_PROCESSING)`

Before
![Before](https://cdn.discordapp.com/attachments/862806580865400903/879410518425743380/unknown.png)
After
![After](https://cdn.discordapp.com/attachments/862806580865400903/879410847183671426/unknown.png)