### PR TITLE
add __str__ method to HTTPException

### DIFF
--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -16,7 +16,7 @@ class HTTPException(StarletteHTTPException):
         super().__init__(status_code=status_code, detail=detail, headers=headers)
 
     def __str__(self) -> str:
-        return f"status_code : {self.status_code}, detail : {self.detail}"
+        return f"HTTPException(status_code: {self.status_code}, detail: {self.detail})"
 
 
 RequestErrorModel: Type[BaseModel] = create_model("Request")

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -15,6 +15,9 @@ class HTTPException(StarletteHTTPException):
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
 
+    def __str__(self) -> str:
+        return f"status_code : {self.status_code}, detail : {self.detail}"
+
 
 RequestErrorModel: Type[BaseModel] = create_model("Request")
 WebSocketErrorModel: Type[BaseModel] = create_model("WebSocket")

--- a/tests/test_string_representation_exception.py
+++ b/tests/test_string_representation_exception.py
@@ -1,0 +1,5 @@
+from fastapi.exceptions import HTTPException
+
+def test_string_representation():
+    exception = HTTPException(status_code=400, detail='detail exception')
+    assert exception.__str__() == 'HTTPException(status_code: 400, detail: detail exception)'

--- a/tests/test_string_representation_exception.py
+++ b/tests/test_string_representation_exception.py
@@ -1,5 +1,9 @@
 from fastapi.exceptions import HTTPException
 
+
 def test_string_representation():
-    exception = HTTPException(status_code=400, detail='detail exception')
-    assert exception.__str__() == 'HTTPException(status_code: 400, detail: detail exception)'
+    exception = HTTPException(status_code=400, detail="detail exception")
+    assert (
+        exception.__str__()
+        == "HTTPException(status_code: 400, detail: detail exception)"
+    )


### PR DESCRIPTION
As mentioned in Iusse #5878 there's a bug in HTTPException's string representation, it seems that \__repr__ method in starlette.exceptions.HTTPException doesn't works correctly without explicit call \__repr__ method. To avoid this I've implemented a \__str__ method in fastapi.exceptions.HTTPException

### Current situation :

![image](https://user-images.githubusercontent.com/100039558/212074854-9b9b6413-4516-48ea-a734-f535a230a594.png)


### After my commit : 

![image](https://user-images.githubusercontent.com/100039558/212075063-bff91996-5478-4026-9206-9cb612906a36.png)



