### PR TITLE
Added support for injection of custom generic classes via Depends()

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -246,12 +246,10 @@ def is_scalar_sequence_field(field: ModelField) -> bool:
 
 
 def is_generic_type(obj: Any) -> bool:
-    return hasattr(obj, '__origin__') and hasattr(obj, '__args__')
+    return hasattr(obj, "__origin__") and hasattr(obj, "__args__")
 
 
-def substitute_generic_type(
-        annotation: Any, typevars: Dict[str, Any]
-) -> Any:
+def substitute_generic_type(annotation: Any, typevars: Dict[str, Any]) -> Any:
     collection_shells = {list: List, set: List, dict: Dict, tuple: Tuple}
     if is_generic_type(annotation):
         args = tuple(
@@ -265,11 +263,10 @@ def substitute_generic_type(
 def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
     typevars = None
     if is_generic_type(call):
-        origin = getattr(call, '__origin__')
+        origin = call.__origin__
         typevars = {
-            typevar.__name__: value for typevar, value in zip(
-                origin.__parameters__, getattr(call, '__args__')
-            )
+            typevar.__name__: value
+            for typevar, value in zip(origin.__parameters__, call.__args__)
         }
         call = origin.__init__
 
@@ -283,16 +280,17 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
             default=param.default,
             annotation=get_typed_annotation(param.annotation, globalns, typevars),
         )
-        for param in signature.parameters.values() if param.name != 'self'
+        for param in signature.parameters.values()
+        if param.name != "self"
     ]
     typed_signature = inspect.Signature(typed_params)
     return typed_signature
 
 
 def get_typed_annotation(
-        annotation: Any,
-        globalns: Dict[str, Any],
-        typevars: Optional[Dict[str, type]] = None,
+    annotation: Any,
+    globalns: Dict[str, Any],
+    typevars: Optional[Dict[str, type]] = None,
 ) -> Any:
     if isinstance(annotation, str):
         annotation = ForwardRef(annotation)
@@ -799,4 +797,3 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
     )
     check_file_field(final_field)
     return final_field
-

--- a/tests/test_dependency_generic_class.py
+++ b/tests/test_dependency_generic_class.py
@@ -1,28 +1,25 @@
-from typing import Generic, List, TypeVar, Dict
-
-from starlette.testclient import TestClient
+from typing import Dict, Generic, List, TypeVar
 
 from fastapi import Depends, FastAPI
+from starlette.testclient import TestClient
 
 T = TypeVar("T")
 C = TypeVar("C")
 
 
 class FirstGenericType(Generic[T]):
-
     def __init__(self, simple: T, lst: List[T]):
         self.simple = simple
         self.lst = lst
 
 
 class SecondGenericType(Generic[T, C]):
-
     def __init__(
-            self,
-            simple: T,
-            lst: List[T],
-            dct: Dict[T, C],
-            custom_class: FirstGenericType[T] = Depends()
+        self,
+        simple: T,
+        lst: List[T],
+        dct: Dict[T, C],
+        custom_class: FirstGenericType[T] = Depends(),
     ):
         self.simple = simple
         self.lst = lst
@@ -41,8 +38,8 @@ def depend_generic_type(obj: SecondGenericType[str, int] = Depends()):
         "dct": obj.dct,
         "custom_class": {
             "simple": obj.custom_class.simple,
-            "lst": obj.custom_class.lst
-        }
+            "lst": obj.custom_class.lst,
+        },
     }
 
 
@@ -50,10 +47,13 @@ client = TestClient(app)
 
 
 def test_generic_class_dependency():
-    response = client.post("/test_generic_class?simple=simple", json={
-        "lst": ["string_1", "string_2"],
-        "dct": {"key": 1},
-    })
+    response = client.post(
+        "/test_generic_class?simple=simple",
+        json={
+            "lst": ["string_1", "string_2"],
+            "dct": {"key": 1},
+        },
+    )
     assert response.status_code == 200, response.json()
     assert response.json() == {
         "custom_class": {

--- a/tests/test_dependency_generic_class.py
+++ b/tests/test_dependency_generic_class.py
@@ -1,0 +1,66 @@
+from typing import Generic, List, TypeVar, Dict
+
+from starlette.testclient import TestClient
+
+from fastapi import Depends, FastAPI
+
+T = TypeVar("T")
+C = TypeVar("C")
+
+
+class FirstGenericType(Generic[T]):
+
+    def __init__(self, simple: T, lst: List[T]):
+        self.simple = simple
+        self.lst = lst
+
+
+class SecondGenericType(Generic[T, C]):
+
+    def __init__(
+            self,
+            simple: T,
+            lst: List[T],
+            dct: Dict[T, C],
+            custom_class: FirstGenericType[T] = Depends()
+    ):
+        self.simple = simple
+        self.lst = lst
+        self.dct = dct
+        self.custom_class = custom_class
+
+
+app = FastAPI()
+
+
+@app.post("/test_generic_class")
+def depend_generic_type(obj: SecondGenericType[str, int] = Depends()):
+    return {
+        "simple": obj.simple,
+        "lst": obj.lst,
+        "dct": obj.dct,
+        "custom_class": {
+            "simple": obj.custom_class.simple,
+            "lst": obj.custom_class.lst
+        }
+    }
+
+
+client = TestClient(app)
+
+
+def test_generic_class_dependency():
+    response = client.post("/test_generic_class?simple=simple", json={
+        "lst": ["string_1", "string_2"],
+        "dct": {"key": 1},
+    })
+    assert response.status_code == 200, response.json()
+    assert response.json() == {
+        "custom_class": {
+            "lst": ["string_1", "string_2"],
+            "simple": "simple",
+        },
+        "lst": ["string_1", "string_2"],
+        "dct": {"key": 1},
+        "simple": "simple",
+    }


### PR DESCRIPTION
**Added support for injecting custom generic class objects via Depends().**
[how it worked before](https://ibb.co/23X6MtL)
[how it works now](https://ibb.co/Zg65g2F)

### The Issue:

Using custom generic classes via Depends() led to an unpredictable result. The fastAPI  could not parse the initializer signature correctly due to the way generic classes work in Python.

### Why is it important?

The ability to use generic classes via Depends() is expected behavior for a typed program. It allows you to make more stable program using DI and avoid writing duplicate code.

Using generics types makes the code more flexible, safer, and more concise.

### What's changed?

dependencies/utils.py module was changed.

- Added function 'is_generic_type':
      – to check whether the object is generic type.

- Added function ‘substitute_generic_type’:
      – to substitute a real annotate in the signature. 

 - Changed function ‘get_typed_annotation’:
       - added optional attribute ‘typevars’;
       - if 'typevars' is received, the function calls ‘substitute_generic_type’;

- Changed function ‘get_typed_signature:
      - it calls ‘is_generic_type ’ function. If the function returns False, it works as before. Otherwise, the typevars and types mapping dict is created. This dict pass to 'get_typed_annotation'.

### Testing:

The changes do not affect the existing implementation of the fastAPI. It only add new functionality.
All basic tests have been completed, and new ones have been added (**tests/test_dependency_generic_class.py**) that check work with custom generic types via Depends().
It has been tested with Python 3.7-3.10.