### PR TITLE
recycle: Move errors list to relevant block

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -132,10 +132,10 @@ def jsonable_encoder(
         if isinstance(obj, classes_tuple):
             return encoder(obj)
 
+    errors: List[Exception] = []
     try:
         data = dict(obj)
     except Exception as e:
-        errors: List[Exception] = []
         errors.append(e)
         try:
             data = vars(obj)

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -132,10 +132,10 @@ def jsonable_encoder(
         if isinstance(obj, classes_tuple):
             return encoder(obj)
 
-    errors: List[Exception] = []
     try:
         data = dict(obj)
     except Exception as e:
+        errors: List[Exception] = []
         errors.append(e)
         try:
             data = vars(obj)


### PR DESCRIPTION
Moved the declaration of `errors` list to the first except clause in `fastapi/encoders.py`