### PR TITLE
⬆ Update HTML for docs/oauth2-redirect using swagger-ui's latest version

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -118,7 +118,7 @@ def get_swagger_ui_oauth2_redirect_html() -> HTMLResponse:
     html = """
     <!DOCTYPE html>
     <html lang="en-US">
-    <body onload="run()">
+    <body>
     </body>
     </html>
     <script>
@@ -146,8 +146,9 @@ def get_swagger_ui_oauth2_redirect_html() -> HTMLResponse:
             isValid = qp.state === sentState
 
             if ((
-            oauth2.auth.schema.get("flow") === "accessCode"||
-            oauth2.auth.schema.get("flow") === "authorizationCode"
+              oauth2.auth.schema.get("flow") === "accessCode"||
+              oauth2.auth.schema.get("flow") === "authorizationCode" ||
+              oauth2.auth.schema.get("flow") === "authorization_code"
             ) && !oauth2.auth.code) {
                 if (!isValid) {
                     oauth2.errCb({
@@ -181,6 +182,14 @@ def get_swagger_ui_oauth2_redirect_html() -> HTMLResponse:
                 oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
             }
             window.close();
+        }
+
+        if( document.readyState !== 'loading' ) {
+          run();
+        } else {
+          document.addEventListener('DOMContentLoaded', function () {
+            run();
+          });
         }
     </script>
         """


### PR DESCRIPTION
When using OpenIDConnect and the "authorization_code with PKCE" flow,
swagger-ui will name the flow `authorization_code` rather than
`authorizationCode`. [0]

The old HTML document generated by fastapi only handled the latter
spelling. This meant that trying to authenticate using the swagger UI
would fail with:

```
auth errorError: Bad Request, error: invalid_request, description: Missing parameter: code
```

This commit updates the HTML used by fastapi for the
`docs/oauth2-redirect` using the latest version published by swagger-ui
[1] which brings in a fix for the bug described above.

The rest of the changes relate to improving support for Chrome and Edge.
[2]

[0] https://github.com/swagger-api/swagger-ui/blob/626defc839f80f0d08105cb72b8f6b7d3334db9c/src/core/components/auth/oauth2.jsx#L130
[1] https://github.com/swagger-api/swagger-ui/blob/626defc839f80f0d08105cb72b8f6b7d3334db9c/dev-helpers/oauth2-redirect.html
[2] https://github.com/swagger-api/swagger-ui/pull/6393