### PR TITLE
➕ [FEATURE] Mounting app creates API definition

### DIFF
--- a/docs_src/extending_openapi/tutorial002.py
+++ b/docs_src/extending_openapi/tutorial002.py
@@ -14,10 +14,11 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 @app.get("/docs", include_in_schema=False)
 async def custom_swagger_ui_html():
     return get_swagger_ui_html(
-        openapi_url=app.openapi_url,
+        openapi_urls=app.openapi_urls,
         title=app.title + " - Swagger UI",
         oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
         swagger_js_url="/static/swagger-ui-bundle.js",
+        swagger_standalone_js_url="/static/swagger-ui-standalone-preset.js",
         swagger_css_url="/static/swagger-ui.css",
     )
 
@@ -30,9 +31,10 @@ async def swagger_ui_redirect():
 @app.get("/redoc", include_in_schema=False)
 async def redoc_html():
     return get_redoc_html(
-        openapi_url=app.openapi_url,
+        openapi_urls=app.openapi_urls,
         title=app.title + " - ReDoc",
         redoc_js_url="/static/redoc.standalone.js",
+        swagger_css_url="/static/swagger-ui.css",
     )
 
 

--- a/tests/test_local_docs.py
+++ b/tests/test_local_docs.py
@@ -65,3 +65,25 @@ def test_google_fonts_in_generated_redoc():
         openapi_urls=[{"url": "/docs"}], title="title", with_google_fonts=False
     ).body.decode()
     assert "fonts.googleapis.com" not in body_without_google_fonts
+
+
+def test_swagger_api_definitions_created():
+    sig = inspect.signature(get_swagger_ui_html)
+    swagger_css_url = sig.parameters.get("swagger_standalone_js_url").default  # type: ignore
+    swagger_ui_body = get_swagger_ui_html(
+        openapi_urls=[{"url": "/docs"}, {"url": "/second", "name": "second_def"}],
+        title="title",
+    ).body.decode()
+    assert swagger_css_url in swagger_ui_body
+    assert "second_def" in swagger_ui_body
+
+
+def test_redoc_api_definitions_created():
+    sig = inspect.signature(get_redoc_html)
+    swagger_css_url = sig.parameters.get("swagger_css_url").default  # type: ignore
+    redoc_ui_body = get_redoc_html(
+        openapi_urls=[{"url": "/docs"}, {"url": "/second", "name": "second_def"}],
+        title="title",
+    ).body.decode()
+    assert swagger_css_url in redoc_ui_body
+    assert "second_def" in redoc_ui_body

--- a/tests/test_local_docs.py
+++ b/tests/test_local_docs.py
@@ -8,7 +8,7 @@ def test_strings_in_generated_swagger():
     swagger_js_url = sig.parameters.get("swagger_js_url").default  # type: ignore
     swagger_css_url = sig.parameters.get("swagger_css_url").default  # type: ignore
     swagger_favicon_url = sig.parameters.get("swagger_favicon_url").default  # type: ignore
-    html = get_swagger_ui_html(openapi_url="/docs", title="title")
+    html = get_swagger_ui_html(openapi_urls=[{"url": "/docs"}], title="title")
     body_content = html.body.decode()
     assert swagger_js_url in body_content
     assert swagger_css_url in body_content
@@ -20,7 +20,7 @@ def test_strings_in_custom_swagger():
     swagger_css_url = "swagger_fake_file.css"
     swagger_favicon_url = "swagger_fake_file.png"
     html = get_swagger_ui_html(
-        openapi_url="/docs",
+        openapi_urls=[{"url": "/docs"}],
         title="title",
         swagger_js_url=swagger_js_url,
         swagger_css_url=swagger_css_url,
@@ -36,7 +36,7 @@ def test_strings_in_generated_redoc():
     sig = inspect.signature(get_redoc_html)
     redoc_js_url = sig.parameters.get("redoc_js_url").default  # type: ignore
     redoc_favicon_url = sig.parameters.get("redoc_favicon_url").default  # type: ignore
-    html = get_redoc_html(openapi_url="/docs", title="title")
+    html = get_redoc_html(openapi_urls=[{"url": "/docs"}], title="title")
     body_content = html.body.decode()
     assert redoc_js_url in body_content
     assert redoc_favicon_url in body_content
@@ -46,7 +46,7 @@ def test_strings_in_custom_redoc():
     redoc_js_url = "fake_redoc_file.js"
     redoc_favicon_url = "fake_redoc_file.png"
     html = get_redoc_html(
-        openapi_url="/docs",
+        openapi_urls=[{"url": "/docs"}],
         title="title",
         redoc_js_url=redoc_js_url,
         redoc_favicon_url=redoc_favicon_url,
@@ -58,10 +58,10 @@ def test_strings_in_custom_redoc():
 
 def test_google_fonts_in_generated_redoc():
     body_with_google_fonts = get_redoc_html(
-        openapi_url="/docs", title="title"
+        openapi_urls=[{"url": "/docs"}], title="title"
     ).body.decode()
     assert "fonts.googleapis.com" in body_with_google_fonts
     body_without_google_fonts = get_redoc_html(
-        openapi_url="/docs", title="title", with_google_fonts=False
+        openapi_urls=[{"url": "/docs"}], title="title", with_google_fonts=False
     ).body.decode()
     assert "fonts.googleapis.com" not in body_without_google_fonts

--- a/tests/test_mount.py
+++ b/tests/test_mount.py
@@ -1,0 +1,56 @@
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app = FastAPI(servers=[{"url": "localhost:8000"}])
+
+main_api_text = {"message": "Hello World from main app"}
+sub_api_text = {"message": "Hello World from sub API"}
+
+
+@app.get("/app")
+def read_main():
+    return main_api_text
+
+
+subapi = FastAPI()
+
+
+@subapi.get("/sub")
+def read_sub():
+    return sub_api_text
+
+
+app.mount("/subapi", subapi)
+
+client = TestClient(app)
+
+
+def test_app_response():
+    response = client.get("/app")
+    assert response.status_code == 200, response.text
+    assert json.loads(response.text) == main_api_text
+
+
+def test_sub_app_response():
+    response = client.get("/subapi/sub")
+    assert response.status_code == 200, response.text
+    assert json.loads(response.text) == sub_api_text
+
+
+def test_app_openapi_response():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+
+
+def test_sub_app_openapi_response():
+    response = client.get("/subapi/openapi.json")
+    assert response.status_code == 200, response.text
+
+
+def test_sub_app_openapi_servers():
+    sub_servers = [{"url": "/subapi"}] + [
+        {"url": server["url"] + "/subapi"} for server in app.servers
+    ]
+    assert sub_servers == subapi.servers


### PR DESCRIPTION
# Feature
With this MR, if `subapp` is mounted to `mainapp`, you will see dropdown with ability to select API definition on the `mainapp` docs page.

# Description 
1. Mount the app as shown below
```
app = FastAPI(title="Main app", servers=[{"url": "http://localhost:8000"}])
@app.get("/app")
def read_main():
    return {"message": "Hello World from main app"}

subapi1 = FastAPI(title="Sub app 1")
@subapi1.get("/sub")
def read_sub():
    return {"message": "Hello World from sub API"}

app.mount("/subapi1", subapi1) # you can specify name of api definition. If not, path used as name
```
2. Go to `http://localhost:8000/docs` and you will see this
<img width="1424" alt="Снимок экрана 2023-02-08 в 00 08 58" src="https://user-images.githubusercontent.com/48096792/217380354-96c89936-4d98-4e03-ab10-83ebf6853b6e.png">
3. You can select the mounted app API from dropdown
<img width="1427" alt="Снимок экрана 2023-02-08 в 00 09 08" src="https://user-images.githubusercontent.com/48096792/217380562-f271c0cd-68a0-4642-b635-f86a1e1202eb.png">
4. Select mounted API and it will appear on the screen
<img width="1426" alt="Снимок экрана 2023-02-08 в 00 09 25" src="https://user-images.githubusercontent.com/48096792/217380706-09ef851e-cea7-46c4-8f05-28ebf394e406.png">
5. ReDoc now comes with same feature
<img width="1433" alt="Снимок экрана 2023-02-08 в 00 10 31" src="https://user-images.githubusercontent.com/48096792/217381008-70ddf7e3-1b34-4f0e-93a8-73968009cbcf.png">

# Help wanted / Discussion 
Swagger UI comes with API definition feature almost out the box, unlike Redoc, that does not have this feature(or i did not found). So current solution is to use customized Swagger UI top bar with some JS on top of it.

So, if somebody know how to add this feature to redoc properly, I'll really appreciate your help.
Maybe Redoc does ned this feature if there's not native support.
 
