### PR TITLE
Added Dockerfile and Docker Compose Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Create image from lightweight python3-alpine (https://hub.docker.com/_/python).
+FROM python:3-alpine
+
+# Exposes container port 8000.
+EXPOSE 8000/tcp
+
+# Set working directory.
+WORKDIR /usr/src/app
+
+# Install git and common text editors.
+RUN apk add git
+RUN apk add vim
+RUN apk add nano
+
+# Clone FastAPI Github repo. (https://github.com/tiangolo/fastapi)
+RUN git clone https://github.com/tiangolo/fastapi.git tmp/
+RUN mv tmp/tests/ .
+RUN rm -r tmp
+
+# Install required FastAPI packages.
+RUN pip install --no-cache-dir fastapi
+RUN pip install uvicorn[standard]
+
+# Docker run command.
+# docker run -it -rm --name FastAPI -p 8000:8000 -w /usr/src/app/tests fastapi:python3-alpine uvicorn --host 0.0.0.0 main:app --reload

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 <a href="https://pypi.org/project/fastapi" target="_blank">
     <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
 </a>
+<!-->
+<a href="https://hub.docker.com/repository/docker/djlouden/fastapi" target="_blank">
+    <img src="https://img.shields.io/docker/pulls/djlouden/fastapi?color=%2334D058&label=Docker%20Pulls" alt="Docker Pulls">
+</a>
+<-->
 </p>
 
 ---
@@ -143,6 +148,41 @@ $ pip install "uvicorn[standard]"
 
 </div>
 
+### Docker
+You can use docker and docker compose to create a container with the server viewable at localhost:8000
+
+- Install [Docker Desktop](https://docs.docker.com/get-docker/) or [Docker Engine](https://docs.docker.com/engine/install/)
+- Install [Docker Compose](https://docs.docker.com/compose/install/)
+
+Review the [Dockerfile](Dockerfile) and [docker-compose.yml](docker-compose.yml).
+
+#### Docker Commands
+```
+# Build a docker image from the Dockerfile
+$ docker build -t fastapi:python3-alpine .
+
+# Run a docker container from the newly built image
+$ docker run -it -rm --name FastAPI -p 8000:8000 -w /usr/src/app/tests fastapi:python3-alpine uvicorn --host 0.0.0.0 main:app --reload
+```
+
+or
+
+```
+# Pull a prebuilt image from dockerhub: https://hub.docker.com/repository/docker/djlouden/fastapi
+$ docker pull djlouden/fastapi
+
+# Run a docker container from the newly built image
+$ docker run -it -rm --name FastAPI -p 8000:8000 -w /usr/src/app/tests fastapi:python3-alpine uvicorn --host 0.0.0.0 main:app --reload
+```
+### Docker Compose Commands
+```
+# Docker Compose pulls/builds and runs the container in one command
+$ docker-compose up -d
+
+# Tear down container
+$ docker-compsoe down
+```
+
 ## Example
 
 ### Create it
@@ -159,12 +199,12 @@ app = FastAPI()
 
 @app.get("/")
 def read_root():
-    return {"Hello": "World"}
+  return {"Hello": "World"}
 
 
 @app.get("/items/{item_id}")
 def read_item(item_id: int, q: Union[str, None] = None):
-    return {"item_id": item_id, "q": q}
+  return {"item_id": item_id, "q": q}
 ```
 
 <details markdown="1">
@@ -345,28 +385,28 @@ item: Item
 ...and with that single declaration you get:
 
 * Editor support, including:
-    * Completion.
-    * Type checks.
+  * Completion.
+  * Type checks.
 * Validation of data:
-    * Automatic and clear errors when the data is invalid.
-    * Validation even for deeply nested JSON objects.
+  * Automatic and clear errors when the data is invalid.
+  * Validation even for deeply nested JSON objects.
 * <abbr title="also known as: serialization, parsing, marshalling">Conversion</abbr> of input data: coming from the network to Python data and types. Reading from:
-    * JSON.
-    * Path parameters.
-    * Query parameters.
-    * Cookies.
-    * Headers.
-    * Forms.
-    * Files.
+  * JSON.
+  * Path parameters.
+  * Query parameters.
+  * Cookies.
+  * Headers.
+  * Forms.
+  * Files.
 * <abbr title="also known as: serialization, parsing, marshalling">Conversion</abbr> of output data: converting from Python data and types to network data (as JSON):
-    * Convert Python types (`str`, `int`, `float`, `bool`, `list`, etc).
-    * `datetime` objects.
-    * `UUID` objects.
-    * Database models.
-    * ...and many more.
+  * Convert Python types (`str`, `int`, `float`, `bool`, `list`, etc).
+  * `datetime` objects.
+  * `UUID` objects.
+  * Database models.
+  * ...and many more.
 * Automatic interactive API documentation, including 2 alternative user interfaces:
-    * Swagger UI.
-    * ReDoc.
+  * Swagger UI.
+  * ReDoc.
 
 ---
 
@@ -374,19 +414,19 @@ Coming back to the previous code example, **FastAPI** will:
 
 * Validate that there is an `item_id` in the path for `GET` and `PUT` requests.
 * Validate that the `item_id` is of type `int` for `GET` and `PUT` requests.
-    * If it is not, the client will see a useful, clear error.
+  * If it is not, the client will see a useful, clear error.
 * Check if there is an optional query parameter named `q` (as in `http://127.0.0.1:8000/items/foo?q=somequery`) for `GET` requests.
-    * As the `q` parameter is declared with `= None`, it is optional.
-    * Without the `None` it would be required (as is the body in the case with `PUT`).
+  * As the `q` parameter is declared with `= None`, it is optional.
+  * Without the `None` it would be required (as is the body in the case with `PUT`).
 * For `PUT` requests to `/items/{item_id}`, Read the body as JSON:
-    * Check that it has a required attribute `name` that should be a `str`.
-    * Check that it has a required attribute `price` that has to be a `float`.
-    * Check that it has an optional attribute `is_offer`, that should be a `bool`, if present.
-    * All this would also work for deeply nested JSON objects.
+  * Check that it has a required attribute `name` that should be a `str`.
+  * Check that it has a required attribute `price` that has to be a `float`.
+  * Check that it has an optional attribute `is_offer`, that should be a `bool`, if present.
+  * All this would also work for deeply nested JSON objects.
 * Convert from and to JSON automatically.
 * Document everything with OpenAPI, that can be used by:
-    * Interactive documentation systems.
-    * Automatic client code generation systems, for many languages.
+  * Interactive documentation systems.
+  * Automatic client code generation systems, for many languages.
 * Provide 2 interactive documentation web interfaces directly.
 
 ---
@@ -426,11 +466,11 @@ For a more complete example including more features, see the <a href="https://fa
 * More advanced (but equally easy) techniques for declaring **deeply nested JSON models** (thanks to Pydantic).
 * **GraphQL** integration with <a href="https://strawberry.rocks" class="external-link" target="_blank">Strawberry</a> and other libraries.
 * Many extra features (thanks to Starlette) as:
-    * **WebSockets**
-    * extremely easy tests based on `requests` and `pytest`
-    * **CORS**
-    * **Cookie Sessions**
-    * ...and more.
+  * **WebSockets**
+  * extremely easy tests based on `requests` and `pytest`
+  * **CORS**
+  * **Cookie Sessions**
+  * ...and more.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 <a href="https://pypi.org/project/fastapi" target="_blank">
     <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
 </a>
-<!-->
+<!--
 <a href="https://hub.docker.com/repository/docker/djlouden/fastapi" target="_blank">
     <img src="https://img.shields.io/docker/pulls/djlouden/fastapi?color=%2334D058&label=Docker%20Pulls" alt="Docker Pulls">
 </a>
-<-->
+-->
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@
 <a href="https://pypi.org/project/fastapi" target="_blank">
     <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
 </a>
-<!-->
-<a href="https://hub.docker.com/repository/docker/djlouden/fastapi" target="_blank">
-    <img src="https://img.shields.io/docker/pulls/djlouden/fastapi?color=%2334D058&label=Docker%20Pulls" alt="Docker Pulls">
-</a>
-<-->
 </p>
 
 ---
@@ -148,41 +143,6 @@ $ pip install "uvicorn[standard]"
 
 </div>
 
-### Docker
-You can use docker and docker compose to create a container with the server viewable at localhost:8000
-
-- Install [Docker Desktop](https://docs.docker.com/get-docker/) or [Docker Engine](https://docs.docker.com/engine/install/)
-- Install [Docker Compose](https://docs.docker.com/compose/install/)
-
-Review the [Dockerfile](Dockerfile) and [docker-compose.yml](docker-compose.yml).
-
-#### Docker Commands
-```
-# Build a docker image from the Dockerfile
-$ docker build -t fastapi:python3-alpine .
-
-# Run a docker container from the newly built image
-$ docker run -it -rm --name FastAPI -p 8000:8000 -w /usr/src/app/tests fastapi:python3-alpine uvicorn --host 0.0.0.0 main:app --reload
-```
-
-or
-
-```
-# Pull a prebuilt image from dockerhub: https://hub.docker.com/repository/docker/djlouden/fastapi
-$ docker pull djlouden/fastapi
-
-# Run a docker container from the newly built image
-$ docker run -it -rm --name FastAPI -p 8000:8000 -w /usr/src/app/tests fastapi:python3-alpine uvicorn --host 0.0.0.0 main:app --reload
-```
-### Docker Compose Commands
-```
-# Docker Compose pulls/builds and runs the container in one command
-$ docker-compose up -d
-
-# Tear down container
-$ docker-compsoe down
-```
-
 ## Example
 
 ### Create it
@@ -199,12 +159,12 @@ app = FastAPI()
 
 @app.get("/")
 def read_root():
-  return {"Hello": "World"}
+    return {"Hello": "World"}
 
 
 @app.get("/items/{item_id}")
 def read_item(item_id: int, q: Union[str, None] = None):
-  return {"item_id": item_id, "q": q}
+    return {"item_id": item_id, "q": q}
 ```
 
 <details markdown="1">
@@ -385,28 +345,28 @@ item: Item
 ...and with that single declaration you get:
 
 * Editor support, including:
-  * Completion.
-  * Type checks.
+    * Completion.
+    * Type checks.
 * Validation of data:
-  * Automatic and clear errors when the data is invalid.
-  * Validation even for deeply nested JSON objects.
+    * Automatic and clear errors when the data is invalid.
+    * Validation even for deeply nested JSON objects.
 * <abbr title="also known as: serialization, parsing, marshalling">Conversion</abbr> of input data: coming from the network to Python data and types. Reading from:
-  * JSON.
-  * Path parameters.
-  * Query parameters.
-  * Cookies.
-  * Headers.
-  * Forms.
-  * Files.
+    * JSON.
+    * Path parameters.
+    * Query parameters.
+    * Cookies.
+    * Headers.
+    * Forms.
+    * Files.
 * <abbr title="also known as: serialization, parsing, marshalling">Conversion</abbr> of output data: converting from Python data and types to network data (as JSON):
-  * Convert Python types (`str`, `int`, `float`, `bool`, `list`, etc).
-  * `datetime` objects.
-  * `UUID` objects.
-  * Database models.
-  * ...and many more.
+    * Convert Python types (`str`, `int`, `float`, `bool`, `list`, etc).
+    * `datetime` objects.
+    * `UUID` objects.
+    * Database models.
+    * ...and many more.
 * Automatic interactive API documentation, including 2 alternative user interfaces:
-  * Swagger UI.
-  * ReDoc.
+    * Swagger UI.
+    * ReDoc.
 
 ---
 
@@ -414,19 +374,19 @@ Coming back to the previous code example, **FastAPI** will:
 
 * Validate that there is an `item_id` in the path for `GET` and `PUT` requests.
 * Validate that the `item_id` is of type `int` for `GET` and `PUT` requests.
-  * If it is not, the client will see a useful, clear error.
+    * If it is not, the client will see a useful, clear error.
 * Check if there is an optional query parameter named `q` (as in `http://127.0.0.1:8000/items/foo?q=somequery`) for `GET` requests.
-  * As the `q` parameter is declared with `= None`, it is optional.
-  * Without the `None` it would be required (as is the body in the case with `PUT`).
+    * As the `q` parameter is declared with `= None`, it is optional.
+    * Without the `None` it would be required (as is the body in the case with `PUT`).
 * For `PUT` requests to `/items/{item_id}`, Read the body as JSON:
-  * Check that it has a required attribute `name` that should be a `str`.
-  * Check that it has a required attribute `price` that has to be a `float`.
-  * Check that it has an optional attribute `is_offer`, that should be a `bool`, if present.
-  * All this would also work for deeply nested JSON objects.
+    * Check that it has a required attribute `name` that should be a `str`.
+    * Check that it has a required attribute `price` that has to be a `float`.
+    * Check that it has an optional attribute `is_offer`, that should be a `bool`, if present.
+    * All this would also work for deeply nested JSON objects.
 * Convert from and to JSON automatically.
 * Document everything with OpenAPI, that can be used by:
-  * Interactive documentation systems.
-  * Automatic client code generation systems, for many languages.
+    * Interactive documentation systems.
+    * Automatic client code generation systems, for many languages.
 * Provide 2 interactive documentation web interfaces directly.
 
 ---
@@ -466,11 +426,11 @@ For a more complete example including more features, see the <a href="https://fa
 * More advanced (but equally easy) techniques for declaring **deeply nested JSON models** (thanks to Pydantic).
 * **GraphQL** integration with <a href="https://strawberry.rocks" class="external-link" target="_blank">Strawberry</a> and other libraries.
 * Many extra features (thanks to Starlette) as:
-  * **WebSockets**
-  * extremely easy tests based on `requests` and `pytest`
-  * **CORS**
-  * **Cookie Sessions**
-  * ...and more.
+    * **WebSockets**
+    * extremely easy tests based on `requests` and `pytest`
+    * **CORS**
+    * **Cookie Sessions**
+    * ...and more.
 
 ## Performance
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+---
+version: "3"
+
+services:
+
+  ## Gives error on first build (compose tries to pull?) but still works.
+  # fastapi:
+  #   build: .
+  #   container_name: fastapi
+  #   image: fastapi:python3-apline
+  #   ports:
+  #     - 8000:8000
+  #   working_dir: /usr/src/app/tests
+  #   command: uvicorn --host 0.0.0.0 main:app --reload
+
+  # Use prebuilt image
+  fastapi:
+    container_name: fastapi
+    image: djlouden/fastapi:python3-alpine
+    ports:
+      - 8000:8000
+    working_dir: /usr/src/app/tests
+    command: uvicorn --host 0.0.0.0 main:app --reload

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -17,6 +17,11 @@
 <a href="https://pypi.org/project/fastapi" target="_blank">
     <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
 </a>
+<!-->
+<a href="https://hub.docker.com/repository/docker/djlouden/fastapi" target="_blank">
+    <img src="https://img.shields.io/docker/pulls/djlouden/fastapi?color=%2334D058&label=Docker%20Pulls" alt="Docker Pulls">
+</a>
+<-->
 </p>
 
 ---
@@ -46,14 +51,17 @@ The key features are:
 
 <!-- sponsors -->
 
-{% if sponsors %}
-{% for sponsor in sponsors.gold -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
-{% endfor -%}
-{%- for sponsor in sponsors.silver -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
-{% endfor %}
-{% endif %}
+<a href="https://bit.ly/3dmXC5S" target="_blank" title="The data structure for unstructured multimodal data"><img src="https://fastapi.tiangolo.com/img/sponsors/docarray.svg"></a>
+<a href="https://bit.ly/3JJ7y5C" target="_blank" title="Build cross-modal and multimodal applications on the cloud"><img src="https://fastapi.tiangolo.com/img/sponsors/jina2.svg"></a>
+<a href="https://cryptapi.io/" target="_blank" title="CryptAPI: Your easy to use, secure and privacy oriented payment gateway."><img src="https://fastapi.tiangolo.com/img/sponsors/cryptapi.svg"></a>
+<a href="https://doist.com/careers/9B437B1615-wa-senior-backend-engineer-python" target="_blank" title="Help us migrate doist to FastAPI"><img src="https://fastapi.tiangolo.com/img/sponsors/doist.svg"></a>
+<a href="https://www.deta.sh/?ref=fastapi" target="_blank" title="The launchpad for all your (team's) ideas"><img src="https://fastapi.tiangolo.com/img/sponsors/deta.svg"></a>
+<a href="https://www.investsuite.com/jobs" target="_blank" title="Wealthtech jobs with FastAPI"><img src="https://fastapi.tiangolo.com/img/sponsors/investsuite.svg"></a>
+<a href="https://training.talkpython.fm/fastapi-courses" target="_blank" title="FastAPI video courses on demand from people you trust"><img src="https://fastapi.tiangolo.com/img/sponsors/talkpython.png"></a>
+<a href="https://testdriven.io/courses/tdd-fastapi/" target="_blank" title="Learn to build high-quality web apps with best practices"><img src="https://fastapi.tiangolo.com/img/sponsors/testdriven.svg"></a>
+<a href="https://github.com/deepset-ai/haystack/" target="_blank" title="Build powerful search from composable, open source building blocks"><img src="https://fastapi.tiangolo.com/img/sponsors/haystack-fastapi.svg"></a>
+<a href="https://www.udemy.com/course/fastapi-rest/" target="_blank" title="Learn FastAPI by building a complete project. Extend your knowledge on advanced web development-AWS, Payments, Emails."><img src="https://fastapi.tiangolo.com/img/sponsors/ines-course.jpg"></a>
+<a href="https://careers.budget-insight.com/" target="_blank" title="Budget Insight is hiring!"><img src="https://fastapi.tiangolo.com/img/sponsors/budget-insight.svg"></a>
 
 <!-- /sponsors -->
 
@@ -140,6 +148,41 @@ $ pip install "uvicorn[standard]"
 
 </div>
 
+### Docker
+You can use docker and docker compose to create a container with the server viewable at localhost:8000
+
+- Install [Docker Desktop](https://docs.docker.com/get-docker/) or [Docker Engine](https://docs.docker.com/engine/install/)
+- Install [Docker Compose](https://docs.docker.com/compose/install/)
+
+Review the [Dockerfile](Dockerfile) and [docker-compose.yml](docker-compose.yml).
+
+#### Docker Commands
+```
+# Build a docker image from the Dockerfile
+$ docker build -t fastapi:python3-alpine .
+
+# Run a docker container from the newly built image
+$ docker run -it -rm --name FastAPI -p 8000:8000 -w /usr/src/app/tests fastapi:python3-alpine uvicorn --host 0.0.0.0 main:app --reload
+```
+
+or
+
+```
+# Pull a prebuilt image from dockerhub: https://hub.docker.com/repository/docker/djlouden/fastapi
+$ docker pull djlouden/fastapi
+
+# Run a docker container from the newly built image
+$ docker run -it -rm --name FastAPI -p 8000:8000 -w /usr/src/app/tests fastapi:python3-alpine uvicorn --host 0.0.0.0 main:app --reload
+```
+### Docker Compose Commands
+```
+# Docker Compose pulls/builds and runs the container in one command
+$ docker-compose up -d
+
+# Tear down container
+$ docker-compsoe down
+```
+
 ## Example
 
 ### Create it
@@ -156,12 +199,12 @@ app = FastAPI()
 
 @app.get("/")
 def read_root():
-    return {"Hello": "World"}
+  return {"Hello": "World"}
 
 
 @app.get("/items/{item_id}")
 def read_item(item_id: int, q: Union[str, None] = None):
-    return {"item_id": item_id, "q": q}
+  return {"item_id": item_id, "q": q}
 ```
 
 <details markdown="1">
@@ -342,28 +385,28 @@ item: Item
 ...and with that single declaration you get:
 
 * Editor support, including:
-    * Completion.
-    * Type checks.
+  * Completion.
+  * Type checks.
 * Validation of data:
-    * Automatic and clear errors when the data is invalid.
-    * Validation even for deeply nested JSON objects.
+  * Automatic and clear errors when the data is invalid.
+  * Validation even for deeply nested JSON objects.
 * <abbr title="also known as: serialization, parsing, marshalling">Conversion</abbr> of input data: coming from the network to Python data and types. Reading from:
-    * JSON.
-    * Path parameters.
-    * Query parameters.
-    * Cookies.
-    * Headers.
-    * Forms.
-    * Files.
+  * JSON.
+  * Path parameters.
+  * Query parameters.
+  * Cookies.
+  * Headers.
+  * Forms.
+  * Files.
 * <abbr title="also known as: serialization, parsing, marshalling">Conversion</abbr> of output data: converting from Python data and types to network data (as JSON):
-    * Convert Python types (`str`, `int`, `float`, `bool`, `list`, etc).
-    * `datetime` objects.
-    * `UUID` objects.
-    * Database models.
-    * ...and many more.
+  * Convert Python types (`str`, `int`, `float`, `bool`, `list`, etc).
+  * `datetime` objects.
+  * `UUID` objects.
+  * Database models.
+  * ...and many more.
 * Automatic interactive API documentation, including 2 alternative user interfaces:
-    * Swagger UI.
-    * ReDoc.
+  * Swagger UI.
+  * ReDoc.
 
 ---
 
@@ -371,19 +414,19 @@ Coming back to the previous code example, **FastAPI** will:
 
 * Validate that there is an `item_id` in the path for `GET` and `PUT` requests.
 * Validate that the `item_id` is of type `int` for `GET` and `PUT` requests.
-    * If it is not, the client will see a useful, clear error.
+  * If it is not, the client will see a useful, clear error.
 * Check if there is an optional query parameter named `q` (as in `http://127.0.0.1:8000/items/foo?q=somequery`) for `GET` requests.
-    * As the `q` parameter is declared with `= None`, it is optional.
-    * Without the `None` it would be required (as is the body in the case with `PUT`).
+  * As the `q` parameter is declared with `= None`, it is optional.
+  * Without the `None` it would be required (as is the body in the case with `PUT`).
 * For `PUT` requests to `/items/{item_id}`, Read the body as JSON:
-    * Check that it has a required attribute `name` that should be a `str`.
-    * Check that it has a required attribute `price` that has to be a `float`.
-    * Check that it has an optional attribute `is_offer`, that should be a `bool`, if present.
-    * All this would also work for deeply nested JSON objects.
+  * Check that it has a required attribute `name` that should be a `str`.
+  * Check that it has a required attribute `price` that has to be a `float`.
+  * Check that it has an optional attribute `is_offer`, that should be a `bool`, if present.
+  * All this would also work for deeply nested JSON objects.
 * Convert from and to JSON automatically.
 * Document everything with OpenAPI, that can be used by:
-    * Interactive documentation systems.
-    * Automatic client code generation systems, for many languages.
+  * Interactive documentation systems.
+  * Automatic client code generation systems, for many languages.
 * Provide 2 interactive documentation web interfaces directly.
 
 ---
@@ -423,11 +466,11 @@ For a more complete example including more features, see the <a href="https://fa
 * More advanced (but equally easy) techniques for declaring **deeply nested JSON models** (thanks to Pydantic).
 * **GraphQL** integration with <a href="https://strawberry.rocks" class="external-link" target="_blank">Strawberry</a> and other libraries.
 * Many extra features (thanks to Starlette) as:
-    * **WebSockets**
-    * extremely easy tests based on `requests` and `pytest`
-    * **CORS**
-    * **Cookie Sessions**
-    * ...and more.
+  * **WebSockets**
+  * extremely easy tests based on `requests` and `pytest`
+  * **CORS**
+  * **Cookie Sessions**
+  * ...and more.
 
 ## Performance
 


### PR DESCRIPTION
- Created and added a Dockerfile to allow users to build a docker image from an officially supported python3-alpine base.

- Created and added a docker-compose.yml file to allow users to utilize docker compose to build or pull and run the FastAPI container with 1 command.

- Updated README.md to include docker/docker compose install instructions and how to build or pull the FastAPI image and run a container using docker and also docker-compose.