### PR TITLE
Add exception chaining for better traceback

### DIFF
--- a/fastapi/middleware/asyncexitstack.py
+++ b/fastapi/middleware/asyncexitstack.py
@@ -18,7 +18,7 @@ class AsyncExitStackMiddleware:
                     await self.app(scope, receive, send)
                 except Exception as e:
                     dependency_exception = e
-                    raise e
+                    raise e from stack
             if dependency_exception:
                 # This exception was possibly handled by the dependency but it should
                 # still bubble up so that the ServerErrorMiddleware can return a 500


### PR DESCRIPTION
if use `depends(get_db)`, it's difficult to trace error when error occured in get_db

before
```
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/starlette/middleware/base.py", line 84, in call_next
    raise app_exc
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 27, in __call__
    raise dependency_exception
  File "/home/hong/PycharmProjects/backend-services/src/infrastructure/database/__init__.py", line 27, in get_db
    yield db
sqlalchemy.exc.InvalidRequestError: Can't compare a collection to an object or collection; use contains() to test for membership.
```

after
```
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/sqlalchemy/sql/operators.py", line 523, in __eq__
    return self.operate(eq, other)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/sqlalchemy/orm/attributes.py", line 444, in operate
    return op(self.comparator, *other, **kwargs)  # type: ignore[return-value]  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hong/.cache/pypoetry/virtualenvs/backend-services-DFfntZsq-py3.11/lib/python3.11/site-packages/sqlalchemy/orm/relationships.py", line 747, in __eq__
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: Can't compare a collection to an object or collection; use contains() to test for membership.
```