### PR TITLE
fix: update middleware stack order allow the AsyncExitStackMiddleware to run before user_middleware

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -161,6 +161,7 @@ class FastAPI(Starlette):
 
         middleware = (
             [Middleware(ServerErrorMiddleware, handler=error_handler, debug=debug)]
+            + [Middleware(AsyncExitStackMiddleware)]
             + self.user_middleware
             + [
                 Middleware(
@@ -186,7 +187,6 @@ class FastAPI(Starlette):
                 # ExceptionMiddleware, now dependencies can catch handled exceptions,
                 # e.g. HTTPException, to customize the teardown code (e.g. DB session
                 # rollback).
-                Middleware(AsyncExitStackMiddleware),
             ]
         )
 


### PR DESCRIPTION
fixing https://github.com/tiangolo/fastapi/issues/5597