### PR TITLE
fix definition param name for step installs material

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: python3.7 -m flit install --deps production --extras doc
       - name: Install Material for MkDocs Insiders
-        if: github.event.pull_request.head.repo.fork == false && steps.cache.outputs.cache-hit != 'true'
+        if: github.event.repository.fork == false && steps.cache.outputs.cache-hit != 'true'
         run: pip install git+https://${{ secrets.ACTIONS_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
       - name: Build Docs
         run: python3.7 ./scripts/docs.py build-all


### PR DESCRIPTION
Step: "Install Material for MkDocs Insiders"
Definition: `github.event.pull_request.head.repo.fork == false && steps.cache.outputs.cache-hit != 'true'`

At step "Dump GitHub context" there is no such field -- `github.event.pull_request.head.repo.fork`, but there is the field `github.event.repository.fork`