### PR TITLE
Improve import time

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -22,12 +22,6 @@ from fastapi.exception_handlers import (
 from fastapi.exceptions import RequestValidationError
 from fastapi.logger import logger
 from fastapi.middleware.asyncexitstack import AsyncExitStackMiddleware
-from fastapi.openapi.docs import (
-    get_redoc_html,
-    get_swagger_ui_html,
-    get_swagger_ui_oauth2_redirect_html,
-)
-from fastapi.openapi.utils import get_openapi
 from fastapi.params import Depends
 from fastapi.types import DecoratedCallable
 from fastapi.utils import generate_unique_id
@@ -197,6 +191,8 @@ class FastAPI(Starlette):
 
     def openapi(self) -> Dict[str, Any]:
         if not self.openapi_schema:
+            from fastapi.openapi.utils import get_openapi
+
             self.openapi_schema = get_openapi(
                 title=self.title,
                 version=self.version,
@@ -228,6 +224,8 @@ class FastAPI(Starlette):
         if self.openapi_url and self.docs_url:
 
             async def swagger_ui_html(req: Request) -> HTMLResponse:
+                from fastapi.openapi.docs import get_swagger_ui_html
+
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 oauth2_redirect_url = self.swagger_ui_oauth2_redirect_url
@@ -246,6 +244,8 @@ class FastAPI(Starlette):
             if self.swagger_ui_oauth2_redirect_url:
 
                 async def swagger_ui_redirect(req: Request) -> HTMLResponse:
+                    from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
+
                     return get_swagger_ui_oauth2_redirect_html()
 
                 self.add_route(
@@ -256,6 +256,8 @@ class FastAPI(Starlette):
         if self.openapi_url and self.redoc_url:
 
             async def redoc_html(req: Request) -> HTMLResponse:
+                from fastapi.openapi.docs import get_redoc_html
+
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 return get_redoc_html(

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 from fastapi.logger import logger
+from fastapi.security.models import APIKey, HTTPBase, HTTPBearer, OAuth2, OpenIdConnect
 from pydantic import AnyUrl, BaseModel, Field
 
 try:
@@ -274,88 +275,6 @@ class PathItem(BaseModel):
 
     class Config:
         extra = "allow"
-
-
-class SecuritySchemeType(Enum):
-    apiKey = "apiKey"
-    http = "http"
-    oauth2 = "oauth2"
-    openIdConnect = "openIdConnect"
-
-
-class SecurityBase(BaseModel):
-    type_: SecuritySchemeType = Field(alias="type")
-    description: Optional[str] = None
-
-    class Config:
-        extra = "allow"
-
-
-class APIKeyIn(Enum):
-    query = "query"
-    header = "header"
-    cookie = "cookie"
-
-
-class APIKey(SecurityBase):
-    type_ = Field(SecuritySchemeType.apiKey, alias="type")
-    in_: APIKeyIn = Field(alias="in")
-    name: str
-
-
-class HTTPBase(SecurityBase):
-    type_ = Field(SecuritySchemeType.http, alias="type")
-    scheme: str
-
-
-class HTTPBearer(HTTPBase):
-    scheme = "bearer"
-    bearerFormat: Optional[str] = None
-
-
-class OAuthFlow(BaseModel):
-    refreshUrl: Optional[str] = None
-    scopes: Dict[str, str] = {}
-
-    class Config:
-        extra = "allow"
-
-
-class OAuthFlowImplicit(OAuthFlow):
-    authorizationUrl: str
-
-
-class OAuthFlowPassword(OAuthFlow):
-    tokenUrl: str
-
-
-class OAuthFlowClientCredentials(OAuthFlow):
-    tokenUrl: str
-
-
-class OAuthFlowAuthorizationCode(OAuthFlow):
-    authorizationUrl: str
-    tokenUrl: str
-
-
-class OAuthFlows(BaseModel):
-    implicit: Optional[OAuthFlowImplicit] = None
-    password: Optional[OAuthFlowPassword] = None
-    clientCredentials: Optional[OAuthFlowClientCredentials] = None
-    authorizationCode: Optional[OAuthFlowAuthorizationCode] = None
-
-    class Config:
-        extra = "allow"
-
-
-class OAuth2(SecurityBase):
-    type_ = Field(SecuritySchemeType.oauth2, alias="type")
-    flows: OAuthFlows
-
-
-class OpenIdConnect(SecurityBase):
-    type_ = Field(SecuritySchemeType.openIdConnect, alias="type")
-    openIdConnectUrl: str
 
 
 SecurityScheme = Union[APIKey, HTTPBase, OAuth2, OpenIdConnect, HTTPBearer]

--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from fastapi.openapi.models import APIKey, APIKeyIn
 from fastapi.security.base import SecurityBase
+from fastapi.security.models import APIKey, APIKeyIn
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_403_FORBIDDEN

--- a/fastapi/security/base.py
+++ b/fastapi/security/base.py
@@ -1,4 +1,4 @@
-from fastapi.openapi.models import SecurityBase as SecurityBaseModel
+from fastapi.security.models import SecurityBase as SecurityBaseModel
 
 
 class SecurityBase:

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -3,9 +3,9 @@ from base64 import b64decode
 from typing import Optional
 
 from fastapi.exceptions import HTTPException
-from fastapi.openapi.models import HTTPBase as HTTPBaseModel
-from fastapi.openapi.models import HTTPBearer as HTTPBearerModel
 from fastapi.security.base import SecurityBase
+from fastapi.security.models import HTTPBase as HTTPBaseModel
+from fastapi.security.models import HTTPBearer as HTTPBearerModel
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request

--- a/fastapi/security/models.py
+++ b/fastapi/security/models.py
@@ -1,0 +1,86 @@
+from enum import Enum
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SecuritySchemeType(Enum):
+    apiKey = "apiKey"
+    http = "http"
+    oauth2 = "oauth2"
+    openIdConnect = "openIdConnect"
+
+
+class SecurityBase(BaseModel):
+    type_: SecuritySchemeType = Field(alias="type")
+    description: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class APIKeyIn(Enum):
+    query = "query"
+    header = "header"
+    cookie = "cookie"
+
+
+class APIKey(SecurityBase):
+    type_ = Field(SecuritySchemeType.apiKey, alias="type")
+    in_: APIKeyIn = Field(alias="in")
+    name: str
+
+
+class HTTPBase(SecurityBase):
+    type_ = Field(SecuritySchemeType.http, alias="type")
+    scheme: str
+
+
+class HTTPBearer(HTTPBase):
+    scheme = "bearer"
+    bearerFormat: Optional[str] = None
+
+
+class OAuthFlow(BaseModel):
+    refreshUrl: Optional[str] = None
+    scopes: Dict[str, str] = {}
+
+    class Config:
+        extra = "allow"
+
+
+class OAuthFlowImplicit(OAuthFlow):
+    authorizationUrl: str
+
+
+class OAuthFlowPassword(OAuthFlow):
+    tokenUrl: str
+
+
+class OAuthFlowClientCredentials(OAuthFlow):
+    tokenUrl: str
+
+
+class OAuthFlowAuthorizationCode(OAuthFlow):
+    authorizationUrl: str
+    tokenUrl: str
+
+
+class OAuthFlows(BaseModel):
+    implicit: Optional[OAuthFlowImplicit] = None
+    password: Optional[OAuthFlowPassword] = None
+    clientCredentials: Optional[OAuthFlowClientCredentials] = None
+    authorizationCode: Optional[OAuthFlowAuthorizationCode] = None
+
+    class Config:
+        extra = "allow"
+
+
+class OAuth2(SecurityBase):
+    type_ = Field(SecuritySchemeType.oauth2, alias="type")
+    flows: OAuthFlows
+
+
+class OpenIdConnect(SecurityBase):
+    type_ = Field(SecuritySchemeType.openIdConnect, alias="type")
+    openIdConnectUrl: str

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, List, Optional, Union
 
 from fastapi.exceptions import HTTPException
-from fastapi.openapi.models import OAuth2 as OAuth2Model
-from fastapi.openapi.models import OAuthFlows as OAuthFlowsModel
 from fastapi.param_functions import Form
 from fastapi.security.base import SecurityBase
+from fastapi.security.models import OAuth2 as OAuth2Model
+from fastapi.security.models import OAuthFlows as OAuthFlowsModel
 from fastapi.security.utils import get_authorization_scheme_param
 from starlette.requests import Request
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from fastapi.openapi.models import OpenIdConnect as OpenIdConnectModel
 from fastapi.security.base import SecurityBase
+from fastapi.security.models import OpenIdConnect as OpenIdConnectModel
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_403_FORBIDDEN


### PR DESCRIPTION
Avoid loading `fastapi.openapi.models` (and `email_validator`) until it is
needed.

Models related to security are moved from `fastapi.openapi.models`
to `fastapi.security.models`.
I'm wondering if it would been better to move the classes into the
existing modules (http, ...).

Measurements of `import fastapi` done on my laptop:
before: ~ 260ms
<details>
<summary><code>PYTHONPROFILEIMPORTTIME=1 python3.11</code> output</summary>
<pre>
import time: self [us] | cumulative | imported package
import time:       793 |        793 |   starlette
import time:       507 |        507 |     warnings
import time:       558 |        558 |       collections.abc
import time:       803 |        803 |       contextlib
import time:       858 |        858 |       _typing
import time:      2293 |       4510 |     typing
import time:       564 |       5580 |   starlette.status
import time:       333 |        333 |             concurrent
import time:       396 |        396 |                       token
import time:      1035 |       1430 |                     tokenize
import time:       377 |       1806 |                   linecache
import time:      1043 |       1043 |                   textwrap
import time:       904 |       3753 |                 traceback
import time:       532 |        532 |                   _weakrefset
import time:       603 |       1135 |                 weakref
import time:        26 |         26 |                   _string
import time:       656 |        682 |                 string
import time:       738 |        738 |                 threading
import time:        26 |         26 |                 atexit
import time:      1673 |       8004 |               logging
import time:       798 |       8802 |             concurrent.futures._base
import time:       581 |       9716 |           concurrent.futures
import time:      2003 |       2003 |             _heapq
import time:       442 |       2445 |           heapq
import time:      1286 |       1286 |             _socket
import time:       684 |        684 |               math
import time:       631 |        631 |               select
import time:       902 |       2216 |             selectors
import time:        39 |         39 |             errno
import time:       612 |        612 |             array
import time:      1325 |       5476 |           socket
import time:        43 |         43 |               _locale
import time:       848 |        890 |             locale
import time:       625 |        625 |             signal
import time:       637 |        637 |             fcntl
import time:        70 |         70 |             msvcrt
import time:       600 |        600 |             _posixsubprocess
import time:       654 |       3474 |           subprocess
import time:      5944 |       5944 |             _ssl
import time:       623 |        623 |                 _struct
import time:       301 |        924 |               struct
import time:       539 |        539 |               binascii
import time:       519 |       1981 |             base64
import time:      1791 |       9714 |           ssl
import time:       365 |        365 |           asyncio.constants
import time:       832 |        832 |                 _ast
import time:       973 |       1805 |               ast
import time:       588 |        588 |                   _opcode
import time:       587 |       1175 |                 opcode
import time:       771 |       1945 |               dis
import time:       380 |        380 |                 importlib
import time:        42 |        421 |               importlib.machinery
import time:      1411 |       5581 |             inspect
import time:       575 |       6155 |           asyncio.coroutines
import time:       520 |        520 |               _contextvars
import time:       358 |        878 |             contextvars
import time:       563 |        563 |             asyncio.format_helpers
import time:       309 |        309 |               asyncio.base_futures
import time:       341 |        341 |               asyncio.exceptions
import time:       276 |        276 |               asyncio.base_tasks
import time:       789 |       1713 |             _asyncio
import time:       570 |       3723 |           asyncio.events
import time:       385 |        385 |           asyncio.futures
import time:       361 |        361 |           asyncio.protocols
import time:       410 |        410 |             asyncio.transports
import time:       339 |        339 |             asyncio.log
import time:       645 |       1393 |           asyncio.sslproto
import time:       262 |        262 |               asyncio.mixins
import time:       394 |        394 |               asyncio.tasks
import time:       591 |       1246 |             asyncio.locks
import time:       405 |       1650 |           asyncio.staggered
import time:       316 |        316 |           asyncio.trsock
import time:       900 |      46067 |         asyncio.base_events
import time:       428 |        428 |         asyncio.runners
import time:       451 |        451 |         asyncio.queues
import time:       441 |        441 |         asyncio.streams
import time:       367 |        367 |         asyncio.subprocess
import time:      1181 |       1181 |         asyncio.taskgroups
import time:       525 |        525 |         asyncio.timeouts
import time:       458 |        458 |         asyncio.threads
import time:       407 |        407 |           asyncio.base_subprocess
import time:       515 |        515 |           asyncio.selector_events
import time:       758 |       1679 |         asyncio.unix_events
import time:       534 |      52126 |       asyncio
import time:        70 |         70 |               org
import time:        11 |         81 |             org.python
import time:         7 |         88 |           org.python.core
import time:       401 |        488 |         copy
import time:       732 |       1220 |       dataclasses
import time:       341 |        341 |         email
import time:       346 |        346 |         quopri
import time:       644 |        644 |               _bisect
import time:       367 |       1010 |             bisect
import time:       684 |        684 |             _random
import time:       602 |        602 |             _sha512
import time:       512 |       2806 |           random
import time:       716 |        716 |             _datetime
import time:       899 |       1614 |           datetime
import time:       380 |        380 |             urllib
import time:      1146 |       1525 |           urllib.parse
import time:       609 |        609 |             calendar
import time:       430 |       1039 |           email._parseaddr
import time:       381 |        381 |             email.base64mime
import time:       483 |        483 |             email.quoprimime
import time:       673 |        673 |             email.errors
import time:       380 |        380 |             email.encoders
import time:       452 |       2367 |           email.charset
import time:       946 |      10296 |         email.utils
import time:      1081 |       1081 |           email.header
import time:       459 |       1540 |         email._policybase
import time:       569 |        569 |         email._encoded_words
import time:       784 |        784 |         email.iterators
import time:       730 |      14603 |       email.message
import time:       592 |        592 |             _json
import time:       490 |       1081 |           json.scanner
import time:       688 |       1769 |         json.decoder
import time:       451 |        451 |         json.encoder
import time:       339 |       2558 |       json
import time:        71 |         71 |               backports_abc
import time:       722 |        722 |               typing_extensions
import time:        60 |         60 |                 backports_abc
import time:        58 |         58 |                   backports_abc
import time:       431 |        431 |                       numbers
import time:      1454 |       1884 |                     _decimal
import time:       332 |       2216 |                   decimal
import time:       305 |        305 |                     fnmatch
import time:        60 |         60 |                       _winapi
import time:        49 |         49 |                       nt
import time:        45 |         45 |                       nt
import time:        45 |         45 |                       nt
import time:        44 |         44 |                       nt
import time:        43 |         43 |                       nt
import time:        56 |        339 |                     ntpath
import time:       677 |       1320 |                   pathlib
import time:        58 |         58 |                     backports_abc
import time:      1033 |       1090 |                   pydantic.typing
import time:      1552 |       6234 |                 pydantic.errors
import time:        59 |         59 |                   backports_abc
import time:        51 |         51 |                     backports_abc
import time:       560 |        610 |                   pydantic.version
import time:      1192 |       1860 |                 pydantic.utils
import time:       866 |       9018 |               pydantic.class_validators
import time:      1057 |       1057 |               pydantic.config
import time:        74 |         74 |                 backports_abc
import time:       976 |        976 |                   ipaddress
import time:       569 |        569 |                     _uuid
import time:       472 |       1041 |                   uuid
import time:        56 |         56 |                     backports_abc
import time:       297 |        297 |                     colorsys
import time:       947 |       1299 |                   pydantic.color
import time:        55 |         55 |                     backports_abc
import time:        52 |         52 |                       backports_abc
import time:      1884 |       1884 |                       pydantic.datetime_parse
import time:      1024 |       2959 |                     pydantic.validators
import time:      1211 |       4225 |                   pydantic.networks
import time:        92 |         92 |                     backports_abc
import time:      2073 |       2164 |                   pydantic.types
import time:       672 |      10374 |                 pydantic.json
import time:       929 |      11376 |               pydantic.error_wrappers
import time:        68 |         68 |                 backports_abc
import time:      1046 |       1113 |               pydantic.fields
import time:        55 |         55 |                 backports_abc
import time:       410 |        410 |                     _compat_pickle
import time:       733 |        733 |                     _pickle
import time:        54 |         54 |                         org
import time:         7 |         60 |                       org.python
import time:         7 |         67 |                     org.python.core
import time:       702 |       1911 |                   pickle
import time:       660 |       2571 |                 pydantic.parse
import time:        54 |         54 |                   backports_abc
import time:       918 |        971 |                 pydantic.schema
import time:      1376 |       4971 |               pydantic.main
import time:      1022 |      29347 |             pydantic.dataclasses
import time:        53 |         53 |               backports_abc
import time:       676 |        729 |             pydantic.annotated_types
import time:       655 |        655 |             pydantic.decorator
import time:        59 |         59 |               backports_abc
import time:       943 |       1001 |             pydantic.env_settings
import time:       726 |        726 |             pydantic.tools
import time:       645 |      33100 |           pydantic
import time:         8 |      33108 |         pydantic.fields
import time:       544 |      33652 |       fastapi.params
import time:       602 |        602 |               zlib
import time:       484 |        484 |                 _compression
import time:       708 |        708 |                 _bz2
import time:       389 |       1580 |               bz2
import time:       939 |        939 |                 _lzma
import time:       346 |       1285 |               lzma
import time:       559 |       4025 |             shutil
import time:       453 |       4477 |           tempfile
import time:       357 |        357 |           shlex
import time:       327 |        327 |                 anyio._core
import time:       665 |        991 |               anyio._core._compat
import time:       297 |        297 |                   sniffio._version
import time:       226 |        226 |                   sniffio._impl
import time:       276 |        798 |                 sniffio
import time:       266 |       1063 |               anyio._core._eventloop
import time:       290 |        290 |               anyio._core._exceptions
import time:       383 |        383 |                     anyio.abc._resources
import time:       252 |        252 |                       anyio._core._typedattr
import time:       252 |        252 |                         anyio.abc._tasks
import time:       501 |        752 |                       anyio.abc._streams
import time:       469 |       1473 |                     anyio.abc._sockets
import time:       407 |        407 |                     anyio.abc._subprocesses
import time:       381 |        381 |                     anyio.abc._testing
import time:       838 |        838 |                       anyio.lowlevel
import time:       347 |        347 |                       anyio._core._tasks
import time:       266 |        266 |                       anyio._core._testing
import time:      1661 |       3109 |                     anyio._core._synchronization
import time:       662 |        662 |                           _queue
import time:       334 |        996 |                         queue
import time:       337 |       1333 |                       concurrent.futures.thread
import time:       474 |       1806 |                     anyio.from_thread
import time:       765 |       8321 |                   anyio.abc
import time:       222 |       8542 |                 anyio.to_thread
import time:       718 |       9260 |               anyio._core._fileio
import time:       258 |        258 |               anyio._core._resources
import time:       231 |        231 |               anyio._core._signals
import time:       213 |        213 |                   anyio.streams
import time:       717 |        930 |                 anyio.streams.stapled
import time:       724 |        724 |                 anyio.streams.tls
import time:       420 |       2073 |               anyio._core._sockets
import time:       812 |        812 |                 anyio.streams.memory
import time:       394 |       1206 |               anyio._core._streams
import time:       335 |        335 |               anyio._core._subprocesses
import time:       369 |      16072 |             anyio
import time:       278 |      16350 |           starlette.concurrency
import time:       255 |        255 |           starlette.types
import time:       973 |      22409 |         starlette.datastructures
import time:       325 |      22734 |       fastapi.datastructures
import time:       202 |        202 |         fastapi.dependencies
import time:       203 |        203 |                 fastapi.openapi
import time:       211 |        211 |                 fastapi.logger
import time:       573 |        573 |                   unicodedata
import time:       346 |        346 |                       dns.version
import time:       252 |        598 |                     dns
import time:       275 |        275 |                     dns.exception
import time:       359 |        359 |                     dns.flags
import time:       245 |        245 |                       dns.ipv4
import time:       330 |        330 |                       dns.ipv6
import time:       250 |        825 |                     dns.inet
import time:       339 |        339 |                             stringprep
import time:       486 |        824 |                           encodings.idna
import time:       298 |        298 |                             idna.package_data
import time:       284 |        284 |                               idna.idnadata
import time:       230 |        230 |                               idna.intranges
import time:       313 |        826 |                             idna.core
import time:       293 |       1416 |                           idna
import time:       216 |        216 |                             dns._immutable_ctx
import time:       298 |        513 |                           dns.immutable
import time:       522 |       3273 |                         dns.name
import time:       265 |       3538 |                       dns.wire
import time:       266 |        266 |                         dns.enum
import time:       303 |        303 |                           dns.rdataclass
import time:       715 |        715 |                           dns.rdatatype
import time:       203 |        203 |                             dns.ttl
import time:       274 |        476 |                           dns.tokenizer
import time:       356 |       1848 |                         dns.rdata
import time:       524 |       2638 |                       dns.edns
import time:       275 |        275 |                       dns.opcode
import time:       956 |        956 |                           _hashlib
import time:       789 |        789 |                           _blake2
import time:       314 |       2058 |                         hashlib
import time:       223 |       2281 |                       dns.entropy
import time:       502 |        502 |                       dns.rcode
import time:       237 |        237 |                           dns.set
import time:       393 |        630 |                         dns.rdataset
import time:       294 |        294 |                             hmac
import time:       436 |        729 |                           dns.tsig
import time:       248 |        977 |                         dns.renderer
import time:      1276 |       2882 |                       dns.rrset
import time:       203 |        203 |                           dns.rdtypes
import time:       333 |        535 |                         dns.rdtypes.ANY
import time:       363 |        898 |                       dns.rdtypes.ANY.OPT
import time:       255 |        255 |                       dns.rdtypes.ANY.TSIG
import time:       569 |      13834 |                     dns.message
import time:       220 |        220 |                       dns.serial
import time:       346 |        346 |                           dns.node
import time:       249 |        249 |                           dns.rdtypes.ANY.SOA
import time:       244 |        244 |                           dns.rdtypes.ANY.ZONEMD
import time:       278 |        278 |                           dns.transaction
import time:       195 |        195 |                           dns.grange
import time:       384 |        384 |                           dns.zonefile
import time:       609 |       2303 |                         dns.zone
import time:       250 |       2552 |                       dns.xfr
import time:       305 |        305 |                           __future__
import time:       210 |        210 |                                   urllib3.packages
import time:       399 |        399 |                                     importlib._abc
import time:        58 |        457 |                                   importlib.util
import time:       725 |       1390 |                                 urllib3.packages.six
import time:        19 |       1409 |                               urllib3.packages.six.moves
import time:      1085 |       1085 |                                 http
import time:       433 |        433 |                                   email.feedparser
import time:       308 |        741 |                                 email.parser
import time:       754 |       2579 |                               http.client
import time:        23 |       4009 |                             urllib3.packages.six.moves.http_client
import time:       690 |       4699 |                           urllib3.exceptions
import time:       217 |        217 |                           urllib3._version
import time:       223 |        223 |                                     urllib3.contrib
import time:       308 |        308 |                                     urllib3.contrib._appengine_environ
import time:       634 |        634 |                                     urllib3.util.wait
import time:       463 |       1627 |                                   urllib3.util.connection
import time:       133 |        133 |                                     brotlicffi
import time:        65 |         65 |                                     brotli
import time:       352 |        549 |                                   urllib3.util.request
import time:       225 |        225 |                                   urllib3.util.response
import time:       367 |        367 |                                   urllib3.util.retry
import time:      3299 |       3299 |                                     urllib3.util.url
import time:       316 |        316 |                                     urllib3.util.ssltransport
import time:       343 |       3956 |                                   urllib3.util.ssl_
import time:       265 |        265 |                                   urllib3.util.timeout
import time:       248 |       7235 |                                 urllib3.util
import time:       219 |       7453 |                               urllib3.util.proxy
import time:       272 |        272 |                               urllib3._collections
import time:       225 |        225 |                               urllib3.util.ssl_match_hostname
import time:       348 |       8296 |                             urllib3.connection
import time:        66 |         66 |                                     _winapi
import time:        51 |         51 |                                     winreg
import time:       459 |        575 |                                   mimetypes
import time:       244 |        819 |                                 urllib3.fields
import time:       231 |       1050 |                               urllib3.filepost
import time:        13 |         13 |                                 urllib3.packages.six.moves.urllib
import time:        17 |         30 |                               urllib3.packages.six.moves.urllib.parse
import time:       220 |       1300 |                             urllib3.request
import time:        53 |         53 |                               brotlicffi
import time:        41 |         41 |                               brotli
import time:       372 |        466 |                             urllib3.response
import time:       239 |        239 |                             urllib3.util.queue
import time:       357 |      10655 |                           urllib3.connectionpool
import time:       721 |        721 |                           urllib3.poolmanager
import time:        57 |         57 |                           urllib3_secure_extra
import time:       340 |      16992 |                         urllib3
import time:        47 |         47 |                             chardet
import time:       382 |        382 |                                   charset_normalizer.assets
import time:       977 |        977 |                                   charset_normalizer.constant
import time:       595 |        595 |                                     charset_normalizer.md__mypyc
import time:       612 |        612 |                                       _multibytecodec
import time:       317 |        929 |                                     charset_normalizer.utils
import time:       697 |       2220 |                                   charset_normalizer.md
import time:       416 |        416 |                                   charset_normalizer.models
import time:       295 |       4288 |                                 charset_normalizer.cd
import time:       486 |       4773 |                               charset_normalizer.api
import time:       308 |        308 |                               charset_normalizer.legacy
import time:       210 |        210 |                               charset_normalizer.version
import time:       271 |       5560 |                             charset_normalizer
import time:        54 |         54 |                             simplejson
import time:       668 |        668 |                                   urllib.response
import time:       286 |        953 |                                 urllib.error
import time:       580 |        580 |                                 _scproxy
import time:       993 |       2525 |                               urllib.request
import time:      1632 |       4156 |                             http.cookiejar
import time:       832 |        832 |                             http.cookies
import time:       361 |      11007 |                           requests.compat
import time:       693 |      11699 |                         requests.exceptions
import time:        60 |         60 |                         chardet
import time:        51 |         51 |                           chardet
import time:       436 |        487 |                         requests.packages
import time:       664 |        664 |                           zipfile
import time:       324 |        324 |                                     importlib.resources.abc
import time:       306 |        306 |                                     importlib.resources._adapters
import time:       410 |       1039 |                                   importlib.resources._common
import time:       431 |        431 |                                   importlib.resources._legacy
import time:       283 |       1753 |                                 importlib.resources
import time:       308 |       2061 |                               certifi.core
import time:       238 |       2298 |                             certifi
import time:       206 |       2503 |                           requests.certs
import time:       279 |        279 |                           requests.__version__
import time:       354 |        354 |                           requests._internal_utils
import time:       340 |        340 |                           requests.cookies
import time:       300 |        300 |                           requests.structures
import time:       338 |        338 |                               importlib.resources._itertools
import time:       358 |        696 |                             importlib.resources.readers
import time:       227 |        922 |                           importlib.readers
import time:       462 |       5821 |                         requests.utils
import time:       279 |        279 |                               requests.auth
import time:       263 |        263 |                                 requests.hooks
import time:       338 |        338 |                                 requests.status_codes
import time:       355 |        956 |                               requests.models
import time:        64 |         64 |                                 socks
import time:       237 |        301 |                               urllib3.contrib.socks
import time:       308 |       1842 |                             requests.adapters
import time:       483 |       2325 |                           requests.sessions
import time:       233 |       2557 |                         requests.api
import time:       314 |      37928 |                       requests
import time:        44 |         44 |                           requests_toolbelt
import time:         6 |         50 |                         requests_toolbelt.adapters
import time:         6 |         55 |                       requests_toolbelt.adapters.source
import time:       307 |        307 |                         httpx.__version__
import time:       910 |        910 |                               httpx._exceptions
import time:       773 |        773 |                                     httpx._types
import time:       373 |        373 |                                       netrc
import time:       553 |        925 |                                     httpx._utils
import time:       351 |       2047 |                                   httpx._multipart
import time:       507 |       2554 |                                 httpx._content
import time:        70 |         70 |                                     brotlicffi
import time:        49 |         49 |                                     brotli
import time:       417 |        535 |                                   httpx._compat
import time:       528 |       1062 |                                 httpx._decoders
import time:       733 |        733 |                                 httpx._status_codes
import time:       203 |        203 |                                         rfc3986.compat
import time:       298 |        298 |                                         rfc3986.exceptions
import time:       257 |        257 |                                           rfc3986.abnf_regexp
import time:      7841 |       8097 |                                         rfc3986.misc
import time:       399 |        399 |                                         rfc3986.normalizers
import time:       256 |        256 |                                             rfc3986.validators
import time:       249 |        504 |                                           rfc3986._mixin
import time:       304 |        808 |                                         rfc3986.uri
import time:       316 |      10119 |                                       rfc3986.iri
import time:       422 |        422 |                                       rfc3986.parseresult
import time:       337 |      10877 |                                     rfc3986.api
import time:       329 |      11206 |                                   rfc3986
import time:       504 |      11710 |                                 httpx._urls
import time:       583 |      16640 |                               httpx._models
import time:       452 |      18001 |                             httpx._auth
import time:       379 |        379 |                             httpx._config
import time:       500 |        500 |                               httpx._transports
import time:       283 |        283 |                               httpx._transports.base
import time:       624 |       1406 |                             httpx._transports.asgi
import time:       413 |        413 |                                   httpcore._models
import time:       362 |        362 |                                         httpcore._exceptions
import time:       208 |        208 |                                         httpcore._ssl
import time:       268 |        268 |                                         httpcore._synchronization
import time:       217 |        217 |                                         httpcore._trace
import time:       204 |        204 |                                           httpcore.backends
import time:       211 |        211 |                                           httpcore._utils
import time:       237 |        237 |                                           httpcore.backends.base
import time:       350 |       1001 |                                         httpcore.backends.sync
import time:       198 |        198 |                                                 h11._abnf
import time:       271 |        271 |                                                   h11._util
import time:       430 |        700 |                                                 h11._headers
import time:      1615 |       2512 |                                               h11._events
import time:       482 |        482 |                                                 h11._receivebuffer
import time:       390 |        390 |                                                 h11._state
import time:       722 |       1593 |                                               h11._readers
import time:       808 |        808 |                                               h11._writers
import time:       496 |       5407 |                                             h11._connection
import time:       310 |        310 |                                             h11._version
import time:       299 |       6014 |                                           h11
import time:       297 |        297 |                                           httpcore._sync.interfaces
import time:       398 |       6708 |                                         httpcore._sync.http11
import time:       388 |       9149 |                                       httpcore._sync.connection
import time:       314 |        314 |                                       httpcore._sync.connection_pool
import time:       343 |        343 |                                       httpcore._sync.http_proxy
import time:        69 |         69 |                                           h2
import time:        12 |         80 |                                         h2.config
import time:       286 |        366 |                                       httpcore._sync.http2
import time:        51 |         51 |                                         socksio
import time:       239 |        290 |                                       httpcore._sync.socks_proxy
import time:       296 |      10754 |                                     httpcore._sync
import time:        15 |      10769 |                                   httpcore._sync.connection_pool
import time:       433 |      11614 |                                 httpcore._api
import time:       229 |        229 |                                     httpcore.backends.auto
import time:       272 |        272 |                                       httpcore._async.interfaces
import time:       343 |        614 |                                     httpcore._async.http11
import time:       483 |       1325 |                                   httpcore._async.connection
import time:       310 |        310 |                                   httpcore._async.connection_pool
import time:       317 |        317 |                                   httpcore._async.http_proxy
import time:        52 |         52 |                                       h2
import time:        11 |         62 |                                     h2.config
import time:       291 |        353 |                                   httpcore._async.http2
import time:        49 |         49 |                                     socksio
import time:       247 |        295 |                                   httpcore._async.socks_proxy
import time:       271 |       2869 |                                 httpcore._async
import time:       307 |      14788 |                               httpcore
import time:       341 |      15128 |                             httpx._transports.default
import time:       268 |        268 |                             httpx._transports.wsgi
import time:       916 |      36095 |                           httpx._client
import time:       316 |      36411 |                         httpx._api
import time:       651 |        651 |                         httpx._transports.mock
import time:      2092 |       2092 |                               gettext
import time:      1134 |       1134 |                                 click._compat
import time:       237 |        237 |                                     click.globals
import time:       351 |        587 |                                   click.utils
import time:       446 |       1033 |                                 click.exceptions
import time:       665 |       2831 |                               click.types
import time:       537 |        537 |                                 click.parser
import time:       310 |        847 |                               click.formatting
import time:       496 |        496 |                               click.termui
import time:      1454 |       7719 |                             click.core
import time:       386 |        386 |                             click.decorators
import time:       365 |       8469 |                           click
import time:       272 |        272 |                             pygments
import time:      1246 |       1246 |                             pygments.lexers._mapping
import time:       355 |        355 |                             pygments.modeline
import time:       226 |        226 |                             pygments.plugin
import time:       505 |        505 |                             pygments.util
import time:       431 |       3031 |                           pygments.lexers
import time:       357 |        357 |                               rich._extension
import time:       373 |        730 |                             rich
import time:      1658 |       1658 |                             platform
import time:       828 |        828 |                               termios
import time:       288 |       1116 |                             getpass
import time:      1112 |       1112 |                               html.entities
import time:       756 |       1867 |                             html
import time:       346 |        346 |                             rich._null_file
import time:       306 |        306 |                             rich.errors
import time:       287 |        287 |                                         rich.color_triplet
import time:       261 |        548 |                                       rich.palette
import time:       271 |        818 |                                     rich._palettes
import time:       324 |        324 |                                     rich.repr
import time:       251 |        251 |                                     rich.terminal_theme
import time:       778 |       2170 |                                   rich.color
import time:       504 |       2673 |                                 rich.style
import time:       411 |       3084 |                               rich.default_styles
import time:      1140 |       1140 |                                 configparser
import time:       333 |       1472 |                               rich.theme
import time:       247 |       4802 |                             rich.themes
import time:      1141 |       1141 |                               rich._emoji_codes
import time:       372 |       1513 |                             rich._emoji_replace
import time:       409 |        409 |                             rich._export_format
import time:       334 |        334 |                                 rich._loop
import time:       219 |        219 |                                 rich._pick
import time:       270 |        270 |                                     rich._cell_widths
import time:       389 |        659 |                                   rich.cells
import time:       321 |        979 |                                 rich._wrap
import time:      1103 |       1103 |                                       rich.segment
import time:       254 |       1356 |                                     rich.jupyter
import time:       203 |        203 |                                       rich.protocol
import time:       314 |        517 |                                     rich.measure
import time:       282 |       2154 |                                   rich.constrain
import time:       367 |       2520 |                                 rich.align
import time:       476 |        476 |                                 rich.containers
import time:       436 |        436 |                                 rich.control
import time:       388 |        388 |                                 rich.emoji
import time:       630 |       5979 |                               rich.text
import time:       344 |       6323 |                             rich._log_render
import time:       310 |        310 |                             rich.highlighter
import time:       747 |        747 |                             rich.markup
import time:       354 |        354 |                             rich.pager
import time:       260 |        260 |                                   attr._compat
import time:       190 |        190 |                                     attr._config
import time:       267 |        267 |                                       attr.exceptions
import time:       199 |        466 |                                     attr.setters
import time:      1471 |       2126 |                                   attr._make
import time:       475 |       2860 |                                 attr.converters
import time:       260 |        260 |                                 attr.filters
import time:      2493 |       2493 |                                 attr.validators
import time:       250 |        250 |                                 attr._cmp
import time:       240 |        240 |                                 attr._funcs
import time:       239 |        239 |                                 attr._next_gen
import time:       573 |        573 |                                 attr._version_info
import time:       340 |       7252 |                               attr
import time:       238 |        238 |                               rich.abc
import time:      1096 |       8584 |                             rich.pretty
import time:       367 |        367 |                             rich.region
import time:       377 |        377 |                                 rich.box
import time:       493 |        493 |                                 rich.padding
import time:       414 |       1284 |                               rich.panel
import time:       677 |        677 |                                   fractions
import time:       318 |        994 |                                 rich._ratio
import time:      1485 |       2478 |                               rich.table
import time:       371 |       4132 |                             rich.scope
import time:       282 |        282 |                             rich.screen
import time:       214 |        214 |                             rich.styled
import time:      1486 |      35539 |                           rich.console
import time:       745 |        745 |                             mmap
import time:       248 |        248 |                             rich.filesize
import time:       503 |        503 |                                 rich.ansi
import time:       235 |        738 |                               rich.file_proxy
import time:       322 |        322 |                               rich.live_render
import time:       346 |       1406 |                             rich.live
import time:       289 |        289 |                             rich.progress_bar
import time:       261 |        261 |                               rich._spinners
import time:       261 |        522 |                             rich.spinner
import time:      1363 |       4570 |                           rich.progress
import time:       293 |        293 |                               pygments.filter
import time:       334 |        334 |                                 pygments.token
import time:       431 |        764 |                               pygments.filters
import time:       315 |        315 |                               pygments.regexopt
import time:       447 |       1817 |                             pygments.lexer
import time:       350 |        350 |                             pygments.style
import time:       250 |        250 |                             pygments.styles
import time:       690 |       3106 |                           rich.syntax
import time:       685 |      55399 |                         httpx._main
import time:       310 |      93075 |                       httpx
import time:        75 |         75 |                       h2
import time:       508 |     134409 |                     dns.query
import time:       241 |        241 |                     dns.reversename
import time:       569 |     151106 |                   dns.resolver
import time:       358 |     152037 |                 email_validator
import time:     14200 |     166649 |               fastapi.openapi.models
import time:       406 |        406 |               fastapi.security.base
import time:       294 |        294 |               starlette.exceptions
import time:       353 |        353 |                     multipart._version
import time:       660 |        660 |                       six
import time:       255 |        255 |                         multipart.exceptions
import time:       321 |        576 |                       multipart.decoders
import time:        69 |         69 |                       urlparse
import time:       608 |       1911 |                     multipart.multipart
import time:       351 |       2614 |                   multipart
import time:       518 |       3132 |                 starlette.formparsers
import time:       429 |       3560 |               starlette.requests
import time:       400 |     171308 |             fastapi.security.api_key
import time:       470 |        470 |               fastapi.exceptions
import time:       210 |        210 |               fastapi.security.utils
import time:       567 |       1246 |             fastapi.security.http
import time:       268 |        268 |               fastapi.param_functions
import time:       391 |        659 |             fastapi.security.oauth2
import time:       220 |        220 |             fastapi.security.open_id_connect_url
import time:       260 |     173690 |           fastapi.security
import time:         9 |     173699 |         fastapi.security.base
import time:       425 |     174324 |       fastapi.dependencies.models
import time:       224 |        224 |         fastapi.concurrency
import time:       226 |        226 |           fastapi.openapi.constants
import time:       399 |        625 |         fastapi.utils
import time:       207 |        207 |           starlette._utils
import time:       269 |        475 |         starlette.background
import time:       211 |        211 |           starlette._compat
import time:       444 |        655 |         starlette.responses
import time:       354 |        354 |         starlette.websockets
import time:       573 |       2904 |       fastapi.dependencies.utils
import time:       374 |        374 |       fastapi.encoders
import time:       217 |        217 |       fastapi.types
import time:       277 |        277 |         starlette.convertors
import time:       225 |        225 |         starlette.middleware
import time:       685 |       1186 |       starlette.routing
import time:       940 |     306832 |     fastapi.routing
import time:       234 |        234 |     fastapi.exception_handlers
import time:       406 |        406 |       fastapi.middleware
import time:       381 |        787 |     fastapi.middleware.asyncexitstack
import time:       243 |        243 |     fastapi.openapi.docs
import time:       740 |        740 |         ujson
import time:       509 |        509 |                 sysconfig
import time:       509 |        509 |                 _sysconfigdata__darwin_darwin
import time:       289 |        289 |                 _osx_support
import time:       776 |       2081 |               zoneinfo._tzpath
import time:       270 |        270 |               zoneinfo._common
import time:       670 |        670 |               _zoneinfo
import time:       275 |       3296 |             zoneinfo
import time:       833 |       4129 |           orjson.orjson
import time:       250 |       4378 |         orjson
import time:       224 |       5340 |       fastapi.responses
import time:       444 |       5784 |     fastapi.openapi.utils
import time:       980 |        980 |       starlette.middleware.base
import time:       255 |        255 |       starlette.middleware.errors
import time:       307 |        307 |       starlette.middleware.exceptions
import time:       347 |       1888 |     starlette.applications
import time:       905 |     316670 |   fastapi.applications
import time:       398 |        398 |   fastapi.background
import time:       329 |        329 |   fastapi.requests
import time:       247 |        247 |   fastapi.websockets
import time:       616 |     324631 | fastapi
</pre>
</details>

now: ~ 82ms
<details>
<summary><code>PYTHONPROFILEIMPORTTIME=1 python3.11</code> output</summary>
<pre>
import time: self [us] | cumulative | imported package
import time:       126 |        126 |   starlette
import time:       220 |        220 |     warnings
import time:       290 |        290 |       collections.abc
import time:       563 |        563 |       contextlib
import time:       377 |        377 |       _typing
import time:      1921 |       3148 |     typing
import time:       207 |       3574 |   starlette.status
import time:       196 |        196 |             concurrent
import time:       138 |        138 |                       token
import time:       693 |        830 |                     tokenize
import time:       117 |        947 |                   linecache
import time:       738 |        738 |                   textwrap
import time:       541 |       2224 |                 traceback
import time:       184 |        184 |                   _weakrefset
import time:       369 |        552 |                 weakref
import time:        20 |         20 |                   _string
import time:       411 |        431 |                 string
import time:       508 |        508 |                 threading
import time:        21 |         21 |                 atexit
import time:      1154 |       4888 |               logging
import time:       433 |       5321 |             concurrent.futures._base
import time:       149 |       5665 |           concurrent.futures
import time:       352 |        352 |             _heapq
import time:       169 |        520 |           heapq
import time:       665 |        665 |             _socket
import time:       412 |        412 |               math
import time:       345 |        345 |               select
import time:       407 |       1163 |             selectors
import time:        35 |         35 |             errno
import time:       334 |        334 |             array
import time:       960 |       3154 |           socket
import time:        40 |         40 |               _locale
import time:       575 |        615 |             locale
import time:       505 |        505 |             signal
import time:       345 |        345 |             fcntl
import time:        68 |         68 |             msvcrt
import time:       355 |        355 |             _posixsubprocess
import time:       426 |       2311 |           subprocess
import time:      2506 |       2506 |             _ssl
import time:       356 |        356 |                 _struct
import time:       107 |        463 |               struct
import time:       350 |        350 |               binascii
import time:       233 |       1044 |             base64
import time:      1500 |       5049 |           ssl
import time:       256 |        256 |           asyncio.constants
import time:       670 |        670 |                 _ast
import time:       618 |       1287 |               ast
import time:       299 |        299 |                   _opcode
import time:       330 |        629 |                 opcode
import time:       488 |       1116 |               dis
import time:       147 |        147 |                 importlib
import time:        33 |        179 |               importlib.machinery
import time:       976 |       3557 |             inspect
import time:       102 |       3659 |           asyncio.coroutines
import time:       227 |        227 |               _contextvars
import time:        83 |        309 |             contextvars
import time:        78 |         78 |             asyncio.format_helpers
import time:        80 |         80 |               asyncio.base_futures
import time:       112 |        112 |               asyncio.exceptions
import time:        71 |         71 |               asyncio.base_tasks
import time:       365 |        627 |             _asyncio
import time:       295 |       1308 |           asyncio.events
import time:       120 |        120 |           asyncio.futures
import time:        99 |         99 |           asyncio.protocols
import time:       134 |        134 |             asyncio.transports
import time:        66 |         66 |             asyncio.log
import time:       306 |        504 |           asyncio.sslproto
import time:        60 |         60 |               asyncio.mixins
import time:       164 |        164 |               asyncio.tasks
import time:       272 |        496 |             asyncio.locks
import time:       172 |        667 |           asyncio.staggered
import time:        84 |         84 |           asyncio.trsock
import time:       555 |      23944 |         asyncio.base_events
import time:       149 |        149 |         asyncio.runners
import time:       175 |        175 |         asyncio.queues
import time:       169 |        169 |         asyncio.streams
import time:       106 |        106 |         asyncio.subprocess
import time:        73 |         73 |         asyncio.taskgroups
import time:       187 |        187 |         asyncio.timeouts
import time:        58 |         58 |         asyncio.threads
import time:       118 |        118 |           asyncio.base_subprocess
import time:       221 |        221 |           asyncio.selector_events
import time:       412 |        749 |         asyncio.unix_events
import time:       180 |      25786 |       asyncio
import time:        54 |         54 |               org
import time:         6 |         60 |             org.python
import time:         6 |         66 |           org.python.core
import time:       117 |        182 |         copy
import time:       320 |        502 |       dataclasses
import time:        85 |         85 |         email
import time:        85 |         85 |         quopri
import time:       260 |        260 |               _bisect
import time:        72 |        332 |             bisect
import time:       249 |        249 |             _random
import time:       258 |        258 |             _sha512
import time:       218 |       1057 |           random
import time:       401 |        401 |             _datetime
import time:       527 |        927 |           datetime
import time:       102 |        102 |             urllib
import time:       609 |        710 |           urllib.parse
import time:       247 |        247 |             calendar
import time:       125 |        372 |           email._parseaddr
import time:        61 |         61 |             email.base64mime
import time:       116 |        116 |             email.quoprimime
import time:       302 |        302 |             email.errors
import time:        69 |         69 |             email.encoders
import time:       111 |        658 |           email.charset
import time:       572 |       4294 |         email.utils
import time:       291 |        291 |           email.header
import time:       145 |        436 |         email._policybase
import time:       124 |        124 |         email._encoded_words
import time:        68 |         68 |         email.iterators
import time:       314 |       5402 |       email.message
import time:       302 |        302 |             _json
import time:       205 |        507 |           json.scanner
import time:       287 |        794 |         json.decoder
import time:       196 |        196 |         json.encoder
import time:       116 |       1106 |       json
import time:        51 |         51 |               backports_abc
import time:       404 |        404 |               typing_extensions
import time:        50 |         50 |                 backports_abc
import time:        46 |         46 |                   backports_abc
import time:       193 |        193 |                       numbers
import time:       752 |        944 |                     _decimal
import time:        85 |       1029 |                   decimal
import time:        84 |         84 |                     fnmatch
import time:        48 |         48 |                       _winapi
import time:        44 |         44 |                       nt
import time:        82 |         82 |                       nt
import time:        50 |         50 |                       nt
import time:        41 |         41 |                       nt
import time:        40 |         40 |                       nt
import time:        55 |        357 |                     ntpath
import time:       401 |        841 |                   pathlib
import time:        55 |         55 |                     backports_abc
import time:       760 |        815 |                   pydantic.typing
import time:      1137 |       3866 |                 pydantic.errors
import time:       105 |        105 |                   backports_abc
import time:        56 |         56 |                     backports_abc
import time:       404 |        459 |                   pydantic.version
import time:      1030 |       1593 |                 pydantic.utils
import time:       537 |       6044 |               pydantic.class_validators
import time:       522 |        522 |               pydantic.config
import time:        49 |         49 |                 backports_abc
import time:       653 |        653 |                   ipaddress
import time:       302 |        302 |                     _uuid
import time:       216 |        518 |                   uuid
import time:        54 |         54 |                     backports_abc
import time:        78 |         78 |                     colorsys
import time:       618 |        748 |                   pydantic.color
import time:        48 |         48 |                     backports_abc
import time:        47 |         47 |                       backports_abc
import time:      1338 |       1338 |                       pydantic.datetime_parse
import time:       668 |       2052 |                     pydantic.validators
import time:       826 |       2925 |                   pydantic.networks
import time:        56 |         56 |                     backports_abc
import time:      1399 |       1455 |                   pydantic.types
import time:       372 |       6667 |                 pydantic.json
import time:       488 |       7204 |               pydantic.error_wrappers
import time:        56 |         56 |                 backports_abc
import time:       699 |        755 |               pydantic.fields
import time:        98 |         98 |                 backports_abc
import time:       158 |        158 |                     _compat_pickle
import time:       403 |        403 |                     _pickle
import time:        47 |         47 |                         org
import time:         6 |         52 |                       org.python
import time:         6 |         57 |                     org.python.core
import time:       474 |       1091 |                   pickle
import time:       400 |       1490 |                 pydantic.parse
import time:        55 |         55 |                   backports_abc
import time:       656 |        710 |                 pydantic.schema
import time:      1112 |       3409 |               pydantic.main
import time:       624 |      19009 |             pydantic.dataclasses
import time:        54 |         54 |               backports_abc
import time:       468 |        521 |             pydantic.annotated_types
import time:       559 |        559 |             pydantic.decorator
import time:        70 |         70 |               backports_abc
import time:       848 |        917 |             pydantic.env_settings
import time:       433 |        433 |             pydantic.tools
import time:       383 |      21820 |           pydantic
import time:         6 |      21825 |         pydantic.fields
import time:       365 |      22190 |       fastapi.params
import time:       373 |        373 |               zlib
import time:       130 |        130 |                 _compression
import time:       350 |        350 |                 _bz2
import time:       182 |        661 |               bz2
import time:       541 |        541 |                 _lzma
import time:       135 |        676 |               lzma
import time:       322 |       2030 |             shutil
import time:       223 |       2253 |           tempfile
import time:       168 |        168 |           shlex
import time:       108 |        108 |                 anyio._core
import time:       397 |        504 |               anyio._core._compat
import time:        76 |         76 |                   sniffio._version
import time:        76 |         76 |                   sniffio._impl
import time:        96 |        248 |                 sniffio
import time:       106 |        354 |               anyio._core._eventloop
import time:       131 |        131 |               anyio._core._exceptions
import time:       153 |        153 |                     anyio.abc._resources
import time:        98 |         98 |                       anyio._core._typedattr
import time:        90 |         90 |                         anyio.abc._tasks
import time:       344 |        433 |                       anyio.abc._streams
import time:       287 |        817 |                     anyio.abc._sockets
import time:       109 |        109 |                     anyio.abc._subprocesses
import time:       153 |        153 |                     anyio.abc._testing
import time:       544 |        544 |                       anyio.lowlevel
import time:       146 |        146 |                       anyio._core._tasks
import time:       113 |        113 |                       anyio._core._testing
import time:      1500 |       2302 |                     anyio._core._synchronization
import time:       460 |        460 |                           _queue
import time:       166 |        626 |                         queue
import time:       151 |        776 |                       concurrent.futures.thread
import time:       943 |       1719 |                     anyio.from_thread
import time:       178 |       5428 |                   anyio.abc
import time:        75 |       5502 |                 anyio.to_thread
import time:       568 |       6069 |               anyio._core._fileio
import time:        92 |         92 |               anyio._core._resources
import time:        73 |         73 |               anyio._core._signals
import time:        59 |         59 |                   anyio.streams
import time:       494 |        552 |                 anyio.streams.stapled
import time:       541 |        541 |                 anyio.streams.tls
import time:       271 |       1363 |               anyio._core._sockets
import time:       638 |        638 |                 anyio.streams.memory
import time:       122 |        760 |               anyio._core._streams
import time:       154 |        154 |               anyio._core._subprocesses
import time:       178 |       9674 |             anyio
import time:       117 |       9790 |           starlette.concurrency
import time:        91 |         91 |           starlette.types
import time:       698 |      12999 |         starlette.datastructures
import time:       147 |      13146 |       fastapi.datastructures
import time:        68 |         68 |         fastapi.dependencies
import time:      3253 |       3253 |                 fastapi.security.models
import time:        54 |       3307 |               fastapi.security.base
import time:       356 |        356 |                 http
import time:       116 |        471 |               starlette.exceptions
import time:       681 |        681 |                 http.cookies
import time:        92 |         92 |                     __future__
import time:        86 |         86 |                     multipart._version
import time:       102 |        102 |                           importlib._abc
import time:        67 |        168 |                         importlib.util
import time:       489 |        657 |                       six
import time:       108 |        108 |                         multipart.exceptions
import time:        83 |        191 |                       multipart.decoders
import time:        55 |         55 |                       urlparse
import time:       361 |       1262 |                     multipart.multipart
import time:       103 |       1541 |                   multipart
import time:       266 |       1806 |                 starlette.formparsers
import time:       212 |       2697 |               starlette.requests
import time:       142 |       6615 |             fastapi.security.api_key
import time:       233 |        233 |               fastapi.exceptions
import time:        57 |         57 |               fastapi.security.utils
import time:       353 |        642 |             fastapi.security.http
import time:       152 |        152 |               fastapi.param_functions
import time:       217 |        368 |             fastapi.security.oauth2
import time:        70 |         70 |             fastapi.security.open_id_connect_url
import time:        76 |       7770 |           fastapi.security
import time:         7 |       7777 |         fastapi.security.base
import time:       182 |       8026 |       fastapi.dependencies.models
import time:        72 |         72 |         fastapi.concurrency
import time:        58 |         58 |         fastapi.logger
import time:        50 |         50 |             fastapi.openapi
import time:        81 |        130 |           fastapi.openapi.constants
import time:       189 |        319 |         fastapi.utils
import time:        47 |         47 |           starlette._utils
import time:       104 |        151 |         starlette.background
import time:        53 |         53 |             _winapi
import time:        45 |         45 |             winreg
import time:       148 |        245 |           mimetypes
import time:       659 |        659 |               _hashlib
import time:       489 |        489 |               _blake2
import time:       245 |       1392 |             hashlib
import time:        61 |       1452 |           starlette._compat
import time:       314 |       2010 |         starlette.responses
import time:       276 |        276 |         starlette.websockets
import time:       348 |       3232 |       fastapi.dependencies.utils
import time:       186 |        186 |       fastapi.encoders
import time:        62 |         62 |       fastapi.types
import time:       211 |        211 |         starlette.convertors
import time:        71 |         71 |         starlette.middleware
import time:       556 |        837 |       starlette.routing
import time:       725 |      81194 |     fastapi.routing
import time:        74 |         74 |     fastapi.exception_handlers
import time:        58 |         58 |       fastapi.middleware
import time:       122 |        179 |     fastapi.middleware.asyncexitstack
import time:       166 |        166 |       starlette.middleware.base
import time:       610 |        610 |           html.entities
import time:       203 |        813 |         html
import time:       177 |        989 |       starlette.middleware.errors
import time:       142 |        142 |       starlette.middleware.exceptions
import time:       173 |       1469 |     starlette.applications
import time:       544 |      83458 |   fastapi.applications
import time:        59 |         59 |   fastapi.background
import time:        55 |         55 |   fastapi.requests
import time:       494 |        494 |     ujson
import time:       292 |        292 |             sysconfig
import time:       321 |        321 |             _sysconfigdata__darwin_darwin
import time:       185 |        185 |             _osx_support
import time:       493 |       1289 |           zoneinfo._tzpath
import time:       111 |        111 |           zoneinfo._common
import time:       428 |        428 |           _zoneinfo
import time:       104 |       1930 |         zoneinfo
import time:       603 |       2532 |       orjson.orjson
import time:        94 |       2626 |     orjson
import time:        76 |       3196 |   fastapi.responses
import time:        50 |         50 |   fastapi.websockets
import time:       262 |      90777 | fastapi
</pre>
</details>