### PR TITLE
Add FromLifespan to extract dependencies from the lifespan state

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -7,6 +7,7 @@ from starlette import status as status
 from .applications import FastAPI as FastAPI
 from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
+from .dependencies._aliases import FromLifespan as FromLifespan
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
 from .param_functions import Body as Body

--- a/fastapi/dependencies/_aliases.py
+++ b/fastapi/dependencies/_aliases.py
@@ -1,7 +1,7 @@
 from inspect import Parameter
 from typing import Any, Dict, Optional, Type, TypeVar, cast
 
-from fastapi.params import Deferred, Depends
+from fastapi.params import Deferred, Depends, DependsContext
 from fastapi.requests import Request
 from typing_extensions import Annotated, get_args, get_origin
 
@@ -19,8 +19,8 @@ def get_type(param: Parameter) -> Type[Any]:
 
 
 class _FromLifespan:
-    def __init__(self, param: Parameter) -> None:
-        self._type = get_type(param)
+    def __init__(self, ctx: DependsContext) -> None:
+        self._type = get_type(ctx.param)
         self._key: Optional[str] = None
 
     def __call__(self, request: Request) -> Any:
@@ -35,7 +35,7 @@ class _FromLifespan:
         return state[self._key]
 
 
-def _from_lifespan(param: Parameter) -> Depends:
+def _from_lifespan(param: DependsContext) -> Depends:
     return Depends(_FromLifespan(param))
 
 

--- a/fastapi/dependencies/_aliases.py
+++ b/fastapi/dependencies/_aliases.py
@@ -1,5 +1,5 @@
 from inspect import Parameter
-from typing import Any, Dict, Optional, TypeVar, cast
+from typing import Any, Dict, Optional, Type, TypeVar, cast
 
 from fastapi.params import Deferred, Depends
 from fastapi.requests import Request
@@ -11,11 +11,11 @@ T = TypeVar("T")
 LifespanState = Dict[str, Any]
 
 
-def get_type(param: Parameter) -> type[Any]:
+def get_type(param: Parameter) -> Type[Any]:
     annotation = param.annotation
     while get_origin(annotation) is Annotated:
         annotation = get_args(annotation)[0]
-    return annotation
+    return annotation  # type: ignore[no-any-return]
 
 
 class _FromLifespan:

--- a/fastapi/dependencies/_aliases.py
+++ b/fastapi/dependencies/_aliases.py
@@ -1,0 +1,42 @@
+from inspect import Parameter
+from typing import Any, Dict, Optional, TypeVar, cast
+
+from fastapi.params import Deferred, Depends
+from fastapi.requests import Request
+from typing_extensions import Annotated, get_args, get_origin
+
+T = TypeVar("T")
+
+
+LifespanState = Dict[str, Any]
+
+
+def get_type(param: Parameter) -> type[Any]:
+    annotation = param.annotation
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    return annotation
+
+
+class _FromLifespan:
+    def __init__(self, param: Parameter) -> None:
+        self._type = get_type(param)
+        self._key: Optional[str] = None
+
+    def __call__(self, request: Request) -> Any:
+        state = cast(LifespanState, request["state"])
+        if self._key is None:
+            for key, value in state.items():
+                if isinstance(value, self._type):
+                    self._key = key
+                    break
+        if self._key is None:
+            raise RuntimeError(f"{self._type} not found in lifespan state")
+        return state[self._key]
+
+
+def _from_lifespan(param: Parameter) -> Depends:
+    return Depends(_FromLifespan(param))
+
+
+FromLifespan = Annotated[T, Deferred(_from_lifespan)]

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -395,7 +395,7 @@ def analyze_param(
         elif isinstance(fastapi_annotation, params.Depends):
             depends = fastapi_annotation
         elif isinstance(fastapi_annotation, params.Deferred):
-            depends = fastapi_annotation(param)
+            depends = fastapi_annotation(params.DependsContext(param))
     elif annotation is not inspect.Signature.empty:
         type_annotation = annotation
 

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from inspect import Parameter
 from typing import Any, Callable, Dict, Optional, Sequence
 
 from pydantic.fields import FieldInfo, Undefined
@@ -379,3 +380,11 @@ class Security(Depends):
     ):
         super().__init__(dependency=dependency, use_cache=use_cache)
         self.scopes = scopes or []
+
+
+class Deferred:
+    def __init__(self, dependency_factory: Callable[[Parameter], Depends]) -> None:
+        self.dependency_factory = dependency_factory
+
+    def __call__(self, param: Parameter) -> Depends:
+        return self.dependency_factory(param)

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -382,9 +382,14 @@ class Security(Depends):
         self.scopes = scopes or []
 
 
+class DependsContext:
+    def __init__(self, param: Parameter) -> None:
+        self.param = param
+
+
 class Deferred:
-    def __init__(self, dependency_factory: Callable[[Parameter], Depends]) -> None:
+    def __init__(self, dependency_factory: Callable[[DependsContext], Depends]) -> None:
         self.dependency_factory = dependency_factory
 
-    def __call__(self, param: Parameter) -> Depends:
+    def __call__(self, param: DependsContext) -> Depends:
         return self.dependency_factory(param)

--- a/tests/test_dependency_from_lifespan.py
+++ b/tests/test_dependency_from_lifespan.py
@@ -1,0 +1,45 @@
+from contextlib import asynccontextmanager
+from typing import Annotated, Any, AsyncIterator, Dict
+
+from fastapi import Depends, FastAPI, FromLifespan
+from fastapi.testclient import TestClient
+
+
+def test_app_extract_from_lifespan() -> None:
+    class DatabaseConnection:
+        async def query(self, __query: str) -> Any:
+            assert __query == "SELECT 42"
+            return 42
+
+    class DatabaseConnectionPool:
+        @asynccontextmanager
+        async def acquire(self) -> AsyncIterator[DatabaseConnection]:
+            yield DatabaseConnection()
+
+    @asynccontextmanager
+    async def connect() -> AsyncIterator[DatabaseConnectionPool]:
+        yield DatabaseConnectionPool()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[Dict[str, Any]]:
+        async with connect() as db:
+            yield {"db": db}
+
+    app = FastAPI(lifespan=lifespan)
+
+    async def get_connection(
+        db: FromLifespan[DatabaseConnectionPool],
+    ) -> AsyncIterator[DatabaseConnection]:
+        async with db.acquire() as conn:
+            yield conn
+
+    DbConnection = Annotated[DatabaseConnection, Depends(get_connection)]
+
+    @app.get("/")
+    async def endpoint(conn: DbConnection) -> int:
+        return await conn.query("SELECT 42")
+
+    with TestClient(app) as client:
+        response = client.get("/")
+        assert response.status_code == 200, response.text
+        assert response.json() == 42

--- a/tests/test_dependency_from_lifespan.py
+++ b/tests/test_dependency_from_lifespan.py
@@ -1,5 +1,7 @@
 from contextlib import asynccontextmanager
-from typing import Annotated, Any, AsyncIterator, Dict
+from typing import Any, AsyncIterator, Dict
+
+from typing_extensions import Annotated
 
 from fastapi import Depends, FastAPI, FromLifespan
 from fastapi.testclient import TestClient

--- a/tests/test_dependency_from_lifespan.py
+++ b/tests/test_dependency_from_lifespan.py
@@ -1,10 +1,9 @@
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict
 
-from typing_extensions import Annotated
-
 from fastapi import Depends, FastAPI, FromLifespan
 from fastapi.testclient import TestClient
+from typing_extensions import Annotated
 
 
 def test_app_extract_from_lifespan() -> None:


### PR DESCRIPTION
This adds a `FromLifespan` annotation that extracts dependencies from lifespans, which I believe satisfies the requests in #617, #9215, part of #3641 and probably several other issues.

It also adds what is essentially an extractor system that allows dependencies to get a view into their parameter; this could effectively allow replacing a lot of `fastapi/dependencies/utils.py` with implementations for each type of parameter, making things like #2077 a lot easier to implement and opening up the door for 3rd party extensions to FastAPI's dependency / extractor system. This does the rest of #3641.

I purposefully added as single docs-style test to demonstrate how this is used and in-lieu of writing docs; I'll do that once / if there's some initial feedback and buy in.