### PR TITLE
♻️ Refactor code to support new HTTPX-based `TestClient`

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -33,9 +33,10 @@ from fastapi.types import DecoratedCallable
 from fastapi.utils import generate_unique_id
 from starlette.applications import Starlette
 from starlette.datastructures import State
-from starlette.exceptions import ExceptionMiddleware, HTTPException
+from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.middleware.errors import ServerErrorMiddleware
+from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import BaseRoute

--- a/tests/test_enforce_once_required_parameter.py
+++ b/tests/test_enforce_once_required_parameter.py
@@ -101,7 +101,7 @@ def test_schema():
 
 
 def test_get_invalid():
-    response = client.get("/foo", params={"client_id": None})
+    response = client.get("/foo")
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -333,7 +333,7 @@ def test_get_api_route_not_decorated():
 
 
 def test_delete():
-    response = client.delete("/items/foo", json={"name": "Foo"})
+    response = client.request("DELETE", "/items/foo", json={"name": "Foo"})
     assert response.status_code == 200, response.text
     assert response.json() == {"item_id": "foo", "item": {"name": "Foo", "price": None}}
 

--- a/tests/test_get_request_body.py
+++ b/tests/test_get_request_body.py
@@ -104,5 +104,5 @@ def test_openapi_schema():
 
 def test_get_with_body():
     body = {"name": "Foo", "description": "Some description", "price": 5.5}
-    response = client.get("/product", json=body)
+    response = client.request("GET", "/product", json=body)
     assert response.json() == body

--- a/tests/test_param_include_in_schema.py
+++ b/tests/test_param_include_in_schema.py
@@ -184,7 +184,8 @@ def test_openapi_schema():
     ],
 )
 def test_hidden_cookie(path, cookies, expected_status, expected_response):
-    response = client.get(path, cookies=cookies)
+    cookie_client = TestClient(app, cookies=cookies)
+    response = cookie_client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
 

--- a/tests/test_security_api_key_cookie.py
+++ b/tests/test_security_api_key_cookie.py
@@ -57,7 +57,8 @@ def test_openapi_schema():
 
 
 def test_security_api_key():
-    response = client.get("/users/me", cookies={"key": "secret"})
+    cookie_client = TestClient(app, cookies={"key": "secret"})
+    response = cookie_client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"username": "secret"}
 

--- a/tests/test_security_api_key_cookie_description.py
+++ b/tests/test_security_api_key_cookie_description.py
@@ -62,7 +62,8 @@ def test_openapi_schema():
 
 
 def test_security_api_key():
-    response = client.get("/users/me", cookies={"key": "secret"})
+    cookie_client = TestClient(app, cookies={"key": "secret"})
+    response = cookie_client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"username": "secret"}
 

--- a/tests/test_security_api_key_cookie_optional.py
+++ b/tests/test_security_api_key_cookie_optional.py
@@ -64,7 +64,8 @@ def test_openapi_schema():
 
 
 def test_security_api_key():
-    response = client.get("/users/me", cookies={"key": "secret"})
+    cookie_client = TestClient(app, cookies={"key": "secret"})
+    response = cookie_client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"username": "secret"}
 

--- a/tests/test_tuples.py
+++ b/tests/test_tuples.py
@@ -252,16 +252,14 @@ def test_tuple_with_model_invalid():
 
 
 def test_tuple_form_valid():
-    response = client.post("/tuple-form/", data=[("values", "1"), ("values", "2")])
+    response = client.post("/tuple-form/", data={"values": ["1", "2"]})
     assert response.status_code == 200, response.text
     assert response.json() == [1, 2]
 
 
 def test_tuple_form_invalid():
-    response = client.post(
-        "/tuple-form/", data=[("values", "1"), ("values", "2"), ("values", "3")]
-    )
+    response = client.post("/tuple-form/", data={"values": ["1", "2", "3"]})
     assert response.status_code == 422, response.text
 
-    response = client.post("/tuple-form/", data=[("values", "1")])
+    response = client.post("/tuple-form/", data={"values": "1"})
     assert response.status_code == 422, response.text

--- a/tests/test_tutorial/test_advanced_middleware/test_tutorial001.py
+++ b/tests/test_tutorial/test_advanced_middleware/test_tutorial001.py
@@ -9,6 +9,6 @@ def test_middleware():
     assert response.status_code == 200, response.text
 
     client = TestClient(app)
-    response = client.get("/", allow_redirects=False)
+    response = client.get("/", follow_redirects=False)
     assert response.status_code == 307, response.text
     assert response.headers["location"] == "https://testserver/"

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -176,7 +176,7 @@ def test_post_broken_body():
     response = client.post(
         "/items/",
         headers={"content-type": "application/json"},
-        data="{some broken json}",
+        content="{some broken json}",
     )
     assert response.status_code == 422, response.text
     assert response.json() == {
@@ -214,7 +214,7 @@ def test_post_form_for_json():
 def test_explicit_content_type():
     response = client.post(
         "/items/",
-        data='{"name": "Foo", "price": 50.5}',
+        content='{"name": "Foo", "price": 50.5}',
         headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 200, response.text
@@ -223,7 +223,7 @@ def test_explicit_content_type():
 def test_geo_json():
     response = client.post(
         "/items/",
-        data='{"name": "Foo", "price": 50.5}',
+        content='{"name": "Foo", "price": 50.5}',
         headers={"Content-Type": "application/geo+json"},
     )
     assert response.status_code == 200, response.text
@@ -232,7 +232,7 @@ def test_geo_json():
 def test_no_content_type_is_json():
     response = client.post(
         "/items/",
-        data='{"name": "Foo", "price": 50.5}',
+        content='{"name": "Foo", "price": 50.5}',
     )
     assert response.status_code == 200, response.text
     assert response.json() == {
@@ -255,17 +255,19 @@ def test_wrong_headers():
         ]
     }
 
-    response = client.post("/items/", data=data, headers={"Content-Type": "text/plain"})
+    response = client.post(
+        "/items/", content=data, headers={"Content-Type": "text/plain"}
+    )
     assert response.status_code == 422, response.text
     assert response.json() == invalid_dict
 
     response = client.post(
-        "/items/", data=data, headers={"Content-Type": "application/geo+json-seq"}
+        "/items/", content=data, headers={"Content-Type": "application/geo+json-seq"}
     )
     assert response.status_code == 422, response.text
     assert response.json() == invalid_dict
     response = client.post(
-        "/items/", data=data, headers={"Content-Type": "application/not-really-json"}
+        "/items/", content=data, headers={"Content-Type": "application/not-really-json"}
     )
     assert response.status_code == 422, response.text
     assert response.json() == invalid_dict

--- a/tests/test_tutorial/test_body/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body/test_tutorial001_py310.py
@@ -185,7 +185,7 @@ def test_post_broken_body(client: TestClient):
     response = client.post(
         "/items/",
         headers={"content-type": "application/json"},
-        data="{some broken json}",
+        content="{some broken json}",
     )
     assert response.status_code == 422, response.text
     assert response.json() == {
@@ -225,7 +225,7 @@ def test_post_form_for_json(client: TestClient):
 def test_explicit_content_type(client: TestClient):
     response = client.post(
         "/items/",
-        data='{"name": "Foo", "price": 50.5}',
+        content='{"name": "Foo", "price": 50.5}',
         headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 200, response.text
@@ -235,7 +235,7 @@ def test_explicit_content_type(client: TestClient):
 def test_geo_json(client: TestClient):
     response = client.post(
         "/items/",
-        data='{"name": "Foo", "price": 50.5}',
+        content='{"name": "Foo", "price": 50.5}',
         headers={"Content-Type": "application/geo+json"},
     )
     assert response.status_code == 200, response.text
@@ -245,7 +245,7 @@ def test_geo_json(client: TestClient):
 def test_no_content_type_is_json(client: TestClient):
     response = client.post(
         "/items/",
-        data='{"name": "Foo", "price": 50.5}',
+        content='{"name": "Foo", "price": 50.5}',
     )
     assert response.status_code == 200, response.text
     assert response.json() == {
@@ -269,17 +269,19 @@ def test_wrong_headers(client: TestClient):
         ]
     }
 
-    response = client.post("/items/", data=data, headers={"Content-Type": "text/plain"})
+    response = client.post(
+        "/items/", content=data, headers={"Content-Type": "text/plain"}
+    )
     assert response.status_code == 422, response.text
     assert response.json() == invalid_dict
 
     response = client.post(
-        "/items/", data=data, headers={"Content-Type": "application/geo+json-seq"}
+        "/items/", content=data, headers={"Content-Type": "application/geo+json-seq"}
     )
     assert response.status_code == 422, response.text
     assert response.json() == invalid_dict
     response = client.post(
-        "/items/", data=data, headers={"Content-Type": "application/not-really-json"}
+        "/items/", content=data, headers={"Content-Type": "application/not-really-json"}
     )
     assert response.status_code == 422, response.text
     assert response.json() == invalid_dict

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001.py
@@ -88,6 +88,7 @@ openapi_schema = {
     ],
 )
 def test(path, cookies, expected_status, expected_response):
-    response = client.get(path, cookies=cookies)
+    cookie_client = TestClient(app, cookies=cookies)
+    response = cookie_client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001_py310.py
@@ -95,6 +95,9 @@ def get_client():
     ],
 )
 def test(path, cookies, expected_status, expected_response, client: TestClient):
-    response = client.get(path, cookies=cookies)
+    from docs_src.cookie_params.tutorial001_py310 import app
+
+    cookie_client = TestClient(app, cookies=cookies)
+    response = cookie_client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial001.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial001.py
@@ -26,7 +26,7 @@ def test_gzip_request(compress):
         data = gzip.compress(data)
         headers["Content-Encoding"] = "gzip"
     headers["Content-Type"] = "application/json"
-    response = client.post("/sum", data=data, headers=headers)
+    response = client.post("/sum", content=data, headers=headers)
     assert response.json() == {"sum": n}
 
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial006.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006.py
@@ -32,6 +32,6 @@ def test_openapi_schema():
 
 
 def test_get():
-    response = client.get("/typer", allow_redirects=False)
+    response = client.get("/typer", follow_redirects=False)
     assert response.status_code == 307, response.text
     assert response.headers["location"] == "https://typer.tiangolo.com"

--- a/tests/test_tutorial/test_custom_response/test_tutorial006b.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006b.py
@@ -27,6 +27,6 @@ def test_openapi_schema():
 
 
 def test_redirect_response_class():
-    response = client.get("/fastapi", allow_redirects=False)
+    response = client.get("/fastapi", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "https://fastapi.tiangolo.com"

--- a/tests/test_tutorial/test_custom_response/test_tutorial006c.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006c.py
@@ -27,6 +27,6 @@ def test_openapi_schema():
 
 
 def test_redirect_status_code():
-    response = client.get("/pydantic", allow_redirects=False)
+    response = client.get("/pydantic", follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["location"] == "https://pydantic-docs.helpmanual.io/"

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial006.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial006.py
@@ -47,7 +47,7 @@ def test_openapi_schema():
 
 
 def test_post():
-    response = client.post("/items/", data=b"this is actually not validated")
+    response = client.post("/items/", content=b"this is actually not validated")
     assert response.status_code == 200, response.text
     assert response.json() == {
         "size": 30,

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial007.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial007.py
@@ -58,7 +58,7 @@ def test_post():
         - x-men
         - x-avengers
         """
-    response = client.post("/items/", data=yaml_data)
+    response = client.post("/items/", content=yaml_data)
     assert response.status_code == 200, response.text
     assert response.json() == {
         "name": "Deadpoolio",
@@ -74,7 +74,7 @@ def test_post_broken_yaml():
         x - x-men
         x - x-avengers
         """
-    response = client.post("/items/", data=yaml_data)
+    response = client.post("/items/", content=yaml_data)
     assert response.status_code == 422, response.text
     assert response.json() == {"detail": "Invalid YAML"}
 
@@ -88,7 +88,7 @@ def test_post_invalid():
         - x-avengers
         - sneaky: object
         """
-    response = client.post("/items/", data=yaml_data)
+    response = client.post("/items/", content=yaml_data)
     assert response.status_code == 422, response.text
     assert response.json() == {
         "detail": [

--- a/tests/test_tutorial/test_websockets/test_tutorial002.py
+++ b/tests/test_tutorial/test_websockets/test_tutorial002.py
@@ -14,10 +14,9 @@ def test_main():
 
 
 def test_websocket_with_cookie():
+    cookie_client = TestClient(app, cookies={"session": "fakesession"})
     with pytest.raises(WebSocketDisconnect):
-        with client.websocket_connect(
-            "/items/foo/ws", cookies={"session": "fakesession"}
-        ) as websocket:
+        with cookie_client.websocket_connect("/items/foo/ws") as websocket:
             message = "Message one"
             websocket.send_text(message)
             data = websocket.receive_text()


### PR DESCRIPTION
♻️ Refactor code to support new HTTPX-based `TestClient`

This was done locally using @Kludex's branch of Starlette migrating the `TestClient` to HTTPX.

These are the changes that will be needed in FastAPI after that is merged.

One import in `applications.py` will be needed either way after upgrading Starlette.

The rest of the changes all make sense and seem sensible. The code would probably make more sense after this. And although some users could need to update their test suite, their code would also look more sensible after the needed refactors.