### PR TITLE
🐛 Fix support for strings in OpenAPI status codes: `default`, `1XX`, `2XX`, `3XX`, `4XX`, `5XX`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ docs_build
 venv
 docs.zip
 archive.zip
-
+.v3.10.5
 # vim temporary files
 *~
 .*.sw?

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ docs_build
 venv
 docs.zip
 archive.zip
-.v3.10.5
+
 # vim temporary files
 *~
 .*.sw?

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -19,7 +19,9 @@ if TYPE_CHECKING:  # pragma: nocover
 
 
 def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:
-    if status_code in [None, 'default', '2XX', '2xx', '3XX', '3xx', '4XX', '4xx', '5XX', '5xx']:
+    if status_code is None:
+        return True
+    if status_code in ['default', '2XX', '2xx', '3XX', '3xx', '4XX', '4xx', '5XX', '5xx']:
         return True
     current_status_code = int(status_code)
     return not (current_status_code < 200 or current_status_code in {204, 304})

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:  # pragma: nocover
 
 
 def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:
-    if status_code is None:
+    if status_code is None or status_code == "default":
         return True
     current_status_code = int(status_code)
     return not (current_status_code < 200 or current_status_code in {204, 304})

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:  # pragma: nocover
 
 
 def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:
-    if status_code is None or status_code == "default":
+    if status_code in [None, 'default', '2XX', '2xx', '3XX', '3xx', '4XX', '4xx', '5XX', '5xx']:
         return True
     current_status_code = int(status_code)
     return not (current_status_code < 200 or current_status_code in {204, 304})

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -19,7 +19,18 @@ if TYPE_CHECKING:  # pragma: nocover
 
 
 def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:
-    if status_code in [None, 'default', '2XX', '2xx', '3XX', '3xx', '4XX', '4xx', '5XX', '5xx']:
+    if status_code in [
+        None,
+        "default",
+        "2XX",
+        "2xx",
+        "3XX",
+        "3xx",
+        "4XX",
+        "4xx",
+        "5XX",
+        "5xx",
+    ]:
         return True
     current_status_code = int(status_code)
     return not (current_status_code < 200 or current_status_code in {204, 304})

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -21,17 +21,15 @@ if TYPE_CHECKING:  # pragma: nocover
 def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:
     if status_code is None:
         return True
-    if status_code in [
+    # Ref: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#patterned-fields-1
+    if status_code in {
         "default",
+        "1XX",
         "2XX",
-        "2xx",
         "3XX",
-        "3xx",
         "4XX",
-        "4xx",
         "5XX",
-        "5xx",
-    ]:
+    }:
         return True
     current_status_code = int(status_code)
     return not (current_status_code < 200 or current_status_code in {204, 304})

--- a/tests/test_additional_responses_router.py
+++ b/tests/test_additional_responses_router.py
@@ -1,5 +1,9 @@
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+class ResponseModel(BaseModel):
+    message: str
 
 app = FastAPI()
 router = APIRouter()
@@ -32,6 +36,16 @@ async def b():
 async def c():
     return "c"
 
+@router.get(
+    "/d",
+    responses={
+        "400": {"description": "Error with str"},
+        "5xx": {"model": ResponseModel},
+        "default": {"model": ResponseModel},
+    },
+)
+async def d():
+    return "d"
 
 app.include_router(router)
 
@@ -80,8 +94,41 @@ openapi_schema = {
                 "summary": "C",
                 "operationId": "c_c_get",
             }
-        },
+        }, 
+        "/d": {
+            "get": {
+                "responses": {
+                    "400": {"description": "Error with str"},
+                    "5XX": {
+                        "description": "Server Error",
+                        "content": {"application/json": {"schema": {
+                                    "$ref": "#/components/schemas/ResponseModel"}}}
+                    },
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "default": {
+                        "description": "Default Response",
+                        "content": {"application/json": {"schema": {
+                                    "$ref": "#/components/schemas/ResponseModel"}}}
+                    }
+                },
+                "summary": "D",
+                "operationId": "d_d_get",
+            }
+        }
     },
+    "components": {
+        "schemas": {
+            "ResponseModel": {
+                "title": "ResponseModel",
+                "required": ["message"],
+                "type": "object",
+                "properties": {"message": {"title": "Message","type": "string"}}
+            }
+        }
+    }
 }
 
 client = TestClient(app)
@@ -109,3 +156,8 @@ def test_c():
     response = client.get("/c")
     assert response.status_code == 200, response.text
     assert response.json() == "c"
+
+def test_d():
+    response = client.get("/d")
+    assert response.status_code == 200, response.text
+    assert response.json() == "d"

--- a/tests/test_additional_responses_router.py
+++ b/tests/test_additional_responses_router.py
@@ -43,7 +43,7 @@ async def c():
     "/d",
     responses={
         "400": {"description": "Error with str"},
-        "5xx": {"model": ResponseModel},
+        "5XX": {"model": ResponseModel},
         "default": {"model": ResponseModel},
     },
 )

--- a/tests/test_additional_responses_router.py
+++ b/tests/test_additional_responses_router.py
@@ -2,8 +2,10 @@ from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
+
 class ResponseModel(BaseModel):
     message: str
+
 
 app = FastAPI()
 router = APIRouter()
@@ -36,6 +38,7 @@ async def b():
 async def c():
     return "c"
 
+
 @router.get(
     "/d",
     responses={
@@ -46,6 +49,7 @@ async def c():
 )
 async def d():
     return "d"
+
 
 app.include_router(router)
 
@@ -94,15 +98,18 @@ openapi_schema = {
                 "summary": "C",
                 "operationId": "c_c_get",
             }
-        }, 
+        },
         "/d": {
             "get": {
                 "responses": {
                     "400": {"description": "Error with str"},
                     "5XX": {
                         "description": "Server Error",
-                        "content": {"application/json": {"schema": {
-                                    "$ref": "#/components/schemas/ResponseModel"}}}
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ResponseModel"}
+                            }
+                        },
                     },
                     "200": {
                         "description": "Successful Response",
@@ -110,14 +117,17 @@ openapi_schema = {
                     },
                     "default": {
                         "description": "Default Response",
-                        "content": {"application/json": {"schema": {
-                                    "$ref": "#/components/schemas/ResponseModel"}}}
-                    }
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ResponseModel"}
+                            }
+                        },
+                    },
                 },
                 "summary": "D",
                 "operationId": "d_d_get",
             }
-        }
+        },
     },
     "components": {
         "schemas": {
@@ -125,10 +135,10 @@ openapi_schema = {
                 "title": "ResponseModel",
                 "required": ["message"],
                 "type": "object",
-                "properties": {"message": {"title": "Message","type": "string"}}
+                "properties": {"message": {"title": "Message", "type": "string"}},
             }
         }
-    }
+    },
 }
 
 client = TestClient(app)
@@ -156,6 +166,7 @@ def test_c():
     response = client.get("/c")
     assert response.status_code == 200, response.text
     assert response.json() == "c"
+
 
 def test_d():
     response = client.get("/d")


### PR DESCRIPTION
Related to https://github.com/tiangolo/fastapi/issues/5166 

