### PR TITLE
Fix OIDC response code when authorization header is missing

### DIFF
--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -4,7 +4,6 @@ from fastapi.openapi.models import OpenIdConnect as OpenIdConnectModel
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_403_FORBIDDEN
 
 
 class OpenIdConnect(SecurityBase):

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -27,7 +27,9 @@ class OpenIdConnect(SecurityBase):
         if not authorization:
             if self.auto_error:
                 raise HTTPException(
-                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail="Not authenticated",
+                    headers={"WWW-Authenticate": "Bearer"},
                 )
             else:
                 return None


### PR DESCRIPTION
Using a 401 instead of 403 aligns with the HTTP standard when authentication is missing and with the [existing OAuth2 dependency](https://github.com/tiangolo/fastapi/blob/b9d7f86743eb9ba2805ae0c8b99a30a3a47a58bb/fastapi/security/oauth2.py#L207-L210).