### PR TITLE
📝 Add documentation for redefined path operations

### DIFF
--- a/docs/en/docs/tutorial/path-params.md
+++ b/docs/en/docs/tutorial/path-params.md
@@ -115,6 +115,14 @@ Because *path operations* are evaluated in order, you need to make sure that the
 
 Otherwise, the path for `/users/{user_id}` would match also for `/users/me`, "thinking" that it's receiving a parameter `user_id` with a value of `"me"`.
 
+Similarly, you cannot redefine a path operation.
+
+```Python hl_lines="6  11"
+{!../../../docs_src/path_params/tutorial006.py!}
+```
+
+The first implementation will always be used since the paths match.
+
 ## Predefined values
 
 If you have a *path operation* that receives a *path parameter*, but you want the possible valid *path parameter* values to be predefined, you can use a standard Python <abbr title="Enumeration">`Enum`</abbr>.

--- a/docs/en/docs/tutorial/path-params.md
+++ b/docs/en/docs/tutorial/path-params.md
@@ -115,13 +115,13 @@ Because *path operations* are evaluated in order, you need to make sure that the
 
 Otherwise, the path for `/users/{user_id}` would match also for `/users/me`, "thinking" that it's receiving a parameter `user_id` with a value of `"me"`.
 
-Similarly, you cannot redefine a path operation.
+Similarly, you cannot redefine a path operation:
 
 ```Python hl_lines="6  11"
-{!../../../docs_src/path_params/tutorial006.py!}
+{!../../../docs_src/path_params/tutorial003b.py!}
 ```
 
-The first implementation will always be used since the paths match.
+The first one will always be used since the path matches first.
 
 ## Predefined values
 

--- a/docs_src/path_params/tutorial003b.py
+++ b/docs_src/path_params/tutorial003b.py
@@ -5,9 +5,9 @@ app = FastAPI()
 
 @app.get("/users")
 async def read_users():
-    return {"user_id": "first behavior"}
+    return ["Rick", "Morty"]
 
 
 @app.get("/users")
-async def read_users():
-    return {"user_id": "second behavior"}
+async def read_users2():
+    return ["Bean", "Elfo"]

--- a/docs_src/path_params/tutorial006.py
+++ b/docs_src/path_params/tutorial006.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/users")
+async def read_users():
+    return {"user_id": "first behavior"}
+
+
+@app.get("/users")
+async def read_users():
+    return {"user_id": "second behavior"}


### PR DESCRIPTION
We define a FastAPI application that needs to have some selective routes overridden, but redefining a route does not change its behavior. This makes some sense once you read https://www.starlette.io/routing/#route-priority but was not entirely clear in https://fastapi.tiangolo.com/tutorial/path-params/#order-matters.

This pull request adds a brief blurb to the "Order matters" section about redefinition of path operations. Preview at https://6272c2ad3e78ba024bb33491--fastapi.netlify.app/tutorial/path-params/#order-matters

I'd also like to open a separate PR to link to the Starlette routing documentation and describe why adding routers with colliding path operations always results in the first router's implementation being used. Let me know if there's a good place for that.