### PR TITLE
🐛 Preserve traceback when an exception is raised in sync dependency with `yield`

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -26,12 +26,15 @@ async def contextmanager_in_threadpool(
     try:
         yield await run_in_threadpool(cm.__enter__)
     except Exception as e:
+        traceback_ = e.__traceback__
         ok = bool(
             await anyio.to_thread.run_sync(
                 cm.__exit__, type(e), e, None, limiter=exit_limiter
             )
         )
         if not ok:
+            if e.__traceback__ is None:
+                e.__traceback__ = traceback_
             raise e
     else:
         await anyio.to_thread.run_sync(


### PR DESCRIPTION
There is a missing of traceback when an exception raised in contextmanager_in_threadpool
Happens on Python 3.11 

I noticed the exception.traceback gets flushed after exiting the context manager.

There is an issue is opened #5740 

Edit by @Kludex : 
- Closes https://github.com/fastapi/fastapi/issues/13022