### PR TITLE
pencil2: Fix link of sponsor doist

### DIFF
--- a/docs/en/data/sponsors.yml
+++ b/docs/en/data/sponsors.yml
@@ -11,7 +11,7 @@ gold:
   - url: https://app.imgwhale.xyz/
     title: The ultimate solution to unlimited and forever cloud storage.
     img: https://fastapi.tiangolo.com/img/sponsors/imgwhale.svg
-  - url: https://doist.com/careers/9B437B1615-wa-senior-backend-engineer-python
+  - url: https://doist.com/careers
     title: Help us migrate doist to FastAPI
     img: https://fastapi.tiangolo.com/img/sponsors/doist.svg
 silver:


### PR DESCRIPTION
Corrects the link of the sponsor 'doist'.

Changes` url: https://doist.com/careers/9B437B1615-wa-senior-backend-engineer-python` to `url: https://doist.com/careers`

The current link redirect to a page like this


![doist_404](https://user-images.githubusercontent.com/37416577/185499557-b0ca2744-09db-463a-9d91-73b9190bfd79.png)
