### PR TITLE
Generate a single tag when the parameter is a string

### DIFF
--- a/docs_src/bigger_applications/app/main.py
+++ b/docs_src/bigger_applications/app/main.py
@@ -12,7 +12,7 @@ app.include_router(items.router)
 app.include_router(
     admin.router,
     prefix="/admin",
-    tags=["admin"],
+    tags="admin",
     dependencies=[Depends(get_token_header)],
     responses={418: {"description": "I'm a teapot"}},
 )

--- a/docs_src/bigger_applications/app/routers/items.py
+++ b/docs_src/bigger_applications/app/routers/items.py
@@ -4,7 +4,7 @@ from ..dependencies import get_token_header
 
 router = APIRouter(
     prefix="/items",
-    tags=["items"],
+    tags="items",
     dependencies=[Depends(get_token_header)],
     responses={404: {"description": "Not found"}},
 )
@@ -27,7 +27,7 @@ async def read_item(item_id: str):
 
 @router.put(
     "/{item_id}",
-    tags=["custom"],
+    tags="custom",
     responses={403: {"description": "Operation forbidden"}},
 )
 async def update_item(item_id: str):

--- a/docs_src/bigger_applications/app/routers/users.py
+++ b/docs_src/bigger_applications/app/routers/users.py
@@ -3,16 +3,16 @@ from fastapi import APIRouter
 router = APIRouter()
 
 
-@router.get("/users/", tags=["users"])
+@router.get("/users/", tags="users")
 async def read_users():
     return [{"username": "Rick"}, {"username": "Morty"}]
 
 
-@router.get("/users/me", tags=["users"])
+@router.get("/users/me", tags="users")
 async def read_user_me():
     return {"username": "fakecurrentuser"}
 
 
-@router.get("/users/{username}", tags=["users"])
+@router.get("/users/{username}", tags="users")
 async def read_user(username: str):
     return {"username": username}

--- a/docs_src/metadata/tutorial004.py
+++ b/docs_src/metadata/tutorial004.py
@@ -18,11 +18,11 @@ tags_metadata = [
 app = FastAPI(openapi_tags=tags_metadata)
 
 
-@app.get("/users/", tags=["users"])
+@app.get("/users/", tags="users")
 async def get_users():
     return [{"name": "Harry"}, {"name": "Ron"}]
 
 
-@app.get("/items/", tags=["items"])
+@app.get("/items/", tags="items")
 async def get_items():
     return [{"name": "wand"}, {"name": "flying broom"}]

--- a/docs_src/path_operation_configuration/tutorial002.py
+++ b/docs_src/path_operation_configuration/tutorial002.py
@@ -14,16 +14,16 @@ class Item(BaseModel):
     tags: Set[str] = set()
 
 
-@app.post("/items/", response_model=Item, tags=["items"])
+@app.post("/items/", response_model=Item, tags="items")
 async def create_item(item: Item):
     return item
 
 
-@app.get("/items/", tags=["items"])
+@app.get("/items/", tags="items")
 async def read_items():
     return [{"name": "Foo", "price": 42}]
 
 
-@app.get("/users/", tags=["users"])
+@app.get("/users/", tags="users")
 async def read_users():
     return [{"username": "johndoe"}]

--- a/docs_src/path_operation_configuration/tutorial002_py310.py
+++ b/docs_src/path_operation_configuration/tutorial002_py310.py
@@ -12,16 +12,16 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, tags=["items"])
+@app.post("/items/", response_model=Item, tags="items")
 async def create_item(item: Item):
     return item
 
 
-@app.get("/items/", tags=["items"])
+@app.get("/items/", tags="items")
 async def read_items():
     return [{"name": "Foo", "price": 42}]
 
 
-@app.get("/users/", tags=["users"])
+@app.get("/users/", tags="users")
 async def read_users():
     return [{"username": "johndoe"}]

--- a/docs_src/path_operation_configuration/tutorial002_py39.py
+++ b/docs_src/path_operation_configuration/tutorial002_py39.py
@@ -14,16 +14,16 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, tags=["items"])
+@app.post("/items/", response_model=Item, tags="items")
 async def create_item(item: Item):
     return item
 
 
-@app.get("/items/", tags=["items"])
+@app.get("/items/", tags="items")
 async def read_items():
     return [{"name": "Foo", "price": 42}]
 
 
-@app.get("/users/", tags=["users"])
+@app.get("/users/", tags="users")
 async def read_users():
     return [{"username": "johndoe"}]

--- a/docs_src/path_operation_configuration/tutorial006.py
+++ b/docs_src/path_operation_configuration/tutorial006.py
@@ -3,16 +3,16 @@ from fastapi import FastAPI
 app = FastAPI()
 
 
-@app.get("/items/", tags=["items"])
+@app.get("/items/", tags="items")
 async def read_items():
     return [{"name": "Foo", "price": 42}]
 
 
-@app.get("/users/", tags=["users"])
+@app.get("/users/", tags="users")
 async def read_users():
     return [{"username": "johndoe"}]
 
 
-@app.get("/elements/", tags=["items"], deprecated=True)
+@app.get("/elements/", tags="items", deprecated=True)
 async def read_elements():
     return [{"item_id": "Foo"}]

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -339,7 +339,7 @@ class FastAPI(Starlette):
         router: routing.APIRouter,
         *,
         prefix: str = "",
-        tags: Optional[List[str]] = None,
+        tags: Union[Optional[List[str]], Optional[str]] = None,
         dependencies: Optional[Sequence[Depends]] = None,
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
         deprecated: Optional[bool] = None,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -634,7 +634,7 @@ class APIRouter(routing.Router):
         router: "APIRouter",
         *,
         prefix: str = "",
-        tags: Optional[List[str]] = None,
+        tags: Union[Optional[List[str]], Optional[str]] = None,
         dependencies: Optional[Sequence[params.Depends]] = None,
         default_response_class: Type[Response] = Default(JSONResponse),
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
@@ -667,6 +667,10 @@ class APIRouter(routing.Router):
                     self.default_response_class,
                 )
                 current_tags = []
+
+                if isinstance(tags, str):
+                    tags = [tags]
+
                 if tags:
                     current_tags.extend(tags)
                 if route.tags:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -438,7 +438,7 @@ class APIRouter(routing.Router):
         self,
         *,
         prefix: str = "",
-        tags: Optional[List[str]] = None,
+        tags: Union[Optional[List[str]], Optional[str]] = None,
         dependencies: Optional[Sequence[params.Depends]] = None,
         default_response_class: Type[Response] = Default(JSONResponse),
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
@@ -466,6 +466,10 @@ class APIRouter(routing.Router):
                 "/"
             ), "A path prefix must not end with '/', as the routes will start with '/'"
         self.prefix = prefix
+
+        if isinstance(tags, str):
+            tags = [tags]
+
         self.tags: List[str] = tags or []
         self.dependencies = list(dependencies or []) or []
         self.deprecated = deprecated
@@ -483,7 +487,7 @@ class APIRouter(routing.Router):
         *,
         response_model: Optional[Type[Any]] = None,
         status_code: Optional[int] = None,
-        tags: Optional[List[str]] = None,
+        tags: Union[Optional[List[str]], Optional[str]] = None,
         dependencies: Optional[Sequence[params.Depends]] = None,
         summary: Optional[str] = None,
         description: Optional[str] = None,
@@ -514,6 +518,10 @@ class APIRouter(routing.Router):
             response_class, self.default_response_class
         )
         current_tags = self.tags.copy()
+
+        if isinstance(tags, str):
+            tags = [tags]
+
         if tags:
             current_tags.extend(tags)
         current_dependencies = self.dependencies.copy()

--- a/tests/test_router_tags.py
+++ b/tests/test_router_tags.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+
+
+def test_router_tags():
+    string_tag = "example"
+    list_tag = ["example"]
+    router1 = APIRouter(tags=string_tag)
+    router2 = APIRouter(tags=list_tag)
+
+    assert router1.tags == router2.tags
+
+
+def test_router_tags_regression():
+    string_tag = "example"
+    old_tag_from_single_string = ["e", "x", "a", "m", "p", "l", "e"]
+    router = APIRouter(tags=string_tag)
+
+    assert router.tags != old_tag_from_single_string


### PR DESCRIPTION
# Summary

Generates a single tag when the parameter is a string, such that `app.include_router(router, tags="test")` generates tag *test* instead of *t*, *e* and *s*.

An alternative may be to reject such parameter: see #4525.

# Motivation

I often use a single tag in my routers, which even the documentation states is very common.

When I include a router in my app, I often do the mistake of using a string instead of a list, which generates a very weird result, as seen below: 

```python
from fastapi import FastAPI, APIRouter

app = FastAPI()
router = APIRouter()

@router.get("")
def test():
    return {"msg" : "Hello, world."}

app.include_router(router, prefix="/test", tags="test")
```

![image](https://user-images.githubusercontent.com/7232812/149621686-3237fac3-42b8-46de-bea9-767bc31d02bb.png)

This lead me to try implement a fix for this itch which often annoys me. I don't know how often it happens to other users, but I find it hard to see a use case for the current behavior - hence the PR.

# Description

In this PR, I test if the object is an instance of string, and if such convert it to a list with one element. This results in a single tag, which is the correct behavior in my opinion. See example below for the same code:

```python
from fastapi import FastAPI, APIRouter

app = FastAPI()
router = APIRouter()

@router.get("")
def test():
    return {"msg" : "Hello, world."}

app.include_router(router, prefix="/test", tags="test")
```

![image](https://user-images.githubusercontent.com/7232812/149621836-b63c872d-f382-462b-bff4-3c416180f28f.png)


I also added tests and updated some single-tag examples.

# Request for comments

I'm a first time contributor, so comments are welcome. Specifically:
- is this a desirable improvement?
- could there be unwanted behavior which I'm unaware of?
- should we update documentation to mention that strings are allowed?
- do these tests make sense?

I would also consider the alternative of raising an exception when the parameter is a string, to force the user to use another iterable such as a list or a tuple.
