### PR TITLE
SQL DB session with middleware - fix for Issue #5335

### DIFF
--- a/docs_src/sql_databases/sql_app/alt_main.py
+++ b/docs_src/sql_databases/sql_app/alt_main.py
@@ -13,7 +13,6 @@ app = FastAPI()
 
 @app.middleware("http")
 async def db_session_middleware(request: Request, call_next):
-    response = Response("Internal server error", status_code=500)
     try:
         request.state.db = SessionLocal()
         response = await call_next(request)

--- a/docs_src/sql_databases/sql_app/alt_main.py
+++ b/docs_src/sql_databases/sql_app/alt_main.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi import Depends, FastAPI, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from . import crud, models, schemas

--- a/docs_src/sql_databases/sql_app_py310/alt_main.py
+++ b/docs_src/sql_databases/sql_app_py310/alt_main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi import Depends, FastAPI, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from . import crud, models, schemas

--- a/docs_src/sql_databases/sql_app_py310/alt_main.py
+++ b/docs_src/sql_databases/sql_app_py310/alt_main.py
@@ -11,7 +11,6 @@ app = FastAPI()
 
 @app.middleware("http")
 async def db_session_middleware(request: Request, call_next):
-    response = Response("Internal server error", status_code=500)
     try:
         request.state.db = SessionLocal()
         response = await call_next(request)

--- a/docs_src/sql_databases/sql_app_py39/alt_main.py
+++ b/docs_src/sql_databases/sql_app_py39/alt_main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi import Depends, FastAPI, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from . import crud, models, schemas

--- a/docs_src/sql_databases/sql_app_py39/alt_main.py
+++ b/docs_src/sql_databases/sql_app_py39/alt_main.py
@@ -11,7 +11,6 @@ app = FastAPI()
 
 @app.middleware("http")
 async def db_session_middleware(request: Request, call_next):
-    response = Response("Internal server error", status_code=500)
     try:
         request.state.db = SessionLocal()
         response = await call_next(request)


### PR DESCRIPTION
This PR removes the unused code fragment for a 500 error code response from the example of the sql db with middleware. Which is described in the issue "[[Doc][Bug] SQL DB session with middleware: Non effective code #5335](https://github.com/tiangolo/fastapi/issues/5335)"