### PR TITLE
Change "files" to "file" in tutorial001.py, because "files" is also used in tutorial002.py and causes confusion if you combine both..

### DIFF
--- a/docs_src/request_files/tutorial001.py
+++ b/docs_src/request_files/tutorial001.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, File, UploadFile
 app = FastAPI()
 
 
-@app.post("/files/")
+@app.post("/file/")
 async def create_file(file: bytes = File(...)):
     return {"file_size": len(file)}
 


### PR DESCRIPTION
Call the endpoint "file" instead of "files" because it clashes with the multipart 
example 2, where the endpoint is also "files".

Since this example doesn't tell you how to write the form needed to test it, 
FastAPI users trying to upload files for the first time are likely to combine both examples 
into one project and then run into problems.

Also: For the simple, one file example, it might be helpful to add a curl example on how to upload a single file against this interface, because it's not easy to guess how to do that.I was thrown off the path by curl not automatically following the HTTP redirect I got from FastAPI, which required to add a "-L" parameter or an extra "/" at the end.