### PR TITLE
🐛 Fix internal Trio test warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,5 +137,6 @@ filterwarnings = [
     'ignore:The loop argument is deprecated since Python 3\.8, and scheduled for removal in Python 3\.10:DeprecationWarning:asyncio',
     'ignore:starlette.middleware.wsgi is deprecated and will be removed in a future release\..*:DeprecationWarning:starlette',
     # see https://trio.readthedocs.io/en/stable/history.html#trio-0-22-0-2022-09-28
-    'ignore::trio.TrioDeprecationWarning',
+    'ignore:trio\.MultiError is deprecated since Trio.*::trio',
+    "ignore:You seem to already have a custom.*:RuntimeWarning:trio",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,5 +138,7 @@ filterwarnings = [
     'ignore:starlette.middleware.wsgi is deprecated and will be removed in a future release\..*:DeprecationWarning:starlette',
     # see https://trio.readthedocs.io/en/stable/history.html#trio-0-22-0-2022-09-28
     "ignore:You seem to already have a custom.*:RuntimeWarning:trio",
-    'ignore::trio.TrioDeprecationWarning',
+    "ignore::trio.TrioDeprecationWarning",
+    # TODO remove pytest-cov
+    'ignore::pytest.PytestDeprecationWarning:pytest_cov',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,6 @@ filterwarnings = [
     'ignore:The loop argument is deprecated since Python 3\.8, and scheduled for removal in Python 3\.10:DeprecationWarning:asyncio',
     'ignore:starlette.middleware.wsgi is deprecated and will be removed in a future release\..*:DeprecationWarning:starlette',
     # see https://trio.readthedocs.io/en/stable/history.html#trio-0-22-0-2022-09-28
-    'ignore:trio\.MultiError is deprecated since Trio.*::trio',
     "ignore:You seem to already have a custom.*:RuntimeWarning:trio",
+    'ignore::trio.TrioDeprecationWarning',
 ]


### PR DESCRIPTION
Hi, without this fastapi is failing again due to trio warnings while testing. See #5545 and https://github.com/pydantic/pydantic/pull/4662.

There are two problems here (or one causing two issues):

There's a runtime warning from trio:

```
RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
```

This was being raised by some tests, but also by the warning line `'ignore::trio.TrioDeprecationWarning',` - hence the new warning ignore has to come before that line.

I've no idea what change is causing this, would be great if every test dep could be frozen, e.g. with `pip-compile`, so these issues don't keep coming up.