### PR TITLE
Fix `Response` `status_code` value on `solve_dependencies()`

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -460,13 +460,7 @@ async def solve_dependencies(
 ]:
     values: Dict[str, Any] = {}
     errors: List[ErrorWrapper] = []
-    response = response or Response(
-        content=None,
-        status_code=None,  # type: ignore
-        headers=None,  # type: ignore # in Starlette
-        media_type=None,  # type: ignore # in Starlette
-        background=None,  # type: ignore # in Starlette
-    )
+    response = response or Response()
     dependency_cache = dependency_cache or {}
     sub_dependant: Dependant
     for sub_dependant in dependant.dependencies:


### PR DESCRIPTION
`None` is not allowed, and now there's a conditional that checks `status_code` on the `Response` initialization. 

Either here or https://github.com/encode/starlette/pull/1402