### PR TITLE
Run sync context managers in a single thread

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -45,10 +45,10 @@ async def contextmanager_in_threadpool(
         0, item_type=Optional[Exception]
     )
     async with AsyncExitStack() as stack:
-        await stack.enter_async_context(rcv_res)
-        await stack.enter_async_context(rcv_err)
-        await stack.enter_async_context(send_res)
-        await stack.enter_async_context(send_err)
+        stack.enter_context(rcv_res)
+        stack.enter_context(rcv_err)
+        stack.enter_context(send_res)
+        stack.enter_context(send_err)
         tg = await stack.enter_async_context(anyio.create_task_group())
         tg.start_soon(run_in_threadpool, _cm_thead_worker, cm, send_res, rcv_err)
         res = await rcv_res.receive()

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -37,9 +37,11 @@ async def contextmanager_in_threadpool(
     cm: ContextManager[_T],
 ) -> AsyncGenerator[_T, None]:
     # streams for the data
-    send_res, rcv_res = anyio.create_memory_object_stream(0, item_type=Any)
+    send_res, rcv_res = anyio.create_memory_object_stream(  # type: ignore
+        0, item_type=Any
+    )
     # streams for exceptions
-    send_err, rcv_err = anyio.create_memory_object_stream(
+    send_err, rcv_err = anyio.create_memory_object_stream(  # type: ignore
         0, item_type=Optional[Exception]
     )
     async with AsyncExitStack() as stack:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,47 @@
+from contextlib import contextmanager
+from threading import BoundedSemaphore
+from time import sleep
+from typing import Iterator
+
+import anyio
+
+import pytest
+from fastapi.concurrency import contextmanager_in_threadpool
+
+
+
+@contextmanager
+def slow_cm(db_pool: BoundedSemaphore) -> Iterator[None]:
+    print("acquiring db token")
+    with db_pool:
+        sleep(0)
+        yield
+        sleep(0)
+        print("releasing db token")
+
+
+async def run_cm(db_pool: BoundedSemaphore) -> None:
+    print("acquiring therad token")
+    async with contextmanager_in_threadpool(slow_cm(db_pool)):
+        await anyio.sleep(0)
+
+
+
+@pytest.mark.anyio
+async def test_contextmanager_in_threadpool_does_not_deadlock() -> None:
+    # simulate a synchronous DB connection pool
+    # first we acquire a token from the thread pool
+    # then we acquire a token from the db pool
+    # previously __exit__ was run in a different thread
+    # so in order to release the db pool token we needed another
+    # thread token
+    # but if we had already exhausted thead tokens then we can't run __exit__
+    # and so we can't free up a db pool token
+    # resulting in a deadlock
+    limiter = anyio.to_thread.current_default_thread_limiter()
+    total_tokens = int(limiter.total_tokens)
+    db_pool = BoundedSemaphore(1)
+    with anyio.fail_after(1):  # deadlock
+        async with anyio.create_task_group() as tg:
+            for _ in range(total_tokens * 2):
+                tg.start_soon(run_cm, db_pool)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -4,10 +4,8 @@ from time import sleep
 from typing import Iterator
 
 import anyio
-
 import pytest
 from fastapi.concurrency import contextmanager_in_threadpool
-
 
 
 @contextmanager
@@ -24,7 +22,6 @@ async def run_cm(db_pool: BoundedSemaphore) -> None:
     print("acquiring therad token")
     async with contextmanager_in_threadpool(slow_cm(db_pool)):
         await anyio.sleep(0)
-
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
This avoids a deadlock where `__exit__` can't be called because there are no thread tokens available. Partially resolves #3205 and other related issues.