### PR TITLE
Allow an array of schemas as a type of array items, fixing the bug mentioned in #4168

### DIFF
--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -123,7 +123,7 @@ class Schema(BaseModel):
     oneOf: Optional[List["Schema"]] = None
     anyOf: Optional[List["Schema"]] = None
     not_: Optional["Schema"] = Field(None, alias="not")
-    items: Optional["Schema"] = None
+    items: Optional[Union["Schema", List["Schema"]]] = None
     properties: Optional[Dict[str, "Schema"]] = None
     additionalProperties: Optional[Union["Schema", Reference, bool]] = None
     description: Optional[str] = None


### PR DESCRIPTION
fixes #4168: To describe tuple types, allow an array of schemas as a type of array items, according to [json schema specification](https://json-schema.org/understanding-json-schema/reference/array.html#tuple-validation).