### PR TITLE
⬆️ Upgrade Starlette version, support new `lifespan` with state

### DIFF
--- a/docs/en/docs/advanced/events.md
+++ b/docs/en/docs/advanced/events.md
@@ -138,9 +138,6 @@ Here, the `shutdown` event handler function will write a text line `"Application
 
     So, we declare the event handler function with standard `def` instead of `async def`.
 
-!!! info
-    You can read more about these event handlers in <a href="https://www.starlette.io/events/" class="external-link" target="_blank">Starlette's  Events' docs</a>.
-
 ### `startup` and `shutdown` together
 
 There's a high chance that the logic for your *startup* and *shutdown* is connected, you might want to start something and then finish it, acquire a resource and then release it, etc.
@@ -154,6 +151,11 @@ Because of that, it's now recommended to instead use the `lifespan` as explained
 Just a technical detail for the curious nerds. 🤓
 
 Underneath, in the ASGI technical specification, this is part of the <a href="https://asgi.readthedocs.io/en/latest/specs/lifespan.html" class="external-link" target="_blank">Lifespan Protocol</a>, and it defines events called `startup` and `shutdown`.
+
+!!! info
+    You can read more about the Starlette `lifespan` handlers in <a href="https://www.starlette.io/lifespan/" class="external-link" target="_blank">Starlette's  Lifespan' docs</a>.
+
+    Including how to handle lifespan state that can be used in other areas of your code.
 
 ## Sub Applications
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import (
     Any,
-    AsyncContextManager,
     Awaitable,
     Callable,
     Coroutine,
@@ -42,7 +41,7 @@ from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import BaseRoute
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
 
 
 class FastAPI(Starlette):
@@ -72,7 +71,7 @@ class FastAPI(Starlette):
         ] = None,
         on_startup: Optional[Sequence[Callable[[], Any]]] = None,
         on_shutdown: Optional[Sequence[Callable[[], Any]]] = None,
-        lifespan: Optional[Callable[["FastAPI"], AsyncContextManager[Any]]] = None,
+        lifespan: Optional[Lifespan] = None,
         terms_of_service: Optional[str] = None,
         contact: Optional[Dict[str, Union[str, Any]]] = None,
         license_info: Optional[Dict[str, Union[str, Any]]] = None,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -7,7 +7,6 @@ from contextlib import AsyncExitStack
 from enum import Enum, IntEnum
 from typing import (
     Any,
-    AsyncContextManager,
     Callable,
     Coroutine,
     Dict,
@@ -58,7 +57,7 @@ from starlette.routing import (
     websocket_session,
 )
 from starlette.status import WS_1008_POLICY_VIOLATION
-from starlette.types import ASGIApp, Scope
+from starlette.types import ASGIApp, Lifespan, Scope
 from starlette.websockets import WebSocket
 
 
@@ -493,7 +492,7 @@ class APIRouter(routing.Router):
         route_class: Type[APIRoute] = APIRoute,
         on_startup: Optional[Sequence[Callable[[], Any]]] = None,
         on_shutdown: Optional[Sequence[Callable[[], Any]]] = None,
-        lifespan: Optional[Callable[[Any], AsyncContextManager[Any]]] = None,
+        lifespan: Optional[Lifespan] = None,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
         generate_unique_id_function: Callable[[APIRoute], str] = Default(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.25.0,<0.26.0",
+    "starlette>=0.26.0,<0.27.0",
     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
⬆️ Upgrade Starlette version, support new `lifespan` with state.

I'm not updating the docs much to include information about the new state because I want to improve how lifespan/global dependencies would work, and the two things would be used for similar use cases, but dependencies would be the most natural in FastAPI.