### PR TITLE
Fix specifying custom_encoder on a model with json_encoders modifies json_encoders

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -44,7 +44,7 @@ def jsonable_encoder(
     if isinstance(obj, BaseModel):
         encoder = getattr(obj.__config__, "json_encoders", {})
         if custom_encoder:
-            encoder.update(custom_encoder)
+            encoder.copy().update(custom_encoder)
         obj_dict = obj.dict(
             include=include,  # type: ignore # in Pydantic
             exclude=exclude,  # type: ignore # in Pydantic


### PR DESCRIPTION
Check the added test to see the issue. Basically using `custom_encoder` with a model that has `json_encoders` causes it to update the model's `json_encoders` with the `custom_encoder`, rather than making a copy.