### PR TITLE
👷 Update `setup-python` action in tests to use new caching feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+          cache-dependency-path: pyproject.toml
       - name: Install Dependencies
         if: steps.setup-python.outputs.cache-hit != 'true'
         run: pip install -e .[all,dev,doc,test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
+        id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-test-v02
+          cache: "pip"
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.setup-python.outputs.cache-hit != 'true'
         run: pip install -e .[all,dev,doc,test]
       - name: Lint
         run: bash scripts/lint.sh


### PR DESCRIPTION
Updates the "Test" GitHub Actions workflow to use the cache feature on the `setup-python` action instead of the separate `cache` action.

This should resolve libffi problems failing builds right now e.g. https://github.com/tiangolo/fastapi/actions/runs/3531449114/jobs/5924630998 and simplify future maintenance.

Unfortunately there is not yet upstream support for caching based on the dependency section of a `pyproject.toml` and there will be a cache miss if unrelated metadata changes. See https://github.com/actions/setup-python/issues/529.