### PR TITLE
📝 Update Sentry link in docs

### DIFF
--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -92,7 +92,7 @@ There are many other ASGI middlewares.
 
 For example:
 
-* <a href="https://docs.sentry.io/platforms/python/asgi/" class="external-link" target="_blank">Sentry</a>
+* <a href="[https://docs.sentry.io/platforms/python/asgi/](https://docs.sentry.io/platforms/python/guides/fastapi/)" class="external-link" target="_blank">Sentry</a>
 * <a href="https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py" class="external-link" target="_blank">Uvicorn's `ProxyHeadersMiddleware`</a>
 * <a href="https://github.com/florimondmanca/msgpack-asgi" class="external-link" target="_blank">MessagePack</a>
 

--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -92,7 +92,7 @@ There are many other ASGI middlewares.
 
 For example:
 
-* <a href="[https://docs.sentry.io/platforms/python/asgi/](https://docs.sentry.io/platforms/python/guides/fastapi/)" class="external-link" target="_blank">Sentry</a>
+* <a href="https://docs.sentry.io/platforms/python/guides/fastapi/" class="external-link" target="_blank">Sentry</a>
 * <a href="https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py" class="external-link" target="_blank">Uvicorn's `ProxyHeadersMiddleware`</a>
 * <a href="https://github.com/florimondmanca/msgpack-asgi" class="external-link" target="_blank">MessagePack</a>
 


### PR DESCRIPTION
Link was bad, and linked to generic ASGI integration, dedicated FastAPI and Starlette integrations now available