### PR TITLE
✏ Fix command to install requirements in Windows

### DIFF
--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -108,7 +108,7 @@ After activating the environment as described above:
 <div class="termy">
 
 ```console
-$ pip install -e ."[dev,doc,test]"
+$ pip install -e ".[dev,doc,test]"
 
 ---> 100%
 ```


### PR DESCRIPTION
This command doesn't work on Windows: `pip install -e ."[dev,doc,test]"`