### PR TITLE
📝 Add OpenAPI warning to "Body - Fields" docs with extra schema extensions

### DIFF
--- a/docs/en/docs/tutorial/body-fields.md
+++ b/docs/en/docs/tutorial/body-fields.md
@@ -55,6 +55,11 @@ You can then use `Field` with model attributes:
 
 You can declare extra information in `Field`, `Query`, `Body`, etc. And it will be included in the generated JSON Schema.
 
+!!! warning
+    Extra keys passed to `Field` will also be present in the resulting OpenAPI schema for your application.
+    These keys may not necessarily be part of the OpenAPI specification, for example, `const` (which pydantic uses to signify a constant value for validation).
+    As OpenAPI expects custom fields to be prefixed with `x-<prefix>-`, various generic OpenAPI tools, for example [the OpenAPI validator](https://validator.swagger.io/), may not work with your generated schema.
+
 You will learn more about adding extra information later in the docs, when learning to declare examples.
 
 ## Recap

--- a/docs/en/docs/tutorial/body-fields.md
+++ b/docs/en/docs/tutorial/body-fields.md
@@ -55,12 +55,11 @@ You can then use `Field` with model attributes:
 
 You can declare extra information in `Field`, `Query`, `Body`, etc. And it will be included in the generated JSON Schema.
 
+You will learn more about adding extra information later in the docs, when learning to declare examples.
+
 !!! warning
     Extra keys passed to `Field` will also be present in the resulting OpenAPI schema for your application.
-    These keys may not necessarily be part of the OpenAPI specification, for example, `const` (which pydantic uses to signify a constant value for validation).
-    As OpenAPI expects custom fields to be prefixed with `x-<prefix>-`, various generic OpenAPI tools, for example [the OpenAPI validator](https://validator.swagger.io/), may not work with your generated schema.
-
-You will learn more about adding extra information later in the docs, when learning to declare examples.
+    As these keys may not necessarily be part of the OpenAPI specification, some OpenAPI tools, for example [the OpenAPI validator](https://validator.swagger.io/), may not work with your generated schema.
 
 ## Recap
 


### PR DESCRIPTION
This PR adds a warning in the docs about generating invalid OpenAPI schemas (see #3745) when using additional keys in pydantic `Field` specifications. This warning only effects versions `fastapi>=0.66`, which could be added to the note if helpful.

I would have liked to include a workaround for those who want to keep generating valid schemas, but is currently non-trivial and either involves overriding a whole chain of field info classes, or writing a custom OpenAPI schema method, to undo the effect of `extra = "allow"` in the `fastapi.openapi.models.Schema` class.
It is a bit of a shame this hasn't been acknowledged as an issue in #3745 but I hope that this warning will be helpful for those who are trying to use generic OpenAPI tools with FastAPI.