### PR TITLE
🌐 Add missing navigator for `encoder.md` in Korean translation

### DIFF
--- a/docs/ko/mkdocs.yml
+++ b/docs/ko/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - tutorial/response-status-code.md
   - tutorial/request-files.md
   - tutorial/request-forms-and-files.md
+  - tutorial/encoder.md
 markdown_extensions:
 - toc:
     permalink: true


### PR DESCRIPTION
add `encoder.md` into `Tutorial - User Guide`

before this PR, there is two same section for `Tutorial - User Guide` (also, `자습서 - 사용자 안내서` in korean)

![image](https://user-images.githubusercontent.com/9527681/183110199-bb661d79-c286-49e2-8e75-facd0dd62ef1.png)
