### PR TITLE
fix: add item_id to body response

### DIFF
--- a/docs/en/docs/tutorial/body-multiple-params.md
+++ b/docs/en/docs/tutorial/body-multiple-params.md
@@ -56,6 +56,7 @@ So, it will then use the parameter names as keys (field names) in the body, and 
 
 ```JSON
 {
+    "item_id": 1,
     "item": {
         "name": "Foo",
         "description": "The pretender",

--- a/docs/zh/docs/tutorial/body-multiple-params.md
+++ b/docs/zh/docs/tutorial/body-multiple-params.md
@@ -40,6 +40,7 @@
 
 ```JSON
 {
+    "item_id": 1,
     "item": {
         "name": "Foo",
         "description": "The pretender",


### PR DESCRIPTION
there was a missing key on the response body, just added that part.

check out [this](https://fastapi.tiangolo.com/tutorial/body-multiple-params/#multiple-body-parameters) on response there is `"item_id": item_id` in `result` variable while it is not in json response.

----------

update: my bad, that was the body not the response