### PR TITLE
Bump Starlette from 0.23.0 to 0.23.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.22.0,<=0.23.0",
+    "starlette>=0.22.0,<=0.23.1",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
https://github.com/encode/starlette/compare/0.23.0...0.23.1

```
## 0.23.1

December 9, 2022

### Fixed
* Only stop receiving stream on `body_stream` if body is empty on the `BaseHTTPMiddleware` [#1940](https://github.com/encode/starlette/pull/1940).
```

@Kludex 