### PR TITLE
🔧 Fix Type hint of `auto_error` which does not need to be `Optional[bool]`

### DIFF
--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -119,7 +119,7 @@ class OAuth2(SecurityBase):
         flows: Union[OAuthFlowsModel, Dict[str, Dict[str, Any]]] = OAuthFlowsModel(),
         scheme_name: Optional[str] = None,
         description: Optional[str] = None,
-        auto_error: Optional[bool] = True
+        auto_error: bool = True
     ):
         self.model = OAuth2Model(flows=flows, description=description)
         self.scheme_name = scheme_name or self.__class__.__name__


### PR DESCRIPTION
Default is True and If someone doesn't want auto_error option, then it should be False instead of None.  
I guess It is more Pythonic.