### PR TITLE
chore: refactor concurrency.py to run sync context managers in a single thread

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -50,6 +50,8 @@ async def contextmanager_in_threadpool(
         stack.enter_context(send_err)
         tg = await stack.enter_async_context(anyio.create_task_group())
         target = partial(
+            # using a partial because start_soon does not accept kw args
+            # but run_sync(..., limiter=...) _must_ be a kw argument
             run_sync, _cm_thead_worker, cm, send_res, rcv_err, limiter=limiter
         )
         tg.start_soon(target)

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -52,7 +52,12 @@ async def contextmanager_in_threadpool(
         target = partial(
             # using a partial because start_soon does not accept kw args
             # but run_sync(..., limiter=...) _must_ be a kw argument
-            run_sync, _cm_thead_worker, cm, send_res, rcv_err, limiter=limiter
+            run_sync,
+            _cm_thead_worker,
+            cm,
+            send_res,
+            rcv_err,
+            limiter=limiter,
         )
         tg.start_soon(target)
         res = await rcv_res.receive()

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,13 +1,7 @@
 from contextlib import AsyncExitStack as AsyncExitStack  # noqa
 from contextlib import asynccontextmanager as asynccontextmanager
 from functools import partial
-from typing import (
-    Any,
-    AsyncGenerator,
-    ContextManager,
-    Optional,
-    TypeVar,
-)
+from typing import Any, AsyncGenerator, ContextManager, Optional, TypeVar
 
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -12,12 +12,12 @@ from starlette.concurrency import (  # noqa
     run_until_first_complete as run_until_first_complete,
 )
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
 def _cm_thead_worker(
-    cm: ContextManager[T],
-    res_stream: MemoryObjectSendStream[T],
+    cm: ContextManager[_T],
+    res_stream: MemoryObjectSendStream[_T],
     err_stream: MemoryObjectReceiveStream[Optional[Exception]],
 ) -> None:
     with cm as res:
@@ -32,9 +32,9 @@ MaybeException = Optional[Exception]
 
 @asynccontextmanager
 async def contextmanager_in_threadpool(
-    cm: ContextManager[T],
+    cm: ContextManager[_T],
     limiter: Optional[anyio.CapacityLimiter] = None,
-) -> AsyncGenerator[T, None]:
+) -> AsyncGenerator[_T, None]:
     # streams for the data
     send_res, rcv_res = anyio.create_memory_object_stream(  # type: ignore
         0, item_type=Any

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -27,7 +27,7 @@ def _cm_thead_worker(
             raise exc
 
 
-MaybeException = Optional[Exception]
+_MaybeException = Optional[Exception]
 
 
 @asynccontextmanager
@@ -41,7 +41,7 @@ async def contextmanager_in_threadpool(
     )
     # streams for exceptions
     send_err, rcv_err = anyio.create_memory_object_stream(  # type: ignore
-        0, item_type=MaybeException
+        0, item_type=_MaybeException
     )
     async with AsyncExitStack() as stack:
         stack.enter_context(rcv_res)

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,40 +1,77 @@
-from contextlib import AsyncExitStack as AsyncExitStack  # noqa
+from contextlib import AsyncExitStack as AsyncExitStack
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import AsyncGenerator, ContextManager, TypeVar
-
-import anyio
-from anyio import CapacityLimiter
-from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
-from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa
-from starlette.concurrency import (  # noqa
-    run_until_first_complete as run_until_first_complete,
+from contextvars import copy_context
+from functools import partial
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    ContextManager,
+    Optional,
+    TypeVar,
 )
 
-_T = TypeVar("_T")
+import anyio
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from anyio.to_thread import run_sync
+
+T = TypeVar("T")
+
+
+def callable_in_thread_pool(
+    call: Callable[..., T], *, limiter: Optional[anyio.CapacityLimiter]
+) -> Callable[..., Awaitable[T]]:
+    def inner(*args: Any, **kwargs: Any) -> "Awaitable[T]":
+        return anyio.to_thread.run_sync(
+            copy_context().run, lambda: call(*args, **kwargs), limiter=limiter
+        )  # type: ignore[return-value]
+
+    return inner
+
+
+def _cm_thead_worker(
+    cm: ContextManager[T],
+    res_stream: MemoryObjectSendStream[T],
+    err_stream: MemoryObjectReceiveStream[Optional[Exception]],
+) -> None:
+    with cm as res:
+        anyio.from_thread.run(res_stream.send, res)
+        exc = anyio.from_thread.run(err_stream.receive)
+        if exc:
+            raise exc
+
+
+MaybeException = Optional[Exception]
 
 
 @asynccontextmanager
 async def contextmanager_in_threadpool(
-    cm: ContextManager[_T],
-) -> AsyncGenerator[_T, None]:
-    # blocking __exit__ from running waiting on a free thread
-    # can create race conditions/deadlocks if the context manager itself
-    # has it's own internal pool (e.g. a database connection pool)
-    # to avoid this we let __exit__ run without a capacity limit
-    # since we're creating a new limiter for each call, any non-zero limit
-    # works (1 is arbitrary)
-    exit_limiter = CapacityLimiter(1)
-    try:
-        yield await run_in_threadpool(cm.__enter__)
-    except Exception as e:
-        ok = bool(
-            await anyio.to_thread.run_sync(
-                cm.__exit__, type(e), e, None, limiter=exit_limiter
-            )
+    cm: ContextManager[T],
+    limiter: Optional[anyio.CapacityLimiter] = None,
+) -> AsyncGenerator[T, None]:
+    # streams for the data
+    send_res, rcv_res = anyio.create_memory_object_stream(  # type: ignore
+        0, item_type=Any
+    )
+    # streams for exceptions
+    send_err, rcv_err = anyio.create_memory_object_stream(  # type: ignore
+        0, item_type=MaybeException
+    )
+    async with AsyncExitStack() as stack:
+        stack.enter_context(rcv_res)
+        stack.enter_context(rcv_err)
+        stack.enter_context(send_res)
+        stack.enter_context(send_err)
+        tg = await stack.enter_async_context(anyio.create_task_group())
+        target = partial(
+            run_sync, _cm_thead_worker, cm, send_res, rcv_err, limiter=limiter
         )
-        if not ok:
-            raise e
-    else:
-        await anyio.to_thread.run_sync(
-            cm.__exit__, None, None, None, limiter=exit_limiter
-        )
+        tg.start_soon(target)
+        res = await rcv_res.receive()
+        try:
+            yield res
+        except Exception as e:
+            await send_err.send(e)
+        else:
+            await send_err.send(None)

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,12 +1,9 @@
-from contextlib import AsyncExitStack as AsyncExitStack
+from contextlib import AsyncExitStack as AsyncExitStack  # noqa
 from contextlib import asynccontextmanager as asynccontextmanager
-from contextvars import copy_context
 from functools import partial
 from typing import (
     Any,
     AsyncGenerator,
-    Awaitable,
-    Callable,
     ContextManager,
     Optional,
     TypeVar,
@@ -15,19 +12,13 @@ from typing import (
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from anyio.to_thread import run_sync
+from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
+from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa
+from starlette.concurrency import (  # noqa
+    run_until_first_complete as run_until_first_complete,
+)
 
 T = TypeVar("T")
-
-
-def callable_in_thread_pool(
-    call: Callable[..., T], *, limiter: Optional[anyio.CapacityLimiter]
-) -> Callable[..., Awaitable[T]]:
-    def inner(*args: Any, **kwargs: Any) -> "Awaitable[T]":
-        return anyio.to_thread.run_sync(
-            copy_context().run, lambda: call(*args, **kwargs), limiter=limiter
-        )  # type: ignore[return-value]
-
-    return inner
 
 
 def _cm_thead_worker(

--- a/tests/test_dependency_contextmanager.py
+++ b/tests/test_dependency_contextmanager.py
@@ -1,5 +1,5 @@
-from contextvars import ContextVar
 import threading
+from contextvars import ContextVar
 from typing import Dict
 
 import pytest
@@ -85,7 +85,6 @@ async def context_b(state: dict = Depends(context_a)):
         state["context_b"] = f"finished b with a: {state['context_a']}"
 
 
-
 ctx: ContextVar[str] = ContextVar("ctx")
 
 
@@ -155,7 +154,7 @@ async def get_context_b_bg(tasks: BackgroundTasks, state: dict = Depends(context
 
 
 @app.get("/check_cm_same_thread")
-async def check_cm_same_thread(_ = Depends(context_same_thread)):
+async def check_cm_same_thread(_=Depends(context_same_thread)):
     return None
 
 


### PR DESCRIPTION
I'm hoping that this (maybe) helps resolve issues like https://github.com/MagicStack/asyncpg/issues/978

This change makes sync context managers acquire and hold onto a thread for the entirety of their execution so that we don't split `__enter__` and `__exit__` calls across threads. I think this will resolve a whole class of intermittent bugs that might crop up for anything using thread locals or context variables.

The main "con" of this approach is that we won't "free" the thread in between `__enter__` and `__exit__` which means more contention for threads in the thread pool. In other words, despite the 40 thread default limit that anyio imposes it was previously possible to run more than 40 sync context managers as FastAPI dependencies since the 41st would just have to wait for any `__enter__` to finish before it could acquire a thread pool. With this change running more than 40 sync context managers will result in a deadlock. I see three options:
1. Do nothing. If users are running into capacity limiters they should probably be managing their own threads instead of relying on automagic behavior from their web framework.
2. Raise an error if we hit the capacity limit (instead of deadlocking)
3. Allow users to pass in their own capacity limit to each APIRoute (maybe with a global one on the FastAPI object as well)
4. Both 2 and 3