### PR TITLE
✨ Allow return type hint with response model of route

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -19,26 +19,6 @@ from typing import (
     Union,
 )
 
-from fastapi import params
-from fastapi.datastructures import Default, DefaultPlaceholder
-from fastapi.dependencies.models import Dependant
-from fastapi.dependencies.utils import (
-    get_body_field,
-    get_dependant,
-    get_parameterless_sub_dependant,
-    get_typed_return_annotation,
-    solve_dependencies,
-)
-from fastapi.encoders import DictIntStrAny, SetIntStr, jsonable_encoder
-from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
-from fastapi.types import DecoratedCallable
-from fastapi.utils import (
-    create_cloned_field,
-    create_response_field,
-    generate_unique_id,
-    get_value_or_default,
-    is_body_allowed_for_status_code,
-)
 from pydantic import BaseModel
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from pydantic.fields import ModelField, Undefined
@@ -59,6 +39,27 @@ from starlette.routing import (
 from starlette.status import WS_1008_POLICY_VIOLATION
 from starlette.types import ASGIApp, Lifespan, Scope
 from starlette.websockets import WebSocket
+
+from fastapi import params
+from fastapi.datastructures import Default, DefaultPlaceholder
+from fastapi.dependencies.models import Dependant
+from fastapi.dependencies.utils import (
+    get_body_field,
+    get_dependant,
+    get_parameterless_sub_dependant,
+    get_typed_return_annotation,
+    solve_dependencies,
+)
+from fastapi.encoders import DictIntStrAny, SetIntStr, jsonable_encoder
+from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
+from fastapi.types import DecoratedCallable
+from fastapi.utils import (
+    create_cloned_field,
+    create_response_field,
+    generate_unique_id,
+    get_value_or_default,
+    is_body_allowed_for_status_code,
+)
 
 
 def _prepare_response_content(
@@ -658,7 +659,7 @@ class APIRouter(routing.Router):
         ),
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
-            def return_type_hint(func):
+            def return_type_hint(func: DecoratedCallable) -> Any:
                 return inspect.getfullargspec(func).annotations.get(
                     "return", Default(None)
                 )

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -658,10 +658,15 @@ class APIRouter(routing.Router):
         ),
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            def return_type_hint(func):
+                return inspect.getfullargspec(func).annotations.get(
+                    "return", Default(None)
+                )
+
             self.add_api_route(
                 path,
                 func,
-                response_model=response_model,
+                response_model=response_model or return_type_hint(func),
                 status_code=status_code,
                 tags=tags,
                 dependencies=dependencies,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -19,27 +19,6 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel
-from pydantic.error_wrappers import ErrorWrapper, ValidationError
-from pydantic.fields import ModelField, Undefined
-from pydantic.utils import lenient_issubclass
-from starlette import routing
-from starlette.concurrency import run_in_threadpool
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
-from starlette.routing import BaseRoute, Match
-from starlette.routing import Mount as Mount  # noqa
-from starlette.routing import (
-    compile_path,
-    get_name,
-    request_response,
-    websocket_session,
-)
-from starlette.status import WS_1008_POLICY_VIOLATION
-from starlette.types import ASGIApp, Lifespan, Scope
-from starlette.websockets import WebSocket
-
 from fastapi import params
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
@@ -60,6 +39,26 @@ from fastapi.utils import (
     get_value_or_default,
     is_body_allowed_for_status_code,
 )
+from pydantic import BaseModel
+from pydantic.error_wrappers import ErrorWrapper, ValidationError
+from pydantic.fields import ModelField, Undefined
+from pydantic.utils import lenient_issubclass
+from starlette import routing
+from starlette.concurrency import run_in_threadpool
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import BaseRoute, Match
+from starlette.routing import Mount as Mount  # noqa
+from starlette.routing import (
+    compile_path,
+    get_name,
+    request_response,
+    websocket_session,
+)
+from starlette.status import WS_1008_POLICY_VIOLATION
+from starlette.types import ASGIApp, Lifespan, Scope
+from starlette.websockets import WebSocket
 
 
 def _prepare_response_content(


### PR DESCRIPTION
✨ Allow return type hint with response model of route

This feature focuses on the concept that fastapi actively utilizes typing.

Allow the following:

```python
# The two route examples below are actually the same.
@app.get("/items/")
async def read_item(skip: int = 0, limit: int = 10) -> ItemModel:
    return fake_items_db[skip : skip + limit]

@app.get("/items/", response_model = ItemModel)
async def read_item(skip: int = 0, limit: int = 10):
    return fake_items_db[skip : skip + limit]
```

I suggest that fastapi can use Type Hint more actively and that it does not affect application performance because it is calculated in import time. 
What do you thing about this? give me your opinions. thank you.