### PR TITLE
Remove emojis from async.md

### DIFF
--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -63,13 +63,13 @@ Let's see that phrase by parts in the sections below:
 
 ## Asynchronous Code
 
-Asynchronous code just means that the language 💬 has a way to tell the computer / program 🤖 that at some point in the code, it 🤖 will have to wait for *something else* to finish somewhere else. Let's say that *something else* is called "slow-file" 📝.
+Asynchronous code just means that the language has a way to tell the computer / program that at some point in the code, it will have to wait for *something else* to finish somewhere else. Let's say that *something else* is called "slow-file".
 
-So, during that time, the computer can go and do some other work, while "slow-file" 📝 finishes.
+So, during that time, the computer can go and do some other work, while "slow-file" finishes.
 
-Then the computer / program 🤖 will come back every time it has a chance because it's waiting again, or whenever it 🤖 finished all the work it had at that point. And it 🤖 will see if any of the tasks it was waiting for have already finished, doing whatever it had to do.
+Then the computer / program will come back every time it has a chance because it's waiting again, or whenever it finished all the work it had at that point. And it will see if any of the tasks it was waiting for have already finished, doing whatever it had to do.
 
-Next, it 🤖 takes the first task to finish (let's say, our "slow-file" 📝) and continues whatever it had to do with it.
+Next, it takes the first task to finish (let's say, our "slow-file") and continues whatever it had to do with it.
 
 That "wait for something else" normally refers to <abbr title="Input and Output">I/O</abbr> operations that are relatively "slow" (compared to the speed of the processor and the RAM memory), like waiting for:
 
@@ -102,111 +102,109 @@ To see the difference, imagine the following story about burgers:
 
 ### Concurrent Burgers
 
-<!-- The gender neutral cook emoji "🧑‍🍳" does not render well in browsers. In the meantime, I'm using a mix of male "👨‍🍳" and female "👩‍🍳" cooks. -->
+You go with your crush to get fast food, you stand in line while the cashier takes the orders from the people in front of you.
 
-You go with your crush 😍 to get fast food 🍔, you stand in line while the cashier 💁 takes the orders from the people in front of you.
+Then it's your turn, you place your order of 2 very fancy burgers for your crush and you.
 
-Then it's your turn, you place your order of 2 very fancy burgers 🍔 for your crush 😍 and you.
+You pay.
 
-You pay 💸.
+The cashier says something to the cook in the kitchen so they know they have to prepare your burgers (even though they are currently preparing the ones for the previous clients).
 
-The cashier 💁 says something to the cook in the kitchen 👨‍🍳 so they know they have to prepare your burgers 🍔 (even though they are currently preparing the ones for the previous clients).
+The cashier gives you the number of your turn.
 
-The cashier 💁 gives you the number of your turn.
+While you are waiting, you go with your crush and pick a table, you sit and talk with your crush for a long time (as your burgers are very fancy and take some time to prepare).
 
-While you are waiting, you go with your crush 😍 and pick a table, you sit and talk with your crush 😍 for a long time (as your burgers are very fancy and take some time to prepare ✨🍔✨).
+As you are sitting on the table with your crush, while you wait for the burgers, you can spend that time admiring how awesome, cute and smart your crush is.
 
-As you are sitting on the table with your crush 😍, while you wait for the burgers 🍔, you can spend that time admiring how awesome, cute and smart your crush is ✨😍✨.
+While waiting and talking to your crush, from time to time, you check the number displayed on the counter to see if it's your turn already.
 
-While waiting and talking to your crush 😍, from time to time, you check the number displayed on the counter to see if it's your turn already.
+Then at some point, it finally is your turn. You go to the counter, get your burgers and come back to the table.
 
-Then at some point, it finally is your turn. You go to the counter, get your burgers 🍔 and come back to the table.
-
-You and your crush 😍 eat the burgers 🍔 and have a nice time ✨.
+You and your crush eat the burgers and have a nice time.
 
 ---
 
-Imagine you are the computer / program 🤖 in that story.
+Imagine you are the computer / program in that story.
 
-While you are at the line, you are just idle 😴, waiting for your turn, not doing anything very "productive". But the line is fast because the cashier 💁 is only taking the orders (not preparing them), so that's fine.
+While you are at the line, you are just idle, waiting for your turn, not doing anything very "productive". But the line is fast because the cashier is only taking the orders (not preparing them), so that's fine.
 
-Then, when it's your turn, you do actual "productive" work 🤓, you process the menu, decide what you want, get your crush's 😍 choice, pay 💸, check that you give the correct bill or card, check that you are charged correctly, check that the order has the correct items, etc.
+Then, when it's your turn, you do actual "productive" work, you process the menu, decide what you want, get your crush's choice, pay, check that you give the correct bill or card, check that you are charged correctly, check that the order has the correct items, etc.
 
-But then, even though you still don't have your burgers 🍔, your work with the cashier 💁 is "on pause" ⏸, because you have to wait 🕙 for your burgers to be ready.
+But then, even though you still don't have your burgers, your work with the cashier is "on pause", because you have to wait for your burgers to be ready.
 
-But as you go away from the counter and sit on the table with a number for your turn, you can switch 🔀 your attention to your crush 😍, and "work" ⏯ 🤓 on that. Then you are again doing something very "productive" 🤓, as is flirting with your crush 😍.
+But as you go away from the counter and sit on the table with a number for your turn, you can switch your attention to your crush, and "work" on that. Then you are again doing something very "productive", as is flirting with your crush.
 
-Then the cashier 💁 says "I'm finished with doing the burgers" 🍔 by putting your number on the counter's display, but you don't jump like crazy immediately when the displayed number changes to your turn number. You know no one will steal your burgers 🍔 because you have the number of your turn, and they have theirs.
+Then the cashier says "I'm finished with doing the burgers" by putting your number on the counter's display, but you don't jump like crazy immediately when the displayed number changes to your turn number. You know no one will steal your burgers because you have the number of your turn, and they have theirs.
 
-So you wait for your crush 😍 to finish the story (finish the current work ⏯ / task being processed 🤓), smile gently and say that you are going for the burgers ⏸.
+So you wait for your crush to finish the story (finish the current work / task being processed), smile gently and say that you are going for the burgers.
 
-Then you go to the counter 🔀, to the initial task that is now finished ⏯, pick the burgers 🍔, say thanks and take them to the table. That finishes that step / task of interaction with the counter ⏹. That in turn, creates a new task, of "eating burgers" 🔀 ⏯, but the previous one of "getting burgers" is finished ⏹.
+Then you go to the counter, to the initial task that is now finished, pick the burgers, say thanks and take them to the table. That finishes that step / task of interaction with the counter. That in turn, creates a new task, of "eating burgers", but the previous one of "getting burgers" is finished.
 
 ### Parallel Burgers
 
 Now let's imagine these aren't "Concurrent Burgers", but "Parallel Burgers".
 
-You go with your crush 😍 to get parallel fast food 🍔.
+You go with your crush to get parallel fast food.
 
-You stand in line while several (let's say 8) cashiers that at the same time are cooks 👩‍🍳👨‍🍳👩‍🍳👨‍🍳👩‍🍳👨‍🍳👩‍🍳👨‍🍳 take the orders from the people in front of you.
+You stand in line while several (let's say 8) cashiers that at the same time are cooks take the orders from the people in front of you.
 
-Everyone before you is waiting 🕙 for their burgers 🍔 to be ready before leaving the counter because each of the 8 cashiers goes and prepares the burger right away before getting the next order.
+Everyone before you is waiting for their burgers to be ready before leaving the counter because each of the 8 cashiers goes and prepares the burger right away before getting the next order.
 
-Then it's finally your turn, you place your order of 2 very fancy burgers 🍔 for your crush 😍 and you.
+Then it's finally your turn, you place your order of 2 very fancy burgers for your crush and you.
 
-You pay 💸.
+You pay.
 
-The cashier goes to the kitchen 👨‍🍳.
+The cashier goes to the kitchen.
 
-You wait, standing in front of the counter 🕙, so that no one else takes your burgers 🍔 before you do, as there are no numbers for turns.
+You wait, standing in front of the counter, so that no one else takes your burgers before you do, as there are no numbers for turns.
 
-As you and your crush 😍 are busy not letting anyone get in front of you and take your burgers whenever they arrive 🕙, you cannot pay attention to your crush 😞.
+As you and your crush are busy not letting anyone get in front of you and take your burgers whenever they arrive, you cannot pay attention to your crush.
 
-This is "synchronous" work, you are "synchronized" with the cashier/cook 👨‍🍳. You have to wait 🕙 and be there at the exact moment that the cashier/cook 👨‍🍳 finishes the burgers 🍔 and gives them to you, or otherwise, someone else might take them.
+This is "synchronous" work, you are "synchronized" with the cashier/cook. You have to wait and be there at the exact moment that the cashier/cook finishes the burgers and gives them to you, or otherwise, someone else might take them.
 
-Then your cashier/cook 👨‍🍳 finally comes back with your burgers 🍔, after a long time waiting 🕙 there in front of the counter.
+Then your cashier/cook finally comes back with your burgers, after a long time waiting there in front of the counter.
 
-You take your burgers 🍔 and go to the table with your crush 😍.
+You take your burgers and go to the table with your crush.
 
-You just eat them, and you are done 🍔 ⏹.
+You just eat them, and you are done.
 
-There was not much talk or flirting as most of the time was spent waiting 🕙 in front of the counter 😞.
-
----
-
-In this scenario of the parallel burgers, you are a computer / program 🤖 with two processors (you and your crush 😍), both waiting 🕙 and dedicating their attention ⏯ to be "waiting on the counter" 🕙 for a long time.
-
-The fast food store has 8 processors (cashiers/cooks) 👩‍🍳👨‍🍳👩‍🍳👨‍🍳👩‍🍳👨‍🍳👩‍🍳👨‍🍳. While the concurrent burgers store might have had only 2 (one cashier and one cook) 💁 👨‍🍳.
-
-But still, the final experience is not the best 😞.
+There was not much talk or flirting as most of the time was spent waiting in front of the counter.
 
 ---
 
-This would be the parallel equivalent story for burgers 🍔.
+In this scenario of the parallel burgers, you are a computer / program with two processors (you and your crush), both waiting and dedicating their attention to be "waiting on the counter" for a long time.
+
+The fast food store has 8 processors (cashiers/cooks). While the concurrent burgers store might have had only 2 (one cashier and one cook).
+
+But still, the final experience is not the best.
+
+---
+
+This would be the parallel equivalent story for burgers.
 
 For a more "real life" example of this, imagine a bank.
 
-Up to recently, most of the banks had multiple cashiers 👨‍💼👨‍💼👨‍💼👨‍💼 and a big line 🕙🕙🕙🕙🕙🕙🕙🕙.
+Up to recently, most of the banks had multiple cashiers and a big line.
 
-All of the cashiers doing all the work with one client after the other 👨‍💼⏯.
+All of the cashiers doing all the work with one client after the other.
 
-And you have to wait 🕙 in the line for a long time or you lose your turn.
+And you have to wait in the line for a long time or you lose your turn.
 
-You probably wouldn't want to take your crush 😍 with you to do errands at the bank 🏦.
+You probably wouldn't want to take your crush with you to do errands at the bank.
 
 ### Burger Conclusion
 
-In this scenario of "fast food burgers with your crush", as there is a lot of waiting 🕙, it makes a lot more sense to have a concurrent system ⏸🔀⏯.
+In this scenario of "fast food burgers with your crush", as there is a lot of waiting, it makes a lot more sense to have a concurrent system.
 
 This is the case for most of the web applications.
 
-Many, many users, but your server is waiting 🕙 for their not-so-good connection to send their requests.
+Many, many users, but your server is waiting for their not-so-good connection to send their requests.
 
-And then waiting 🕙 again for the responses to come back.
+And then waiting again for the responses to come back.
 
-This "waiting" 🕙 is measured in microseconds, but still, summing it all, it's a lot of waiting in the end.
+This "waiting" is measured in microseconds, but still, summing it all, it's a lot of waiting in the end.
 
-That's why it makes a lot of sense to use asynchronous ⏸🔀⏯ code for web APIs.
+That's why it makes a lot of sense to use asynchronous code for web APIs.
 
 Most of the existing popular Python frameworks (including Flask and Django) were created before the new asynchronous features in Python existed. So, the ways they can be deployed support parallel execution and an older form of asynchronous execution that is not as powerful as the new capabilities.
 
@@ -232,13 +230,13 @@ So, to balance that out, imagine the following short story:
 
 ---
 
-There's no waiting 🕙 anywhere, just a lot of work to be done, on multiple places of the house.
+There's no waiting anywhere, just a lot of work to be done, on multiple places of the house.
 
-You could have turns as in the burgers example, first the living room, then the kitchen, but as you are not waiting 🕙 for anything, just cleaning and cleaning, the turns wouldn't affect anything.
+You could have turns as in the burgers example, first the living room, then the kitchen, but as you are not waiting for anything, just cleaning and cleaning, the turns wouldn't affect anything.
 
 It would take the same amount of time to finish with or without turns (concurrency) and you would have done the same amount of work.
 
-But in this case, if you could bring the 8 ex-cashier/cooks/now-cleaners 👩‍🍳👨‍🍳👩‍🍳👨‍🍳👩‍🍳👨‍🍳👩‍🍳👨‍🍳, and each one of them (plus you) could take a zone of the house to clean it, you could do all the work in **parallel**, with the extra help, and finish much sooner.
+But in this case, if you could bring the 8 ex-cashier/cooks/now-cleaners, and each one of them (plus you) could take a zone of the house to clean it, you could do all the work in **parallel**, with the extra help, and finish much sooner.
 
 In this scenario, each one of the cleaners (including you) would be a processor, doing their part of the job.
 
@@ -275,7 +273,7 @@ When there is an operation that will require waiting before giving the results a
 burgers = await get_burgers(2)
 ```
 
-The key here is the `await`. It tells Python that it has to wait ⏸ for `get_burgers(2)` to finish doing its thing 🕙 before storing the results in `burgers`. With that, Python will know that it can go and do something else 🔀 ⏯ in the meanwhile (like receiving another request).
+The key here is the `await`. It tells Python that it has to wait for `get_burgers(2)` to finish doing its thing before storing the results in `burgers`. With that, Python will know that it can go and do something else in the meanwhile (like receiving another request).
 
 For `await` to work, it has to be inside a function that supports this asynchronicity. To do that, you just declare it with `async def`:
 
@@ -294,7 +292,7 @@ def get_sequential_burgers(number: int):
     return burgers
 ```
 
-With `async def`, Python knows that, inside that function, it has to be aware of `await` expressions, and that it can "pause" ⏸ the execution of that function and go do something else 🔀 before coming back.
+With `async def`, Python knows that, inside that function, it has to be aware of `await` expressions, and that it can "pause" the execution of that function and go do something else before coming back.
 
 When you want to call an `async def` function, you have to "await" it. So, this won't work:
 
@@ -342,7 +340,7 @@ In previous versions of NodeJS / Browser JavaScript, you would have used "callba
 
 ## Coroutines
 
-**Coroutine** is just the very fancy term for the thing returned by an `async def` function. Python knows that it is something like a function that it can start and that it will end at some point, but that it might be paused ⏸ internally too, whenever there is an `await` inside of it.
+**Coroutine** is just the very fancy term for the thing returned by an `async def` function. Python knows that it is something like a function that it can start and that it will end at some point, but that it might be paused internally too, whenever there is an `await` inside of it.
 
 But all this functionality of using asynchronous code with `async` and `await` is many times summarized as using "coroutines". It is comparable to the main key feature of Go, the "Goroutines".
 

--- a/docs/es/docs/async.md
+++ b/docs/es/docs/async.md
@@ -63,13 +63,13 @@ Veamos esa frase por partes en las secciones siguientes:
 
 ## Código Asíncrono
 
-El código asíncrono sólo significa que el lenguaje 💬 tiene una manera de decirle al sistema / programa 🤖 que, en algún momento del código, 🤖 tendrá que esperar a que *algo más* termine en otro sitio. Digamos que ese *algo más* se llama, por ejemplo, "archivo lento" 📝.
+El código asíncrono sólo significa que el lenguaje tiene una manera de decirle al sistema / programa que, en algún momento del código, tendrá que esperar a que *algo más* termine en otro sitio. Digamos que ese *algo más* se llama, por ejemplo, "archivo lento".
 
-Durante ese tiempo, el sistema puede hacer otras cosas, mientras "archivo lento" 📝 termina.
+Durante ese tiempo, el sistema puede hacer otras cosas, mientras "archivo lento" termina.
 
-Entonces el sistema / programa 🤖 volverá cada vez que pueda, sea porque está esperando otra vez, porque 🤖 ha terminado todo el trabajo que tenía en ese momento. Y 🤖 verá si alguna de las tareas por las que estaba esperando ha terminado, haciendo lo que tenía que hacer.
+Entonces el sistema / programa volverá cada vez que pueda, sea porque está esperando otra vez, porque ha terminado todo el trabajo que tenía en ese momento. Y verá si alguna de las tareas por las que estaba esperando ha terminado, haciendo lo que tenía que hacer.
 
-Luego, 🤖 cogerá la primera tarea finalizada (digamos, nuestro "archivo lento" 📝) y continuará con lo que tenía que hacer con esa tarea.
+Luego, cogerá la primera tarea finalizada (digamos, nuestro "archivo lento") y continuará con lo que tenía que hacer con esa tarea.
 
 Esa "espera de otra cosa" normalmente se refiere a operaciones <abbr title = "Input and Output, en español: Entrada y Salida.">I/O</abbr> que son relativamente "lentas" (en relación a la velocidad del procesador y memoria RAM), como por ejemplo esperar por:
 
@@ -102,109 +102,109 @@ Para entender las diferencias, imagina la siguiente historia sobre hamburguesas:
 
 ### Hamburguesas Concurrentes
 
-Vas con la persona que te gusta 😍 a pedir comida rápida 🍔, haces cola mientras el cajero 💁 recoge los pedidos de las personas de delante tuyo.
+Vas con la persona que te gusta a pedir comida rápida, haces cola mientras el cajero recoge los pedidos de las personas de delante tuyo.
 
-Llega tu turno, haces tu pedido de 2 hamburguesas impresionantes para esa persona 😍 y para ti.
+Llega tu turno, haces tu pedido de 2 hamburguesas impresionantes para esa persona y para ti.
 
-Pagas 💸.
+Pagas.
 
-El cajero 💁 le dice algo al chico de la cocina 👨‍🍳 para que sepa que tiene que preparar tus hamburguesas 🍔 (a pesar de que actualmente está preparando las de los clientes anteriores).
+El cajero le dice algo al chico de la cocina para que sepa que tiene que preparar tus hamburguesas (a pesar de que actualmente está preparando las de los clientes anteriores).
 
-El cajero 💁 te da el número de tu turno.
+El cajero te da el número de tu turno.
 
-Mientras esperas, vas con esa persona 😍 y eliges una mesa, se sientan y hablan durante un rato largo (ya que las hamburguesas son muy impresionantes y necesitan un rato para prepararse ✨🍔✨).
+Mientras esperas, vas con esa persona y eliges una mesa, se sientan y hablan durante un rato largo (ya que las hamburguesas son muy impresionantes y necesitan un rato para prepararse).
 
-Mientras te sientas en la mesa con esa persona 😍, esperando las hamburguesas 🍔, puedes disfrutar ese tiempo admirando lo increíble, inteligente, y bien que se ve ✨😍✨.
+Mientras te sientas en la mesa con esa persona, esperando las hamburguesas, puedes disfrutar ese tiempo admirando lo increíble, inteligente, y bien que se ve.
 
-Mientras esperas y hablas con esa persona 😍, de vez en cuando, verificas el número del mostrador para ver si ya es tu turno.
+Mientras esperas y hablas con esa persona, de vez en cuando, verificas el número del mostrador para ver si ya es tu turno.
 
-Al final, en algún momento, llega tu turno. Vas al mostrador, coges tus hamburguesas 🍔 y vuelves a la mesa.
+Al final, en algún momento, llega tu turno. Vas al mostrador, coges tus hamburguesas y vuelves a la mesa.
 
-Tú y esa persona 😍 se comen las hamburguesas 🍔 y la pasan genial ✨.
+Tú y esa persona se comen las hamburguesas y la pasan genial.
 
 ---
 
-Imagina que eres el sistema / programa 🤖 en esa historia.
+Imagina que eres el sistema / programa en esa historia.
 
-Mientras estás en la cola, estás quieto 😴, esperando tu turno, sin hacer nada muy "productivo". Pero la línea va rápida porque el cajero 💁 solo recibe los pedidos (no los prepara), así que está bien.
+Mientras estás en la cola, estás quieto, esperando tu turno, sin hacer nada muy "productivo". Pero la línea va rápida porque el cajero solo recibe los pedidos (no los prepara), así que está bien.
 
-Luego, cuando llega tu turno, haces un trabajo "productivo" real 🤓, procesas el menú, decides lo que quieres, lo que quiere esa persona 😍, pagas 💸, verificas que das el billete o tarjeta correctos, verificas que te cobren correctamente, que el pedido tiene los artículos correctos, etc.
+Luego, cuando llega tu turno, haces un trabajo "productivo" real, procesas el menú, decides lo que quieres, lo que quiere esa persona, pagas 💸, verificas que das el billete o tarjeta correctos, verificas que te cobren correctamente, que el pedido tiene los artículos correctos, etc.
 
-Pero entonces, aunque aún no tienes tus hamburguesas 🍔, el trabajo hecho con el cajero 💁 está "en pausa" ⏸, porque debes esperar 🕙 a que tus hamburguesas estén listas.
+Pero entonces, aunque aún no tienes tus hamburguesas, el trabajo hecho con el cajero está "en pausa", porque debes esperar a que tus hamburguesas estén listas.
 
-Pero como te alejas del mostrador y te sientas en la mesa con un número para tu turno, puedes cambiar tu atención 🔀 a esa persona 😍 y "trabajar" ⏯ 🤓 en eso. Entonces nuevamente estás haciendo algo muy "productivo" 🤓, como coquetear con esa persona 😍.
+Pero como te alejas del mostrador y te sientas en la mesa con un número para tu turno, puedes cambiar tu atención a esa persona y "trabajar" en eso. Entonces nuevamente estás haciendo algo muy "productivo", como coquetear con esa persona.
 
-Después, el 💁 cajero dice "he terminado de hacer las hamburguesas" 🍔 poniendo tu número en la pantalla del mostrador, pero no saltas al momento que el número que se muestra es el tuyo. Sabes que nadie robará tus hamburguesas 🍔 porque tienes el número de tu turno y ellos tienen el suyo.
+Después, el cajero dice "he terminado de hacer las hamburguesas" poniendo tu número en la pantalla del mostrador, pero no saltas al momento que el número que se muestra es el tuyo. Sabes que nadie robará tus hamburguesas porque tienes el número de tu turno y ellos tienen el suyo.
 
-Así que esperas a que esa persona 😍 termine la historia (terminas el trabajo actual ⏯ / tarea actual que se está procesando 🤓), sonríes gentilmente y le dices que vas por las hamburguesas ⏸.
+Así que esperas a que esa persona termine la historia (terminas el trabajo actual / tarea actual que se está procesando), sonríes gentilmente y le dices que vas por las hamburguesas.
 
-Luego vas al mostrador 🔀, a la tarea inicial que ya está terminada ⏯, recoges las hamburguesas 🍔, les dices gracias y las llevas a la mesa. Eso termina esa fase / tarea de interacción con el mostrador ⏹. Eso a su vez, crea una nueva tarea, "comer hamburguesas" 🔀 ⏯, pero la anterior de "conseguir hamburguesas" está terminada ⏹.
+Luego vas al mostrador, a la tarea inicial que ya está terminada, recoges las hamburguesas, les dices gracias y las llevas a la mesa. Eso termina esa fase / tarea de interacción con el mostrador. Eso a su vez, crea una nueva tarea, "comer hamburguesas", pero la anterior de "conseguir hamburguesas" está terminada.
 
 ### Hamburguesas Paralelas
 
 Ahora imagina que estas no son "Hamburguesas Concurrentes" sino "Hamburguesas Paralelas".
 
-Vas con la persona que te gusta 😍 por comida rápida paralela 🍔.
+Vas con la persona que te gusta por comida rápida paralela.
 
-Haces la cola mientras varios cajeros (digamos 8) que a la vez son cocineros 👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳 toman los pedidos de las personas que están delante de ti.
+Haces la cola mientras varios cajeros (digamos 8) que a la vez son cocineros toman los pedidos de las personas que están delante de ti.
 
-Todos los que están antes de ti están esperando 🕙 que sus hamburguesas 🍔 estén listas antes de dejar el mostrador porque cada uno de los 8 cajeros prepara la hamburguesa de inmediato antes de recibir el siguiente pedido.
+Todos los que están antes de ti están esperando que sus hamburguesas estén listas antes de dejar el mostrador porque cada uno de los 8 cajeros prepara la hamburguesa de inmediato antes de recibir el siguiente pedido.
 
-Entonces finalmente es tu turno, haces tu pedido de 2 hamburguesas 🍔 impresionantes para esa persona 😍 y para ti.
+Entonces finalmente es tu turno, haces tu pedido de 2 hamburguesas impresionantes para esa persona y para ti.
 
-Pagas 💸.
+Pagas.
 
-El cajero va a la cocina 👨‍🍳.
+El cajero va a la cocina.
 
-Esperas, de pie frente al mostrador 🕙, para que nadie más recoja tus hamburguesas 🍔, ya que no hay números para los turnos.
+Esperas, de pie frente al mostrador, para que nadie más recoja tus hamburguesas, ya que no hay números para los turnos.
 
-Como tu y esa persona 😍 están ocupados en impedir que alguien se ponga delante y recoja tus hamburguesas apenas llegan 🕙, tampoco puedes prestarle atención a esa persona 😞.
+Como tu y esa persona están ocupados en impedir que alguien se ponga delante y recoja tus hamburguesas apenas llegan, tampoco puedes prestarle atención a esa persona.
 
-Este es un trabajo "síncrono", estás "sincronizado" con el cajero / cocinero 👨‍🍳. Tienes que esperar y estar allí en el momento exacto en que el cajero / cocinero 👨‍🍳 termina las hamburguesas 🍔 y te las da, o de lo contrario, alguien más podría cogerlas.
+Este es un trabajo "síncrono", estás "sincronizado" con el cajero / cocinero. Tienes que esperar y estar allí en el momento exacto en que el cajero / cocinero termina las hamburguesas y te las da, o de lo contrario, alguien más podría cogerlas.
 
-Luego, el cajero / cocinero 👨‍🍳 finalmente regresa con tus hamburguesas 🍔, después de mucho tiempo esperando 🕙 frente al mostrador.
+Luego, el cajero / cocinero finalmente regresa con tus hamburguesas, después de mucho tiempo esperando frente al mostrador.
 
-Cojes tus hamburguesas 🍔 y vas a la mesa con esa persona 😍.
+Cojes tus hamburguesas y vas a la mesa con esa persona.
 
-Sólo las comes y listo 🍔 ⏹.
+Sólo las comes y listo.
 
-No has hablado ni coqueteado mucho, ya que has pasado la mayor parte del tiempo esperando 🕙 frente al mostrador 😞.
-
----
-
-En este escenario de las hamburguesas paralelas, tú eres un sistema / programa 🤖 con dos procesadores (tú y la persona que te gusta 😍), ambos esperando 🕙 y dedicando su atención ⏯ a estar "esperando en el mostrador" 🕙 durante mucho tiempo.
-
-La tienda de comida rápida tiene 8 procesadores (cajeros / cocineros) 👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳. Mientras que la tienda de hamburguesas concurrentes podría haber tenido solo 2 (un cajero y un cocinero) 💁 👨‍🍳.
-
-Pero aún así, la experiencia final no es la mejor 😞.
+No has hablado ni coqueteado mucho, ya que has pasado la mayor parte del tiempo esperando frente al mostrador.
 
 ---
 
-Esta sería la historia paralela equivalente de las hamburguesas 🍔.
+En este escenario de las hamburguesas paralelas, tú eres un sistema / programa con dos procesadores (tú y la persona que te gusta), ambos esperando y dedicando su atención a estar "esperando en el mostrador" durante mucho tiempo.
+
+La tienda de comida rápida tiene 8 procesadores (cajeros / cocineros). Mientras que la tienda de hamburguesas concurrentes podría haber tenido solo 2 (un cajero y un cocinero).
+
+Pero aún así, la experiencia final no es la mejor.
+
+---
+
+Esta sería la historia paralela equivalente de las hamburguesas.
 
 Para un ejemplo más "real" de ésto, imagina un banco.
 
-Hasta hace poco, la mayoría de los bancos tenían varios cajeros 👨‍💼👨‍💼👨‍💼👨‍💼 y una gran línea 🕙🕙🕙🕙🕙🕙🕙🕙.
+Hasta hace poco, la mayoría de los bancos tenían varios cajeros y una gran línea.
 
-Todos los cajeros haciendo todo el trabajo con un cliente tras otro 👨‍💼⏯.
+Todos los cajeros haciendo todo el trabajo con un cliente tras otro.
 
-Y tienes que esperar 🕙 en la fila durante mucho tiempo o perderás tu turno.
+Y tienes que esperar en la fila durante mucho tiempo o perderás tu turno.
 
-Probablemente no querrás llevar contigo a la persona que te gusta 😍 a hacer encargos al banco 🏦.
+Probablemente no querrás llevar contigo a la persona que te gusta a hacer encargos al banco.
 
 ### Conclusión de las Hamburguesa
 
-En este escenario de "hamburguesas de comida rápida con tu pareja", debido a que hay mucha espera 🕙, tiene mucho más sentido tener un sistema con concurrencia ⏸🔀⏯.
+En este escenario de "hamburguesas de comida rápida con tu pareja", debido a que hay mucha espera, tiene mucho más sentido tener un sistema con concurrencia.
 
 Este es el caso de la mayoría de las aplicaciones web.
 
-Muchos, muchos usuarios, pero el servidor está esperando 🕙 el envío de las peticiones ya que su conexión no es buena.
+Muchos, muchos usuarios, pero el servidor está esperando el envío de las peticiones ya que su conexión no es buena.
 
-Y luego esperando 🕙 nuevamente a que las respuestas retornen.
+Y luego esperando nuevamente a que las respuestas retornen.
 
-Esta "espera" 🕙 se mide en microsegundos, pero aun así, sumando todo, al final es mucha espera.
+Esta "espera" se mide en microsegundos, pero aun así, sumando todo, al final es mucha espera.
 
-Es por eso que tiene mucho sentido usar código asíncrono ⏸🔀⏯ para las API web.
+Es por eso que tiene mucho sentido usar código asíncrono para las API web.
 
 La mayoría de los framework populares de Python existentes (incluidos Flask y Django) se crearon antes de que existieran las nuevas funciones asíncronas en Python. Por lo tanto, las formas en que pueden implementarse admiten la ejecución paralela y una forma más antigua de ejecución asíncrona que no es tan potente como la actual.
 
@@ -230,13 +230,13 @@ Entonces, para explicar eso, imagina la siguiente historia corta:
 
 ---
 
-No hay esperas 🕙, solo hay mucho trabajo por hacer, en varios lugares de la casa.
+No hay esperas, solo hay mucho trabajo por hacer, en varios lugares de la casa.
 
 Podrías tener turnos como en el ejemplo de las hamburguesas, primero la sala de estar, luego la cocina, pero como no estás esperando nada, solo limpiando y limpiando, los turnos no afectarían nada.
 
 Tomaría la misma cantidad de tiempo terminar con o sin turnos (concurrencia) y habrías hecho la misma cantidad de trabajo.
 
-Pero en este caso, si pudieras traer a los 8 ex cajeros / cocineros / ahora limpiadores 👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳, y cada uno de ellos (y tú) podría tomar una zona de la casa para limpiarla, podría hacer todo el trabajo en **paralelo**, con la ayuda adicional y terminar mucho antes.
+Pero en este caso, si pudieras traer a los 8 ex cajeros / cocineros / ahora limpiadores, y cada uno de ellos (y tú) podría tomar una zona de la casa para limpiarla, podría hacer todo el trabajo en **paralelo**, con la ayuda adicional y terminar mucho antes.
 
 En este escenario, cada uno de los limpiadores (incluido tú) sería un procesador, haciendo su parte del trabajo.
 
@@ -273,7 +273,7 @@ Cuando hay una operación que requerirá esperar antes de dar los resultados y t
 burgers = await get_burgers(2)
 ```
 
-La clave aquí es `await`. Eso le dice a Python que tiene que esperar ⏸ a que `get_burgers (2)` termine de hacer lo suyo 🕙 antes de almacenar los resultados en `hamburguesas`. Con eso, Python sabrá que puede ir y hacer otra cosa 🔀 ⏯ mientras tanto (como recibir otra solicitud).
+La clave aquí es `await`. Eso le dice a Python que tiene que esperar a que `get_burgers (2)` termine de hacer lo suyo antes de almacenar los resultados en `hamburguesas`. Con eso, Python sabrá que puede ir y hacer otra cosa mientras tanto (como recibir otra solicitud).
 
 Para que `await` funcione, tiene que estar dentro de una función que admita esta asincronía. Para hacer eso, simplemente lo declaras con `async def`:
 
@@ -292,7 +292,7 @@ def get_sequential_burgers(number: int):
     return burgers
 ```
 
-Con `async def`, Python sabe que, dentro de esa función, debe tener en cuenta las expresiones `wait` y que puede "pausar" ⏸ la ejecución de esa función e ir a hacer otra cosa 🔀 antes de regresar.
+Con `async def`, Python sabe que, dentro de esa función, debe tener en cuenta las expresiones `wait` y que puede "pausar" la ejecución de esa función e ir a hacer otra cosa antes de regresar.
 
 Cuando desees llamar a una función `async def`, debes "esperarla". Entonces, esto no funcionará:
 
@@ -340,7 +340,7 @@ En versiones anteriores de NodeJS / Browser JavaScript, habrías utilizado "call
 
 ## Coroutines
 
-**Coroutine** es un término sofisticado para referirse a la cosa devuelta por una función `async def`. Python sabe que es algo así como una función que puede iniciar y que terminará en algún momento, pero que también podría pausarse ⏸ internamente, siempre que haya un `await` dentro de ella.
+**Coroutine** es un término sofisticado para referirse a la cosa devuelta por una función `async def`. Python sabe que es algo así como una función que puede iniciar y que terminará en algún momento, pero que también podría pausarse internamente, siempre que haya un `await` dentro de ella.
 
 Pero toda esta funcionalidad de usar código asincrónico con `async` y `await` se resume muchas veces como usar "coroutines". Es comparable a la característica principal de Go, las "Goroutines".
 
@@ -350,7 +350,7 @@ Veamos la misma frase de arriba:
 
 > Las versiones modernas de Python tienen soporte para **"código asíncrono"** usando algo llamado **"coroutines"**, con la sintaxis **`async` y `await`**.
 
-Eso ya debería tener más sentido ahora. ✨
+Eso ya debería tener más sentido ahora.
 
 Todo eso es lo que impulsa FastAPI (a través de Starlette) y lo que hace que tenga un rendimiento tan impresionante.
 

--- a/docs/fr/docs/async.md
+++ b/docs/fr/docs/async.md
@@ -62,13 +62,13 @@ Analysons les différentes parties de cette phrase dans les sections suivantes :
 
 ## Code asynchrone
 
-Faire du code asynchrone signifie que le langage 💬 est capable de dire à l'ordinateur / au programme 🤖 qu'à un moment du code, il 🤖 devra attendre que *quelque chose d'autre* se termine autre part. Disons que ce *quelque chose d'autre* est appelé "fichier-lent" 📝.
+Faire du code asynchrone signifie que le langage est capable de dire à l'ordinateur / au programme qu'à un moment du code, il devra attendre que *quelque chose d'autre* se termine autre part. Disons que ce *quelque chose d'autre* est appelé "fichier-lent".
 
-Donc, pendant ce temps, l'ordinateur pourra effectuer d'autres tâches, pendant que "fichier-lent" 📝 se termine.
+Donc, pendant ce temps, l'ordinateur pourra effectuer d'autres tâches, pendant que "fichier-lent" se termine.
 
-Ensuite l'ordinateur / le programme 🤖 reviendra à chaque fois qu'il en a la chance que ce soit parce qu'il attend à nouveau, ou car il 🤖 a fini tout le travail qu'il avait à faire. Il 🤖 regardera donc si les tâches qu'il attend ont terminé d'être effectuées.
+Ensuite l'ordinateur / le programme reviendra à chaque fois qu'il en a la chance que ce soit parce qu'il attend à nouveau, ou car il a fini tout le travail qu'il avait à faire. Il regardera donc si les tâches qu'il attend ont terminé d'être effectuées.
 
-Ensuite, il 🤖 prendra la première tâche à finir (disons, notre "fichier-lent" 📝) et continuera à faire avec cette dernière ce qu'il était censé.
+Ensuite, il prendra la première tâche à finir (disons, notre "fichier-lent") et continuera à faire avec cette dernière ce qu'il était censé.
 
 Ce "attendre quelque chose d'autre" fait généralement référence à des opérations <abbr title="Input/Output ou Entrées et Sorties ">I/O</abbr> qui sont relativement "lentes" (comparées à la vitesse du processeur et de la mémoire RAM) telles qu'attendre que :
 
@@ -101,109 +101,109 @@ Pour expliquer la différence, voici une histoire de burgers :
 
 #### Burgers concurrents
 
-Vous amenez votre crush 😍 dans votre fast food 🍔 favori, et faites la queue pendant que le serveur 💁 prend les commandes des personnes devant vous.
+Vous amenez votre crush dans votre fast food favori, et faites la queue pendant que le serveur prend les commandes des personnes devant vous.
 
-Puis vient votre tour, vous commandez alors 2 magnifiques burgers 🍔 pour votre crush 😍 et vous.
+Puis vient votre tour, vous commandez alors 2 magnifiques burgers pour votre crush et vous.
 
-Vous payez 💸.
+Vous payez.
 
-Le serveur 💁 dit quelque chose à son collègue dans la cuisine 👨‍🍳 pour qu'il sache qu'il doit préparer vos burgers 🍔 (bien qu'il soit déjà en train de préparer ceux des clients précédents).
+Le serveur dit quelque chose à son collègue dans la cuisine pour qu'il sache qu'il doit préparer vos burgers (bien qu'il soit déjà en train de préparer ceux des clients précédents).
 
-Le serveur 💁 vous donne le numéro assigné à votre commande.
+Le serveur vous donne le numéro assigné à votre commande.
 
-Pendant que vous attendez, vous allez choisir une table avec votre crush 😍, vous discutez avec votre crush 😍 pendant un long moment (les burgers étant "magnifiques" ils sont très longs à préparer ✨🍔✨).
+Pendant que vous attendez, vous allez choisir une table avec votre crush, vous discutez avec votre crush pendant un long moment (les burgers étant "magnifiques" ils sont très longs à préparer).
 
-Pendant que vous êtes assis à table, en attendant que les burgers 🍔 soient prêts, vous pouvez passer ce temps à admirer à quel point votre crush 😍 est géniale, mignonne et intelligente ✨😍✨.
+Pendant que vous êtes assis à table, en attendant que les burgers soient prêts, vous pouvez passer ce temps à admirer à quel point votre crush est géniale, mignonne et intelligente.
 
-Pendant que vous discutez avec votre crush 😍, de temps en temps vous jetez un coup d'oeil au nombre affiché au-dessus du comptoir pour savoir si c'est à votre tour d'être servis.
+Pendant que vous discutez avec votre crush, de temps en temps vous jetez un coup d'oeil au nombre affiché au-dessus du comptoir pour savoir si c'est à votre tour d'être servis.
 
-Jusqu'au moment où c'est (enfin) votre tour. Vous allez au comptoir, récupérez vos burgers 🍔 et revenez à votre table.
+Jusqu'au moment où c'est (enfin) votre tour. Vous allez au comptoir, récupérez vos burgers et revenez à votre table.
 
-Vous et votre crush 😍 mangez les burgers 🍔 et passez un bon moment ✨.
+Vous et votre crush mangez les burgers et passez un bon moment.
 
 ---
 
-Imaginez que vous êtes l'ordinateur / le programme 🤖 dans cette histoire.
+Imaginez que vous êtes l'ordinateur / le programme dans cette histoire.
 
-Pendant que vous faites la queue, vous être simplement inactif 😴, attendant votre tour, ne faisant rien de "productif". Mais la queue est rapide car le serveur 💁 prend seulement les commandes (et ne les prépare pas), donc tout va bien.
+Pendant que vous faites la queue, vous être simplement inactif, attendant votre tour, ne faisant rien de "productif". Mais la queue est rapide car le serveur prend seulement les commandes (et ne les prépare pas), donc tout va bien.
 
-Ensuite, quand c'est votre tour, vous faites des actions "productives" 🤓, vous étudiez le menu, décidez ce que vous voulez, demandez à votre crush 😍 son choix, payez 💸, vérifiez que vous utilisez la bonne carte de crédit, vérifiez que le montant débité sur la carte est correct, vérifiez que la commande contient les bons produits, etc.
+Ensuite, quand c'est votre tour, vous faites des actions "productives", vous étudiez le menu, décidez ce que vous voulez, demandez à votre crush son choix, payez, vérifiez que vous utilisez la bonne carte de crédit, vérifiez que le montant débité sur la carte est correct, vérifiez que la commande contient les bons produits, etc.
 
-Mais ensuite, même si vous n'avez pas encore vos burgers 🍔, votre travail avec le serveur 💁 est "en pause" ⏸, car vous devez attendre 🕙 que vos burgers soient prêts.
+Mais ensuite, même si vous n'avez pas encore vos burgers, votre travail avec le serveur est "en pause", car vous devez attendre que vos burgers soient prêts.
 
-Après vous être écarté du comptoir et vous être assis à votre table avec le numéro de votre commande, vous pouvez tourner 🔀 votre attention vers votre crush 😍, et "travailler" ⏯ 🤓 là-dessus. Vous êtes donc à nouveau en train de faire quelque chose de "productif" 🤓, vous flirtez avec votre crush 😍.
+Après vous être écarté du comptoir et vous être assis à votre table avec le numéro de votre commande, vous pouvez tourner votre attention vers votre crush, et "travailler" là-dessus. Vous êtes donc à nouveau en train de faire quelque chose de "productif", vous flirtez avec votre crush.
 
-Puis le serveur 💁 dit "J'ai fini de préparer les burgers" 🍔 en mettant votre numéro sur l'affichage du comptoir, mais vous ne courrez pas immédiatement au moment où votre numéro s'affiche. Vous savez que personne ne volera vos burgers 🍔 car vous avez votre numéro et les autres clients ont le leur.
+Puis le serveur dit "J'ai fini de préparer les burgers" en mettant votre numéro sur l'affichage du comptoir, mais vous ne courrez pas immédiatement au moment où votre numéro s'affiche. Vous savez que personne ne volera vos burgers car vous avez votre numéro et les autres clients ont le leur.
 
-Vous attendez donc que votre crush 😍 finisse son histoire, souriez gentiment et dites que vous allez chercher les burgers ⏸.
+Vous attendez donc que votre crush finisse son histoire, souriez gentiment et dites que vous allez chercher les burgers.
 
-Pour finir vous allez au comptoir 🔀, vers la tâche initiale qui est désormais terminée ⏯, récupérez les burgers 🍔, remerciez le serveur et ramenez les burgers 🍔 à votre table. Ceci termine l'étape / la tâche d'interaction avec le comptoir ⏹. Ce qui ensuite, crée une nouvelle tâche de "manger les burgers"  🔀 ⏯, mais la précédente, "récupérer les burgers" est terminée ⏹.
+Pour finir vous allez au comptoir, vers la tâche initiale qui est désormais terminée, récupérez les burgers, remerciez le serveur et ramenez les burgers à votre table. Ceci termine l'étape / la tâche d'interaction avec le comptoir. Ce qui ensuite, crée une nouvelle tâche de "manger les burgers" , mais la précédente, "récupérer les burgers" est terminée.
 
 #### Burgers parallèles
 
 Imaginons désormais que ce ne sont pas des "burgers concurrents" mais des "burgers parallèles".
 
-Vous allez avec votre crush 😍 dans un fast food 🍔 parallélisé.
+Vous allez avec votre crush dans un fast food parallélisé.
 
-Vous attendez pendant que plusieurs (disons 8) serveurs qui sont aussi des cuisiniers 👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳 prennent les commandes des personnes devant vous.
+Vous attendez pendant que plusieurs (disons 8) serveurs qui sont aussi des cuisiniers prennent les commandes des personnes devant vous.
 
-Chaque personne devant vous attend 🕙 que son burger 🍔 soit prêt avant de quitter le comptoir car chacun des 8 serveurs va lui-même préparer le burger directement avant de prendre la commande suivante.
+Chaque personne devant vous attend que son burger soit prêt avant de quitter le comptoir car chacun des 8 serveurs va lui-même préparer le burger directement avant de prendre la commande suivante.
 
-Puis c'est enfin votre tour, vous commandez 2 magnifiques burgers 🍔 pour vous et votre crush 😍.
+Puis c'est enfin votre tour, vous commandez 2 magnifiques burgers pour vous et votre crush.
 
-Vous payez 💸.
+Vous payez.
 
-Le serveur va dans la cuisine 👨‍🍳.
+Le serveur va dans la cuisine.
 
-Vous attendez devant le comptoir afin que personne ne prenne vos burgers 🍔 avant vous, vu qu'il n'y a pas de numéro de commande.
+Vous attendez devant le comptoir afin que personne ne prenne vos burgers avant vous, vu qu'il n'y a pas de numéro de commande.
 
-Vous et votre crush 😍 étant occupés à vérifier que personne ne passe devant vous prendre vos burgers au moment où ils arriveront 🕙, vous ne pouvez pas vous préoccuper de votre crush 😞.
+Vous et votre crush étant occupés à vérifier que personne ne passe devant vous prendre vos burgers au moment où ils arriveront, vous ne pouvez pas vous préoccuper de votre crush.
 
-C'est du travail "synchrone", vous être "synchronisés" avec le serveur/cuisinier 👨‍🍳. Vous devez attendre 🕙 et être présent au moment exact où le serveur/cuisinier 👨‍🍳 finira les burgers 🍔 et vous les donnera, sinon quelqu'un risque de vous les prendre.
+C'est du travail "synchrone", vous être "synchronisés" avec le serveur/cuisinier. Vous devez attendre et être présent au moment exact où le serveur/cuisinier finira les burgers et vous les donnera, sinon quelqu'un risque de vous les prendre.
 
-Puis le serveur/cuisinier 👨‍🍳 revient enfin avec vos burgers 🍔, après un long moment d'attente 🕙 devant le comptoir.
+Puis le serveur/cuisinier revient enfin avec vos burgers, après un long moment d'attente devant le comptoir.
 
-Vous prenez vos burgers 🍔 et allez à une table avec votre crush 😍
+Vous prenez vos burgers et allez à une table avec votre crush
 
-Vous les mangez, et vous avez terminé 🍔 ⏹.
+Vous les mangez, et vous avez terminé.
 
-Durant tout ce processus, il n'y a presque pas eu de discussions ou de flirts car la plupart de votre temps à été passé à attendre 🕙 devant le comptoir 😞.
-
----
-
-Dans ce scénario de burgers parallèles, vous êtes un ordinateur / programme 🤖 avec deux processeurs (vous et votre crush 😍) attendant 🕙 à deux et dédiant votre attention 🕙 à "attendre devant le comptoir" pour une longue durée.
-
-Le fast-food a 8 processeurs (serveurs/cuisiniers) 👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳. Alors que le fast-food de burgers concurrents en avait 2 (un serveur et un cuisinier).
-
-Et pourtant l'expérience finale n'est pas meilleure 😞.
+Durant tout ce processus, il n'y a presque pas eu de discussions ou de flirts car la plupart de votre temps à été passé à attendre devant le comptoir.
 
 ---
 
-C'est donc l'histoire équivalente parallèle pour les burgers 🍔.
+Dans ce scénario de burgers parallèles, vous êtes un ordinateur / programme avec deux processeurs (vous et votre crush) attendant à deux et dédiant votre attention à "attendre devant le comptoir" pour une longue durée.
+
+Le fast-food a 8 processeurs (serveurs/cuisiniers). Alors que le fast-food de burgers concurrents en avait 2 (un serveur et un cuisinier).
+
+Et pourtant l'expérience finale n'est pas meilleure.
+
+---
+
+C'est donc l'histoire équivalente parallèle pour les burgers.
 
 Pour un exemple plus courant dans la "vie réelle", imaginez une banque.
 
-Jusqu'à récemment, la plupart des banques avaient plusieurs caisses (et banquiers) 👨‍💼👨‍💼👨‍💼👨‍💼 et une unique file d'attente 🕙🕙🕙🕙🕙🕙🕙🕙.
+Jusqu'à récemment, la plupart des banques avaient plusieurs caisses (et banquiers) et une unique file d'attente.
 
-Tous les banquiers faisaient l'intégralité du travail avec chaque client avant de passer au suivant 👨‍💼⏯.
+Tous les banquiers faisaient l'intégralité du travail avec chaque client avant de passer au suivant.
 
-Et vous deviez attendre 🕙 dans la file pendant un long moment ou vous perdiez votre place.
+Et vous deviez attendre dans la file pendant un long moment ou vous perdiez votre place.
 
-Vous n'auriez donc probablement pas envie d'amener votre crush 😍 avec vous à la banque 🏦.
+Vous n'auriez donc probablement pas envie d'amener votre crush avec vous à la banque.
 
 #### Conclusion
 
-Dans ce scénario des "burgers du fast-food avec votre crush", comme il y a beaucoup d'attente 🕙, il est très logique d'avoir un système concurrent ⏸🔀⏯.
+Dans ce scénario des "burgers du fast-food avec votre crush", comme il y a beaucoup d'attente, il est très logique d'avoir un système concurrent.
 
 Et c'est le cas pour la plupart des applications web.
 
-Vous aurez de nombreux, nombreux utilisateurs, mais votre serveur attendra 🕙 que leur connexion peu performante envoie des requêtes.
+Vous aurez de nombreux, nombreux utilisateurs, mais votre serveur attendra que leur connexion peu performante envoie des requêtes.
 
-Puis vous attendrez 🕙 de nouveau que leurs réponses reviennent.
+Puis vous attendrez de nouveau que leurs réponses reviennent.
 
-Cette "attente" 🕙 se mesure en microsecondes, mais tout de même, en cumulé cela fait beaucoup d'attente.
+Cette "attente" se mesure en microsecondes, mais tout de même, en cumulé cela fait beaucoup d'attente.
 
-C'est pourquoi il est logique d'utiliser du code asynchrone ⏸🔀⏯ pour des APIs web.
+C'est pourquoi il est logique d'utiliser du code asynchrone pour des APIs web.
 
 La plupart des frameworks Python existants (y compris Flask et Django) ont été créés avant que les nouvelles fonctionnalités asynchrones de Python n'existent. Donc, les façons dont ils peuvent être déployés supportent l'exécution parallèle  et une ancienne forme d'exécution asynchrone qui n'est pas aussi puissante que les nouvelles fonctionnalités de Python.
 
@@ -229,13 +229,13 @@ Donc pour équilibrer tout ça, imaginez l'histoire suivante :
 
 ---
 
-Il n'y a plus d'attente 🕙 nulle part, juste beaucoup de travail à effectuer, dans différentes pièces de la maison.
+Il n'y a plus d'attente nulle part, juste beaucoup de travail à effectuer, dans différentes pièces de la maison.
 
-Vous pourriez diviser en différentes sections comme avec les burgers, d'abord le salon, puis la cuisine, etc. Mais vous n'attendez 🕙 rien, vous ne faites que nettoyer et nettoyer, la séparation en sections ne changerait rien au final.
+Vous pourriez diviser en différentes sections comme avec les burgers, d'abord le salon, puis la cuisine, etc. Mais vous n'attendez rien, vous ne faites que nettoyer et nettoyer, la séparation en sections ne changerait rien au final.
 
 Cela prendrait autant de temps pour finir avec ou sans sections (concurrence) et vous auriez effectué la même quantité de travail.
 
-Mais dans ce cas, si pouviez amener 8 ex-serveurs/cuisiniers/devenus-nettoyeurs 👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳👨‍🍳, et que chacun d'eux (plus vous) pouvait prendre une zone de la maison pour la nettoyer, vous pourriez faire tout le travail en parallèle, et finir plus tôt.
+Mais dans ce cas, si pouviez amener 8 ex-serveurs/cuisiniers/devenus-nettoyeurs, et que chacun d'eux (plus vous) pouvait prendre une zone de la maison pour la nettoyer, vous pourriez faire tout le travail en parallèle, et finir plus tôt.
 
 Dans ce scénario, chacun des nettoyeurs (vous y compris) serait un processeur, faisant sa partie du travail.
 
@@ -272,7 +272,7 @@ Pour une opération qui nécessite de l'attente avant de donner un résultat et 
 burgers = await get_burgers(2)
 ```
 
-Le mot-clé important ici est `await`. Il informe Python qu'il faut attendre ⏸ que `get_burgers(2)` finisse d'effectuer ses opérations 🕙 avant de stocker les résultats dans la variable `burgers`. Grâce à cela, Python saura qu'il peut aller effectuer d'autres opérations 🔀 ⏯ pendant ce temps (comme par exemple recevoir une autre requête).
+Le mot-clé important ici est `await`. Il informe Python qu'il faut attendre que `get_burgers(2)` finisse d'effectuer ses opérations avant de stocker les résultats dans la variable `burgers`. Grâce à cela, Python saura qu'il peut aller effectuer d'autres opérations pendant ce temps (comme par exemple recevoir une autre requête).
 
 Pour que `await` fonctionne, il doit être placé dans une fonction qui supporte l'asynchronicité. Pour que ça soit le cas, il faut déclarer cette dernière avec `async def` :
 
@@ -291,7 +291,7 @@ def get_sequential_burgers(number: int):
     return burgers
 ```
 
-Avec `async def`, Python sait que dans cette fonction il doit prendre en compte les expressions `await`, et qu'il peut mettre en pause ⏸ l'exécution de la fonction pour aller faire autre chose 🔀 avant de revenir.
+Avec `async def`, Python sait que dans cette fonction il doit prendre en compte les expressions `await`, et qu'il peut mettre en pause l'exécution de la fonction pour aller faire autre chose avant de revenir.
 
 Pour appeler une fonction définie avec `async def`, vous devez utiliser `await`. Donc ceci ne marche pas : 
 
@@ -340,7 +340,7 @@ Dans les versions précédentes de Javascript NodeJS / Navigateur, vous auriez u
 
 ## Coroutines
 
-**Coroutine** est juste un terme élaboré pour désigner ce qui est retourné par une fonction définie avec `async def`. Python sait que c'est comme une fonction classique qui va démarrer à un moment et terminer à un autre, mais qu'elle peut aussi être mise en pause ⏸, du moment qu'il y a un `await` dans son contenu.
+**Coroutine** est juste un terme élaboré pour désigner ce qui est retourné par une fonction définie avec `async def`. Python sait que c'est comme une fonction classique qui va démarrer à un moment et terminer à un autre, mais qu'elle peut aussi être mise en pause, du moment qu'il y a un `await` dans son contenu.
 
 Mais toutes ces fonctionnalités d'utilisation de code asynchrone avec `async` et `await` sont souvent résumées comme l'utilisation des *coroutines*. On peut comparer cela à la principale fonctionnalité clé de Go, les "Goroutines".
 
@@ -350,7 +350,7 @@ Reprenons la phrase du début de la page :
 
 > Les versions modernes de Python supportent le **code asynchrone** grâce aux **"coroutines"** avec les syntaxes **`async` et `await`**.
 
-Ceci devrait être plus compréhensible désormais. ✨
+Ceci devrait être plus compréhensible désormais.
 
 Tout ceci est donc ce qui donne sa force à **FastAPI** (à travers Starlette) et lui permet d'avoir des performances aussi impressionnantes.
 

--- a/docs/pt/docs/async.md
+++ b/docs/pt/docs/async.md
@@ -63,13 +63,13 @@ Vamos ver aquela frase por partes na seção abaixo:
 
 ## Código assíncrono
 
-Código assíncrono apenas significa que a linguagem 💬 tem um jeito de dizer para o computador / programa que em certo ponto, ele terá que esperar por *algo* para finalizar em outro lugar. Vamos dizer que esse *algo* seja chamado "arquivo lento" 📝.
+Código assíncrono apenas significa que a linguagem tem um jeito de dizer para o computador / programa que em certo ponto, ele terá que esperar por *algo* para finalizar em outro lugar. Vamos dizer que esse *algo* seja chamado "arquivo lento".
 
-Então, durante esse tempo, o computador pode ir e fazer outro trabalho, enquanto o "arquivo lento" 📝 termine.
+Então, durante esse tempo, o computador pode ir e fazer outro trabalho, enquanto o "arquivo lento" termine.
 
 Então o computador / programa irá voltar toda hora que tiver uma chance porquê ele ainda está esperando o "arquivo lento", ou ele nunca irá terminar todo o trabalho que tem até esse ponto. E ele irá ver se alguma das tarefas que estava esperando já terminaram, fazendo o que quer que tinham que fazer.
 
-Depois, ele pega a primeira tarefa para finalizar (vamos dizer, nosso "arquivo lento" 📝) e continua o que ele tem que fazer com isso.
+Depois, ele pega a primeira tarefa para finalizar (vamos dizer, nosso "arquivo lento") e continua o que ele tem que fazer com isso.
 
 Esse "esperar por algo" normalmente se refere a operações <abbr title="Entrada e Saída">I/O</abbr> que são relativamente "lentas" (comparadas a velocidade do processador e da memória RAM), como esperar por:
 

--- a/docs/pt/docs/async.md
+++ b/docs/pt/docs/async.md
@@ -63,13 +63,13 @@ Vamos ver aquela frase por partes na seção abaixo:
 
 ## Código assíncrono
 
-Código assíncrono apenas significa que a linguagem 💬 tem um jeito de dizer para o computador / programa 🤖 que em certo ponto, ele 🤖 terá que esperar por *algo* para finalizar em outro lugar. Vamos dizer que esse *algo* seja chamado "arquivo lento" 📝.
+Código assíncrono apenas significa que a linguagem 💬 tem um jeito de dizer para o computador / programa que em certo ponto, ele terá que esperar por *algo* para finalizar em outro lugar. Vamos dizer que esse *algo* seja chamado "arquivo lento" 📝.
 
 Então, durante esse tempo, o computador pode ir e fazer outro trabalho, enquanto o "arquivo lento" 📝 termine.
 
-Então o computador / programa 🤖 irá voltar toda hora que tiver uma chance porquê ele ainda está esperando o "arquivo lento", ou ele 🤖 nunca irá terminar todo o trabalho que tem até esse ponto. E ele 🤖 irá ver se alguma das tarefas que estava esperando já terminaram, fazendo o que quer que tinham que fazer.
+Então o computador / programa irá voltar toda hora que tiver uma chance porquê ele ainda está esperando o "arquivo lento", ou ele nunca irá terminar todo o trabalho que tem até esse ponto. E ele irá ver se alguma das tarefas que estava esperando já terminaram, fazendo o que quer que tinham que fazer.
 
-Depois, ele 🤖 pega a primeira tarefa para finalizar (vamos dizer, nosso "arquivo lento" 📝) e continua o que ele tem que fazer com isso.
+Depois, ele pega a primeira tarefa para finalizar (vamos dizer, nosso "arquivo lento" 📝) e continua o que ele tem que fazer com isso.
 
 Esse "esperar por algo" normalmente se refere a operações <abbr title="Entrada e Saída">I/O</abbr> que são relativamente "lentas" (comparadas a velocidade do processador e da memória RAM), como esperar por:
 


### PR DESCRIPTION
This PR removes all emojis from the documentation page `async.md` to help with readability.

A while back, I opened an issue regarding the amount of emojis in `async.md` (#3273).
Since then, the overwhelming majority has expressed their support in removing emojis from the page (25+👍 vs 2👎)!

With these changes, I can read the page much more easily (more details in the issue above).

**This PR should not be considered complete yet**. The non-english versions have to be read by native speakers to make sure I didn't accidentally remove emojis which replaced verbs or nouns in a sentence.
In addition, this PR is a 100% removal of emojis - I'm sure they can be added back but in a less distracting manner (maybe only once and not after every instance of a word). I appreciate any comments regarding this.