### PR TITLE
Specificy a minimum version for flit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit"]
+requires = ["flit >=3.2"]
 build-backend = "flit.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
If we leave the flit version unbound and by change an 1.x or 2.x version
is already installed, failures will happen, as an attempt will be done
to import flit_core.inifile, which doesn't exist, as there is no
flit_core in onder versions.