### PR TITLE
make sure sub_value type is a function

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -690,7 +690,8 @@ async def request_body_to_args(
 
                 async with anyio.create_task_group() as tg:
                     for sub_value in value:
-                        tg.start_soon(process_fn, sub_value.read)
+                        if isinstance(sub_value, FunctionType):
+                            tg.start_soon(process_fn, sub_value.read)
                 value = sequence_shape_to_type[field.shape](results)
 
             v_, errors_ = field.validate(value, values, loc=loc)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -690,7 +690,7 @@ async def request_body_to_args(
 
                 async with anyio.create_task_group() as tg:
                     for sub_value in value:
-                        if isinstance(sub_value, FunctionType):
+                        if not isinstance(sub_value, str):
                             tg.start_soon(process_fn, sub_value.read)
                 value = sequence_shape_to_type[field.shape](results)
 


### PR DESCRIPTION
to fix

fastapi/dependencies/utils.py", line 693, in request_body_to_args
    tg.start_soon(process_fn, sub_value.read)
AttributeError: 'str' object has no attribute 'read'