### PR TITLE
merge nonparam security dependency scopes into endpoint parameter security scopes

### DIFF
--- a/docs/en/docs/advanced/security/oauth2-scopes.md
+++ b/docs/en/docs/advanced/security/oauth2-scopes.md
@@ -266,4 +266,15 @@ The most secure is the code flow, but is more complex to implement as it require
 
 ## `Security` in decorator `dependencies`
 
-The same way you can define a `list` of `Depends` in the decorator's `dependencies` parameter (as explained in [Dependencies in path operation decorators](../../tutorial/dependencies/dependencies-in-path-operation-decorators.md){.internal-link target=_blank}), you could also use `Security` with `scopes` there.
+The same way you can define a `list` of `Depends` in the decorator's `dependencies` parameter (as explained in [Dependencies in path operation decorators](../../tutorial/dependencies/dependencies-in-path-operation-decorators.md){.internal-link target=_blank}), you could also use `Security` with `scopes` there.  Similarly, they can be added
+as `dependencies` arguments to the `FastAPI` application object, and to `APIRouter` objects.
+
+### Merging of scopes from decorator `dependencies`
+
+If you add a `Security` into a decorator's `dependencies` parameter, and that same function is also present as a `Security` or `Depends` parameter for the endpoint, it results
+in the `scopes` lists being joined: The scopes from the decorator get **prepended** to any scopes of the endpoint dependencies (a `Depends` object is equivalent to a
+`Security` object with an empty list for its `scopes` argument).  This works recursively:  Wherever the same `Security` is seen in the dependency hierarchy
+of the endpoint argument dependencies, the scopes get joined.
+
+Using this mechanism, you can add a single scope requirement at the root of the **app** (using the `FastAPI` `dependencies` argument), or at individual `APIRouter` instances,
+and then refine the scopes required on the endpoint dependencies.

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -57,4 +57,7 @@ class Dependant:
         # Store the path to be able to re-generate a dependable from it in overrides
         self.path = path
         # Save the cache key at creation to optimize performance
+        self.set_cache_key()
+
+    def set_cache_key(self) -> None:
         self.cache_key = (self.call, tuple(sorted(set(self.security_scopes or []))))

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -32,6 +32,7 @@ class Dependant:
         background_tasks_param_name: Optional[str] = None,
         security_scopes_param_name: Optional[str] = None,
         security_scopes: Optional[List[str]] = None,
+        dependency_scopes: Optional[List[str]] = None,
         use_cache: bool = True,
         path: Optional[str] = None,
     ) -> None:
@@ -48,6 +49,7 @@ class Dependant:
         self.response_param_name = response_param_name
         self.background_tasks_param_name = background_tasks_param_name
         self.security_scopes = security_scopes
+        self.dependency_scopes = dependency_scopes
         self.security_scopes_param_name = security_scopes_param_name
         self.name = name
         self.call = call

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -145,6 +145,7 @@ def get_sub_dependant(
 ) -> Dependant:
     security_requirement = None
     security_scopes = security_scopes or []
+    dependency_scopes = None
     if isinstance(depends, params.Security):
         dependency_scopes = depends.scopes
         security_scopes = security_scopes + list(dependency_scopes)
@@ -160,6 +161,7 @@ def get_sub_dependant(
         call=dependency,
         name=name,
         security_scopes=security_scopes,
+        dependency_scopes=dependency_scopes,
         use_cache=depends.use_cache,
     )
     if security_requirement:
@@ -275,6 +277,7 @@ def get_dependant(
     call: Callable[..., Any],
     name: Optional[str] = None,
     security_scopes: Optional[List[str]] = None,
+    dependency_scopes: Optional[List[str]] = None,
     use_cache: bool = True,
 ) -> Dependant:
     path_param_names = get_path_param_names(path)
@@ -285,6 +288,7 @@ def get_dependant(
         name=name,
         path=path,
         security_scopes=security_scopes,
+        dependency_scopes=dependency_scopes,
         use_cache=use_cache,
     )
     for param_name, param in signature_params.items():

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -182,7 +182,12 @@ def merge_depends_into_dependant(
     found: bool = False
     for sub_dependant in dependant.dependencies:
         if sub_dependant.call is depends.dependency:
+            # Depends and Security with empty scopes just need to be found,
+            # there is no scope propagation.
             found = True
+            if not isinstance(depends, params.Security):
+                break  # Depends has no scopes.
+
             # extend the inherited scope prefix for this and lower
             # dependants.
             # figure out the inherited part of the security_scopes
@@ -194,6 +199,8 @@ def merge_depends_into_dependant(
             new_prefix = old_prefix + list(depends.scopes)
             if old_prefix != new_prefix:
                 extend_scope_prefix(sub_dependant, old_prefix, new_prefix)
+            else:
+                break  # this Security had no scopes.
         else:
             if merge_depends_into_dependant(depends, sub_dependant):
                 found = True

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -147,7 +147,7 @@ def get_sub_dependant(
     security_scopes = security_scopes or []
     if isinstance(depends, params.Security):
         dependency_scopes = depends.scopes
-        security_scopes.extend(dependency_scopes)
+        security_scopes = security_scopes + list(dependency_scopes)
     if isinstance(dependency, SecurityBase):
         use_scopes: List[str] = []
         if isinstance(dependency, (OAuth2, OpenIdConnect)):

--- a/tests/test_dependency_scope_merge.py
+++ b/tests/test_dependency_scope_merge.py
@@ -7,24 +7,50 @@ from fastapi.testclient import TestClient
 
 
 def app_dependency(scopes: SecurityScopes):
-    return _app_dependency(scopes.scopes)
+    _app_dependency(scopes.scopes)
+    return scopes.scopes
 
 
-def _app_dependency(scopes):
+def _app_dependency(scopes):  # pragma: no cover
+    pass
+
+
+def app_dependency2(scopes: SecurityScopes):
+    _app_dependency2(scopes.scopes)
+    return scopes.scopes
+
+
+def _app_dependency2(scopes):  # pragma: no cover
     pass
 
 
 def dep2(foo=Depends(app_dependency)):
-    pass
+    return foo
 
 
 def dep3(foo=Depends(app_dependency)):
-    pass
+    return foo
+
+
+def dep4(foo=Security(dep2, scopes=["dep4"])):
+    return foo
+
+
+def dep5(foo=Depends(app_dependency2)):
+    return foo
+
+
+def dep6(foo=Security(app_dependency2, scopes=["dep6"])):
+    return foo
+
+
+def dep7(foo=Security(dep6, scopes=["dep7"])):
+    return foo
 
 
 @pytest.fixture
 def mocks():
-    with patch.dict(globals(), {"_app_dependency": Mock()}):
+    with patch.dict(globals(), {"_app_dependency": Mock(), "_app_dependency2": Mock()}):
         yield
 
 
@@ -38,19 +64,47 @@ def root():
 
 @app.get("/endpoint")
 def endpoint(dep=Security(dep2, scopes=["endpoint"])):
-    return {}
+    return {"dep": dep}
 
 
 @app.get("/endpoint2")
 def endpoint2(dep=Security(dep3, scopes=["endpoint"])):
-    return {}
+    return {"dep": dep}
 
 
 @app.get("/endpoint3")
 def endpoint3(
     dep=Security(dep3, scopes=["endpoint1"]), dep2=Security(dep2, scopes=["endpoint2"])
 ):
-    return {}
+    return {"dep": dep, "dep2": dep2}
+
+
+@app.get("/endpoint4")
+def endpoint4(
+    dep=Security(dep2),
+):
+    return {"dep": dep}
+
+
+@app.get("/endpoint5")
+def endpoint5(
+    dep=Depends(dep4),
+):
+    return {"dep": dep}
+
+
+@app.get("/endpoint6", dependencies=[Security(app_dependency2, scopes=["endpoint6"])])
+def endpoint6(
+    dep=Depends(dep5),
+):
+    return {"dep": dep}
+
+
+@app.get("/endpoint7", dependencies=[Security(dep6, scopes=["endpoint7-np"])])
+def endpoint7(
+    dep=Security(dep7, scopes=["endpoint7-p"]),
+):
+    return {"dep": dep}
 
 
 client = TestClient(app)
@@ -60,31 +114,80 @@ def test_root(mocks):
     """
     Test that the single app security dependency gets called
     """
-    client.get("root")
+    result = client.get("root")
     _app_dependency.assert_has_calls([call(["root1", "root2"])])
+    assert result.json() == {}
 
 
-def test_endpoint(mocks):
+def test_merge(mocks):
     """
     Test that the app security scopes get prepended in front of the dependency security
     """
-    client.get("endpoint")
+    result = client.get("endpoint")
     _app_dependency.assert_has_calls([call(["root1", "root2", "endpoint"])])
+    assert result.json() == {"dep": ["root1", "root2", "endpoint"]}
 
 
-def test_endpoint2(mocks):
+def test_merge_incorrect(mocks):
     """
     Test that the app security scopes don't get prepended on a different dependency
     """
-    client.get("endpoint2")
+    result = client.get("endpoint2")
     _app_dependency.assert_has_calls([call(["root1", "root2"]), call(["endpoint"])])
+    assert result.json() == {"dep": ["endpoint"]}
 
 
-def test_endpoint3(mocks):
+def test_merge_correct(mocks):
     """
     Test that the app security scopes get prepended on the correct dependency
     """
-    client.get("endpoint3")
+    result = client.get("endpoint3")
     _app_dependency.assert_has_calls(
         [call(["endpoint1"]), call(["root1", "root2", "endpoint2"])]
     )
+    assert result.json() == {
+        "dep": ["endpoint1"],
+        "dep2": ["root1", "root2", "endpoint2"],
+    }
+
+
+def test_merge_with_empty(mocks):
+    """
+    Test that the app security scopes get prepended on a dependency with no scopes
+    """
+    result = client.get("endpoint4")
+    _app_dependency.assert_has_calls([call(["root1", "root2"])])
+    assert result.json() == {"dep": ["root1", "root2"]}
+
+
+def test_lower_level_security(mocks):
+    """
+    Test that we find the Security in a lower level dependency
+    """
+    result = client.get("endpoint5")
+    _app_dependency.assert_has_calls([call(["root1", "root2", "dep4"])])
+    assert result.json() == {"dep": ["root1", "root2", "dep4"]}
+
+
+def test_depends_works_like_security(mocks):
+    """
+    Test that an Depends works like a Security with scopes=[] when
+    descending the dependency graph
+    """
+    result = client.get("endpoint6")
+    _app_dependency2.assert_has_calls([call(["endpoint6"])])
+    assert result.json() == {"dep": ["endpoint6"]}
+
+
+def test_scopes_inherited_by_higher_security(mocks):
+    """
+    Test that scopes merged to a dependency, are also inherited by lower
+    level different dependencies
+    """
+    result = client.get("endpoint7")
+    # first scope is the scope added to dep7 by endpoint 7, second
+    # is scope added to dep6 from the non-parameter scope.
+    _app_dependency2.assert_has_calls(
+        [call(["endpoint7-p", "endpoint7-np", "dep7", "dep6"])]
+    )
+    assert result.json() == {"dep": ["endpoint7-p", "endpoint7-np", "dep7", "dep6"]}

--- a/tests/test_dependency_scope_merge.py
+++ b/tests/test_dependency_scope_merge.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock, call, patch
+
+import pytest
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import SecurityScopes
+from fastapi.testclient import TestClient
+
+
+def app_dependency(scopes: SecurityScopes):
+    return _app_dependency(scopes.scopes)
+
+
+def _app_dependency(scopes):
+    pass
+
+
+def dep2(foo=Depends(app_dependency)):
+    pass
+
+
+def dep3(foo=Depends(app_dependency)):
+    pass
+
+
+@pytest.fixture
+def mocks():
+    with patch.dict(globals(), {"_app_dependency": Mock()}):
+        yield
+
+
+app = FastAPI(dependencies=[Security(dep2, scopes=["root1", "root2"])])
+
+
+@app.get("/root")
+def root():
+    return {}
+
+
+@app.get("/endpoint")
+def endpoint(dep=Security(dep2, scopes=["endpoint"])):
+    return {}
+
+
+@app.get("/endpoint2")
+def endpoint2(dep=Security(dep3, scopes=["endpoint"])):
+    return {}
+
+
+@app.get("/endpoint3")
+def endpoint3(
+    dep=Security(dep3, scopes=["endpoint1"]), dep2=Security(dep2, scopes=["endpoint2"])
+):
+    return {}
+
+
+client = TestClient(app)
+
+
+def test_root(mocks):
+    """
+    Test that the single app security dependency gets called
+    """
+    client.get("root")
+    _app_dependency.assert_has_calls([call(["root1", "root2"])])
+
+
+def test_endpoint(mocks):
+    """
+    Test that the app security scopes get prepended in front of the dependency security
+    """
+    client.get("endpoint")
+    _app_dependency.assert_has_calls([call(["root1", "root2", "endpoint"])])
+
+
+def test_endpoint2(mocks):
+    """
+    Test that the app security scopes don't get prepended on a different dependency
+    """
+    client.get("endpoint2")
+    _app_dependency.assert_has_calls([call(["root1", "root2"]), call(["endpoint"])])
+
+
+def test_endpoint3(mocks):
+    """
+    Test that the app security scopes get prepended on the correct dependency
+    """
+    client.get("endpoint3")
+    _app_dependency.assert_has_calls(
+        [call(["endpoint1"]), call(["root1", "root2", "endpoint2"])]
+    )


### PR DESCRIPTION
This PR adds the possibility to declare `Security` `scopes` at the `FastAPI` or `APIRouter` level as *parameterless* dependencies, and then have the scopes **prepended** to any scopes on the same dependencies that are endpoint _parameters_.

This allows refining/adding scopes at the endpoint to already required parameterless scopes.

For example, the *app* can have a `dependencies=[Security(my_security, scopes=["live"])]` parameter, and the endpoint can specify
```
def my_endpoint(user=Security(my_security, scopes=["client"]): pass
```
causing the `my_security()` dependency to be called **once** with scopes `["live", "client']`.

This allows setting general scopes at higher levels and refine them at individual endpoints, alloweing better _factoring_ and DRY.

It also reduces the calling overhead of Scopes dependencies.  The above example, without this PR, would cause __two__ calls to the `my_security()` dependency.  This PR causes it to be called only __once__.

An added benefit of this is that it allows a **least privilege** approach to scopes.  if the top level scopes are, for example `["client, "admin"]`, requiring both scopes for all endpoints, an individual endpoint could then add the scope `["-admin"]`, causing the security dependency to be called with scopes `["client", "admin", "-admin"]`.  A suitably written dependency could then interpret this as _not_ requiring the `admin` scope on this endpoint.    See also #5433 which also merges scopes in the hierarchy of `dependencies` properties, and allows to _remove_ parametereless dependencies on individual endpoints.

As a bonus, parameterless dependencies which are also direct or indirect parameter dependencies are not applied to the endpoint, reducing invokation overhead.
