### PR TITLE
Fixing 'relative imports issue' on 'sql_databases' tutorial.

### DIFF
--- a/docs_src/sql_databases/sql_app/alt_main.py
+++ b/docs_src/sql_databases/sql_app/alt_main.py
@@ -3,8 +3,11 @@ from typing import List
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from sqlalchemy.orm import Session
 
-from . import crud, models, schemas
-from .database import SessionLocal, engine
+import crud
+import models
+import schemas
+
+from database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -50,9 +53,9 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/users/{user_id}/items/", response_model=schemas.Item)
-def create_item_for_user(
-    user_id: int, item: schemas.ItemCreate, db: Session = Depends(get_db)
-):
+def create_item_for_user(user_id: int,
+                         item: schemas.ItemCreate,
+                         db: Session = Depends(get_db)):
     return crud.create_user_item(db=db, item=item, user_id=user_id)
 
 

--- a/docs_src/sql_databases/sql_app/crud.py
+++ b/docs_src/sql_databases/sql_app/crud.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
-from . import models, schemas
+import models
+import schemas
 
 
 def get_user(db: Session, user_id: int):
@@ -17,7 +18,8 @@ def get_users(db: Session, skip: int = 0, limit: int = 100):
 
 def create_user(db: Session, user: schemas.UserCreate):
     fake_hashed_password = user.password + "notreallyhashed"
-    db_user = models.User(email=user.email, hashed_password=fake_hashed_password)
+    db_user = models.User(email=user.email,
+                          hashed_password=fake_hashed_password)
     db.add(db_user)
     db.commit()
     db.refresh(db_user)

--- a/docs_src/sql_databases/sql_app/main.py
+++ b/docs_src/sql_databases/sql_app/main.py
@@ -3,8 +3,11 @@ from typing import List
 from fastapi import Depends, FastAPI, HTTPException
 from sqlalchemy.orm import Session
 
-from . import crud, models, schemas
-from .database import SessionLocal, engine
+import crud
+import models
+import schemas
+
+from database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -43,9 +46,9 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/users/{user_id}/items/", response_model=schemas.Item)
-def create_item_for_user(
-    user_id: int, item: schemas.ItemCreate, db: Session = Depends(get_db)
-):
+def create_item_for_user(user_id: int,
+                         item: schemas.ItemCreate,
+                         db: Session = Depends(get_db)):
     return crud.create_user_item(db=db, item=item, user_id=user_id)
 
 

--- a/docs_src/sql_databases/sql_app/models.py
+++ b/docs_src/sql_databases/sql_app/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
-from .database import Base
+from database import Base
 
 
 class User(Base):

--- a/docs_src/sql_databases/sql_app_py310/alt_main.py
+++ b/docs_src/sql_databases/sql_app_py310/alt_main.py
@@ -1,8 +1,10 @@
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from sqlalchemy.orm import Session
 
-from . import crud, models, schemas
-from .database import SessionLocal, engine
+import crud
+import models
+import schemas
+from database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -48,9 +50,9 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/users/{user_id}/items/", response_model=schemas.Item)
-def create_item_for_user(
-    user_id: int, item: schemas.ItemCreate, db: Session = Depends(get_db)
-):
+def create_item_for_user(user_id: int,
+                         item: schemas.ItemCreate,
+                         db: Session = Depends(get_db)):
     return crud.create_user_item(db=db, item=item, user_id=user_id)
 
 

--- a/docs_src/sql_databases/sql_app_py310/crud.py
+++ b/docs_src/sql_databases/sql_app_py310/crud.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
-from . import models, schemas
+import models
+import schemas
 
 
 def get_user(db: Session, user_id: int):
@@ -17,7 +18,8 @@ def get_users(db: Session, skip: int = 0, limit: int = 100):
 
 def create_user(db: Session, user: schemas.UserCreate):
     fake_hashed_password = user.password + "notreallyhashed"
-    db_user = models.User(email=user.email, hashed_password=fake_hashed_password)
+    db_user = models.User(email=user.email,
+                          hashed_password=fake_hashed_password)
     db.add(db_user)
     db.commit()
     db.refresh(db_user)

--- a/docs_src/sql_databases/sql_app_py310/main.py
+++ b/docs_src/sql_databases/sql_app_py310/main.py
@@ -1,8 +1,10 @@
 from fastapi import Depends, FastAPI, HTTPException
 from sqlalchemy.orm import Session
 
-from . import crud, models, schemas
-from .database import SessionLocal, engine
+import crud
+import models
+import schemas
+from database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -41,9 +43,9 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/users/{user_id}/items/", response_model=schemas.Item)
-def create_item_for_user(
-    user_id: int, item: schemas.ItemCreate, db: Session = Depends(get_db)
-):
+def create_item_for_user(user_id: int,
+                         item: schemas.ItemCreate,
+                         db: Session = Depends(get_db)):
     return crud.create_user_item(db=db, item=item, user_id=user_id)
 
 

--- a/docs_src/sql_databases/sql_app_py310/models.py
+++ b/docs_src/sql_databases/sql_app_py310/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
-from .database import Base
+from database import Base
 
 
 class User(Base):

--- a/docs_src/sql_databases/sql_app_py39/alt_main.py
+++ b/docs_src/sql_databases/sql_app_py39/alt_main.py
@@ -1,8 +1,10 @@
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from sqlalchemy.orm import Session
 
-from . import crud, models, schemas
-from .database import SessionLocal, engine
+import crud
+import models
+import schemas
+from database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -48,9 +50,9 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/users/{user_id}/items/", response_model=schemas.Item)
-def create_item_for_user(
-    user_id: int, item: schemas.ItemCreate, db: Session = Depends(get_db)
-):
+def create_item_for_user(user_id: int,
+                         item: schemas.ItemCreate,
+                         db: Session = Depends(get_db)):
     return crud.create_user_item(db=db, item=item, user_id=user_id)
 
 

--- a/docs_src/sql_databases/sql_app_py39/crud.py
+++ b/docs_src/sql_databases/sql_app_py39/crud.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
-from . import models, schemas
+import models
+import schemas
 
 
 def get_user(db: Session, user_id: int):
@@ -17,7 +18,8 @@ def get_users(db: Session, skip: int = 0, limit: int = 100):
 
 def create_user(db: Session, user: schemas.UserCreate):
     fake_hashed_password = user.password + "notreallyhashed"
-    db_user = models.User(email=user.email, hashed_password=fake_hashed_password)
+    db_user = models.User(email=user.email,
+                          hashed_password=fake_hashed_password)
     db.add(db_user)
     db.commit()
     db.refresh(db_user)

--- a/docs_src/sql_databases/sql_app_py39/main.py
+++ b/docs_src/sql_databases/sql_app_py39/main.py
@@ -1,8 +1,10 @@
 from fastapi import Depends, FastAPI, HTTPException
 from sqlalchemy.orm import Session
 
-from . import crud, models, schemas
-from .database import SessionLocal, engine
+import crud
+import models
+import schemas
+from database import SessionLocal, engine
 
 models.Base.metadata.create_all(bind=engine)
 
@@ -41,9 +43,9 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 
 @app.post("/users/{user_id}/items/", response_model=schemas.Item)
-def create_item_for_user(
-    user_id: int, item: schemas.ItemCreate, db: Session = Depends(get_db)
-):
+def create_item_for_user(user_id: int,
+                         item: schemas.ItemCreate,
+                         db: Session = Depends(get_db)):
     return crud.create_user_item(db=db, item=item, user_id=user_id)
 
 

--- a/docs_src/sql_databases/sql_app_py39/models.py
+++ b/docs_src/sql_databases/sql_app_py39/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
-from .database import Base
+from database import Base
 
 
 class User(Base):


### PR DESCRIPTION
I was following the tutorial on 'sql databases', which can be found here:

[https://fastapi.tiangolo.com/tutorial/sql-databases/](url)

and found some problems with the code presented in the tutorial.
in most cases the problem is that files that have 'relative imports' produce an import error.


I attach screenshots of the errors.
![1](https://user-images.githubusercontent.com/11828023/152587073-4022d611-2044-4c67-b5ec-3d6150411c7e.png)
![2](https://user-images.githubusercontent.com/11828023/152587080-028a96c5-2f42-43e4-a771-0259203f5b6c.png)
![3](https://user-images.githubusercontent.com/11828023/152587083-ff3f60e0-995b-4f34-adc6-b977f49822b6.png)
![4](https://user-images.githubusercontent.com/11828023/152587085-c7ea0a34-4ea5-4a00-a3e6-616133cf5971.png)


in all cases the error is:
`ImportError: attempted relative import with no know parent package `

this PR is my fix for that problem.
In short, I changed the imports from:

`from .database import Base`

to:

`from database import Base`

changing that, the tutorial worked perfectly fine.