### PR TITLE
Remove redundant if condition

### DIFF
--- a/docs_src/query_params_str_validations/tutorial006.py
+++ b/docs_src/query_params_str_validations/tutorial006.py
@@ -5,7 +5,5 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str = Query(..., min_length=3)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
-    if q:
-        results.update({"q": q})
+    results = {"q": q, "items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     return results


### PR DESCRIPTION
Since the query parameter `q` is a mandatory one, we don't need an if condition in [Make it required](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#make-it-required) section tutorial. For the sake of code clarity and readability, it would be better to get rid of it. So, it could be as follows.

```python
@app.get("/items/")
async def read_items(q: str = Query(..., min_length=3)):
    results = {"q": q, "items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
    return results
```

instead of

```python
@app.get("/items/")
async def read_items(q: str = Query(..., min_length=3)):
    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
    if q:
        results.update({"q": q})
    return results
```