### PR TITLE
✏ Fix typos in `docs/en/docs/tutorial/path-params-numeric-validations.md`

### DIFF
--- a/docs/en/docs/tutorial/path-params-numeric-validations.md
+++ b/docs/en/docs/tutorial/path-params-numeric-validations.md
@@ -1,6 +1,6 @@
 # Path Parameters and Numeric Validations
 
-The same way you can declare more validations and metadata for query parameters with `Query`, you can declare the same type of validations and metadata for path parameters with `Path`.
+In the same way that you can declare more validations and metadata for query parameters with `Query`, you can declare the same type of validations and metadata for path parameters with `Path`.
 
 ## Import Path
 
@@ -77,7 +77,7 @@ Python won't do anything with that `*`, but it will know that all the following 
 
 ## Number validations: greater than or equal
 
-With `Query` and `Path` (and other's you'll see later) you can declare string constraints, but also number constraints.
+With `Query` and `Path` (and others you'll see later) you can declare number constraints.
 
 Here, with `ge=1`, `item_id` will need to be an integer number "`g`reater than or `e`qual" to `1`.
 


### PR DESCRIPTION
Option 1 (Preferred): Remove "string constraints, but also "
Option 2: Add "not only" string constraints, but also