### PR TITLE
🔊 Log GraphQL errors in FastAPI People, because it returns 200, with a payload with an error

### DIFF
--- a/.github/actions/people/app/main.py
+++ b/.github/actions/people/app/main.py
@@ -381,6 +381,10 @@ def get_graphql_response(
         logging.error(response.text)
         raise RuntimeError(response.text)
     data = response.json()
+    if "errors" in data:
+        logging.error(f"Errors in response, after: {after}, category_id: {category_id}")
+        logging.error(response.text)
+        raise RuntimeError(response.text)
     return data
 
 


### PR DESCRIPTION
🔊 Log GraphQL errors in FastAPI People, because it returns 200, with a payload with an error