### PR TITLE
🐛 Recurse into dataclass when encoding

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -63,7 +63,14 @@ def jsonable_encoder(
             sqlalchemy_safe=sqlalchemy_safe,
         )
     if dataclasses.is_dataclass(obj):
-        return jsonable_encoder(dataclasses.asdict(obj))
+        obj_dict = dataclasses.asdict(obj)
+        return jsonable_encoder(
+            obj_dict,
+            exclude_none=exclude_none,
+            exclude_defaults=exclude_defaults,
+            custom_encoder=custom_encoder,
+            sqlalchemy_safe=sqlalchemy_safe,
+        )
     if isinstance(obj, Enum):
         return obj.value
     if isinstance(obj, PurePath):

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -63,7 +63,7 @@ def jsonable_encoder(
             sqlalchemy_safe=sqlalchemy_safe,
         )
     if dataclasses.is_dataclass(obj):
-        return dataclasses.asdict(obj)
+        return jsonable_encoder(dataclasses.asdict(obj))
     if isinstance(obj, Enum):
         return obj.value
     if isinstance(obj, PurePath):

--- a/tests/test_serialize_response_dataclass.py
+++ b/tests/test_serialize_response_dataclass.py
@@ -1,8 +1,9 @@
+from dataclasses import dataclass
+from datetime import date
 from typing import List, Optional
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from pydantic.dataclasses import dataclass
 
 app = FastAPI()
 
@@ -12,6 +13,11 @@ class Item:
     name: str
     price: Optional[float] = None
     owner_ids: Optional[List[int]] = None
+
+
+@dataclass
+class EncodingItem:
+    date: date
 
 
 @app.get("/items/valid", response_model=Item)
@@ -27,6 +33,11 @@ def get_object():
 @app.get("/items/coerce", response_model=Item)
 def get_coerce():
     return {"name": "coerce", "price": "1.0"}
+
+
+@app.get("/items/encoding", response_model=EncodingItem)
+def get_encoding():
+    return {"date": date(2022, 1, 20)}
 
 
 @app.get("/items/validlist", response_model=List[Item])
@@ -80,6 +91,12 @@ def test_coerce():
     response = client.get("/items/coerce")
     response.raise_for_status()
     assert response.json() == {"name": "coerce", "price": 1.0, "owner_ids": None}
+
+
+def test_encoding():
+    response = client.get("/items/encoding")
+    response.raise_for_status()
+    assert response.json() == {"date": "2022-01-20"}
 
 
 def test_validlist():


### PR DESCRIPTION
Context:
PR #3576 added support for dataclasses as response objects.

Problem:
`json_encoder` doesn't recurse into dataclasses as it does for pydantic models, dictionaries, and other collections. Custom encoders aren't applied to attributes on dataclasses.

Solution:
Recurse into dataclasses when encoding. Also change dataclass tests to use dataclasses rather than pydantic models.

Example:
```
from datetime import datetime
from fastapi import FastAPI
import dataclasses
import pydantic

app = FastAPI()

@pydantic.dataclasses.dataclass
class PydanticDataclass:
    timestamp: datetime = datetime.now()

@dataclasses.dataclass
class ClassicDataclass:
    timestamp: datetime = datetime.now()

@app.get("/pydantic", response_model=PydanticDataclass)
async def pydantic_dataclass():
    return PydanticDataclass()


@app.get("/classic", response_model=ClassicDataclass)
async def classic_dataclass():
    return ClassicDataclass()

```

```
$ curl localhost:8000/pydantic
-> {"timestamp":"2022-01-24T20:51:42.316967"}
$ curl localhost:8000/classic
-> TypeError: Object of type datetime is not JSON serializable
```