### PR TITLE
Make argument for update_languages in docs.py optional. Fixed typehint

### DIFF
--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -295,7 +295,7 @@ def update_single_lang(lang: str):
 
 @app.command()
 def update_languages(
-    lang: str = typer.Argument(
+    lang: Optional[str] = typer.Argument(
         None, callback=lang_callback, autocompletion=complete_existing_lang
     )
 ):


### PR DESCRIPTION
My IDE gives me warnings because argument *lang* for update_languages str, but it gets None as an argument in several places. 

According to documentation: *Optional* tells the type checker that either an object of the specific type is required, or None is required.

You can read more: https://docs.python.org/3/library/typing.html#typing.Optional

Also from mypy documentation:
> Optional[str] is just a shorthand or alias for Union[str, None]. It exists mostly as a convenience to help function signatures look a little cleaner

Source: https://mypy.readthedocs.io/en/stable/getting_started.html#the-typing-module