### PR TITLE
Docs: fix incorrect example for dicts in 3.6+

### DIFF
--- a/docs/en/docs/python-types.md
+++ b/docs/en/docs/python-types.md
@@ -252,7 +252,7 @@ The second type parameter is for the values of the `dict`:
 === "Python 3.9 and above"
 
     ```Python hl_lines="1"
-    {!> ../../../docs_src/python_types/tutorial008.py!}
+    {!> ../../../docs_src/python_types/tutorial008_py39.py!}
     ```
 
 This means:

--- a/docs_src/python_types/tutorial008_py39.py
+++ b/docs_src/python_types/tutorial008_py39.py
@@ -1,7 +1,4 @@
-from typing import Dict
-
-
-def process_items(prices: Dict[str, float]):
+def process_items(prices: dict[str, float]):
     for item_name, item_price in prices.items():
         print(item_name)
         print(item_price)


### PR DESCRIPTION
As part of the new python 3.9+ examples (commit d08a062ee2121f446537f06c8425cdeb1209e4ea) there's been a small error in the example for dicts. Instead of adding a new example, the old code was replaced and linked to be used for both 3.6+ and 3.9+.

This merely restores the old example for 3.6 and moves the new example to a new file with the "_py39" suffix (so it's in line with the other similar examples) and fixes the link in the markdown.