### PR TITLE
Update tutorial005_py39.py

### DIFF
--- a/docs_src/security/tutorial005_py39.py
+++ b/docs_src/security/tutorial005_py39.py
@@ -153,7 +153,7 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
         data={"sub": user.username, "scopes": form_data.scopes},
         expires_delta=access_token_expires,
     )
-    return {"access_token": access_token, "token_type": "bearer"}
+    return Token(acces_token=acces_token, token_type="bearer")
 
 
 @app.get("/users/me/", response_model=User)


### PR DESCRIPTION
In line 146 the `response_mode` is specified as `Token`.  When we return a `dict` instead of a `Token` object, pydantic raise a `Validation error`