### PR TITLE
fix: remove assertion for annotations

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -384,10 +384,6 @@ def analyze_param(
         fastapi_annotation = next(iter(fastapi_annotations), None)
         if isinstance(fastapi_annotation, FieldInfo):
             field_info = fastapi_annotation
-            assert field_info.default is Undefined or field_info.default is Required, (
-                f"`{field_info.__class__.__name__}` default value cannot be set in"
-                f" `Annotated` for {param_name!r}. Set the default value with `=` instead."
-            )
             if value is not inspect.Signature.empty:
                 assert not is_path_param, "Path parameters cannot have default values"
                 field_info.default = value


### PR DESCRIPTION
## What
- Remove assertion for `field_info.default` of `Annotated` parameters.

## Why
- `analyze_param` is called multi-times for `router` endpoints.
  1. when assigning the endpoint to `router` like `@router.get("/default")`
  2. when the router is added to the parent router or app
- `analyze_param` overwrites `field_info.default` by the default value.
  - As a result, the `field_info.default` is filled by the `1.` step, which causes an assertion error on `2`

To reproduce this, please restore the assert statement and run the tests that I modified.
It seems that there is no good way to store the number of called times of `analyze_param` for each endpoint, then assert it conditionally.
So remove it.
