### PR TITLE
Fix PR checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
     "python-multipart >=0.0.5,<0.0.6",
     "flask >=1.1.2,<3.0.0",
     "anyio[trio] >=3.2.1,<4.0.0",
+    "trio < 0.22.0",
     "python-jose[cryptography] >=3.3.0,<4.0.0",
     "pyyaml >=5.3.1,<7.0.0",
     "passlib[bcrypt] >=1.7.2,<2.0.0",

--- a/tests/test_route_scope.py
+++ b/tests/test_route_scope.py
@@ -46,5 +46,5 @@ def test_websocket():
 
 def test_websocket_invalid_path_doesnt_match():
     with pytest.raises(WebSocketDisconnect):
-        with client.websocket_connect("/itemsx/portal-gun") as websocket:
-            websocket.receive_json()
+        with client.websocket_connect("/itemsx/portal-gun"):
+            raise AssertionError("websocket_connect should fail")  # pragma: no cover


### PR DESCRIPTION
I noticed a couple of failures on my other PR that weren't related to my changes, so I decided to address them:

- On `test_websocket_invalid_path_doesnt_match`, the code inside the `with` block is not suppose to execute, so a `# pragma: no cover` was added
- [trio release 0.22](https://pypi.org/project/trio/0.22.0/) from a few days ago breaks anyio tests due to a DeprecationWarning. 
  It will be fixed in the next anyio release, but in me meantime I added a constraint for `trio < 0.22.0`