### PR TITLE
✏ Fix typo/bug in inline code example in `docs/en/docs/tutorial/query-params-str-validations.md`

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -199,7 +199,7 @@ Instead use the actual default value of the function parameter. Otherwise, it wo
 For example, this is not allowed:
 
 ```Python
-q: Annotated[str Query(default="rick")] = "morty"
+q: Annotated[str, Query(default="rick")] = "morty"
 ```
 
 ...because it's not clear if the default value should be `"rick"` or `"morty"`.


### PR DESCRIPTION
There was a missing comma in the docs that threw me off :)

Thanks for the great using `Annotated` !