### PR TITLE
✏ Fix typo in `docs/en/docs/tutorial/bigger-applications.md`, "codes" to "code"

### DIFF
--- a/docs/en/docs/tutorial/bigger-applications.md
+++ b/docs/en/docs/tutorial/bigger-applications.md
@@ -189,7 +189,7 @@ The end result is that the item paths are now:
 
 ### Import the dependencies
 
-This codes lives in the module `app.routers.items`, the file `app/routers/items.py`.
+This code lives in the module `app.routers.items`, the file `app/routers/items.py`.
 
 And we need to get the dependency function from the module `app.dependencies`, the file `app/dependencies.py`.
 


### PR DESCRIPTION
Typo in docs: it should be code instead of codes