### PR TITLE
⬆ Upgrade python-multipart to support 0.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ test = [
     "databases[sqlite] >=0.3.2,<0.7.0",
     "orjson >=3.2.1,<4.0.0",
     "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,<6.0.0",
-    "python-multipart >=0.0.5,<0.0.6",
+    "python-multipart >=0.0.5,<0.0.7",
     "flask >=1.1.2,<3.0.0",
     "anyio[trio] >=3.2.1,<4.0.0",
     "python-jose[cryptography] >=3.3.0,<4.0.0",


### PR DESCRIPTION
Upstream changelog: https://github.com/andrew-d/python-multipart/blob/0.0.6/CHANGELOG.md

I ran the FastAPI tests locally with this PR and they all passed.