### PR TITLE
📝 Remove unneeded Django/Flask references from async topic intro

### DIFF
--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -232,11 +232,7 @@ This "waiting" 🕙 is measured in microseconds, but still, summing it all, it's
 
 That's why it makes a lot of sense to use asynchronous ⏸🔀⏯ code for web APIs.
 
-Most of the existing popular Python frameworks (including Flask and Django) were created before the new asynchronous features in Python existed. So, the ways they can be deployed support parallel execution and an older form of asynchronous execution that is not as powerful as the new capabilities.
-
-Even though the main specification for asynchronous web Python (ASGI) was developed at Django, to add support for WebSockets.
-
-That kind of asynchronicity is what made NodeJS popular (even though NodeJS is not parallel) and that's the strength of Go as a programming language.
+This kind of asynchronicity is what made NodeJS popular (even though NodeJS is not parallel) and that's the strength of Go as a programming language.
 
 And that's the same level of performance you get with **FastAPI**.
 

--- a/docs/fr/docs/async.md
+++ b/docs/fr/docs/async.md
@@ -205,10 +205,6 @@ Cette "attente" 🕙 se mesure en microsecondes, mais tout de même, en cumulé 
 
 C'est pourquoi il est logique d'utiliser du code asynchrone ⏸🔀⏯ pour des APIs web.
 
-La plupart des frameworks Python existants (y compris Flask et Django) ont été créés avant que les nouvelles fonctionnalités asynchrones de Python n'existent. Donc, les façons dont ils peuvent être déployés supportent l'exécution parallèle  et une ancienne forme d'exécution asynchrone qui n'est pas aussi puissante que les nouvelles fonctionnalités de Python.
-
-Et cela, bien que les spécifications principales du web asynchrone en Python (ou ASGI) ont été développées chez Django, pour ajouter le support des WebSockets.
-
 Ce type d'asynchronicité est ce qui a rendu NodeJS populaire (bien que NodeJS ne soit pas parallèle) et c'est la force du Go en tant que langage de programmation.
 
 Et c'est le même niveau de performance que celui obtenu avec **FastAPI**.


### PR DESCRIPTION
Reading this lovely introduction to async yesterday, I was struck by the Flask and Django references, which seemed unneeded, and increasingly not really accurate. 

I thought the document would read better simply dropping them. 

So I thought I'd suggest that. 

Keep up the good work! 🎁 