### PR TITLE
Add default to Path parameter

### DIFF
--- a/docs_src/path_params_numeric_validations/tutorial001_py310.py
+++ b/docs_src/path_params_numeric_validations/tutorial001_py310.py
@@ -5,7 +5,7 @@ app = FastAPI()
 
 @app.get("/items/{item_id}")
 async def read_items(
-    item_id: int = Path(title="The ID of the item to get"),
+    item_id: int = Path(default=None, title="The ID of the item to get"),
     q: str | None = Query(default=None, alias="item-query"),
 ):
     results = {"item_id": item_id}


### PR DESCRIPTION
This is an example on the documentation site. I found this bug while reading through the tutorial. Specifically, this snippet is found on `tutorial/path-params-numeric-validations/`.

If the `default` argument to `Path` is omitted, a TypeError is raised

```python
TypeError: Path() missing 1 required positional argument: 'default'
```