### PR TITLE
✏ Allow integer constraints on openapi schema

### DIFF
--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -103,11 +103,11 @@ class ExternalDocumentation(BaseModel):
 class Schema(BaseModel):
     ref: Optional[str] = Field(default=None, alias="$ref")
     title: Optional[str] = None
-    multipleOf: Optional[float] = None
-    maximum: Optional[float] = None
-    exclusiveMaximum: Optional[float] = None
-    minimum: Optional[float] = None
-    exclusiveMinimum: Optional[float] = None
+    multipleOf: Optional[Union[float, int]] = None
+    maximum: Optional[Union[float, int]] = None
+    exclusiveMaximum: Optional[Union[float, int]] = None
+    minimum: Optional[Union[float, int]] = None
+    exclusiveMinimum: Optional[Union[float, int]] = None
     maxLength: Optional[int] = Field(default=None, gte=0)
     minLength: Optional[int] = Field(default=None, gte=0)
     pattern: Optional[str] = None
@@ -140,6 +140,7 @@ class Schema(BaseModel):
 
     class Config:
         extra: str = "allow"
+        smart_union = True
 
 
 class Example(BaseModel):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -627,7 +627,7 @@ openapi_schema = {
                         "required": True,
                         "schema": {
                             "title": "Item Id",
-                            "exclusiveMaximum": 3.0,
+                            "exclusiveMaximum": 3,
                             "type": "integer",
                         },
                         "name": "item_id",
@@ -661,7 +661,7 @@ openapi_schema = {
                         "required": True,
                         "schema": {
                             "title": "Item Id",
-                            "exclusiveMinimum": 3.0,
+                            "exclusiveMinimum": 3,
                             "type": "integer",
                         },
                         "name": "item_id",
@@ -695,7 +695,7 @@ openapi_schema = {
                         "required": True,
                         "schema": {
                             "title": "Item Id",
-                            "maximum": 3.0,
+                            "maximum": 3,
                             "type": "integer",
                         },
                         "name": "item_id",
@@ -729,7 +729,7 @@ openapi_schema = {
                         "required": True,
                         "schema": {
                             "title": "Item Id",
-                            "minimum": 3.0,
+                            "minimum": 3,
                             "type": "integer",
                         },
                         "name": "item_id",
@@ -763,8 +763,8 @@ openapi_schema = {
                         "required": True,
                         "schema": {
                             "title": "Item Id",
-                            "exclusiveMaximum": 3.0,
-                            "exclusiveMinimum": 1.0,
+                            "exclusiveMaximum": 3,
+                            "exclusiveMinimum": 1,
                             "type": "integer",
                         },
                         "name": "item_id",
@@ -798,8 +798,8 @@ openapi_schema = {
                         "required": True,
                         "schema": {
                             "title": "Item Id",
-                            "maximum": 3.0,
-                            "minimum": 1.0,
+                            "maximum": 3,
+                            "minimum": 1,
                             "type": "integer",
                         },
                         "name": "item_id",


### PR DESCRIPTION
Hi everyone,

I'm opening this PR because I've recently found a weird behavior when dealing with constrained integers. Consider the following example:

```python
from typing import Annotated

from fastapi import FastAPI, Query

app = FastAPI()


@app.get("/item")
async def get_items(limit: Annotated[int, Query(ge=1, le=1000)] = 100):
    return {"message": f"Got items with limit {limit}"}
```

It will produce the following schema (not relevant sections elided):
```json
{
  "paths": {
    "/item": {
      "get": {
        "summary": "Get Items",
        "operationId": "get_items_item_get",
        "parameters": [
          {
            "required": false,
            "schema": {
              "title": "Limit",
              "maximum": 1000.0,
              "minimum": 1.0,
              "type": "integer",
              "default": 100
            },
            "name": "limit",
            "in": "query"
          }
        ],
  },
}
```

As you can see even though `ge=1` and `le=1000` were defined as integers, the internal pydantic model coherces them to floats (`"maximum": 1000.0` and `"minimum": 1.0`). This is a problem when using some security tools like [42 Crunch](https://42crunch.com/) because the mismatch between type and values is reported as a possible vulnerability.

With this PR fastapi will keep the constraints as defined in the source code leveraging the [smart union feature of pydantic](https://docs.pydantic.dev/usage/model_config/#smart-union), therefore in example above fastapi will produce the following schema:

```json
{
  "paths": {
    "/item": {
      "get": {
        "summary": "Get Items",
        "operationId": "get_items_item_get",
        "parameters": [
          {
            "required": false,
            "schema": {
              "title": "Limit",
              "maximum": 1000,
              "minimum": 1,
              "type": "integer",
              "default": 100
            },
            "name": "limit",
            "in": "query"
          }
        ],
  },
}
```