### PR TITLE
Fix mutable default argument in jsonable_encoder

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -34,9 +34,10 @@ def jsonable_encoder(
     exclude_unset: bool = False,
     exclude_defaults: bool = False,
     exclude_none: bool = False,
-    custom_encoder: Dict[Any, Callable[[Any], Any]] = {},
+    custom_encoder: Optional[Dict[Any, Callable[[Any], Any]]] = None,
     sqlalchemy_safe: bool = True,
 ) -> Any:
+    custom_encoder = custom_encoder or {}
     if include is not None and not isinstance(include, (set, dict)):
         include = set(include)
     if exclude is not None and not isinstance(exclude, (set, dict)):


### PR DESCRIPTION
I discovered a bug in the `jsonable_encoder` function. That function contains a mutable default argument "custom_encoder", which in this case is a dictionary.

I believe the implications of this are pretty obvious, but for anyone reading along that's unfamiliar with why this is problematic and would like to learn more, I refer you to https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/.

PS: I'm a huge fan of FastAPI, please keep up the good work and honored to have helped make it 1% better than it already was :)

