### PR TITLE
Allow return type of endpoint to be response model

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+app = FastAPI()
+
+class ResponseModelA(BaseModel):
+    a: str
+
+class ResponseModelB(BaseModel):
+    b: str
+
+@app.get("/a", response_model=ResponseModelA)
+def get_a_with_response_model_a():
+    return ResponseModelA(a="a")
+
+@app.get("/b", response_model=ResponseModelA)
+def get_b_with_response_model_a_and_return_model_b() -> ResponseModelB:
+    return ResponseModelA(a="a")
+
+@app.get("/c")
+def get_c_with_return_type_b() -> ResponseModelB:
+    return ResponseModelB(b="b")
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/app.py
+++ b/app.py
@@ -1,27 +1,33 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-
 app = FastAPI()
+
 
 class ResponseModelA(BaseModel):
     a: str
 
+
 class ResponseModelB(BaseModel):
     b: str
+
 
 @app.get("/a", response_model=ResponseModelA)
 def get_a_with_response_model_a():
     return ResponseModelA(a="a")
 
+
 @app.get("/b", response_model=ResponseModelA)
 def get_b_with_response_model_a_and_return_model_b() -> ResponseModelB:
     return ResponseModelA(a="a")
+
 
 @app.get("/c")
 def get_c_with_return_type_b() -> ResponseModelB:
     return ResponseModelB(b="b")
 
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -349,6 +349,7 @@ class APIRoute(routing.Route):
         self.response_model = response_model
         self.summary = summary
         self.response_description = response_description
+        
         self.deprecated = deprecated
         self.operation_id = operation_id
         self.response_model_include = response_model_include

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import email.message
+from functools import partial
 import inspect
 import json
 from enum import Enum, IntEnum
@@ -347,9 +348,12 @@ class APIRoute(routing.Route):
         self.path = path
         self.endpoint = endpoint
         self.response_model = response_model
+        if type(endpoint) != partial:
+            self.response_model = response_model or endpoint.__annotations__.get("return")
+        else:
+            self.response_model = response_model or endpoint.func.__annotations__.get("return")
         self.summary = summary
         self.response_description = response_description
-        
         self.deprecated = deprecated
         self.operation_id = operation_id
         self.response_model_include = response_model_include

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -4,7 +4,6 @@ import email.message
 import inspect
 import json
 from enum import Enum, IntEnum
-from functools import partial
 from typing import (
     Any,
     Callable,
@@ -35,6 +34,7 @@ from fastapi.utils import (
     create_cloned_field,
     create_response_field,
     generate_unique_id,
+    get_return_type_of_callable,
     get_value_or_default,
     is_body_allowed_for_status_code,
 )
@@ -347,15 +347,9 @@ class APIRoute(routing.Route):
     ) -> None:
         self.path = path
         self.endpoint = endpoint
-        self.response_model = response_model
-        if type(endpoint) != partial:
-            self.response_model = response_model or endpoint.__annotations__.get(
-                "return"
-            )
-        else:
-            self.response_model = response_model or endpoint.func.__annotations__.get(
-                "return"
-            )
+        self.response_model = (
+            response_model if response_model else get_return_type_of_callable(endpoint)
+        )
         self.summary = summary
         self.response_description = response_description
         self.deprecated = deprecated

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,10 +1,10 @@
 import asyncio
 import dataclasses
 import email.message
-from functools import partial
 import inspect
 import json
 from enum import Enum, IntEnum
+from functools import partial
 from typing import (
     Any,
     Callable,
@@ -349,9 +349,13 @@ class APIRoute(routing.Route):
         self.endpoint = endpoint
         self.response_model = response_model
         if type(endpoint) != partial:
-            self.response_model = response_model or endpoint.__annotations__.get("return")
+            self.response_model = response_model or endpoint.__annotations__.get(
+                "return"
+            )
         else:
-            self.response_model = response_model or endpoint.func.__annotations__.get("return")
+            self.response_model = response_model or endpoint.func.__annotations__.get(
+                "return"
+            )
         self.summary = summary
         self.response_description = response_description
         self.deprecated = deprecated

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -157,7 +157,7 @@ def generate_operation_id_for_path(
     return operation_id
 
 
-def generate_unique_id(route: "APIRoute") -> str:
+def generate_unique_id(route: APIRoute) -> str:
     operation_id = route.name + route.path_format
     operation_id = re.sub("[^0-9a-zA-Z_]", "_", operation_id)
     assert route.methods

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -3,7 +3,7 @@ import re
 import warnings
 from dataclasses import is_dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, Type, Union, cast
 
 import fastapi
 from fastapi.datastructures import DefaultPlaceholder, DefaultType
@@ -16,6 +16,12 @@ from pydantic.utils import lenient_issubclass
 
 if TYPE_CHECKING:  # pragma: nocover
     from .routing import APIRoute
+
+
+def get_return_type_of_callable(endpoint: Callable) -> Union[type, None]:
+    if issubclass(type(endpoint), functools.partial):
+        endpoint = endpoint.func
+    return endpoint.__annotations__.get("return")
 
 
 def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,10 +1,10 @@
 import functools
+from inspect import isclass
 import re
 import warnings
 from dataclasses import is_dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, Type, Union, cast
-
 import fastapi
 from fastapi.datastructures import DefaultPlaceholder, DefaultType
 from fastapi.openapi.constants import REF_PREFIX
@@ -18,10 +18,12 @@ if TYPE_CHECKING:  # pragma: nocover
     from .routing import APIRoute
 
 
-def get_return_type_of_callable(endpoint: Callable) -> Union[type, None]:
-    if issubclass(type(endpoint), functools.partial):
-        endpoint = endpoint.func
-    return endpoint.__annotations__.get("return")
+def get_return_type_of_callable(endpoint: Union[functools.partial[Any], Callable[..., Any]]) -> Union[type, None]:
+    if isinstance(endpoint, functools.partial):
+        c = endpoint.func
+    else:
+        c = endpoint
+    return c.__annotations__.get("return", None)
 
 
 def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,10 +1,10 @@
 import functools
-from inspect import isclass
 import re
 import warnings
 from dataclasses import is_dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, Type, Union, cast
+
 import fastapi
 from fastapi.datastructures import DefaultPlaceholder, DefaultType
 from fastapi.openapi.constants import REF_PREFIX
@@ -18,7 +18,9 @@ if TYPE_CHECKING:  # pragma: nocover
     from .routing import APIRoute
 
 
-def get_return_type_of_callable(endpoint: Union[functools.partial[Any], Callable[..., Any]]) -> Union[type, None]:
+def get_return_type_of_callable(
+    endpoint: Union[functools.partial[Any], Callable[..., Any]]
+) -> Union[type, None]:
     if isinstance(endpoint, functools.partial):
         c = endpoint.func
     else:

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import re
 import warnings
@@ -19,7 +21,7 @@ if TYPE_CHECKING:  # pragma: nocover
 
 
 def get_return_type_of_callable(
-    endpoint: Union[functools.partial[Any], Callable[..., Any]]
+    endpoint: Union[Type[functools.partial[Any]], Callable[..., Any]]
 ) -> Union[type, None]:
     if isinstance(endpoint, functools.partial):
         c = endpoint.func

--- a/tests/test_endpoint_response_model_return_type.py
+++ b/tests/test_endpoint_response_model_return_type.py
@@ -1,0 +1,136 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class ResponseModelA(BaseModel):
+    a: str
+
+
+class ResponseModelB(BaseModel):
+    b: str
+
+
+@app.get("/a", response_model=ResponseModelA)
+def get_a_with_response_model():
+    return ResponseModelA(a="a")
+
+
+@app.get("/b", response_model=ResponseModelA)
+def get_b_with_response_model() -> ResponseModelB:
+    return ResponseModelA(a="a")
+
+
+@app.get("/c")
+def get_c_with_return_type() -> ResponseModelB:
+    return ResponseModelB(b="b")
+
+
+openapi_schema = {
+    "openapi": "3.0.2",
+    "info": {"title": "FastAPI", "version": "0.1.0"},
+    "paths": {
+        "/a": {
+            "get": {
+                "summary": "Get A With Response Model",
+                "operationId": "get_a_with_response_model_a_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseModelA"
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
+        "/b": {
+            "get": {
+                "summary": "Get B With Response Model",
+                "operationId": "get_b_with_response_model_b_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseModelA"
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
+        "/c": {
+            "get": {
+                "summary": "Get C With Return Type",
+                "operationId": "get_c_with_return_type_c_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseModelB"
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    },
+    "components": {
+        "schemas": {
+            "ResponseModelA": {
+                "title": "ResponseModelA",
+                "required": ["a"],
+                "type": "object",
+                "properties": {"a": {"title": "A", "type": "string"}},
+            },
+            "ResponseModelB": {
+                "title": "ResponseModelB",
+                "required": ["b"],
+                "type": "object",
+                "properties": {"b": {"title": "B", "type": "string"}},
+            },
+        }
+    },
+}
+
+
+client = TestClient(app)
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == openapi_schema
+
+
+def test_response_model_a():
+    response = client.get("/a")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"a": "a"}
+    assert ResponseModelA(**response.json())
+
+
+def test_response_model_takes_precedence():
+    response = client.get("/b")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"a": "a"}
+    assert ResponseModelA(**response.json())
+
+
+def test_response_model_from_return_type():
+    response = client.get("/c")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"b": "b"}
+    assert ResponseModelB(**response.json())


### PR DESCRIPTION
Based on the discussion here:

Fixes https://github.com/tiangolo/fastapi/issues/5215

This would allow the developer to choose between using something like 
```python
@app.get("/", response_model=MyModel)
def root():
    pass
```
and 
```python
@app.get("/")
def root() -> MyModel:
    pass
```

The latter is more idiomatic. In this PR, the `reponse_model=` method takes precedence, as all documentation is in that style. That means if both are set, then the return type will be ignored. 