### PR TITLE
Make pyproject.toml PEP 621 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fastapi"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 readme = "README.md"
 requires-python = ">=3.7"
-license = "MIT"
+license = {text = "MIT"}
 authors = [
     { name = "Sebastián Ramírez", email = "tiangolo@gmail.com" },
 ]


### PR DESCRIPTION
The issue is (had issues with building this with buildroot), which requires this to be correct:

```text
$ validate-pyproject pyproject.toml                          
Invalid file: pyproject.toml
[ERROR] `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
```

For more info: https://peps.python.org/pep-0621/#license

After this change:

```text
$ validate-pyproject pyproject.toml
Valid file: pyproject.toml
```

For the record:

```text
$ validate-pyproject --version     
validate_pyproject 0.10.1
```