### PR TITLE
✨ Add support of endpoint return type as response_model

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -35,6 +35,7 @@ from fastapi.utils import (
     create_response_field,
     generate_operation_id_for_path,
     get_value_or_default,
+    return_type,
 )
 from pydantic import BaseModel
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
@@ -513,6 +514,7 @@ class APIRouter(routing.Router):
         current_response_class = get_value_or_default(
             response_class, self.default_response_class
         )
+        current_response_model = response_model or return_type(endpoint)
         current_tags = self.tags.copy()
         if tags:
             current_tags.extend(tags)
@@ -525,7 +527,7 @@ class APIRouter(routing.Router):
         route = route_class(
             self.prefix + path,
             endpoint=endpoint,
-            response_model=response_model,
+            response_model=current_response_model,
             status_code=status_code,
             tags=current_tags,
             dependencies=current_dependencies,

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -2,7 +2,7 @@ import functools
 import re
 from dataclasses import is_dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Set, Type, Union, cast
+from typing import Any, Callable, Dict, Optional, Set, Type, Union, cast
 
 import fastapi
 from fastapi.datastructures import DefaultPlaceholder, DefaultType
@@ -154,3 +154,15 @@ def get_value_or_default(
         if not isinstance(item, DefaultPlaceholder):
             return item
     return first_item
+
+
+def return_type(func: Callable[..., Any]) -> Optional[Any]:
+    """
+    Extract return type of given function.
+    partial functions are unwrapped first.
+    """
+    if isinstance(func, functools.partial):
+        func = func.func
+    return (
+        func.__annotations__.get("return") if hasattr(func, "__annotations__") else None
+    )

--- a/tests/test_response_class_is_return_type.py
+++ b/tests/test_response_class_is_return_type.py
@@ -1,0 +1,114 @@
+from typing import Dict
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Model(BaseModel):
+    text: str
+
+
+@app.get("/")
+def f() -> Model:
+    return Model(text="Looks and feels natural")
+
+
+@app.get("/no_type")
+def no_type():
+    return Model(text="No type no life")
+
+
+@app.get("/response_model_priority", response_model=Model)
+def response_model_priority() -> Dict[str, str]:
+    return Model(text="Backward compatible")
+
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "FastAPI", "version": "0.1.0"},
+    "paths": {
+        "/": {
+            "get": {
+                "summary": "F",
+                "operationId": "f__get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Model"}
+                            }
+                        },
+                    }
+                },
+            }
+        },
+        "/no_type": {
+            "get": {
+                "summary": "No Type",
+                "operationId": "no_type_no_type_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    }
+                },
+            }
+        },
+        "/response_model_priority": {
+            "get": {
+                "summary": "Response Model Priority",
+                "operationId": "response_model_priority_response_model_priority_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Model"}
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "Model": {
+                "title": "Model",
+                "type": "object",
+                "properties": {"text": {"title": "Text", "type": "string"}},
+                "required": ["text"],
+            }
+        }
+    },
+}
+
+client = TestClient(app)
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == openapi_schema
+
+
+def test_get_api_route():
+    response = client.get("/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"text": "Looks and feels natural"}
+
+
+def test_get_api_route_no_return_type():
+    response = client.get("/no_type")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"text": "No type no life"}
+
+
+def test_get_api_route_response_model_priority():
+    response = client.get("/response_model_priority")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"text": "Backward compatible"}


### PR DESCRIPTION
# Why this PR is open?
Tl;Dr; Generate endpoint response OpenAPI schema based on the endpoint return type.

In order to declare endpoint params' schema, you can just add typing to a param like this:
```python
@app.get("/items/")
async def read_item(skip: int = 0, limit: int = 10):
    return fake_items_db[skip : skip + limit]
```
and it naturally generates OpenAPi spec for parameter types
![image](https://user-images.githubusercontent.com/4522842/150662923-83088468-3dc7-4708-a500-715f0b6408c9.png)

The same applies to the request body, which is very convenient and feels natural and expected by the [principal of least surprise](principles-wiki.net/principles:principle_of_least_surprise) 👍🏻 

However, when you add return type - no response schema generated, return schema stays an arbitrary string.
```python
@app.get("/items/")
async def read_item(skip: int = 0, limit: int = 10) -> List[Item]:
    return Item(fake_items_db[skip : skip + limit])
```
![image](https://user-images.githubusercontent.com/4522842/150662797-faedb3e0-743a-4579-9700-5ffde958119b.png)

Unless you specify `response_model` to generate OpenAPI spec:
```python
@app.get("/items/", response_model=List[Item])
async def read_item(skip: int = 0, limit: int = 10):
    return Item(fake_items_db[skip : skip + limit])
```
![image](https://user-images.githubusercontent.com/4522842/150662833-f71ae781-e380-4981-a448-ad62e6683d84.png)

# What this PR does?
It aligns behaviour of an endpoint parameter and return type to generate OpenAPI spec.
```python
@app.get("/items/")
async def read_item(skip: int = 0, limit: int = 10) -> List[Item]:
    return Item(fake_items_db[skip : skip + limit])
```
![image](https://user-images.githubusercontent.com/4522842/150662833-f71ae781-e380-4981-a448-ad62e6683d84.png)

It is also backward compatible with existing code that has to put `response_model` in FastAPI route decorator.

# How this PR was tested?
`pytest tests/test_response_class_is_return_type.py`
`./scripts/test.sh`
and run modified `docs_src/query_params/tutorial001.py` locally.

WDYT?