### PR TITLE
Bump starlette from 0.20.0 to 0.20.1

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -33,9 +33,10 @@ from fastapi.types import DecoratedCallable
 from fastapi.utils import generate_unique_id
 from starlette.applications import Starlette
 from starlette.datastructures import State
-from starlette.exceptions import ExceptionMiddleware, HTTPException
+from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.middleware.errors import ServerErrorMiddleware
+from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import BaseRoute

--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -27,7 +27,7 @@ class APIKeyQuery(APIKeyBase):
         self.auto_error = auto_error
 
     async def __call__(self, request: Request) -> Optional[str]:
-        api_key: str = request.query_params.get(self.model.name)
+        api_key = request.query_params.get(self.model.name)
         if not api_key:
             if self.auto_error:
                 raise HTTPException(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 requires = [
-    "starlette @ git+ssh://git@github.com/encode/starlette@master#egg=starlette",
+    "starlette @ git+https://github.com/encode/starlette.git#master",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",
 ]
 description-file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 requires = [
-    "starlette @ git+https://github.com/encode/starlette.git#master",
+    "starlette==0.20.1",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",
 ]
 description-file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 requires = [
-    "starlette==0.19.1",
+    "starlette @ git+ssh://git@github.com/encode/starlette@master#egg=starlette",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",
 ]
 description-file = "README.md"


### PR DESCRIPTION
Python 3.6 needs to be dropped on https://github.com/tiangolo/fastapi/pull/4820 for the pipeline to pass.