### PR TITLE
✏ Fix minor typo in `docs/en/docs/features.md`

### DIFF
--- a/docs/en/docs/features.md
+++ b/docs/en/docs/features.md
@@ -195,6 +195,6 @@ With **FastAPI** you get all of **Pydantic**'s features (as FastAPI is based on 
     * Use of hierarchical Pydantic models, Python `typing`’s `List` and `Dict`, etc.
     * And validators allow complex data schemas to be clearly and easily defined, checked and documented as JSON Schema.
     * You can have deeply **nested JSON** objects and have them all validated and annotated.
-* **Extendible**:
+* **Extensible**:
     * Pydantic allows custom data types to be defined or you can extend validation with methods on a model decorated with the validator decorator.
 * 100% test coverage.


### PR DESCRIPTION
Replace "Extendible" with "Extensible"