### PR TITLE
Use flit-core as build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "fastapi"


### PR DESCRIPTION
Build functionality has been moved into flit-core which makes repackaging (e.g. for Conda or Linux distros) easier.