### PR TITLE
➖ Temporarily remove typer-cli from dependencies and upgrade Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ doc = [
     "mkdocs-markdownextradata-plugin >=0.1.7,<0.3.0",
     # TODO: upgrade and enable typer-cli once it supports Click 8.x.x
     # "typer-cli >=0.0.12,<0.0.13",
+    "typer >=0.4.1,<0.5.0",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ doc = [
     # "typer-cli >=0.0.12,<0.0.13",
     "typer >=0.4.1,<0.5.0",
     # TODO: remove Click
-    "click >=8.1.0,<9.0.0",
+    # "click >=8.1.0,<9.0.0",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,6 @@ doc = [
     # TODO: upgrade and enable typer-cli once it supports Click 8.x.x
     # "typer-cli >=0.0.12,<0.0.13",
     "typer >=0.4.1,<0.5.0",
-    # TODO: remove Click
-    # "click >=8.1.0,<9.0.0",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "pytest-cov >=2.12.0,<4.0.0",
     "mypy ==0.910",
     "flake8 >=3.8.3,<4.0.0",
-    "black ==21.9b0",
+    "black == 22.3.0",
     "isort >=5.0.6,<6.0.0",
     "requests >=2.24.0,<3.0.0",
     "httpx >=0.14.0,<0.19.0",
@@ -77,6 +77,8 @@ doc = [
     # TODO: upgrade and enable typer-cli once it supports Click 8.x.x
     # "typer-cli >=0.0.12,<0.0.13",
     "typer >=0.4.1,<0.5.0",
+    # TODO: remove Click
+    "click >=8.1.0,<9.0.0",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,8 @@ doc = [
     "mkdocs-material >=8.1.4,<9.0.0",
     "mdx-include >=1.4.1,<2.0.0",
     "mkdocs-markdownextradata-plugin >=0.1.7,<0.3.0",
-    "typer-cli >=0.0.12,<0.0.13",
+    # TODO: upgrade and enable typer-cli once it supports Click 8.x.x
+    # "typer-cli >=0.0.12,<0.0.13",
     "pyyaml >=5.3.1,<6.0.0"
 ]
 dev = [

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -162,7 +162,7 @@ def test_post_file(tmp_path):
 
 
 def test_post_large_file(tmp_path):
-    default_pydantic_max_size = 2 ** 16
+    default_pydantic_max_size = 2**16
     path = tmp_path / "test.txt"
     path.write_bytes(b"x" * (default_pydantic_max_size + 1))
 


### PR DESCRIPTION
➖ Temporarily remove typer-cli from dependencies until it supports Click 8.x.x, to unblock pydantic CI

Also upgrade Black, as it has the same type of Click conflicts as Typer