### PR TITLE
Fix OpenAPI examples from Body

### DIFF
--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -246,6 +246,8 @@ class Body(FieldInfo):
         self.embed = embed
         self.media_type = media_type
         self.example = example
+        if self.example != Undefined:
+            extra["example"] = self.example
         self.examples = examples
         super().__init__(
             default,

--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -6,7 +6,7 @@ app = FastAPI()
 
 
 class Item(BaseModel):
-    data: str
+    data: str = Body(..., example={"data": "Data in Body example"})
 
     class Config:
         schema_extra = {"example": {"data": "Data in schema_extra"}}
@@ -278,7 +278,11 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
+                            "schema": {
+                                "allOf": [{"$ref": "#/components/schemas/Item"}],
+                                "example": {"data": "Data in Body example"},
+                                "title": "Item",
+                            },
                             "example": {"data": "Data in Body example"},
                         }
                     },
@@ -350,7 +354,11 @@ openapi_schema = {
                 "requestBody": {
                     "content": {
                         "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
+                            "schema": {
+                                "allOf": [{"$ref": "#/components/schemas/Item"}],
+                                "example": {"data": "Overriden example"},
+                                "title": "Item",
+                            },
                             "examples": {
                                 "example1": {
                                     "value": {"data": "examples example_examples 1"}
@@ -819,7 +827,13 @@ openapi_schema = {
                 "title": "Item",
                 "required": ["data"],
                 "type": "object",
-                "properties": {"data": {"title": "Data", "type": "string"}},
+                "properties": {
+                    "data": {
+                        "title": "Data",
+                        "type": "string",
+                        "example": {"data": "Data in Body example"},
+                    }
+                },
                 "example": {"data": "Data in schema_extra"},
             },
             "ValidationError": {
@@ -846,8 +860,9 @@ def test_openapi_schema():
     Test that example overrides work:
 
     * pydantic model schema_extra is included
-    * Body(example={}) overrides schema_extra in pydantic model
-    * Body(examples{}) overrides Body(example={}) and schema_extra in pydantic model
+    * Body(example={}) does not override schema_extra in pydantic model
+    * Body(examples{}) does not override Body(example={}) and schema_extra in pydantic model
+    * Endpoint examples override pydantic model examples
     """
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text


### PR DESCRIPTION
FastAPI documentation states that examples can be added to the OpenAPI docs in three different ways. Two of these ways ([schema_extra](https://fastapi.tiangolo.com/tutorial/schema-extra-example/?h=exampl#pydantic-schema_extra) and the [`example` kwarg](https://fastapi.tiangolo.com/tutorial/schema-extra-example/?h=exampl#field-additional-arguments)) are currently broken, as identified in #3359, a bug introduced by PR #1267 (support for multiple named examples in OpenAPI docs). This PR fixes this behavior by passing the `example` kwarg through to the Pydantic superclass. Note that this still allows for the possibility of overriding model examples using the [`examples` kwarg](https://fastapi.tiangolo.com/tutorial/schema-extra-example/?h=exampl#body-with-multiple-examples).