### PR TITLE
🎨 Fix default value as set in tutorial for Path Operations Advanced Configurations

### DIFF
--- a/docs_src/path_operation_advanced_configuration/tutorial004.py
+++ b/docs_src/path_operation_advanced_configuration/tutorial004.py
@@ -11,7 +11,7 @@ class Item(BaseModel):
     description: Optional[str] = None
     price: float
     tax: Optional[float] = None
-    tags: Set[str] = []
+    tags: Set[str] = set()
 
 
 @app.post("/items/", response_model=Item, summary="Create an item")


### PR DESCRIPTION
🎨 Fix default value as set in tutorial for Path Operations Advanced Configurations

This is to replace https://github.com/tiangolo/fastapi/pull/3173 as that branch was removed and I can't commit on top/update it.