### PR TITLE
✨ Add support in `jsonable_encoder` for include and exclude with dataclasses

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -71,11 +71,14 @@ def jsonable_encoder(
             sqlalchemy_safe=sqlalchemy_safe,
         )
     if dataclasses.is_dataclass(obj):
-        obj_dict = dataclasses.asdict(obj)
         return jsonable_encoder(
-            obj_dict,
-            exclude_none=exclude_none,
+            dataclasses.asdict(obj),
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
         )

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -71,8 +71,9 @@ def jsonable_encoder(
             sqlalchemy_safe=sqlalchemy_safe,
         )
     if dataclasses.is_dataclass(obj):
+        obj_dict = dataclasses.asdict(obj)
         return jsonable_encoder(
-            dataclasses.asdict(obj),
+            obj_dict,
             include=include,
             exclude=exclude,
             by_alias=by_alias,

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import PurePath, PurePosixPath, PureWindowsPath
@@ -17,6 +18,12 @@ class Pet:
     def __init__(self, owner: Person, name: str):
         self.owner = owner
         self.name = name
+
+
+@dataclass
+class Item:
+    name: str
+    count: int
 
 
 class DictablePerson(Person):
@@ -129,6 +136,15 @@ def test_encode_dictable():
         "name": "Firulais",
         "owner": {"name": "Foo"},
     }
+
+
+def test_encode_dataclass():
+    item = Item(name="foo", count=100)
+    assert jsonable_encoder(item) == {"name": "foo", "count": 100}
+    assert jsonable_encoder(item, include={"name"}) == {"name": "foo"}
+    assert jsonable_encoder(item, exclude={"count"}) == {"name": "foo"}
+    assert jsonable_encoder(item, include={}) == {}
+    assert jsonable_encoder(item, exclude={}) == {"name": "foo", "count": 100}
 
 
 def test_encode_unsupported():


### PR DESCRIPTION
Originally if the object is a dataclass, `jsonable_encoder` won't respect the `include` and `exclude` arguments.
This PR fixes this issue by applying `jsonable_encoder` to the dict of the dataclass.