### PR TITLE
Hotfix: redoc tables have to be fullwidth, but they aren't

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -103,6 +103,9 @@ def get_redoc_html(
         margin: 0;
         padding: 0;
       }}
+      table {{
+        display: table !important;
+      }}
     </style>
     </head>
     <body>


### PR DESCRIPTION
The reason is tables have CSS property `{ display: block }`, that's why they renders wrong