### PR TITLE
Makes HTTPException picklable

### DIFF
--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Sequence, Type, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple, Type
 
 from pydantic import BaseModel, ValidationError, create_model
 from pydantic.error_wrappers import ErrorList
@@ -15,7 +15,7 @@ class HTTPException(StarletteHTTPException):
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
 
-    def __reduce__(self) -> Tuple['HTTPException', Tuple[Any, ...]]:
+    def __reduce__(self) -> Tuple["HTTPException", Tuple[Any, ...]]:
         return (self.__class__, (self.status_code,))
 
 

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -15,8 +15,8 @@ class HTTPException(StarletteHTTPException):
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
 
-    def __reduce__(self) -> Tuple["HTTPException", Tuple[Any, ...]]:
-        return (self.__class__, (self.status_code,))
+    def __reduce__(self) -> Tuple[Type["HTTPException"], Tuple[int]]:
+        return self.__class__, (self.status_code,)
 
 
 RequestErrorModel: Type[BaseModel] = create_model("Request")

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Sequence, Type
+from typing import Any, Dict, Optional, Sequence, Type, Tuple
 
 from pydantic import BaseModel, ValidationError, create_model
 from pydantic.error_wrappers import ErrorList
@@ -15,7 +15,7 @@ class HTTPException(StarletteHTTPException):
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple['HTTPException', Tuple[Any, ...]]:
         return (self.__class__, (self.status_code,))
 
 

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -14,6 +14,9 @@ class HTTPException(StarletteHTTPException):
         headers: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
+        
+    def __reduce__(self):
+        return (self.__class__, (self.status_code,))
 
 
 RequestErrorModel: Type[BaseModel] = create_model("Request")

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -14,7 +14,7 @@ class HTTPException(StarletteHTTPException):
         headers: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
-        
+
     def __reduce__(self):
         return (self.__class__, (self.status_code,))
 

--- a/tests/test_exception_picklable.py
+++ b/tests/test_exception_picklable.py
@@ -1,0 +1,9 @@
+from pickle import dumps, loads
+
+from fastapi import HTTPException
+
+
+def test_http_exception_is_picklable():
+    exc = HTTPException(status_code=415)
+    serialized_exc = dumps(exc)
+    loads(serialized_exc)


### PR DESCRIPTION
Following simple code

```python
import pickle

from fastapi.exceptions import HTTPException

x = pickle.dumps(HTTPException(status_code=415, detail={'foo': 'bar'}))
xx = pickle.loads(x)
```

leads to an error:

```
Traceback (most recent call last):
  File "...", line 6, in <module>
    xx = pickle.loads(x)
TypeError: __init__() missing 1 required positional argument: 'status_code'
```

This behavior can breaks serialization/deserialization mechanics in case of complex systems (rpc/queues/etc).

This PR makes HTTPException unpicklable.