### PR TITLE
⬆ Bump Starlette to version `0.22.0` to fix bad encoding for query parameters in `TestClient`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette==0.21.0",
+    "starlette==0.22.0",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",
 ]
 dynamic = ["version"]

--- a/tests/test_starlette_urlconvertors.py
+++ b/tests/test_starlette_urlconvertors.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Path
+from fastapi import FastAPI, Path, Query
 from fastapi.testclient import TestClient
 
 app = FastAPI()
@@ -17,6 +17,11 @@ def float_convertor(param: float = Path()):
 @app.get("/path/{param:path}")
 def path_convertor(param: str = Path()):
     return {"path": param}
+
+
+@app.get("/query/")
+def query_convertor(param: str = Query()):
+    return {"query": param}
 
 
 client = TestClient(app)
@@ -43,6 +48,13 @@ def test_route_converters_path():
     response = client.get("/path/some/example")
     assert response.status_code == 200, response.text
     assert response.json() == {"path": "some/example"}
+
+
+def test_route_converters_query():
+    # Test query conversion
+    response = client.get("/query", params={"param": "Qué tal!"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"query": "Qué tal!"}
 
 
 def test_url_path_for_path_convertor():


### PR DESCRIPTION
Update `starlette` to [v0.22.0](https://github.com/encode/starlette/releases/tag/0.22.0) to fix issue with `TestClient` doing an extra `unquote` in the URL query 

(https://github.com/encode/starlette/issues/1952 and https://github.com/encode/starlette/pull/1953), introduced with the _(tests)-Breaking_ change in v0.21.0 with the swap from `requests.Session` to `httpx.Client` for the `TestClient`

closes #5646 