### PR TITLE
quote pip install command for zsh compatibility

### DIFF
--- a/docs/en/docs/tutorial/index.md
+++ b/docs/en/docs/tutorial/index.md
@@ -43,7 +43,7 @@ For the tutorial, you might want to install it with all the optional dependencie
 <div class="termy">
 
 ```console
-$ pip install fastapi[all]
+$ pip install "fastapi[all]"
 
 ---> 100%
 ```


### PR DESCRIPTION
Hey there. 👋🏼 

I'm a zsh user, making my way through the tutorial. I noticed that typing `pip install fastapi[all]` doesn't work in my shell because square brackets have some special meaning in zsh.

This PR updates the tutorial to wrap the commands in quotes, which should work on all shells.

Without quotes:

```
$ pip install fastapi[all]
zsh: no matches found: fastapi[all]
```

With quotes:

```
$ pip install "fastapi[all]"
Collecting fastapi[all]
  Downloading fastapi-0.68.1-py3-none-any.whl (52 kB)
  ...
```