### PR TITLE
Use dict (ordered set) for APIRouter.tags 

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -499,7 +499,7 @@ class APIRouter(routing.Router):
                 "/"
             ), "A path prefix must not end with '/', as the routes will start with '/'"
         self.prefix = prefix
-        self.tags: List[Union[str, Enum]] = tags or []
+        self.tags: Dict[Union[str, Enum]] = dict.fromkeys(tags) if tags else {}
         self.dependencies = list(dependencies or []) or []
         self.deprecated = deprecated
         self.include_in_schema = include_in_schema
@@ -552,7 +552,7 @@ class APIRouter(routing.Router):
         )
         current_tags = self.tags.copy()
         if tags:
-            current_tags.extend(tags)
+            current_tags.update(dict.fromkeys(tags))
         current_dependencies = self.dependencies.copy()
         if dependencies:
             current_dependencies.extend(dependencies)
@@ -567,7 +567,7 @@ class APIRouter(routing.Router):
             endpoint=endpoint,
             response_model=response_model,
             status_code=status_code,
-            tags=current_tags,
+            tags=list(current_tags),
             dependencies=current_dependencies,
             summary=summary,
             description=description,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -499,7 +499,7 @@ class APIRouter(routing.Router):
                 "/"
             ), "A path prefix must not end with '/', as the routes will start with '/'"
         self.prefix = prefix
-        self.tags: Dict[Union[str, Enum]] = dict.fromkeys(tags) if tags else {}
+        self.tags: Dict[Union[str, Enum], None] = dict.fromkeys(tags) if tags else {}
         self.dependencies = list(dependencies or []) or []
         self.deprecated = deprecated
         self.include_in_schema = include_in_schema

--- a/tests/test_duplicate_tags.py
+++ b/tests/test_duplicate_tags.py
@@ -16,7 +16,7 @@ def read_items(request: Request):
 app.include_router(router)
 
 
-@app.get('/test/', tags=["test", "test"])
+@app.get("/test/", tags=["test", "test"])
 def read_test():
     return "test"
 

--- a/tests/test_duplicate_tags.py
+++ b/tests/test_duplicate_tags.py
@@ -1,0 +1,31 @@
+"""Test case for possible tag duplication to prevent issues with '/redoc'"""
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+router = APIRouter(tags=["items", "items"])
+
+
+@router.get("/items/")
+def read_items(request: Request):
+    return JSONResponse({"hello": "world"})
+
+
+app.include_router(router)
+
+
+@app.get('/test/', tags=["test", "test"])
+def read_test():
+    return "test"
+
+
+client = TestClient(app)
+
+
+def test_sub_router():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert '"tags":["items"]' in response.text
+    assert '"tags":["test"]' in response.text

--- a/tests/test_duplicate_tags.py
+++ b/tests/test_duplicate_tags.py
@@ -24,8 +24,18 @@ def read_test():
 client = TestClient(app)
 
 
-def test_sub_router():
+def test_openapi_for_duplicates():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
     assert '"tags":["items"]' in response.text
     assert '"tags":["test"]' in response.text
+
+
+def test_items_url():
+    response = client.get("/items")
+    assert response.status_code == 200, response.text
+
+
+def test_test_url():
+    response = client.get("/test")
+    assert response.status_code == 200, response.text


### PR DESCRIPTION
It was possible to specify the same tags multiple times which caused issues with ReDoc Discovered while using fastapi-utils' CBV