### PR TITLE
📝 Add tip about using alias for form data fields

### DIFF
--- a/docs/en/docs/tutorial/request-forms.md
+++ b/docs/en/docs/tutorial/request-forms.md
@@ -27,7 +27,7 @@ For example, in one of the ways the OAuth2 specification can be used (called "pa
 
 The <abbr title="specification">spec</abbr> requires the fields to be exactly named `username` and `password`, and to be sent as form fields, not JSON.
 
-With `Form` you can declare the same metadata and validation as with `Body` (and `Query`, `Path`, `Cookie`).
+With `Form` you can declare the same configurations as with `Body` (and `Query`, `Path`, `Cookie`), including validation, examples, an alias (e.g. `user-name` instead of `username`), etc.
 
 !!! info
     `Form` is a class that inherits directly from `Body`.


### PR DESCRIPTION
📝 Add tip about using alias for form data fields.

This would supersede https://github.com/tiangolo/fastapi/pull/2706