### PR TITLE
✏ Fix typos in `tests/test_schema_extra_examples.py`

### DIFF
--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -149,7 +149,7 @@ def query_example_examples(
         default=None,
         example="query_overriden",
         examples={
-            "example1": {"summary": "Qeury example 1", "value": "query1"},
+            "example1": {"summary": "Query example 1", "value": "query1"},
             "example2": {"value": "query2"},
         },
     ),
@@ -186,7 +186,7 @@ def header_example_examples(
         default=None,
         example="header_overriden",
         examples={
-            "example1": {"summary": "Qeury example 1", "value": "header1"},
+            "example1": {"summary": "Query example 1", "value": "header1"},
             "example2": {"value": "header2"},
         },
     ),
@@ -223,7 +223,7 @@ def cookie_example_examples(
         default=None,
         example="cookie_overriden",
         examples={
-            "example1": {"summary": "Qeury example 1", "value": "cookie1"},
+            "example1": {"summary": "Query example 1", "value": "cookie1"},
             "example2": {"value": "cookie2"},
         },
     ),

--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -561,7 +561,7 @@ openapi_schema = {
                         "schema": {"title": "Data", "type": "string"},
                         "examples": {
                             "example1": {
-                                "summary": "Qeury example 1",
+                                "summary": "Query example 1",
                                 "value": "query1",
                             },
                             "example2": {"value": "query2"},
@@ -666,7 +666,7 @@ openapi_schema = {
                         "schema": {"title": "Data", "type": "string"},
                         "examples": {
                             "example1": {
-                                "summary": "Qeury example 1",
+                                "summary": "Query example 1",
                                 "value": "header1",
                             },
                             "example2": {"value": "header2"},
@@ -771,7 +771,7 @@ openapi_schema = {
                         "schema": {"title": "Data", "type": "string"},
                         "examples": {
                             "example1": {
-                                "summary": "Qeury example 1",
+                                "summary": "Query example 1",
                                 "value": "cookie1",
                             },
                             "example2": {"value": "cookie2"},


### PR DESCRIPTION
While doing a typing test on speedtyper.dev, I got a snippet that had a typo, so decided to drop by and fix it ;)