### PR TITLE
APIRouter: add a `APIRouter.exception_handler` decorator to register handlers in big aplications

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -436,6 +436,8 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             generate_unique_id_function=generate_unique_id_function,
         )
+        for exc_or_code, handler in router.exception_handlers.items():
+            self.add_exception_handler(exc_or_code, handler)
 
     def get(
         self,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -7,6 +7,7 @@ from contextlib import AsyncExitStack
 from enum import Enum, IntEnum
 from typing import (
     Any,
+    Awaitable,
     Callable,
     Coroutine,
     Dict,
@@ -500,6 +501,12 @@ class APIRouter(routing.Router):
         generate_unique_id_function: Callable[[APIRoute], str] = Default(
             generate_unique_id
         ),
+        exception_handlers: Optional[
+            Dict[
+                Union[int, Type[Exception]],
+                Callable[[Request, Any], Coroutine[Any, Any, Response]],
+            ]
+        ] = None,
     ) -> None:
         super().__init__(
             routes=routes,
@@ -525,6 +532,9 @@ class APIRouter(routing.Router):
         self.route_class = route_class
         self.default_response_class = default_response_class
         self.generate_unique_id_function = generate_unique_id_function
+        self.exception_handlers: Dict[
+            Any, Callable[[Request, Any], Union[Response, Awaitable[Response]]]
+        ] = ({} if exception_handlers is None else dict(exception_handlers))
 
     def route(
         self,
@@ -830,6 +840,8 @@ class APIRouter(routing.Router):
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:
             self.add_event_handler("shutdown", handler)
+        for exc_or_code, handler in router.exception_handlers.items():
+            self.exception_handlers[exc_or_code] = handler
 
     def get(
         self,
@@ -1285,5 +1297,19 @@ class APIRouter(routing.Router):
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             self.add_event_handler(event_type, func)
             return func
+
+        return decorator
+
+    def exception_handler(
+        self, exc_or_status_code: Union[int, Type[Exception]]
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        """
+        Register an exception handler like you would from root FastAPI app.
+        See https://fastapi.tiangolo.com/tutorial/handling-errors/
+        """
+
+        def decorator(fn: DecoratedCallable) -> DecoratedCallable:
+            self.exception_handlers[exc_or_status_code] = fn
+            return fn
 
         return decorator

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 from starlette.responses import JSONResponse
@@ -65,3 +65,105 @@ def test_override_server_error_exception_response():
     response = client.get("/server-error")
     assert response.status_code == 500
     assert response.json() == {"exception": "server-error"}
+
+
+sub = APIRouter()
+nested = APIRouter()
+
+
+class CustomError(ValueError):
+    pass
+
+
+class AnotherError(ValueError):
+    pass
+
+
+@app.exception_handler(ValueError)
+def value_error_handler(request: Request, exc: ValueError):
+    return JSONResponse(status_code=400, content={"message": "ValueError"})
+
+
+@sub.exception_handler(CustomError)
+def custom_error_handler(request: Request, exc: CustomError):
+    return JSONResponse(status_code=400, content={"message": "CustomError"})
+
+
+@nested.exception_handler(AnotherError)
+def another_error_handler(request: Request, exc: AnotherError):
+    return JSONResponse(status_code=400, content={"message": "AnotherError"})
+
+
+@app.get("/app/value-error")
+def app_value_error():
+    raise ValueError()
+
+
+@sub.get("/sub/value-error")
+def sub_value_error():
+    raise ValueError()
+
+
+@nested.get("/nested/value-error")
+def nested_value_error():
+    raise ValueError()
+
+
+@app.get("/app/custom-error")
+def app_custom_error():
+    raise CustomError()
+
+
+@sub.get("/sub/custom-error")
+def sub_custom_error():
+    raise CustomError()
+
+
+@nested.get("/nested/custom-error")
+def nested_custom_error():
+    raise CustomError()
+
+
+@app.get("/app/another-error")
+def app_another_error():
+    raise AnotherError()
+
+
+@sub.get("/sub/another-error")
+def sub_another_error():
+    raise AnotherError()
+
+
+@nested.get("/nested/another-error")
+def nested_another_error():
+    raise AnotherError()
+
+
+# Routing and soexception handlers are not lazy
+# router inclusion mest happens after routes
+# and error handlers declaration
+sub.include_router(nested)
+app.include_router(sub)
+
+
+@pytest.fixture(params=("app", "sub", "nested"))
+def prefix(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+def test_app_exception_handler(prefix):
+    response = client.get(f"/{prefix}/value-error")
+    assert response.status_code == 400
+    assert response.json() == {"message": "ValueError"}
+
+
+def test_apirouter_exception_handler(prefix):
+    response = client.get(f"/{prefix}/custom-error")
+    assert response.status_code == 400
+    assert response.json() == {"message": "CustomError"}
+
+
+def test_nested_apirouter_exception_handler(prefix):
+    response = client.get(f"/{prefix}/another-error")
+    assert response.status_code == 400
+    assert response.json() == {"message": "AnotherError"}


### PR DESCRIPTION
Hello 👋🏼 

Here's a quick and simple pull-request exposing a `exception_handler` decorator on `APIRouter` allowing to register custom exception handler on the `APIRouter` (especially useful for big applications where most of the time you have by-package business errors you need to register once on the `FastAPI` app instance).

This works with nested routers with the same constraints (aka. order matters, `include_router()` needs to happen after exceptions registration like it is the case for routes).

Note: the error handlers are not scoped to the router, meaning that the custom processing applies for the entire application like it would if it was declared on the `FastAPI` app instance itself.