### PR TITLE
add OpenAPIAnnotation params to add info to simple Annotated type

### DIFF
--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -11,6 +11,28 @@ class ParamTypes(Enum):
     cookie = "cookie"
 
 
+class OpenAPIAnnotation:
+    def __init__(
+        self,
+        *,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        example: Any = Undefined,
+        examples: Optional[Dict[str, Any]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+    ):
+        self.title = title
+        self.description = description
+        self.deprecated = deprecated
+        self.examples = examples
+        self.example = example
+        self.include_in_schema = include_in_schema
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}"
+
+
 class Param(FieldInfo):
     in_: ParamTypes
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -109,15 +109,15 @@ openapi_schema = {
                 "operationId": "description_description_get",
                 "parameters": [
                     {
+                        "description": "description",
                         "required": False,
                         "schema": {
                             "title": "get a description",
                             "type": "string",
-                            "default": "foo",
-                            "description": "description",
+                            "description": "description"
                         },
                         "name": "foo",
-                        "in": "query",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -144,14 +144,15 @@ openapi_schema = {
                 "operationId": "description_description__foo__get",
                 "parameters": [
                     {
+                        "description": "description",
                         "required": True,
                         "schema": {
                             "title": "get a description",
                             "type": "string",
-                            "description": "description",
+                            "description": "description"
                         },
                         "name": "foo",
-                        "in": "path",
+                        "in": "path"
                     }
                 ],
                 "responses": {
@@ -290,6 +291,8 @@ foo_is_short = {
         ("/default", 200, {"foo": "foo"}),
         ("/default?foo=bar", 200, {"foo": "bar"}),
         ("/required?foo=bar", 200, {"foo": "bar"}),
+        ("/description?foo=bar", 200, {"foo": "bar"}),
+        ("/description/bar", 200, {"foo": "bar"}),
         ("/required", 422, foo_is_missing),
         ("/required?foo=", 422, foo_is_short),
         ("/multiple?foo=bar", 200, {"foo": "bar"}),

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi import FastAPI, Query
+from fastapi.params import OpenAPIAnnotation
 from fastapi.testclient import TestClient
 from typing_extensions import Annotated
 
@@ -15,6 +16,10 @@ async def default(foo: Annotated[str, Query()] = "foo"):
 async def required(foo: Annotated[str, Query(min_length=1)]):
     return {"foo": foo}
 
+@app.get("/description/{foo}")
+@app.get("/description")
+async def description(foo: Annotated[str, OpenAPIAnnotation(title="get a description", description="description")] = None):
+    return {"foo": foo}
 
 @app.get("/multiple")
 async def multiple(foo: Annotated[str, object(), Query(min_length=1)]):
@@ -72,6 +77,66 @@ openapi_schema = {
                         "schema": {"title": "Foo", "minLength": 1, "type": "string"},
                         "name": "foo",
                         "in": "query",
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/description": {
+            "get": {
+                "summary": "Description",
+                "operationId": "description_description_get",
+                "parameters": [
+                    {
+                        "required": False,
+                        "schema": {"title": "get a description", "type": "string", "default": "foo", "description": "description"},
+                        "name": "foo",
+                        "in": "query",
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {"application/json": {"schema": {}}},
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/description/{foo}": {
+            "get": {
+                "summary": "Description",
+                "operationId": "description_description__foo__get",
+                "parameters": [
+                    {
+                        "required": True,
+                        "schema": {"title": "get a description", "type": "string", "description": "description"},
+                        "name": "foo",
+                        "in": "path",
                     }
                 ],
                 "responses": {

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -114,10 +114,10 @@ openapi_schema = {
                         "schema": {
                             "title": "get a description",
                             "type": "string",
-                            "description": "description"
+                            "description": "description",
                         },
                         "name": "foo",
-                        "in": "query"
+                        "in": "query",
                     }
                 ],
                 "responses": {
@@ -149,10 +149,10 @@ openapi_schema = {
                         "schema": {
                             "title": "get a description",
                             "type": "string",
-                            "description": "description"
+                            "description": "description",
                         },
                         "name": "foo",
-                        "in": "path"
+                        "in": "path",
                     }
                 ],
                 "responses": {

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -16,10 +16,16 @@ async def default(foo: Annotated[str, Query()] = "foo"):
 async def required(foo: Annotated[str, Query(min_length=1)]):
     return {"foo": foo}
 
+
 @app.get("/description/{foo}")
 @app.get("/description")
-async def description(foo: Annotated[str, OpenAPIAnnotation(title="get a description", description="description")] = None):
+async def description(
+    foo: Annotated[
+        str, OpenAPIAnnotation(title="get a description", description="description")
+    ] = None
+):
     return {"foo": foo}
+
 
 @app.get("/multiple")
 async def multiple(foo: Annotated[str, object(), Query(min_length=1)]):
@@ -104,7 +110,12 @@ openapi_schema = {
                 "parameters": [
                     {
                         "required": False,
-                        "schema": {"title": "get a description", "type": "string", "default": "foo", "description": "description"},
+                        "schema": {
+                            "title": "get a description",
+                            "type": "string",
+                            "default": "foo",
+                            "description": "description",
+                        },
                         "name": "foo",
                         "in": "query",
                     }
@@ -134,7 +145,11 @@ openapi_schema = {
                 "parameters": [
                     {
                         "required": True,
-                        "schema": {"title": "get a description", "type": "string", "description": "description"},
+                        "schema": {
+                            "title": "get a description",
+                            "type": "string",
+                            "description": "description",
+                        },
                         "name": "foo",
                         "in": "path",
                     }


### PR DESCRIPTION
this is rather a complex solution to fix the issue we have with FastAPI 0.95 (see https://github.com/tiangolo/fastapi/discussions/9278). 

With `>=0.95`, a param of type `Path`(defined in the route) cannot be use as a param of type `Query` (defined in the endpoint function). This was something not officially documented but mentioned couple times (https://github.com/tiangolo/fastapi/issues/945#issuecomment-585993501) 

Enabling a `mix` of Query/Path, is pretty useful when you have a multi routes endpoint with optional parameters
```python
from fastapi import FastAPI, Query

app = FastAPI()

@app.get("/test/{val}")
@app.get("/test")
def endpoint(val: str = Query("yo", description="a value")):
    return val
```

☝️ This code won't work with >=0.95 and give
```
File fastapi/dependencies/utils.py:461, in analyze_param(param_name, annotation, value, is_path_param)
    458 if field_info is not None:
    459     if is_path_param:
    460         assert isinstance(field_info, params.Path), (
--> 461             f"Cannot use `{field_info.__class__.__name__}` for path param"
    462             f" {param_name!r}"
    463         )
    464     elif (
    465         isinstance(field_info, params.Param)
    466         and getattr(field_info, "in_", None) is None
    467     ):
    468         field_info.in_ = params.ParamTypes.query

AssertionError: Cannot use `Query` for path param 'val'
```

### 2 Solutions:

- The first solution as proposed in https://github.com/tiangolo/fastapi/discussions/9278 is to not use any FieldInfo class (Path or Query), because FastAPI will be smart enough to assign either a `param.Query` or `param.Path` [here](https://github.com/tiangolo/fastapi/blob/d666ccb62216e45ca78643b52c235ba0d2c53986/fastapi/dependencies/utils.py#L429-L437) 

```python
from fastapi import FastAPI, Query

app = FastAPI()

@app.get("/test/{val}")
@app.get("/test")
def endpoint(val: str = "yo"):
    return val
```

But then we can't have anything forwarded to the OpenAPI doc (title, description, ...) which is one of the nice feature of the FastAPI Query/Path param 😭  

- The second solution (as introduced by this PR) is to hypothetically use a neutral class (has no direct influence on how the code is run) which only purpose is to forward information to the OpenAPI doc:

```python
from fastapi import FastAPI
from fastapi.params import OpenAPIAnnotation

@app.get("/description/{foo}")
@app.get("/description")
async def description(
    foo: Annotated[
        str, 
        OpenAPIAnnotation(title="get a description", description="description")
    ]
) = None:
    return {"foo": foo}
```

I totally agree that adding a new class might not be the best solution but it's the only thing I could think off 😅 

I really appreciate any help/comment 🙏 
