### PR TITLE
Customizable Request Handler in APIRoute

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -159,7 +159,7 @@ class RequestHandler:
         else:
             self.actual_response_class = self.response_class
 
-    def get_decoder(self, request: Request) -> Callable[[bytes], Any] | None:
+    def get_decoder(self, request: Request) -> Optional[Callable[[bytes], Any]]:
         content_type_value = request.headers.get("content-type")
         if not content_type_value:
             return json_loads
@@ -206,7 +206,7 @@ class RequestHandler:
             return jsonable_encoder(response_content)
 
     async def __call__(self, request: Request) -> Coroutine[Any, Any, Response]:
-        body: dict | bytes | FormData = None
+        body: Optional[Union[dict, bytes, FormData]] = None
         try:
             if self.is_body_form:
                 body = await request.form()
@@ -478,7 +478,9 @@ class APIRoute(routing.Route):
         )
 
         # Awaiting https://github.com/encode/starlette/pull/1444/files to remove this workaround
-        async def wrap_async_call(*args, **kwargs):
+        async def wrap_async_call(
+            *args, **kwargs
+        ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
             return await request_handler(*args, **kwargs)
 
         return wrap_async_call

--- a/tests/test_custom_request_handler.py
+++ b/tests/test_custom_request_handler.py
@@ -35,12 +35,12 @@ class CustomRequestHandler(RequestHandler):
         data = json.loads(raw.decode())
         return CustomType.from_type(data)
 
-    def get_decoder(self, request: Request):
+    def get_body_decoder(self, request: Request):
         content_type = request.headers.get("content-type")
         if content_type == "application/x-custom-decoder":
             return self.custom_decoder
 
-        return super().get_decoder(request)
+        return super().get_body_decoder(request)
 
 
 class CustomAPIRoute(APIRoute):

--- a/tests/test_custom_request_handler.py
+++ b/tests/test_custom_request_handler.py
@@ -1,0 +1,79 @@
+import json
+from typing import Any, Dict
+
+import pydantic as pyd
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute, RequestHandler
+from fastapi.testclient import TestClient
+from starlette.routing import Request
+
+
+class CustomType(pyd.BaseModel):
+    _TYPES: dict = {}
+    _type: int
+
+    @classmethod
+    def from_type(cls, data: Dict[str, Any]):
+        cls_type: int = data.get("_type")
+        new_cls = cls._TYPES.get(cls_type)
+        if new_cls is not None:
+            return new_cls(**data.get("fields", {}))
+        return data
+
+
+class Payload(CustomType):
+    _type: int = 1
+    field: str
+
+
+CustomType._TYPES.update({cls._type: cls for cls in [Payload]})
+
+
+class CustomRequestHandler(RequestHandler):
+    def custom_decoder(self, raw: bytes) -> str:
+        data = json.loads(raw.decode())
+        return CustomType.from_type(data)
+
+    def get_decoder(self, request: Request):
+        content_type = request.headers.get("content-type")
+        if content_type == "application/x-custom-decoder":
+            return self.custom_decoder
+
+        return super().get_decoder(request)
+
+
+class CustomAPIRoute(APIRoute):
+    def __init__(
+        self, *args, request_handler_class: RequestHandler = None, **kwargs
+    ) -> None:
+        super().__init__(
+            *args,
+            request_handler_class=request_handler_class or CustomRequestHandler,
+            **kwargs,
+        )
+
+
+app = FastAPI()
+router = APIRouter(route_class=CustomAPIRoute)
+
+
+@router.post("/", response_model=Payload)
+def post(payload: Payload):
+    return payload
+
+
+app.include_router(router=router)
+
+
+client = TestClient(app)
+
+
+def test_custom_decoder():
+    response = client.post(
+        "/",
+        json={"_type": 1, "fields": {"field": "value"}},
+        headers={"content-type": "application/x-custom-decoder"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"field": "value"}


### PR DESCRIPTION
End goal was to provide customizable request decoding and response encoding and to forego `jsonable_encoder` in favor of one handled in my own custom serialization lib. 

This PR refactors the get_request_handler logic into an overridable class that can be passed into APIRoute which allows more options for modifying steps of request/response handling.

Typically flooded by github notifs, but I can by reached at the email on my profile if I forget to check for any updates here.