### PR TITLE
📝 Update Python Types docs, add missing 3.6 / 3.9 example

### DIFF
--- a/docs/en/docs/python-types.md
+++ b/docs/en/docs/python-types.md
@@ -252,7 +252,7 @@ The second type parameter is for the values of the `dict`:
 === "Python 3.9 and above"
 
     ```Python hl_lines="1"
-    {!> ../../../docs_src/python_types/tutorial008.py!}
+    {!> ../../../docs_src/python_types/tutorial008_py39.py!}
     ```
 
 This means:

--- a/docs_src/python_types/tutorial008_py39.py
+++ b/docs_src/python_types/tutorial008_py39.py
@@ -1,7 +1,4 @@
-from typing import Dict
-
-
-def process_items(prices: Dict[str, float]):
+def process_items(prices: dict[str, float]):
     for item_name, item_price in prices.items():
         print(item_name)
         print(item_price)


### PR DESCRIPTION
📝 Update Python Types docs, add missing 3.6 / 3.9 example