### PR TITLE
websocket disconnect

### DIFF
--- a/docs_src/websockets/tutorial003.py
+++ b/docs_src/websockets/tutorial003.py
@@ -51,7 +51,8 @@ class ConnectionManager:
         await websocket.accept()
         self.active_connections.append(websocket)
 
-    def disconnect(self, websocket: WebSocket):
+    async def disconnect(self, websocket: WebSocket):
+        await websocket.close()
         self.active_connections.remove(websocket)
 
     async def send_personal_message(self, message: str, websocket: WebSocket):
@@ -79,5 +80,5 @@ async def websocket_endpoint(websocket: WebSocket, client_id: int):
             await manager.send_personal_message(f"You wrote: {data}", websocket)
             await manager.broadcast(f"Client #{client_id} says: {data}")
     except WebSocketDisconnect:
-        manager.disconnect(websocket)
+        await manager.disconnect(websocket)
         await manager.broadcast(f"Client #{client_id} left the chat")


### PR DESCRIPTION
Previously in the `disconnect` method, the connection was not closed. The WebSocket object was removed from the list only.
I have called the `close` method before removing the object from the `list`.