### PR TITLE
Fix typo in "Behind Proxy" guide

### DIFF
--- a/docs/en/docs/advanced/behind-a-proxy.md
+++ b/docs/en/docs/advanced/behind-a-proxy.md
@@ -251,7 +251,7 @@ We get the same response:
 
 but this time at the URL with the prefix path provided by the proxy: `/api/v1`.
 
-Of course, the idea here is that everyone would access the app through the proxy, so the version with the path prefix `/app/v1` is the "correct" one.
+Of course, the idea here is that everyone would access the app through the proxy, so the version with the path prefix `/api/v1` is the "correct" one.
 
 And the version without the path prefix (`http://127.0.0.1:8000/app`), provided by Uvicorn directly, would be exclusively for the _proxy_ (Traefik) to access it.
 


### PR DESCRIPTION
The correct path prefix is "/api/v1"