### PR TITLE
📝 DOCS (safari browser): set fix font-size to adjust text to box

### DIFF
--- a/docs/en/docs/advanced/behind-a-proxy.md
+++ b/docs/en/docs/advanced/behind-a-proxy.md
@@ -31,12 +31,13 @@ Because we have a proxy with a path prefix of `/api/v1` for our app, the fronten
 ```mermaid
 graph LR
 
-browser("Browser")
-proxy["Proxy on http://0.0.0.0:9999/api/v1/app"]
-server["Server on http://127.0.0.1:8000/app"]
+browser("Browser"):::FixFont;
+proxy["Proxy on http://0.0.0.0:9999/api/v1/app"]:::FixFont;
+server["Server on http://127.0.0.1:8000/app"]:::FixFont;
 
 browser --> proxy
 proxy --> server
+classDef FixFont font-size:14px
 ```
 
 !!! tip


### PR DESCRIPTION
| It is my first open-source contribution, so, I apologize in advance if some procedure is not accurate |
| --- |

## Detailed change description

### Type of change
📝 Documentation

### Background 
I have accessed the documentation (via the SAFARI web browser 🌐 ) to fix a redirection problem I was experiencing. The documentation was very helpful, but when I read it, I realised that the text in a mermaid graphic did not fit.

### Preview (current view in Safari)
<img width="633" alt="image" src="https://user-images.githubusercontent.com/69576384/174241888-af5040c9-e59a-4b0e-8ef4-dab70db5d26f.png">

> This problem does not appear in Mozzila Firefox 🦊 

### Change/Proposal
Add a fixed font-size to mermaid text to adjust to box margins

### New view
I have tested in several screen resolutions (27'' LG, MacBook Air 13.3''), and now it looks:
<img width="633" alt="image" src="https://user-images.githubusercontent.com/69576384/174242369-2a2d291f-8aef-4637-8936-6c419cd5e2e1.png">

It keeps being correctly shown in Firefox (but the text a little smaller than before)

Hope it can be useful!
