### PR TITLE
Fix sql_app_py39 and py310 tests

### DIFF
--- a/docs_src/sql_databases/sql_app_py310/tests/test_sql_app.py
+++ b/docs_src/sql_databases/sql_app_py310/tests/test_sql_app.py
@@ -32,16 +32,16 @@ client = TestClient(app)
 def test_create_user():
     response = client.post(
         "/users/",
-        json={"email": "deadpool@example.com", "password": "chimichangas4life"},
+        json={"email": "deadpool310@example.com", "password": "chimichangas4life"},
     )
     assert response.status_code == 200, response.text
     data = response.json()
-    assert data["email"] == "deadpool@example.com"
+    assert data["email"] == "deadpool310@example.com"
     assert "id" in data
     user_id = data["id"]
 
     response = client.get(f"/users/{user_id}")
     assert response.status_code == 200, response.text
     data = response.json()
-    assert data["email"] == "deadpool@example.com"
+    assert data["email"] == "deadpool310@example.com"
     assert data["id"] == user_id

--- a/docs_src/sql_databases/sql_app_py39/tests/test_sql_app.py
+++ b/docs_src/sql_databases/sql_app_py39/tests/test_sql_app.py
@@ -32,16 +32,16 @@ client = TestClient(app)
 def test_create_user():
     response = client.post(
         "/users/",
-        json={"email": "deadpool@example.com", "password": "chimichangas4life"},
+        json={"email": "deadpool39@example.com", "password": "chimichangas4life"},
     )
     assert response.status_code == 200, response.text
     data = response.json()
-    assert data["email"] == "deadpool@example.com"
+    assert data["email"] == "deadpool39@example.com"
     assert "id" in data
     user_id = data["id"]
 
     response = client.get(f"/users/{user_id}")
     assert response.status_code == 200, response.text
     data = response.json()
-    assert data["email"] == "deadpool@example.com"
+    assert data["email"] == "deadpool39@example.com"
     assert data["id"] == user_id


### PR DESCRIPTION
Docs examples `sql_app_py39` and `sql_app_310` were introduced in #3712. But they are using the same database for creating the same record, and this causes a unique constraint violation.

This log is produced by `test fastAPI` CI workflow of samuelcolvin/pydantic:

https://github.com/dolfinus/pydantic/runs/4766471975?check_suite_focus=true
```
=================================== FAILURES ===================================
_______________________________ test_create_user _______________________________

    def test_create_user():
        response = client.post(
            "/users/",
            json={"email": "deadpool@example.com", "password": "chimichangas4life"},
        )
>       assert response.status_code == 200, response.text
E       AssertionError: {"detail":"Email already registered"}
E       assert 400 == 200
E        +  where 400 = <Response [400]>.status_code

docs_src/sql_databases/sql_app_py310/tests/test_sql_app.py:37: AssertionError
_______________________________ test_create_user _______________________________

    def test_create_user():
        response = client.post(
            "/users/",
            json={"email": "deadpool@example.com", "password": "chimichangas4life"},
        )
>       assert response.status_code == 200, response.text
E       AssertionError: {"detail":"Email already registered"}
E       assert 400 == 200
E        +  where 400 = <Response [400]>.status_code

docs_src/sql_databases/sql_app_py39/tests/test_sql_app.py:37: AssertionError
=========================== short test summary info ============================
FAILED docs_src/sql_databases/sql_app_py310/tests/test_sql_app.py::test_create_user
FAILED docs_src/sql_databases/sql_app_py39/tests/test_sql_app.py::test_create_user
======================= 2 failed, 1250 passed in 27.57s ========================
make: *** [Makefile:83: test-fastapi] Error 1
```

I've changed e-mail addresses used by tests to avoid this issue.