### PR TITLE
perf: improve solve_dependencies increasing requests/s by 18%

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -539,9 +539,8 @@ async def solve_dependencies(
     values: Dict[str, Any] = {}
     errors: List[Any] = []
     if response is None:
-        # HACK: avoid generating the content-length header by setting the status code
-        # to a number lower than 200.
-        response = Response(status_code=0)
+        response = Response()
+        del response.headers["content-length"]
         response.status_code = None  # type: ignore
     dependency_cache = dependency_cache or {}
     sub_dependant: Dependant


### PR DESCRIPTION
Improve performance of function `solve_dependencies` by reducing accesses to headers, cookies and other request/response properties, which are slow in starlette. This yields and increase of requests / second of about 18%.

The PR include two changes:
The first were we use `Response(status_code=0)` to avoid creating the response with the `Content-Length` header, because accessing response.headers and mutating it is slow.

The second change checks whether there are going to be changes to the values. If not, then we don't access the request properties.

Note that the funciton `request_params_to_args` will return empty if the first argument is an empty list.

## Performance Tests
The change was tested using uvicorn with the following settings

```
uvicorn --no-access-log --no-proxy-headers test:app
```

and the following app

```py
from typing import Any

import fastapi
from fastapi import responses, routing

app = fastapi.FastAPI()

@app.get("/sync")
def sync():
    return "ok"

@app.get("/async")
async def asynch():
    return "ok"
```

### Baseline
```
$ wrk -d 30 http://localhost:8000/async
Running 30s test @ http://localhost:8000/async
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.22ms  204.74us   8.43ms   94.62%
    Req/Sec     4.06k   273.50     7.16k    92.18%
  243045 requests in 30.10s, 29.67MB read
Requests/sec:   8074.13
```

### With the change
```
$ wrk -d 30 http://localhost:8000/async
Running 30s test @ http://localhost:8000/async
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.04ms  307.42us  10.70ms   97.48%
    Req/Sec     4.80k   308.87     5.06k    94.67%
  286439 requests in 30.01s, 34.97MB read
Requests/sec:   9544.14
Transfer/sec:      1.17MB
```

Note that the original PR had also another change that allows it to squeeze some more performance gains, although minimal.

Instead of constructing the response as

```py
response = Response()
del response.headers["content-length"]
```

we changed it to

```py
response = Response(status_code=0)
```

which avoids creating the headers in the first place, which in turns also avoid creating a mutable copy of the headers.
