### PR TITLE
🐛 Fix removing body from status codes that do not support it

### DIFF
--- a/fastapi/openapi/constants.py
+++ b/fastapi/openapi/constants.py
@@ -1,3 +1,2 @@
 METHODS_WITH_BODY = {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"}
-STATUS_CODES_WITH_NO_BODY = {100, 101, 102, 103, 204, 304}
 REF_PREFIX = "#/components/schemas/"

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -9,11 +9,7 @@ from fastapi.datastructures import DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import get_flat_dependant, get_flat_params
 from fastapi.encoders import jsonable_encoder
-from fastapi.openapi.constants import (
-    METHODS_WITH_BODY,
-    REF_PREFIX,
-    STATUS_CODES_WITH_NO_BODY,
-)
+from fastapi.openapi.constants import METHODS_WITH_BODY, REF_PREFIX
 from fastapi.openapi.models import OpenAPI
 from fastapi.params import Body, Param
 from fastapi.responses import Response
@@ -21,6 +17,7 @@ from fastapi.utils import (
     deep_dict_update,
     generate_operation_id_for_path,
     get_model_definitions,
+    is_body_allowed_for_status_code,
 )
 from pydantic import BaseModel
 from pydantic.fields import ModelField, Undefined
@@ -265,9 +262,8 @@ def get_openapi_path(
             operation.setdefault("responses", {}).setdefault(status_code, {})[
                 "description"
             ] = route.response_description
-            if (
-                route_response_media_type
-                and route.status_code not in STATUS_CODES_WITH_NO_BODY
+            if route_response_media_type and is_body_allowed_for_status_code(
+                route.status_code
             ):
                 response_schema = {"type": "string"}
                 if lenient_issubclass(current_response_class, JSONResponse):

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -18,6 +18,13 @@ if TYPE_CHECKING:  # pragma: nocover
     from .routing import APIRoute
 
 
+def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:
+    if status_code is None:
+        return True
+    current_status_code = int(status_code)
+    return not (current_status_code < 200 or current_status_code in {204, 304})
+
+
 def get_model_definitions(
     *,
     flat_models: Set[Union[Type[BaseModel], Type[Enum]]],

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -28,7 +28,7 @@ class JsonApiError(BaseModel):
     responses={500: {"description": "Error", "model": JsonApiError}},
 )
 async def a():
-    pass  # pragma: no cover
+    pass
 
 
 @app.get("/b", responses={204: {"description": "No Content"}})
@@ -106,3 +106,10 @@ def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
     assert response.json() == openapi_schema
+
+
+def test_get_response():
+    response = client.get("/a")
+    assert response.status_code == 204, response.text
+    assert "content-length" not in response.headers
+    assert response.content == b""


### PR DESCRIPTION
🐛 Fix removing body from status codes that do not support it

This is related to this issue here: https://github.com/tiangolo/fastapi/issues/4050

Related to this issue in Starlette: https://github.com/encode/starlette/issues/1764

And related to this PR in Starlette: https://github.com/encode/starlette/pull/1765

This removes `fastapi.openapi.constants.STATUS_CODES_WITH_NO_BODY`, it is replaced by a function in utils.