### PR TITLE
✨ Allow Annotated FieldInfo with default values

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -344,14 +344,16 @@ def analyze_param(
             field_info = copy_field_info(
                 field_info=fastapi_annotation, annotation=annotation
             )
-            assert field_info.default is Undefined or field_info.default is Required, (
-                f"`{field_info.__class__.__name__}` default value cannot be set in"
-                f" `Annotated` for {param_name!r}. Set the default value with `=` instead."
-            )
             if value is not inspect.Signature.empty:
                 assert not is_path_param, "Path parameters cannot have default values"
+                assert (
+                    field_info.default is Undefined or field_info.default is Required
+                ), (
+                    f"`{field_info.__class__.__name__}` default value cannot be set in"
+                    f" `Annotated` for {param_name!r} while regular default value is specified."
+                )
                 field_info.default = value
-            else:
+            elif field_info.default is Undefined:
                 field_info.default = Required
         elif isinstance(fastapi_annotation, params.Depends):
             depends = fastapi_annotation

--- a/tests/test_ambiguous_params.py
+++ b/tests/test_ambiguous_params.py
@@ -18,13 +18,13 @@ def test_no_annotated_defaults():
     with pytest.raises(
         AssertionError,
         match=(
-            "`Query` default value cannot be set in `Annotated` for 'item_id'. Set the"
-            " default value with `=` instead."
+            "`Query` default value cannot be set in `Annotated` for 'item_id' "
+            "while regular default value is specified."
         ),
     ):
 
         @app.get("/")
-        async def get(item_id: Annotated[int, Query(default=1)]):
+        async def get(item_id: Annotated[int, Query(default=1)] = 3):
             pass  # pragma: nocover
 
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -313,3 +313,27 @@ def test_openapi_schema():
             }
         },
     }
+
+
+def test_default_annotated():
+    app = FastAPI()
+
+    @app.get("/test")
+    async def test(var: Annotated[str, Query("bar")]):
+        return {"foo": var}
+
+    client = TestClient(app)
+
+    response = client.get("/test")
+    assert response.status_code == 200
+    assert response.json() == {"foo": "bar"}
+
+    response = client.get("/test?var=baz")
+    assert response.status_code == 200
+    assert response.json() == {"foo": "baz"}
+
+    # while calling the function directly there is no default value
+    with pytest.raises(
+        TypeError, match="missing 1 required positional argument: 'var'"
+    ):
+        test()


### PR DESCRIPTION
This allows creating annotated arguments (Body/Path/Query) with default value definition as part of the FieldInfo instance.

Which allows:
1) setting up default value for the FastAPI endpoint that will not be part of the function definition if called directly (see test). 
2) setting the default value in a shared annotated type e.g. `Verbose=Annotated[bool, Query(True)]`.