### PR TITLE
🌐 Fix French translation for `docs/tutorial/body.md`

### DIFF
--- a/docs/fr/docs/tutorial/body.md
+++ b/docs/fr/docs/tutorial/body.md
@@ -111,7 +111,7 @@ Mais vous auriez le même support de l'éditeur avec <a href="https://www.jetbra
 <img src="/img/tutorial/body/image05.png">
 
 !!! tip "Astuce"
-    Si vous utilisez <a href="https://www.jetbrains.com/pycharm/" class="external-link" target="_blank">PyCharm</a> comme éditeur, vous pouvez utiliser le Plugin <a href="https://www.jetbrains.com/pycharm/" class="external-link" target="_blank">PyCharm</a>.
+    Si vous utilisez <a href="https://www.jetbrains.com/pycharm/" class="external-link" target="_blank">PyCharm</a> comme éditeur, vous pouvez utiliser le Plugin <a href="https://github.com/koxudaxi/pydantic-pycharm-plugin/" class="external-link" target="_blank">Pydantic PyCharm Plugin</a>.
 
     Ce qui améliore le support pour les modèles Pydantic avec :
 


### PR DESCRIPTION
As mentioned by @papysam [here](https://github.com/tiangolo/fastapi/issues/1972#issuecomment-1000831022) there was an issue with the link to [Pydantic PyCharm Plugin](https://github.com/koxudaxi/pydantic-pycharm-plugin/) in the Tutorial - Body page of the french translation.

This should fix it.