### PR TITLE
✏ Reword and clarify text in tutorial `docs/en/docs/tutorial/body-nested-models.md`

### DIFF
--- a/docs/en/docs/tutorial/body-nested-models.md
+++ b/docs/en/docs/tutorial/body-nested-models.md
@@ -18,7 +18,7 @@ You can define an attribute to be a subtype. For example, a Python `list`:
     {!> ../../../docs_src/body_nested_models/tutorial001_py310.py!}
     ```
 
-This will make `tags` be a list of items. Although it doesn't declare the type of each of the items.
+This will make `tags` be a list, although it doesn't declare the type of the elements of the list.
 
 ## List fields with type parameter
 


### PR DESCRIPTION
It currently says _"list of items"_, and since the entity in the example is called `Item`, this was a little confusing for me. Avoiding the word _"item"_ in this sentence is probably better.