### PR TITLE
✏ Update `zip-docs.sh` internal script, remove extra space

### DIFF
--- a/scripts/zip-docs.sh
+++ b/scripts/zip-docs.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set -x
 set -e


### PR DESCRIPTION
espacio entre «shebang».