### PR TITLE
FIX: add right module reference to avoid breaking failure for lower version (3.7)

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -48,7 +48,7 @@ from pydantic.fields import (
     Undefined,
 )
 from pydantic.schema import get_annotation_from_field_info
-from pydantic.typing import evaluate_forwardref, get_args, get_origin
+from pydantic.typing import evaluate_forwardref
 from pydantic.utils import lenient_issubclass
 from starlette.background import BackgroundTasks
 from starlette.concurrency import run_in_threadpool
@@ -56,7 +56,7 @@ from starlette.datastructures import FormData, Headers, QueryParams, UploadFile
 from starlette.requests import HTTPConnection, Request
 from starlette.responses import Response
 from starlette.websockets import WebSocket
-from typing_extensions import Annotated
+from typing_extensions import Annotated, get_args, get_origin
 
 sequence_shapes = {
     SHAPE_LIST,

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -369,7 +369,7 @@ def analyze_param(
     type_annotation: Any = Any
     if (
         annotation is not inspect.Signature.empty
-        and get_origin(annotation) is Annotated  # type: ignore[comparison-overlap]
+        and get_origin(annotation) is Annotated
     ):
         annotated_args = get_args(annotation)
         type_annotation = annotated_args[0]


### PR DESCRIPTION
The method references would handle breaking failures to other lower version of python
![image](https://user-images.githubusercontent.com/97904101/227785535-d2f4d638-a92f-4cef-9bc7-0c743e2ede87.png)
