### PR TITLE
Add SPDX style license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP",
 ]
+license = "MIT"
 requires = [
     "starlette ==0.17.1",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",


### PR DESCRIPTION
Many automated scanning tools look for an SPDX style license identifier to
find the license being used by a package in an automated fashion
(even though PEP 639 is still in draft).