### PR TITLE
Update codecov-action to v2 (v1 being deprecated)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Test
         run: bash scripts/test.sh
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
v1 will be deprecated as of 01 February 2022 

https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1