### PR TITLE
Upgrade databases and SQLAlchemy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ xfail_strict = true
 junit_family = "xunit2"
 filterwarnings = [
     "error",
+    # TODO: remove once Pydantic v1 is no longer supported and we can always test with SQLAlchemy 2.x
+    'ignore::sqlalchemy.exc.MovedIn20Warning',
     'ignore:starlette.middleware.wsgi is deprecated and will be removed in a future release\..*:DeprecationWarning:starlette',
     # For passlib
     "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning",

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,10 +5,8 @@ coverage[toml] >= 6.5.0,< 8.0
 mypy ==1.8.0
 ruff ==0.6.1
 dirty-equals ==0.6.0
-# TODO: once removing databases from tutorial, upgrade SQLAlchemy
-# probably when including SQLModel
-sqlalchemy >=1.3.18,<2.0.33
-databases[sqlite] >=0.3.2,<0.7.0
+sqlalchemy >=1.4.42,<3.0.0
+databases[sqlite] >=0.7.2,<0.10.0
 flask >=1.1.2,<3.0.0
 anyio[trio] >=3.2.1,<4.0.0
 PyJWT==2.8.0


### PR DESCRIPTION
Incompatibilities with recent SQLAlchemy versions are fixed in databases 0.7.0. By requiring `databases[sqlite] >=0.7.0,<0.8.0` for testing, we can stop pinning an old SQLAlchemy version, instead requiring `sqlalchemy >=1.4.42,<1.5`.

Fixes https://github.com/tiangolo/fastapi/issues/5556.