### PR TITLE
✨ Include route in scope to allow middleware and other tools to extract its information

### DIFF
--- a/tests/test_route_scope.py
+++ b/tests/test_route_scope.py
@@ -1,0 +1,50 @@
+import pytest
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.routing import APIRoute, APIWebSocketRoute
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+
+@app.get("/users/{user_id}")
+async def get_user(user_id: str, request: Request):
+    route: APIRoute = request.scope["route"]
+    return {"user_id": user_id, "path": route.path}
+
+
+@app.websocket("/items/{item_id}")
+async def websocket_item(item_id: str, websocket: WebSocket):
+    route: APIWebSocketRoute = websocket.scope["route"]
+    await websocket.accept()
+    await websocket.send_json({"item_id": item_id, "path": route.path})
+
+
+client = TestClient(app)
+
+
+def test_get():
+    response = client.get("/users/rick")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"user_id": "rick", "path": "/users/{user_id}"}
+
+
+def test_invalid_method_doesnt_match():
+    response = client.post("/users/rick")
+    assert response.status_code == 405, response.text
+
+
+def test_invalid_path_doesnt_match():
+    response = client.post("/usersx/rick")
+    assert response.status_code == 404, response.text
+
+
+def test_websocket():
+    with client.websocket_connect("/items/portal-gun") as websocket:
+        data = websocket.receive_json()
+        assert data == {"item_id": "portal-gun", "path": "/items/{item_id}"}
+
+
+def test_websocket_invalid_path_doesnt_match():
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/itemsx/portal-gun") as websocket:
+            websocket.receive_json()


### PR DESCRIPTION
This is useful, in particular, for external tools handling errors, logs, observability, etc. like Sentry.

There's a counterpart PR in Sentry: https://github.com/getsentry/sentry-python/pull/1349

---

If you need this now, you can update Sentry's middleware like this:

```Python
from typing import TYPE_CHECKING, Any, Optional

from fastapi import FastAPI
from fastapi.routing import APIRoute
from sentry_sdk.integrations.asgi import SentryAsgiMiddleware

if TYPE_CHECKING:
    from sentry_sdk._types import Event, Hint

app = FastAPI()


class CustomSentryAsgiMiddleware(SentryAsgiMiddleware):
    def event_processor(
        self, event: "Event", hint: "Hint", asgi_scope: Any
    ) -> "Optional[Event]":
        result_event = super().event_processor(event, hint, asgi_scope)
        route: Optional[APIRoute] = asgi_scope.get("route")
        if route and result_event:
            result_event["transaction"] = route.path
        return result_event


app.add_middleware(CustomSentryAsgiMiddleware)
```