### PR TITLE
return authorization token in OpenIdConnect

### DIFF
--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from fastapi.openapi.models import OpenIdConnect as OpenIdConnectModel
 from fastapi.security.base import SecurityBase
+from fastapi.security.utils import get_authorization_scheme_param
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_403_FORBIDDEN
@@ -24,11 +25,12 @@ class OpenIdConnect(SecurityBase):
 
     async def __call__(self, request: Request) -> Optional[str]:
         authorization: str = request.headers.get("Authorization")
-        if not authorization:
+        scheme, param = get_authorization_scheme_param(authorization)
+        if not authorization or scheme.lower() != "bearer":
             if self.auto_error:
                 raise HTTPException(
                     status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
                 )
             else:
                 return None
-        return authorization
+        return param


### PR DESCRIPTION
In all oauth based security middlewares, the token is directly returned, IMO this should be the same in oidc , which is just oauth2 + a bunch of service discovery.

This could be a breaking change, or even wrong? In my case I would return the token directly because I didnt see any other authorization header other than bearer header