### PR TITLE
option to hide curl from swagger ui

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -65,6 +65,7 @@ class FastAPI(Starlette):
         callbacks: Optional[List[BaseRoute]] = None,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
+        hide_curl: bool = False,
         **extra: Any,
     ) -> None:
         self._debug: bool = debug
@@ -129,6 +130,7 @@ class FastAPI(Starlette):
             assert self.title, "A title must be provided for OpenAPI, e.g.: 'My API'"
             assert self.version, "A version must be provided for OpenAPI, e.g.: '2.1.0'"
         self.openapi_schema: Optional[Dict[str, Any]] = None
+        self.hide_curl=hide_curl
         self.setup()
 
     def openapi(self) -> Dict[str, Any]:
@@ -174,6 +176,7 @@ class FastAPI(Starlette):
                     title=self.title + " - Swagger UI",
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
+                    hide_curl=self.hide_curl
                 )
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -14,6 +14,7 @@ def get_swagger_ui_html(
     swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
     oauth2_redirect_url: Optional[str] = None,
     init_oauth: Optional[Dict[str, Any]] = None,
+    hide_curl: bool:False,
 ) -> HTMLResponse:
 
     html = f"""
@@ -30,8 +31,21 @@ def get_swagger_ui_html(
     <script src="{swagger_js_url}"></script>
     <!-- `SwaggerUIBundle` is now available on the page -->
     <script>
+    const HideCurlPlugin = () => {{
+        return {{
+            wrapComponents:  {{
+                curl: () => () => null
+            }}
+        }}
+    }}
     const ui = SwaggerUIBundle({{
         url: '{openapi_url}',
+    """
+    if hide_curl:
+        html += """
+        plugins: [
+            HideCurlPlugin
+        ],
     """
 
     if oauth2_redirect_url:


### PR DESCRIPTION
what?
The following PR adds the option to hide the curl response.

why?
For long requests, either long vectors, or just multiple entries. The curl response covers the whole page, it's unpleasant for a show case, a client testing the api, or as a developer u need to scroll.

How?
adding a wrap component as a pluging in SwaggerUIBundle

