### PR TITLE
Add packaging status of fastapi for various linux distros to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ FastAPI stands on the shoulders of giants:
 
 ## Installation
 
+<a href="https://repology.org/project/python:fastapi/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/python:fastapi.svg" alt="Packaging status" align="right">
+</a>
+
 <div class="termy">
 
 ```console
@@ -142,6 +146,8 @@ $ pip install "uvicorn[standard]"
 ```
 
 </div>
+
+You can also install fastapi from the offical [repos](https://repology.org/project/python:fastapi/versions) of various linux distributions using a package manager
 
 ## Example
 


### PR DESCRIPTION
This would provide an overview of the different versions of fastapi available in various linux distributions.
This would be helpful for people who would prefer to install software using package managers like apt/dnf/pacman.