### PR TITLE
Allow a _least privilege_ model of automatic dependencies by "disabling" dependencies for individulal routers or endpoints.

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -135,6 +135,20 @@ def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> De
     return get_sub_dependant(depends=depends, dependency=depends.dependency, path=path)
 
 
+def collapse_dependencies(dependencies: list[params.Depends]) -> list[params.Depends]:
+    """
+    Process a list of dependencies, removing any prior instance
+    of a dependency if one with `disable==True` is encountered
+    """
+    result: list[params.Depends] = []
+    for depends in dependencies:
+        if depends.disable:
+            result = [d for d in result if d.dependency != depends.dependency]
+        else:
+            result.append(depends)
+    return result
+
+
 def get_sub_dependant(
     *,
     depends: params.Depends,

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -276,9 +276,12 @@ def File(  # noqa: N802
 
 
 def Depends(  # noqa: N802
-    dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
+    dependency: Optional[Callable[..., Any]] = None,
+    *,
+    use_cache: bool = True,
+    disable: bool = False,
 ) -> Any:
-    return params.Depends(dependency=dependency, use_cache=use_cache)
+    return params.Depends(dependency=dependency, use_cache=use_cache, disable=disable)
 
 
 def Security(  # noqa: N802

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -289,5 +289,8 @@ def Security(  # noqa: N802
     *,
     scopes: Optional[Sequence[str]] = None,
     use_cache: bool = True,
+    disable: bool = False,
 ) -> Any:
-    return params.Security(dependency=dependency, scopes=scopes, use_cache=use_cache)
+    return params.Security(
+        dependency=dependency, scopes=scopes, use_cache=use_cache, disable=disable
+    )

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -367,11 +367,14 @@ class Depends:
         self.use_cache = use_cache
         self.disable = disable
 
-    def __repr__(self) -> str:
+    def repr_helper(self, extra: str = "") -> str:
         attr = getattr(self.dependency, "__name__", type(self.dependency).__name__)
         cache = "" if self.use_cache else ", use_cache=False"
         disable = "" if not self.disable else ", disable=True"
-        return f"{self.__class__.__name__}({attr}{cache}{disable})"
+        return f"{self.__class__.__name__}({attr}{extra}{cache}{disable})"
+
+    def __repr__(self) -> str:
+        return self.repr_helper()
 
 
 class Security(Depends):
@@ -381,6 +384,10 @@ class Security(Depends):
         *,
         scopes: Optional[Sequence[str]] = None,
         use_cache: bool = True,
+        disable: bool = False,
     ):
-        super().__init__(dependency=dependency, use_cache=use_cache)
+        super().__init__(dependency=dependency, use_cache=use_cache, disable=disable)
         self.scopes = scopes or []
+
+    def __repr__(self) -> str:
+        return self.repr_helper(f", {self.scopes}")

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -357,15 +357,21 @@ class File(Form):
 
 class Depends:
     def __init__(
-        self, dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
+        self,
+        dependency: Optional[Callable[..., Any]] = None,
+        *,
+        use_cache: bool = True,
+        disable: bool = False,
     ):
         self.dependency = dependency
         self.use_cache = use_cache
+        self.disable = disable
 
     def __repr__(self) -> str:
         attr = getattr(self.dependency, "__name__", type(self.dependency).__name__)
         cache = "" if self.use_cache else ", use_cache=False"
-        return f"{self.__class__.__name__}({attr}{cache})"
+        disable = "" if not self.disable else ", disable=True"
+        return f"{self.__class__.__name__}({attr}{cache}{disable})"
 
 
 class Security(Depends):

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -389,5 +389,5 @@ class Security(Depends):
         super().__init__(dependency=dependency, use_cache=use_cache, disable=disable)
         self.scopes = scopes or []
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
         return self.repr_helper(f", {self.scopes}")

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -23,6 +23,7 @@ from fastapi import params
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import (
+    collapse_dependencies,
     get_body_field,
     get_dependant,
     get_parameterless_sub_dependant,
@@ -436,7 +437,7 @@ class APIRoute(routing.Route):
 
         assert callable(endpoint), "An endpoint must be a callable"
         self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
-        for depends in self.dependencies[::-1]:
+        for depends in collapse_dependencies(self.dependencies)[::-1]:
             self.dependant.dependencies.insert(
                 0,
                 get_parameterless_sub_dependant(depends=depends, path=self.path_format),

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -23,7 +23,7 @@ from fastapi import params
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import (
-    collapse_dependencies,
+    collapse_parameterless_depends,
     get_body_field,
     get_dependant,
     get_parameterless_sub_dependant,
@@ -437,7 +437,7 @@ class APIRoute(routing.Route):
 
         assert callable(endpoint), "An endpoint must be a callable"
         self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
-        for depends in collapse_dependencies(self.dependencies)[::-1]:
+        for depends in collapse_parameterless_depends(self.dependencies)[::-1]:
             self.dependant.dependencies.insert(
                 0,
                 get_parameterless_sub_dependant(depends=depends, path=self.path_format),

--- a/tests/test_dependency_disable.py
+++ b/tests/test_dependency_disable.py
@@ -1,0 +1,73 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import APIRouter, Depends, FastAPI
+from fastapi.testclient import TestClient
+
+
+def app_dependency():
+    return _app_dependency()
+
+
+def _app_dependency():
+    pass
+
+
+@pytest.fixture
+def mocks():
+    with patch.dict(globals(), {"_app_dependency": Mock()}):
+        yield
+
+
+app = FastAPI(dependencies=[Depends(app_dependency)])
+
+router1 = APIRouter()
+disable_root = APIRouter(dependencies=[Depends(app_dependency, disable=True)])
+
+
+@app.get("/root")
+def root():
+    return {}
+
+@app.get("/root_disabled", dependencies=[Depends(app_dependency, disable=True)])
+def root_disabled():
+    return {}
+
+
+
+@router1.get("/test1")
+def test1():
+    return {}
+
+
+@disable_root.get("/test2")
+def test2():
+    return {}
+
+@disable_root.get("/test2_re_enable", dependencies=[Depends(app_dependency)])
+def test2_re():
+    return {}
+
+
+app.include_router(router1, dependencies=[Depends(app_dependency, disable=True)])
+app.include_router(disable_root)
+client = TestClient(app)
+
+
+def test_root(mocks):
+    client.get("root_disabled")
+    _app_dependency.assert_not_called()
+    client.get("root")
+    _app_dependency.assert_called()
+
+
+def test_router1(mocks):
+    client.get("test1")
+    _app_dependency.assert_not_called()
+
+
+def test_router2(mocks):
+    client.get("test2")
+    _app_dependency.assert_not_called()
+    client.get("test2_re_enable")
+    _app_dependency.assert_called()

--- a/tests/test_dependency_disable.py
+++ b/tests/test_dependency_disable.py
@@ -1,7 +1,8 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
-from fastapi import APIRouter, Depends, FastAPI
+from fastapi import APIRouter, Depends, FastAPI, Security
+from fastapi.security import SecurityScopes
 from fastapi.testclient import TestClient
 
 
@@ -9,47 +10,86 @@ def app_dependency():
     return _app_dependency()
 
 
-def _app_dependency():
+def app_security(scopes: SecurityScopes):
+    _app_security(scopes.scopes)
+
+
+def _app_dependency():  # pragma: no cover
+    pass
+
+
+def _app_security(scopes):  # pragma: no cover
     pass
 
 
 @pytest.fixture
 def mocks():
-    with patch.dict(globals(), {"_app_dependency": Mock()}):
+    with patch.dict(globals(), {"_app_dependency": Mock(), "_app_security": Mock()}):
         yield
 
 
-app = FastAPI(dependencies=[Depends(app_dependency)])
+app = FastAPI(
+    dependencies=[Depends(app_dependency), Security(app_security, scopes=["b", "a"])]
+)
 
 router1 = APIRouter()
-disable_root = APIRouter(dependencies=[Depends(app_dependency, disable=True)])
+disable_root = APIRouter(
+    dependencies=[
+        Depends(app_dependency, disable=True),
+        Security(app_security, scopes=["a"], disable=True),
+    ]
+)
 
 
 @app.get("/root")
 def root():
     return {}
 
-@app.get("/root_disabled", dependencies=[Depends(app_dependency, disable=True)])
+
+@app.get(
+    "/root_disabled",
+    dependencies=[
+        Depends(app_dependency, disable=True),
+        Security(app_security, disable=True),
+    ],
+)
 def root_disabled():
     return {}
 
 
-
-@router1.get("/test1")
-def test1():
+@app.get(
+    "/root_double",
+    dependencies=[Depends(app_dependency), Security(app_security, scopes=["c"])],
+)
+def root_double():
     return {}
 
 
-@disable_root.get("/test2")
-def test2():
-    return {}
-
-@disable_root.get("/test2_re_enable", dependencies=[Depends(app_dependency)])
-def test2_re():
+@router1.get("/router1_test")
+def router1_test1():
     return {}
 
 
-app.include_router(router1, dependencies=[Depends(app_dependency, disable=True)])
+@disable_root.get("/disable_root_test")
+def disable_root_test():
+    return {}
+
+
+@disable_root.get(
+    "/disable_root_re_enable",
+    dependencies=[Depends(app_dependency), Security(app_security, scopes=["c"])],
+)
+def disable_root_re_enable():
+    return {}
+
+
+app.include_router(
+    router1,
+    dependencies=[
+        Depends(app_dependency, disable=True),
+        Security(app_security, scopes=["b"], disable=True),
+    ],
+)
 app.include_router(disable_root)
 client = TestClient(app)
 
@@ -57,17 +97,28 @@ client = TestClient(app)
 def test_root(mocks):
     client.get("root_disabled")
     _app_dependency.assert_not_called()
+    _app_security.assert_not_called()
     client.get("root")
-    _app_dependency.assert_called()
+    _app_dependency.assert_has_calls([call()])
+    _app_security.assert_has_calls([call(["b", "a"])])
+
+
+def test_root_collapse(mocks):
+    client.get("root_double")
+    _app_dependency.assert_has_calls([call()])
+    _app_security.assert_has_calls([call(["b", "a", "c"])])
 
 
 def test_router1(mocks):
-    client.get("test1")
+    client.get("router1_test")
     _app_dependency.assert_not_called()
+    _app_security.assert_has_calls([call(["a"])])
 
 
-def test_router2(mocks):
-    client.get("test2")
+def test_disable_root(mocks):
+    client.get("disable_root_test")
     _app_dependency.assert_not_called()
-    client.get("test2_re_enable")
-    _app_dependency.assert_called()
+    _app_security.assert_has_calls([call(["b"])])
+    client.get("disable_root_re_enable")
+    _app_dependency.assert_has_calls([call()])
+    _app_security.assert_has_calls([call(["b", "c"])])


### PR DESCRIPTION
Issue #2481 Mentions how it is difficult to remove a global dependency on a subset of endpoint.  The proposed solution in that defect is to add global depdencies on individual `APIRouter` instances and combine a set of those into the app.

This PR proposes a complimentary solution.  Anywhere where a `Depends(foo)` or `Security(bar)` is added as an item in a `dependencies` keyword argument, it can receive a `disable=True` keyword argument.

Once the final parameterless dependencies are gathered and added on a route, these are then processes and collapsed.  This allows an `APIRouter` to disable a global dependency which has already been added on an app object.

This allows a *least privilege* approach to API design, where nothing is allowed by default unless explicitly allowed on a case by case basis:  The `app` object can have a global dependency which requires **all** scopes, and then individual endpoints, for example those that deal with authentication, or other less privileged actions, can remove the more stringent scopes to allow access.

Additionally, multiple stacked calls to the same `Security` dependency are collapsed, merging all the provided *scopes* into a single list.  This allows the creation of virtual scopes, for example, prefixing a scope with a "-" do disable it, handling the processing of the all the scopes to a single call.  This is yet-another way disabling a scope requirement.

This is currently an undocumented feature request / proposal, containing tests.
