### PR TITLE
Fix test_extra_routes on latest Starlette

### DIFF
--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
+from fastapi.responses import Response
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
@@ -32,12 +32,12 @@ def delete_item(item_id: str, item: Item):
 
 @app.head("/items/{item_id}")
 def head_item(item_id: str):
-    return JSONResponse(headers={"x-fastapi-item-id": item_id})
+    return Response(headers={"x-fastapi-item-id": item_id})
 
 
 @app.options("/items/{item_id}")
 def options_item(item_id: str):
-    return JSONResponse(headers={"x-fastapi-item-id": item_id})
+    return Response(headers={"x-fastapi-item-id": item_id})
 
 
 @app.patch("/items/{item_id}")
@@ -47,7 +47,7 @@ def patch_item(item_id: str, item: Item):
 
 @app.trace("/items/{item_id}")
 def trace_item(item_id: str):
-    return JSONResponse(media_type="message/http")
+    return Response(media_type="message/http")
 
 
 client = TestClient(app)


### PR DESCRIPTION
This modified some endpoints to use raw `Response` instead of JSONResponse on methods that do not have response bodies.

This is necessary on latest starlette versions, as [JSONResponse contents is now a required argument](https://github.com/encode/starlette/pull/1431)