### PR TITLE
4402

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -18,7 +18,7 @@ from fastapi.openapi.docs import (
 )
 from fastapi.openapi.utils import get_openapi
 from fastapi.params import Depends
-from fastapi.types import DecoratedCallable
+from fastapi.types import DecoratedCallable, DataclassDictFactoryType
 from fastapi.utils import generate_unique_id
 from starlette.applications import Starlette
 from starlette.datastructures import State
@@ -450,6 +450,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.get(
             path,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -292,7 +292,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> None:
         self.router.add_api_route(
             path,
@@ -352,7 +352,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             self.router.add_api_route(
@@ -459,7 +459,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.get(
             path,
@@ -518,7 +518,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.put(
             path,
@@ -577,7 +577,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.post(
             path,
@@ -636,7 +636,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.delete(
             path,
@@ -695,7 +695,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.options(
             path,
@@ -754,7 +754,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.head(
             path,
@@ -813,7 +813,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.patch(
             path,
@@ -872,7 +872,7 @@ class FastAPI(Starlette):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.trace(
             path,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -291,6 +291,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> None:
         self.router.add_api_route(
             path,
@@ -317,6 +319,8 @@ class FastAPI(Starlette):
             name=name,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def api_route(
@@ -347,6 +351,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             self.router.add_api_route(
@@ -374,6 +380,8 @@ class FastAPI(Starlette):
                 name=name,
                 openapi_extra=openapi_extra,
                 generate_unique_id_function=generate_unique_id_function,
+                reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+                dataclass_dict_factory=dataclass_dict_factory,
             )
             return func
 
@@ -477,6 +485,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def put(
@@ -507,6 +517,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.put(
             path,
@@ -532,6 +544,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def post(
@@ -562,6 +576,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.post(
             path,
@@ -587,6 +603,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def delete(
@@ -617,6 +635,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.delete(
             path,
@@ -642,6 +662,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def options(
@@ -672,6 +694,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.options(
             path,
@@ -697,6 +721,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def head(
@@ -727,6 +753,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.head(
             path,
@@ -752,6 +780,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def patch(
@@ -782,6 +812,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.patch(
             path,
@@ -807,6 +839,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )
 
     def trace(
@@ -837,6 +871,8 @@ class FastAPI(Starlette):
         generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
             generate_unique_id
         ),
+        reconcile_nested_dataclasses: bool = False,
+        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.router.trace(
             path,
@@ -862,4 +898,6 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             openapi_extra=openapi_extra,
             generate_unique_id_function=generate_unique_id_function,
+            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+            dataclass_dict_factory=dataclass_dict_factory,
         )

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -18,7 +18,7 @@ from fastapi.openapi.docs import (
 )
 from fastapi.openapi.utils import get_openapi
 from fastapi.params import Depends
-from fastapi.types import DecoratedCallable, DataclassDictFactoryType
+from fastapi.types import DataclassDictFactoryType, DecoratedCallable
 from fastapi.utils import generate_unique_id
 from starlette.applications import Starlette
 from starlette.datastructures import State

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -722,8 +722,6 @@ class APIRouter(routing.Router):
         generate_unique_id_function: Callable[[APIRoute], str] = Default(
             generate_unique_id
         ),
-        reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
     ) -> None:
         if prefix:
             assert prefix.startswith("/"), "A path prefix must start with '/'"

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -30,7 +30,7 @@ from fastapi.dependencies.utils import (
 from fastapi.encoders import DictIntStrAny, SetIntStr, jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
 from fastapi.openapi.constants import STATUS_CODES_WITH_NO_BODY
-from fastapi.types import DecoratedCallable, DataclassDictFactoryType
+from fastapi.types import DataclassDictFactoryType, DecoratedCallable
 from fastapi.utils import (
     create_cloned_field,
     create_response_field,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -65,7 +65,7 @@ def _prepare_response_content(
     exclude_defaults: bool = False,
     exclude_none: bool = False,
     reconcile_nested_dataclasses: bool = False,
-    dataclass_dict_factory: DataclassDictFactoryType = None,
+    dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
 ) -> Any:
     if isinstance(res, BaseModel):
         read_with_orm_mode = getattr(res.__config__, "read_with_orm_mode", None)
@@ -83,15 +83,14 @@ def _prepare_response_content(
         )
         if reconcile_nested_dataclasses:
             for k, v in res.items():
-                if dataclasses.is_dataclass(v):
-                    res[k] = _prepare_response_content(
-                        v,
-                        exclude_unset=exclude_unset,
-                        exclude_defaults=exclude_defaults,
-                        exclude_none=exclude_none,
-                        reconcile_nested_dataclasses=reconcile_nested_dataclasses,
-                        dataclass_dict_factory=dataclass_dict_factory,
-                    )
+                res[k] = _prepare_response_content(
+                    v,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                    reconcile_nested_dataclasses=reconcile_nested_dataclasses,
+                    dataclass_dict_factory=dataclass_dict_factory,
+                )
         return res
     elif isinstance(res, list):
         return [
@@ -134,7 +133,7 @@ async def serialize_response(
     exclude_none: bool = False,
     is_coroutine: bool = True,
     reconcile_nested_dataclasses: bool = False,
-    dataclass_dict_factory: DataclassDictFactoryType = None,
+    dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
 ) -> Any:
     if field:
         errors = []
@@ -198,7 +197,7 @@ def get_request_handler(
     response_model_exclude_none: bool = False,
     dependency_overrides_provider: Optional[Any] = None,
     reconcile_nested_dataclasses: bool = False,
-    dataclass_dict_factory: DataclassDictFactoryType = None,
+    dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
 ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
     assert dependant.call is not None, "dependant.call must be a function"
     is_coroutine = asyncio.iscoroutinefunction(dependant.call)
@@ -365,7 +364,7 @@ class APIRoute(routing.Route):
             Callable[["APIRoute"], str], DefaultPlaceholder
         ] = Default(generate_unique_id),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> None:
         self.path = path
         self.endpoint = endpoint
@@ -389,7 +388,7 @@ class APIRoute(routing.Route):
         self.tags = tags or []
         self.responses = responses or {}
         self.name = get_name(endpoint) if name is None else name
-        self.reconcile_nested_dataclasses = reconcile_nested_dataclasses,
+        self.reconcile_nested_dataclasses = reconcile_nested_dataclasses
         self.dataclass_dict_factory = dataclass_dict_factory
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
         if methods is None:
@@ -567,7 +566,7 @@ class APIRouter(routing.Router):
             Callable[[APIRoute], str], DefaultPlaceholder
         ] = Default(generate_unique_id),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> None:
         route_class = route_class_override or self.route_class
         responses = responses or {}
@@ -649,7 +648,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             self.add_api_route(
@@ -795,8 +794,8 @@ class APIRouter(routing.Router):
                     callbacks=current_callbacks,
                     openapi_extra=route.openapi_extra,
                     generate_unique_id_function=current_generate_unique_id,
-                    reconcile_nested_dataclasses=reconcile_nested_dataclasses,
-                    dataclass_dict_factory=dataclass_dict_factory,
+                    reconcile_nested_dataclasses=route.reconcile_nested_dataclasses,
+                    dataclass_dict_factory=route.dataclass_dict_factory,
                 )
             elif isinstance(route, routing.Route):
                 methods = list(route.methods or [])  # type: ignore # in Starlette
@@ -849,7 +848,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.api_route(
             path=path,
@@ -909,7 +908,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.api_route(
             path=path,
@@ -969,7 +968,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.api_route(
             path=path,
@@ -1029,7 +1028,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.api_route(
             path=path,
@@ -1089,7 +1088,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.api_route(
             path=path,
@@ -1149,7 +1148,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.api_route(
             path=path,
@@ -1209,7 +1208,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         return self.api_route(
             path=path,
@@ -1269,7 +1268,7 @@ class APIRouter(routing.Router):
             generate_unique_id
         ),
         reconcile_nested_dataclasses: bool = False,
-        dataclass_dict_factory: DataclassDictFactoryType = None,
+        dataclass_dict_factory: Optional[DataclassDictFactoryType] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
 
         return self.api_route(

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -80,8 +80,6 @@ def _prepare_response_content(
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
-            reconcile_nested_dataclasses=reconcile_nested_dataclasses,
-            dataclass_dict_factory=dataclass_dict_factory,
         )
         if reconcile_nested_dataclasses:
             for k, v in res.items():

--- a/fastapi/types.py
+++ b/fastapi/types.py
@@ -1,3 +1,4 @@
 from typing import Any, Callable, TypeVar
 
 DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
+DataclassDictFactoryType = Callable[[list[tuple[str, Any]]], dict]

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-env/bin/python -m mypy fastapi
-env/bin/python -m flake8 fastapi tests
-env/bin/python -m black fastapi tests --check
-env/bin/python -m isort fastapi tests docs_src scripts --check-only
+mypy fastapi
+flake8 fastapi tests
+black fastapi tests --check
+isort fastapi tests docs_src scripts --check-only

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-mypy fastapi
-flake8 fastapi tests
-black fastapi tests --check
-isort fastapi tests docs_src scripts --check-only
+env/bin/python -m mypy fastapi
+env/bin/python -m flake8 fastapi tests
+env/bin/python -m black fastapi tests --check
+env/bin/python -m isort fastapi tests docs_src scripts --check-only

--- a/tests/test_serialize_response_dataclass.py
+++ b/tests/test_serialize_response_dataclass.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any
+from typing import Any, List, Optional
 
 import pytest
 from fastapi import FastAPI
@@ -77,12 +77,12 @@ def get_no_response_model_objectlist():
 
 
 def _test_item_model() -> ItemModel:
-    item = Item(name='foo', price=1.0, owner_ids=[1, 2, 3])
+    item = Item(name="foo", price=1.0, owner_ids=[1, 2, 3])
     return ItemModel(
         item=item,
         item_list=[item, item],
-        item_dict={'foo': item, 'bar': item},
-        item_dataclass=ItemDataclass(item=item)
+        item_dict={"foo": item, "bar": item},
+        item_dataclass=ItemDataclass(item=item),
     )
 
 
@@ -179,35 +179,37 @@ def test_response_model_nested_dataclass_invalid():
 def test_response_model_nested_dataclass_valid():
     response = client.get("/items/response-model-nested-dataclass/valid")
     assert response.json() == {
-        'item': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0},
-        'item_list': [
-            {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0},
-            {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0}
+        "item": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
+        "item_list": [
+            {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
+            {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
         ],
-        'item_dict': {
-            'bar': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0},
-            'foo': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0}
+        "item_dict": {
+            "bar": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
+            "foo": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
         },
-        'item_dataclass': {
-            'item': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0},
-            'option': None
+        "item_dataclass": {
+            "item": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
+            "option": None,
         },
     }
 
 
 def test_response_model_nested_dataclass_specify_dataclass_dict_factory():
-    response = client.get("/items/response-model-nested-dataclass/specify-dataclass-dict-factory")
+    response = client.get(
+        "/items/response-model-nested-dataclass/specify-dataclass-dict-factory"
+    )
     assert response.json() == {
-        'item': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0},
-        'item_list': [
-            {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0},
-            {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0}
+        "item": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
+        "item_list": [
+            {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
+            {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
         ],
-        'item_dict': {
-            'bar': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0},
-            'foo': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0}
+        "item_dict": {
+            "bar": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
+            "foo": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0},
         },
-        'item_dataclass': {
-            'item': {'name': 'foo', 'owner_ids': [1, 2, 3], 'price': 1.0}
+        "item_dataclass": {
+            "item": {"name": "foo", "owner_ids": [1, 2, 3], "price": 1.0}
         },
     }


### PR DESCRIPTION
addresses #4402 and adds `dict_factory` pass through for `dataclasses.asdict`

the alternative to this was to recursively iterate through the response dict to check for dataclasses **by default**, so since this part of the code manages all responses, i opted to be conservative and make the recursive dataclass reconcilation opt in with a new argument to the route decorator signatures

- [x] tests
- [ ] docs