### PR TITLE
✅ Refactor OpenAPI tests, prepare for Pydantic v2

### DIFF
--- a/tests/test_additional_properties.py
+++ b/tests/test_additional_properties.py
@@ -19,92 +19,91 @@ def foo(items: Items):
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/foo": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Foo",
-                "operationId": "foo_foo_post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Items"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Items": {
-                "title": "Items",
-                "required": ["items"],
-                "type": "object",
-                "properties": {
-                    "items": {
-                        "title": "Items",
-                        "type": "object",
-                        "additionalProperties": {"type": "integer"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_additional_properties_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_additional_properties_post():
     response = client.post("/foo", json={"items": {"foo": 1, "bar": 2}})
     assert response.status_code == 200, response.text
     assert response.json() == {"foo": 1, "bar": 2}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/foo": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Foo",
+                    "operationId": "foo_foo_post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Items"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Items": {
+                    "title": "Items",
+                    "required": ["items"],
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "title": "Items",
+                            "type": "object",
+                            "additionalProperties": {"type": "integer"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_additional_response_extra.py
+++ b/tests/test_additional_response_extra.py
@@ -17,36 +17,33 @@ router.include_router(sub_router, prefix="/items")
 
 app.include_router(router)
 
-
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__get",
-            }
-        }
-    },
-}
-
 client = TestClient(app)
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_path_operation():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == {"id": "foo"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__get",
+                }
+            }
+        },
+    }

--- a/tests/test_additional_responses_custom_model_in_callback.py
+++ b/tests/test_additional_responses_custom_model_in_callback.py
@@ -25,114 +25,116 @@ def main_route(callback_url: HttpUrl):
     pass  # pragma: no cover
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "post": {
-                "summary": "Main Route",
-                "operationId": "main_route__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Callback Url",
-                            "maxLength": 2083,
-                            "minLength": 1,
-                            "type": "string",
-                            "format": "uri",
-                        },
-                        "name": "callback_url",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "callbacks": {
-                    "callback_route": {
-                        "{$callback_url}/callback/": {
-                            "get": {
-                                "summary": "Callback Route",
-                                "operationId": "callback_route__callback_url__callback__get",
-                                "responses": {
-                                    "400": {
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/CustomModel"
-                                                }
-                                            }
-                                        },
-                                        "description": "Bad Request",
-                                    },
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "CustomModel": {
-                "title": "CustomModel",
-                "required": ["a"],
-                "type": "object",
-                "properties": {"a": {"title": "A", "type": "integer"}},
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 client = TestClient(app)
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "post": {
+                    "summary": "Main Route",
+                    "operationId": "main_route__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Callback Url",
+                                "maxLength": 2083,
+                                "minLength": 1,
+                                "type": "string",
+                                "format": "uri",
+                            },
+                            "name": "callback_url",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "callbacks": {
+                        "callback_route": {
+                            "{$callback_url}/callback/": {
+                                "get": {
+                                    "summary": "Callback Route",
+                                    "operationId": "callback_route__callback_url__callback__get",
+                                    "responses": {
+                                        "400": {
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/CustomModel"
+                                                    }
+                                                }
+                                            },
+                                            "description": "Bad Request",
+                                        },
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "CustomModel": {
+                    "title": "CustomModel",
+                    "required": ["a"],
+                    "type": "object",
+                    "properties": {"a": {"title": "A", "type": "integer"}},
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_additional_responses_custom_validationerror.py
+++ b/tests/test_additional_responses_custom_validationerror.py
@@ -30,71 +30,70 @@ async def a(id):
     pass  # pragma: no cover
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a/{id}": {
-            "get": {
-                "responses": {
-                    "422": {
-                        "description": "Error",
-                        "content": {
-                            "application/vnd.api+json": {
-                                "schema": {"$ref": "#/components/schemas/JsonApiError"}
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/vnd.api+json": {"schema": {}}},
-                    },
-                },
-                "summary": "A",
-                "operationId": "a_a__id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Id"},
-                        "name": "id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Error": {
-                "title": "Error",
-                "required": ["status", "title"],
-                "type": "object",
-                "properties": {
-                    "status": {"title": "Status", "type": "string"},
-                    "title": {"title": "Title", "type": "string"},
-                },
-            },
-            "JsonApiError": {
-                "title": "JsonApiError",
-                "required": ["errors"],
-                "type": "object",
-                "properties": {
-                    "errors": {
-                        "title": "Errors",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Error"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a/{id}": {
+                "get": {
+                    "responses": {
+                        "422": {
+                            "description": "Error",
+                            "content": {
+                                "application/vnd.api+json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/JsonApiError"
+                                    }
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/vnd.api+json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "A",
+                    "operationId": "a_a__id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Id"},
+                            "name": "id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Error": {
+                    "title": "Error",
+                    "required": ["status", "title"],
+                    "type": "object",
+                    "properties": {
+                        "status": {"title": "Status", "type": "string"},
+                        "title": {"title": "Title", "type": "string"},
+                    },
+                },
+                "JsonApiError": {
+                    "title": "JsonApiError",
+                    "required": ["errors"],
+                    "type": "object",
+                    "properties": {
+                        "errors": {
+                            "title": "Errors",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Error"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_additional_responses_default_validationerror.py
+++ b/tests/test_additional_responses_default_validationerror.py
@@ -9,77 +9,76 @@ async def a(id):
     pass  # pragma: no cover
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a/{id}": {
-            "get": {
-                "responses": {
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "A",
-                "operationId": "a_a__id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Id"},
-                        "name": "id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a/{id}": {
+                "get": {
+                    "responses": {
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "A",
+                    "operationId": "a_a__id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Id"},
+                            "name": "id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_additional_responses_response_class.py
+++ b/tests/test_additional_responses_response_class.py
@@ -35,83 +35,82 @@ async def b():
     pass  # pragma: no cover
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a": {
-            "get": {
-                "responses": {
-                    "500": {
-                        "description": "Error",
-                        "content": {
-                            "application/vnd.api+json": {
-                                "schema": {"$ref": "#/components/schemas/JsonApiError"}
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/vnd.api+json": {"schema": {}}},
-                    },
-                },
-                "summary": "A",
-                "operationId": "a_a_get",
-            }
-        },
-        "/b": {
-            "get": {
-                "responses": {
-                    "500": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Error"}
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "B",
-                "operationId": "b_b_get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Error": {
-                "title": "Error",
-                "required": ["status", "title"],
-                "type": "object",
-                "properties": {
-                    "status": {"title": "Status", "type": "string"},
-                    "title": {"title": "Title", "type": "string"},
-                },
-            },
-            "JsonApiError": {
-                "title": "JsonApiError",
-                "required": ["errors"],
-                "type": "object",
-                "properties": {
-                    "errors": {
-                        "title": "Errors",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Error"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a": {
+                "get": {
+                    "responses": {
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/vnd.api+json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/JsonApiError"
+                                    }
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/vnd.api+json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "A",
+                    "operationId": "a_a_get",
+                }
+            },
+            "/b": {
+                "get": {
+                    "responses": {
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Error"}
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "B",
+                    "operationId": "b_b_get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Error": {
+                    "title": "Error",
+                    "required": ["status", "title"],
+                    "type": "object",
+                    "properties": {
+                        "status": {"title": "Status", "type": "string"},
+                        "title": {"title": "Title", "type": "string"},
+                    },
+                },
+                "JsonApiError": {
+                    "title": "JsonApiError",
+                    "required": ["errors"],
+                    "type": "object",
+                    "properties": {
+                        "errors": {
+                            "title": "Errors",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Error"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_additional_responses_router.py
+++ b/tests/test_additional_responses_router.py
@@ -53,101 +53,8 @@ async def d():
 
 app.include_router(router)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a": {
-            "get": {
-                "responses": {
-                    "501": {"description": "Error 1"},
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "A",
-                "operationId": "a_a_get",
-            }
-        },
-        "/b": {
-            "get": {
-                "responses": {
-                    "502": {"description": "Error 2"},
-                    "4XX": {"description": "Error with range, upper"},
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "B",
-                "operationId": "b_b_get",
-            }
-        },
-        "/c": {
-            "get": {
-                "responses": {
-                    "400": {"description": "Error with str"},
-                    "5XX": {"description": "Error with range, lower"},
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "default": {"description": "A default response"},
-                },
-                "summary": "C",
-                "operationId": "c_c_get",
-            }
-        },
-        "/d": {
-            "get": {
-                "responses": {
-                    "400": {"description": "Error with str"},
-                    "5XX": {
-                        "description": "Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/ResponseModel"}
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "default": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/ResponseModel"}
-                            }
-                        },
-                    },
-                },
-                "summary": "D",
-                "operationId": "d_d_get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ResponseModel": {
-                "title": "ResponseModel",
-                "required": ["message"],
-                "type": "object",
-                "properties": {"message": {"title": "Message", "type": "string"}},
-            }
-        }
-    },
-}
 
 client = TestClient(app)
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_a():
@@ -172,3 +79,99 @@ def test_d():
     response = client.get("/d")
     assert response.status_code == 200, response.text
     assert response.json() == "d"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a": {
+                "get": {
+                    "responses": {
+                        "501": {"description": "Error 1"},
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "A",
+                    "operationId": "a_a_get",
+                }
+            },
+            "/b": {
+                "get": {
+                    "responses": {
+                        "502": {"description": "Error 2"},
+                        "4XX": {"description": "Error with range, upper"},
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "B",
+                    "operationId": "b_b_get",
+                }
+            },
+            "/c": {
+                "get": {
+                    "responses": {
+                        "400": {"description": "Error with str"},
+                        "5XX": {"description": "Error with range, lower"},
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "default": {"description": "A default response"},
+                    },
+                    "summary": "C",
+                    "operationId": "c_c_get",
+                }
+            },
+            "/d": {
+                "get": {
+                    "responses": {
+                        "400": {"description": "Error with str"},
+                        "5XX": {
+                            "description": "Server Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/ResponseModel"
+                                    }
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "default": {
+                            "description": "Default Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/ResponseModel"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "D",
+                    "operationId": "d_d_get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ResponseModel": {
+                    "title": "ResponseModel",
+                    "required": ["message"],
+                    "type": "object",
+                    "properties": {"message": {"title": "Message", "type": "string"}},
+                }
+            }
+        },
+    }

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -28,161 +28,6 @@ async def unrelated(foo: Annotated[str, object()]):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/default": {
-            "get": {
-                "summary": "Default",
-                "operationId": "default_default_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Foo", "type": "string", "default": "foo"},
-                        "name": "foo",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/required": {
-            "get": {
-                "summary": "Required",
-                "operationId": "required_required_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Foo", "minLength": 1, "type": "string"},
-                        "name": "foo",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/multiple": {
-            "get": {
-                "summary": "Multiple",
-                "operationId": "multiple_multiple_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Foo", "minLength": 1, "type": "string"},
-                        "name": "foo",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/unrelated": {
-            "get": {
-                "summary": "Unrelated",
-                "operationId": "unrelated_unrelated_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Foo", "type": "string"},
-                        "name": "foo",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
 foo_is_missing = {
     "detail": [
         {
@@ -217,7 +62,6 @@ foo_is_short = {
         ("/multiple?foo=", 422, foo_is_short),
         ("/unrelated?foo=bar", 200, {"foo": "bar"}),
         ("/unrelated", 422, foo_is_missing),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get(path, expected_status, expected_response):
@@ -227,11 +71,14 @@ def test_get(path, expected_status, expected_response):
 
 
 def test_multiple_path():
+    app = FastAPI()
+
     @app.get("/test1")
     @app.get("/test2")
     async def test(var: Annotated[str, Query()] = "bar"):
         return {"foo": var}
 
+    client = TestClient(app)
     response = client.get("/test1")
     assert response.status_code == 200
     assert response.json() == {"foo": "bar"}
@@ -265,3 +112,177 @@ def test_nested_router():
     response = client.get("/nested/test")
     assert response.status_code == 200
     assert response.json() == {"foo": "bar"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/default": {
+                "get": {
+                    "summary": "Default",
+                    "operationId": "default_default_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Foo",
+                                "type": "string",
+                                "default": "foo",
+                            },
+                            "name": "foo",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/required": {
+                "get": {
+                    "summary": "Required",
+                    "operationId": "required_required_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Foo",
+                                "minLength": 1,
+                                "type": "string",
+                            },
+                            "name": "foo",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/multiple": {
+                "get": {
+                    "summary": "Multiple",
+                    "operationId": "multiple_multiple_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Foo",
+                                "minLength": 1,
+                                "type": "string",
+                            },
+                            "name": "foo",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/unrelated": {
+                "get": {
+                    "summary": "Unrelated",
+                    "operationId": "unrelated_unrelated_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Foo", "type": "string"},
+                            "name": "foo",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -5,1128 +5,6 @@ from .main import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/api_route": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Non Operation",
-                "operationId": "non_operation_api_route_get",
-            }
-        },
-        "/non_decorated_route": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Non Decorated Route",
-                "operationId": "non_decorated_route_non_decorated_route_get",
-            }
-        },
-        "/text": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Get Text",
-                "operationId": "get_text_text_get",
-            }
-        },
-        "/path/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Id",
-                "operationId": "get_id_path__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/str/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Str Id",
-                "operationId": "get_str_id_path_str__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/int/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Int Id",
-                "operationId": "get_int_id_path_int__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/float/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Float Id",
-                "operationId": "get_float_id_path_float__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "number"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/bool/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Bool Id",
-                "operationId": "get_bool_id_path_bool__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "boolean"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Id",
-                "operationId": "get_path_param_id_path_param__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-minlength/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Min Length",
-                "operationId": "get_path_param_min_length_path_param_minlength__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "minLength": 3,
-                            "type": "string",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-maxlength/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Max Length",
-                "operationId": "get_path_param_max_length_path_param_maxlength__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "maxLength": 3,
-                            "type": "string",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-min_maxlength/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Min Max Length",
-                "operationId": "get_path_param_min_max_length_path_param_min_maxlength__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "maxLength": 3,
-                            "minLength": 2,
-                            "type": "string",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-gt/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Gt",
-                "operationId": "get_path_param_gt_path_param_gt__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMinimum": 3.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-gt0/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Gt0",
-                "operationId": "get_path_param_gt0_path_param_gt0__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMinimum": 0.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-ge/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Ge",
-                "operationId": "get_path_param_ge_path_param_ge__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "minimum": 3.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-lt/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Lt",
-                "operationId": "get_path_param_lt_path_param_lt__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMaximum": 3.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-lt0/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Lt0",
-                "operationId": "get_path_param_lt0_path_param_lt0__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMaximum": 0.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-le/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Le",
-                "operationId": "get_path_param_le_path_param_le__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "maximum": 3.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-lt-gt/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Lt Gt",
-                "operationId": "get_path_param_lt_gt_path_param_lt_gt__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMaximum": 3.0,
-                            "exclusiveMinimum": 1.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-le-ge/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Le Ge",
-                "operationId": "get_path_param_le_ge_path_param_le_ge__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "maximum": 3.0,
-                            "minimum": 1.0,
-                            "type": "number",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-lt-int/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Lt Int",
-                "operationId": "get_path_param_lt_int_path_param_lt_int__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMaximum": 3.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-gt-int/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Gt Int",
-                "operationId": "get_path_param_gt_int_path_param_gt_int__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMinimum": 3.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-le-int/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Le Int",
-                "operationId": "get_path_param_le_int_path_param_le_int__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "maximum": 3.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-ge-int/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Ge Int",
-                "operationId": "get_path_param_ge_int_path_param_ge_int__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "minimum": 3.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-lt-gt-int/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Lt Gt Int",
-                "operationId": "get_path_param_lt_gt_int_path_param_lt_gt_int__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "exclusiveMaximum": 3.0,
-                            "exclusiveMinimum": 1.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/path/param-le-ge-int/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Path Param Le Ge Int",
-                "operationId": "get_path_param_le_ge_int_path_param_le_ge_int__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "maximum": 3.0,
-                            "minimum": 1.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/query": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query",
-                "operationId": "get_query_query_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Query"},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/query/optional": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query Optional",
-                "operationId": "get_query_optional_query_optional_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Query"},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/query/int": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query Type",
-                "operationId": "get_query_type_query_int_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Query", "type": "integer"},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/query/int/optional": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query Type Optional",
-                "operationId": "get_query_type_optional_query_int_optional_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Query", "type": "integer"},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/query/int/default": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query Type Int Default",
-                "operationId": "get_query_type_int_default_query_int_default_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Query", "type": "integer", "default": 10},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/query/param": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query Param",
-                "operationId": "get_query_param_query_param_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Query"},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/query/param-required": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query Param Required",
-                "operationId": "get_query_param_required_query_param_required_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Query"},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/query/param-required/int": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Query Param Required Type",
-                "operationId": "get_query_param_required_type_query_param_required_int_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Query", "type": "integer"},
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-            }
-        },
-        "/enum-status-code": {
-            "get": {
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "Get Enum Status Code",
-                "operationId": "get_enum_status_code_enum_status_code_get",
-            }
-        },
-        "/query/frozenset": {
-            "get": {
-                "summary": "Get Query Type Frozenset",
-                "operationId": "get_query_type_frozenset_query_frozenset_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Query",
-                            "uniqueItems": True,
-                            "type": "array",
-                            "items": {"type": "integer"},
-                        },
-                        "name": "query",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -1134,7 +12,6 @@ openapi_schema = {
         ("/api_route", 200, {"message": "Hello World"}),
         ("/non_decorated_route", 200, {"message": "Hello World"}),
         ("/nonexistent", 404, {"detail": "Not Found"}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get_path(path, expected_status, expected_response):
@@ -1172,3 +49,1135 @@ def test_enum_status_code_response():
     response = client.get("/enum-status-code")
     assert response.status_code == 201, response.text
     assert response.json() == "foo bar"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/api_route": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Non Operation",
+                    "operationId": "non_operation_api_route_get",
+                }
+            },
+            "/non_decorated_route": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Non Decorated Route",
+                    "operationId": "non_decorated_route_non_decorated_route_get",
+                }
+            },
+            "/text": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Get Text",
+                    "operationId": "get_text_text_get",
+                }
+            },
+            "/path/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Id",
+                    "operationId": "get_id_path__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/str/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Str Id",
+                    "operationId": "get_str_id_path_str__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/int/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Int Id",
+                    "operationId": "get_int_id_path_int__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/float/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Float Id",
+                    "operationId": "get_float_id_path_float__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "number"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/bool/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Bool Id",
+                    "operationId": "get_bool_id_path_bool__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "boolean"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Id",
+                    "operationId": "get_path_param_id_path_param__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-minlength/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Min Length",
+                    "operationId": "get_path_param_min_length_path_param_minlength__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "minLength": 3,
+                                "type": "string",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-maxlength/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Max Length",
+                    "operationId": "get_path_param_max_length_path_param_maxlength__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "maxLength": 3,
+                                "type": "string",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-min_maxlength/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Min Max Length",
+                    "operationId": "get_path_param_min_max_length_path_param_min_maxlength__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "maxLength": 3,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-gt/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Gt",
+                    "operationId": "get_path_param_gt_path_param_gt__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMinimum": 3.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-gt0/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Gt0",
+                    "operationId": "get_path_param_gt0_path_param_gt0__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMinimum": 0.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-ge/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Ge",
+                    "operationId": "get_path_param_ge_path_param_ge__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "minimum": 3.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-lt/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Lt",
+                    "operationId": "get_path_param_lt_path_param_lt__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMaximum": 3.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-lt0/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Lt0",
+                    "operationId": "get_path_param_lt0_path_param_lt0__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMaximum": 0.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-le/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Le",
+                    "operationId": "get_path_param_le_path_param_le__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "maximum": 3.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-lt-gt/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Lt Gt",
+                    "operationId": "get_path_param_lt_gt_path_param_lt_gt__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMaximum": 3.0,
+                                "exclusiveMinimum": 1.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-le-ge/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Le Ge",
+                    "operationId": "get_path_param_le_ge_path_param_le_ge__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "maximum": 3.0,
+                                "minimum": 1.0,
+                                "type": "number",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-lt-int/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Lt Int",
+                    "operationId": "get_path_param_lt_int_path_param_lt_int__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMaximum": 3.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-gt-int/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Gt Int",
+                    "operationId": "get_path_param_gt_int_path_param_gt_int__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMinimum": 3.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-le-int/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Le Int",
+                    "operationId": "get_path_param_le_int_path_param_le_int__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "maximum": 3.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-ge-int/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Ge Int",
+                    "operationId": "get_path_param_ge_int_path_param_ge_int__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "minimum": 3.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-lt-gt-int/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Lt Gt Int",
+                    "operationId": "get_path_param_lt_gt_int_path_param_lt_gt_int__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "exclusiveMaximum": 3.0,
+                                "exclusiveMinimum": 1.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/path/param-le-ge-int/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Path Param Le Ge Int",
+                    "operationId": "get_path_param_le_ge_int_path_param_le_ge_int__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "maximum": 3.0,
+                                "minimum": 1.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/query": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query",
+                    "operationId": "get_query_query_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Query"},
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/query/optional": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query Optional",
+                    "operationId": "get_query_optional_query_optional_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Query"},
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/query/int": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query Type",
+                    "operationId": "get_query_type_query_int_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Query", "type": "integer"},
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/query/int/optional": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query Type Optional",
+                    "operationId": "get_query_type_optional_query_int_optional_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Query", "type": "integer"},
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/query/int/default": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query Type Int Default",
+                    "operationId": "get_query_type_int_default_query_int_default_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Query",
+                                "type": "integer",
+                                "default": 10,
+                            },
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/query/param": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query Param",
+                    "operationId": "get_query_param_query_param_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Query"},
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/query/param-required": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query Param Required",
+                    "operationId": "get_query_param_required_query_param_required_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Query"},
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/query/param-required/int": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Query Param Required Type",
+                    "operationId": "get_query_param_required_type_query_param_required_int_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Query", "type": "integer"},
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            },
+            "/enum-status-code": {
+                "get": {
+                    "responses": {
+                        "201": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "Get Enum Status Code",
+                    "operationId": "get_enum_status_code_enum_status_code_get",
+                }
+            },
+            "/query/frozenset": {
+                "get": {
+                    "summary": "Get Query Type Frozenset",
+                    "operationId": "get_query_type_frozenset_query_frozenset_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Query",
+                                "uniqueItems": True,
+                                "type": "array",
+                                "items": {"type": "integer"},
+                            },
+                            "name": "query",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_custom_route_class.py
+++ b/tests/test_custom_route_class.py
@@ -46,49 +46,6 @@ app.include_router(router=router_a, prefix="/a")
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Get A",
-                "operationId": "get_a_a__get",
-            }
-        },
-        "/a/b/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Get B",
-                "operationId": "get_b_a_b__get",
-            }
-        },
-        "/a/b/c/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Get C",
-                "operationId": "get_c_a_b_c__get",
-            }
-        },
-    },
-}
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -96,7 +53,6 @@ openapi_schema = {
         ("/a", 200, {"msg": "A"}),
         ("/a/b", 200, {"msg": "B"}),
         ("/a/b/c", 200, {"msg": "C"}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get_path(path, expected_status, expected_response):
@@ -113,3 +69,50 @@ def test_route_classes():
     assert getattr(routes["/a/"], "x_type") == "A"  # noqa: B009
     assert getattr(routes["/a/b/"], "x_type") == "B"  # noqa: B009
     assert getattr(routes["/a/b/c/"], "x_type") == "C"  # noqa: B009
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Get A",
+                    "operationId": "get_a_a__get",
+                }
+            },
+            "/a/b/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Get B",
+                    "operationId": "get_b_a_b__get",
+                }
+            },
+            "/a/b/c/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Get C",
+                    "operationId": "get_c_a_b_c__get",
+                }
+            },
+        },
+    }

--- a/tests/test_dependency_duplicates.py
+++ b/tests/test_dependency_duplicates.py
@@ -44,156 +44,6 @@ async def no_duplicates_sub(
     return [item, sub_items]
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/with-duplicates": {
-            "post": {
-                "summary": "With Duplicates",
-                "operationId": "with_duplicates_with_duplicates_post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/no-duplicates": {
-            "post": {
-                "summary": "No Duplicates",
-                "operationId": "no_duplicates_no_duplicates_post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_no_duplicates_no_duplicates_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/with-duplicates-sub": {
-            "post": {
-                "summary": "No Duplicates Sub",
-                "operationId": "no_duplicates_sub_with_duplicates_sub_post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_no_duplicates_no_duplicates_post": {
-                "title": "Body_no_duplicates_no_duplicates_post",
-                "required": ["item", "item2"],
-                "type": "object",
-                "properties": {
-                    "item": {"$ref": "#/components/schemas/Item"},
-                    "item2": {"$ref": "#/components/schemas/Item"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["data"],
-                "type": "object",
-                "properties": {"data": {"title": "Data", "type": "string"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_no_duplicates_invalid():
     response = client.post("/no-duplicates", json={"item": {"data": "myitem"}})
     assert response.status_code == 422, response.text
@@ -230,3 +80,152 @@ def test_sub_duplicates():
         {"data": "myitem"},
         [{"data": "myitem"}, {"data": "myitem"}],
     ]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/with-duplicates": {
+                "post": {
+                    "summary": "With Duplicates",
+                    "operationId": "with_duplicates_with_duplicates_post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/no-duplicates": {
+                "post": {
+                    "summary": "No Duplicates",
+                    "operationId": "no_duplicates_no_duplicates_post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_no_duplicates_no_duplicates_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/with-duplicates-sub": {
+                "post": {
+                    "summary": "No Duplicates Sub",
+                    "operationId": "no_duplicates_sub_with_duplicates_sub_post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_no_duplicates_no_duplicates_post": {
+                    "title": "Body_no_duplicates_no_duplicates_post",
+                    "required": ["item", "item2"],
+                    "type": "object",
+                    "properties": {
+                        "item": {"$ref": "#/components/schemas/Item"},
+                        "item2": {"$ref": "#/components/schemas/Item"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["data"],
+                    "type": "object",
+                    "properties": {"data": {"title": "Data", "type": "string"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_deprecated_openapi_prefix.py
+++ b/tests/test_deprecated_openapi_prefix.py
@@ -11,34 +11,32 @@ def read_main(request: Request):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/app": {
-            "get": {
-                "summary": "Read Main",
-                "operationId": "read_main_app_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-    "servers": [{"url": "/api/v1"}],
-}
-
-
-def test_openapi():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
-
 
 def test_main():
     response = client.get("/app")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World", "root_path": "/api/v1"}
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/app": {
+                "get": {
+                    "summary": "Read Main",
+                    "operationId": "read_main_app_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+        "servers": [{"url": "/api/v1"}],
+    }

--- a/tests/test_duplicate_models_openapi.py
+++ b/tests/test_duplicate_models_openapi.py
@@ -23,60 +23,57 @@ def f():
     return {"c": {}, "d": {"a": {}}}
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "summary": "F",
-                "operationId": "f__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Model3"}
-                            }
-                        },
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Model": {"title": "Model", "type": "object", "properties": {}},
-            "Model2": {
-                "title": "Model2",
-                "required": ["a"],
-                "type": "object",
-                "properties": {"a": {"$ref": "#/components/schemas/Model"}},
-            },
-            "Model3": {
-                "title": "Model3",
-                "required": ["c", "d"],
-                "type": "object",
-                "properties": {
-                    "c": {"$ref": "#/components/schemas/Model"},
-                    "d": {"$ref": "#/components/schemas/Model2"},
-                },
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_get_api_route():
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert response.json() == {"c": {}, "d": {"a": {}}}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "summary": "F",
+                    "operationId": "f__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Model3"}
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Model": {"title": "Model", "type": "object", "properties": {}},
+                "Model2": {
+                    "title": "Model2",
+                    "required": ["a"],
+                    "type": "object",
+                    "properties": {"a": {"$ref": "#/components/schemas/Model"}},
+                },
+                "Model3": {
+                    "title": "Model3",
+                    "required": ["c", "d"],
+                    "type": "object",
+                    "properties": {
+                        "c": {"$ref": "#/components/schemas/Model"},
+                        "d": {"$ref": "#/components/schemas/Model2"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -52,273 +52,6 @@ def trace_item(item_id: str):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Items",
-                "operationId": "get_items_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Delete Item",
-                "operationId": "delete_item_items__item_id__delete",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-            "options": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Options Item",
-                "operationId": "options_item_items__item_id__options",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            },
-            "head": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Head Item",
-                "operationId": "head_item_items__item_id__head",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            },
-            "patch": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Patch Item",
-                "operationId": "patch_item_items__item_id__patch",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-            "trace": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Trace Item",
-                "operationId": "trace_item_items__item_id__trace",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            },
-        },
-        "/items-not-decorated/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Not Decorated",
-                "operationId": "get_not_decorated_items_not_decorated__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_api_route():
     response = client.get("/items/foo")
@@ -360,3 +93,270 @@ def test_trace():
     response = client.request("trace", "/items/foo")
     assert response.status_code == 200, response.text
     assert response.headers["content-type"] == "message/http"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Items",
+                    "operationId": "get_items_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                },
+                "delete": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Delete Item",
+                    "operationId": "delete_item_items__item_id__delete",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+                "options": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Options Item",
+                    "operationId": "options_item_items__item_id__options",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                },
+                "head": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Head Item",
+                    "operationId": "head_item_items__item_id__head",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                },
+                "patch": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Patch Item",
+                    "operationId": "patch_item_items__item_id__patch",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+                "trace": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Trace Item",
+                    "operationId": "trace_item_items__item_id__trace",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                },
+            },
+            "/items-not-decorated/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Get Not Decorated",
+                    "operationId": "get_not_decorated_items_not_decorated__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_filter_pydantic_sub_model.py
+++ b/tests/test_filter_pydantic_sub_model.py
@@ -40,99 +40,6 @@ async def get_model_a(name: str, model_c=Depends(get_model_c)):
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/model/{name}": {
-            "get": {
-                "summary": "Get Model A",
-                "operationId": "get_model_a_model__name__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Name", "type": "string"},
-                        "name": "name",
-                        "in": "path",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/ModelA"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ModelA": {
-                "title": "ModelA",
-                "required": ["name", "model_b"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "model_b": {"$ref": "#/components/schemas/ModelB"},
-                },
-            },
-            "ModelB": {
-                "title": "ModelB",
-                "required": ["username"],
-                "type": "object",
-                "properties": {"username": {"title": "Username", "type": "string"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_filter_sub_model():
     response = client.get("/model/modelA")
     assert response.status_code == 200, response.text
@@ -153,3 +60,95 @@ def test_validator_is_cloned():
             "type": "value_error",
         }
     ]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/model/{name}": {
+                "get": {
+                    "summary": "Get Model A",
+                    "operationId": "get_model_a_model__name__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Name", "type": "string"},
+                            "name": "name",
+                            "in": "path",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ModelA"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ModelA": {
+                    "title": "ModelA",
+                    "required": ["name", "model_b"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "model_b": {"$ref": "#/components/schemas/ModelB"},
+                    },
+                },
+                "ModelB": {
+                    "title": "ModelB",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {"username": {"title": "Username", "type": "string"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_get_request_body.py
+++ b/tests/test_get_request_body.py
@@ -19,90 +19,89 @@ async def create_item(product: Product):
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/product": {
-            "get": {
-                "summary": "Create Item",
-                "operationId": "create_item_product_get",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Product"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Product": {
-                "title": "Product",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
+def test_get_with_body():
+    body = {"name": "Foo", "description": "Some description", "price": 5.5}
+    response = client.request("GET", "/product", json=body)
+    assert response.json() == body
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_get_with_body():
-    body = {"name": "Foo", "description": "Some description", "price": 5.5}
-    response = client.request("GET", "/product", json=body)
-    assert response.json() == body
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/product": {
+                "get": {
+                    "summary": "Create Item",
+                    "operationId": "create_item_product_get",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Product"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Product": {
+                    "title": "Product",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_include_router_defaults_overrides.py
+++ b/tests/test_include_router_defaults_overrides.py
@@ -343,16 +343,6 @@ app.include_router(router2_default)
 client = TestClient(app)
 
 
-def test_openapi():
-    client = TestClient(app)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        response = client.get("/openapi.json")
-        assert issubclass(w[-1].category, UserWarning)
-        assert "Duplicate Operation ID" in str(w[-1].message)
-    assert response.json() == openapi_schema
-
-
 def test_level1_override():
     response = client.get("/override1?level1=foo")
     assert response.json() == "foo"
@@ -445,6179 +435,6863 @@ def test_paths_level5(override1, override2, override3, override4, override5):
     assert not override5 or "x-level5" in response.headers
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/override1": {
-            "get": {
-                "tags": ["path1a", "path1b"],
-                "summary": "Path1 Override",
-                "operationId": "path1_override_override1_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level1", "type": "string"},
-                        "name": "level1",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-1": {"schema": {}}},
+def test_openapi():
+    client = TestClient(app)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        response = client.get("/openapi.json")
+        assert issubclass(w[-1].category, UserWarning)
+        assert "Duplicate Operation ID" in str(w[-1].message)
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/override1": {
+                "get": {
+                    "tags": ["path1a", "path1b"],
+                    "summary": "Path1 Override",
+                    "operationId": "path1_override_override1_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level1", "type": "string"},
+                            "name": "level1",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-1": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
                     },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
                                 }
                             }
                         },
                     },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/default1": {
-            "get": {
-                "summary": "Path1 Default",
-                "operationId": "path1_default_default1_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level1", "type": "string"},
-                        "name": "level1",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-0": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-            }
-        },
-        "/level1/level2/override3": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "path3a",
-                    "path3b",
-                ],
-                "summary": "Path3 Override Router2 Override",
-                "operationId": "path3_override_router2_override_level1_level2_override3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/default3": {
-            "get": {
-                "tags": ["level1a", "level1b", "level2a", "level2b"],
-                "summary": "Path3 Default Router2 Override",
-                "operationId": "path3_default_router2_override_level1_level2_default3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-2": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/level3/level4/override5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "level3a",
-                    "level3b",
-                    "level4a",
-                    "level4b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level1_level2_level3_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/level3/level4/default5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "level3a",
-                    "level3b",
-                    "level4a",
-                    "level4b",
-                ],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level1_level2_level3_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/level3/override5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "level3a",
-                    "level3b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_level1_level2_level3_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/level3/default5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "level3a",
-                    "level3b",
-                ],
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_level1_level2_level3_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/level4/override5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "level4a",
-                    "level4b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level1_level2_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/level4/default5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "level4a",
-                    "level4b",
-                ],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level1_level2_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/override5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level2a",
-                    "level2b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_level1_level2_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level2/default5": {
-            "get": {
-                "tags": ["level1a", "level1b", "level2a", "level2b"],
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_level1_level2_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-2": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "402": {"description": "Client error level 2"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "502": {"description": "Server error level 2"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/override3": {
-            "get": {
-                "tags": ["level1a", "level1b", "path3a", "path3b"],
-                "summary": "Path3 Override Router2 Default",
-                "operationId": "path3_override_router2_default_level1_override3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/default3": {
-            "get": {
-                "tags": ["level1a", "level1b"],
-                "summary": "Path3 Default Router2 Default",
-                "operationId": "path3_default_router2_default_level1_default3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-1": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-            }
-        },
-        "/level1/level3/level4/override5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level3a",
-                    "level3b",
-                    "level4a",
-                    "level4b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level1_level3_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level3/level4/default5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level3a",
-                    "level3b",
-                    "level4a",
-                    "level4b",
-                ],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level1_level3_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level3/override5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level3a",
-                    "level3b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_level1_level3_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "403": {"description": "Client error level 3"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "503": {"description": "Server error level 3"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level3/default5": {
-            "get": {
-                "tags": ["level1a", "level1b", "level3a", "level3b"],
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_level1_level3_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-            }
-        },
-        "/level1/level4/override5": {
-            "get": {
-                "tags": [
-                    "level1a",
-                    "level1b",
-                    "level4a",
-                    "level4b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level1_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/level4/default5": {
-            "get": {
-                "tags": ["level1a", "level1b", "level4a", "level4b"],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level1_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/override5": {
-            "get": {
-                "tags": ["level1a", "level1b", "path5a", "path5b"],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_level1_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level1/default5": {
-            "get": {
-                "tags": ["level1a", "level1b"],
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_level1_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-1": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "401": {"description": "Client error level 1"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "501": {"description": "Server error level 1"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback1": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback1",
-                                "operationId": "callback1__get",
-                                "parameters": [
-                                    {
-                                        "name": "level1",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level1", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-            }
-        },
-        "/level2/override3": {
-            "get": {
-                "tags": ["level2a", "level2b", "path3a", "path3b"],
-                "summary": "Path3 Override Router2 Override",
-                "operationId": "path3_override_router2_override_level2_override3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/default3": {
-            "get": {
-                "tags": ["level2a", "level2b"],
-                "summary": "Path3 Default Router2 Override",
-                "operationId": "path3_default_router2_override_level2_default3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-2": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/level3/level4/override5": {
-            "get": {
-                "tags": [
-                    "level2a",
-                    "level2b",
-                    "level3a",
-                    "level3b",
-                    "level4a",
-                    "level4b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level2_level3_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/level3/level4/default5": {
-            "get": {
-                "tags": [
-                    "level2a",
-                    "level2b",
-                    "level3a",
-                    "level3b",
-                    "level4a",
-                    "level4b",
-                ],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level2_level3_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/level3/override5": {
-            "get": {
-                "tags": [
-                    "level2a",
-                    "level2b",
-                    "level3a",
-                    "level3b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_level2_level3_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/level3/default5": {
-            "get": {
-                "tags": ["level2a", "level2b", "level3a", "level3b"],
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_level2_level3_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/level4/override5": {
-            "get": {
-                "tags": [
-                    "level2a",
-                    "level2b",
-                    "level4a",
-                    "level4b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level2_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/level4/default5": {
-            "get": {
-                "tags": ["level2a", "level2b", "level4a", "level4b"],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level2_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/override5": {
-            "get": {
-                "tags": ["level2a", "level2b", "path5a", "path5b"],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_level2_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level2/default5": {
-            "get": {
-                "tags": ["level2a", "level2b"],
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_level2_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-2": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "402": {"description": "Client error level 2"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "502": {"description": "Server error level 2"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback2": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback2",
-                                "operationId": "callback2__get",
-                                "parameters": [
-                                    {
-                                        "name": "level2",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level2", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/override3": {
-            "get": {
-                "tags": ["path3a", "path3b"],
-                "summary": "Path3 Override Router2 Default",
-                "operationId": "path3_override_router2_default_override3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/default3": {
-            "get": {
-                "summary": "Path3 Default Router2 Default",
-                "operationId": "path3_default_router2_default_default3_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level3", "type": "string"},
-                        "name": "level3",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-0": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-            }
-        },
-        "/level3/level4/override5": {
-            "get": {
-                "tags": [
-                    "level3a",
-                    "level3b",
-                    "level4a",
-                    "level4b",
-                    "path5a",
-                    "path5b",
-                ],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level3_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level3/level4/default5": {
-            "get": {
-                "tags": ["level3a", "level3b", "level4a", "level4b"],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level3_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "403": {"description": "Client error level 3"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "503": {"description": "Server error level 3"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level3/override5": {
-            "get": {
-                "tags": ["level3a", "level3b", "path5a", "path5b"],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_level3_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "403": {"description": "Client error level 3"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "503": {"description": "Server error level 3"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level3/default5": {
-            "get": {
-                "tags": ["level3a", "level3b"],
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_level3_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-3": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "403": {"description": "Client error level 3"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "503": {"description": "Server error level 3"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback3": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback3",
-                                "operationId": "callback3__get",
-                                "parameters": [
-                                    {
-                                        "name": "level3",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level3", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-            }
-        },
-        "/level4/override5": {
-            "get": {
-                "tags": ["level4a", "level4b", "path5a", "path5b"],
-                "summary": "Path5 Override Router4 Override",
-                "operationId": "path5_override_router4_override_level4_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "404": {"description": "Client error level 4"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "504": {"description": "Server error level 4"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/level4/default5": {
-            "get": {
-                "tags": ["level4a", "level4b"],
-                "summary": "Path5 Default Router4 Override",
-                "operationId": "path5_default_router4_override_level4_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-4": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "404": {"description": "Client error level 4"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "504": {"description": "Server error level 4"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback4": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback4",
-                                "operationId": "callback4__get",
-                                "parameters": [
-                                    {
-                                        "name": "level4",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level4", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/override5": {
-            "get": {
-                "tags": ["path5a", "path5b"],
-                "summary": "Path5 Override Router4 Default",
-                "operationId": "path5_override_router4_default_override5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-5": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "405": {"description": "Client error level 5"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                    "505": {"description": "Server error level 5"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "callback5": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback5",
-                                "operationId": "callback5__get",
-                                "parameters": [
-                                    {
-                                        "name": "level5",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level5", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-                "deprecated": True,
-            }
-        },
-        "/default5": {
-            "get": {
-                "summary": "Path5 Default Router4 Default",
-                "operationId": "path5_default_router4_default_default5_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Level5", "type": "string"},
-                        "name": "level5",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/x-level-0": {"schema": {}}},
-                    },
-                    "400": {"description": "Client error level 0"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                    "500": {"description": "Server error level 0"},
-                },
-                "callbacks": {
-                    "callback0": {
-                        "/": {
-                            "get": {
-                                "summary": "Callback0",
-                                "operationId": "callback0__get",
-                                "parameters": [
-                                    {
-                                        "name": "level0",
-                                        "in": "query",
-                                        "required": True,
-                                        "schema": {"title": "Level0", "type": "string"},
-                                    }
-                                ],
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
+                    "deprecated": True,
+                }
             },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+            "/default1": {
+                "get": {
+                    "summary": "Path1 Default",
+                    "operationId": "path1_default_default1_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level1", "type": "string"},
+                            "name": "level1",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-0": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
                     },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
             },
-        }
-    },
-}
+            "/level1/level2/override3": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "path3a",
+                        "path3b",
+                    ],
+                    "summary": "Path3 Override Router2 Override",
+                    "operationId": "path3_override_router2_override_level1_level2_override3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/default3": {
+                "get": {
+                    "tags": ["level1a", "level1b", "level2a", "level2b"],
+                    "summary": "Path3 Default Router2 Override",
+                    "operationId": "path3_default_router2_override_level1_level2_default3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-2": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/level3/level4/override5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "level3a",
+                        "level3b",
+                        "level4a",
+                        "level4b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level1_level2_level3_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/level3/level4/default5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "level3a",
+                        "level3b",
+                        "level4a",
+                        "level4b",
+                    ],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level1_level2_level3_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/level3/override5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "level3a",
+                        "level3b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_level1_level2_level3_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/level3/default5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "level3a",
+                        "level3b",
+                    ],
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_level1_level2_level3_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/level4/override5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "level4a",
+                        "level4b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level1_level2_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/level4/default5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "level4a",
+                        "level4b",
+                    ],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level1_level2_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/override5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level2a",
+                        "level2b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_level1_level2_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level2/default5": {
+                "get": {
+                    "tags": ["level1a", "level1b", "level2a", "level2b"],
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_level1_level2_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-2": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "402": {"description": "Client error level 2"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "502": {"description": "Server error level 2"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/override3": {
+                "get": {
+                    "tags": ["level1a", "level1b", "path3a", "path3b"],
+                    "summary": "Path3 Override Router2 Default",
+                    "operationId": "path3_override_router2_default_level1_override3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/default3": {
+                "get": {
+                    "tags": ["level1a", "level1b"],
+                    "summary": "Path3 Default Router2 Default",
+                    "operationId": "path3_default_router2_default_level1_default3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-1": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                }
+            },
+            "/level1/level3/level4/override5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level3a",
+                        "level3b",
+                        "level4a",
+                        "level4b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level1_level3_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level3/level4/default5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level3a",
+                        "level3b",
+                        "level4a",
+                        "level4b",
+                    ],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level1_level3_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level3/override5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level3a",
+                        "level3b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_level1_level3_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "403": {"description": "Client error level 3"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "503": {"description": "Server error level 3"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level3/default5": {
+                "get": {
+                    "tags": ["level1a", "level1b", "level3a", "level3b"],
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_level1_level3_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                }
+            },
+            "/level1/level4/override5": {
+                "get": {
+                    "tags": [
+                        "level1a",
+                        "level1b",
+                        "level4a",
+                        "level4b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level1_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/level4/default5": {
+                "get": {
+                    "tags": ["level1a", "level1b", "level4a", "level4b"],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level1_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/override5": {
+                "get": {
+                    "tags": ["level1a", "level1b", "path5a", "path5b"],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_level1_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level1/default5": {
+                "get": {
+                    "tags": ["level1a", "level1b"],
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_level1_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-1": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "401": {"description": "Client error level 1"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "501": {"description": "Server error level 1"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback1": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback1",
+                                    "operationId": "callback1__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level1",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level1",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                }
+            },
+            "/level2/override3": {
+                "get": {
+                    "tags": ["level2a", "level2b", "path3a", "path3b"],
+                    "summary": "Path3 Override Router2 Override",
+                    "operationId": "path3_override_router2_override_level2_override3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/default3": {
+                "get": {
+                    "tags": ["level2a", "level2b"],
+                    "summary": "Path3 Default Router2 Override",
+                    "operationId": "path3_default_router2_override_level2_default3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-2": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/level3/level4/override5": {
+                "get": {
+                    "tags": [
+                        "level2a",
+                        "level2b",
+                        "level3a",
+                        "level3b",
+                        "level4a",
+                        "level4b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level2_level3_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/level3/level4/default5": {
+                "get": {
+                    "tags": [
+                        "level2a",
+                        "level2b",
+                        "level3a",
+                        "level3b",
+                        "level4a",
+                        "level4b",
+                    ],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level2_level3_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/level3/override5": {
+                "get": {
+                    "tags": [
+                        "level2a",
+                        "level2b",
+                        "level3a",
+                        "level3b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_level2_level3_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/level3/default5": {
+                "get": {
+                    "tags": ["level2a", "level2b", "level3a", "level3b"],
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_level2_level3_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/level4/override5": {
+                "get": {
+                    "tags": [
+                        "level2a",
+                        "level2b",
+                        "level4a",
+                        "level4b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level2_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/level4/default5": {
+                "get": {
+                    "tags": ["level2a", "level2b", "level4a", "level4b"],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level2_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/override5": {
+                "get": {
+                    "tags": ["level2a", "level2b", "path5a", "path5b"],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_level2_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level2/default5": {
+                "get": {
+                    "tags": ["level2a", "level2b"],
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_level2_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-2": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "402": {"description": "Client error level 2"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "502": {"description": "Server error level 2"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback2": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback2",
+                                    "operationId": "callback2__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level2",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level2",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/override3": {
+                "get": {
+                    "tags": ["path3a", "path3b"],
+                    "summary": "Path3 Override Router2 Default",
+                    "operationId": "path3_override_router2_default_override3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/default3": {
+                "get": {
+                    "summary": "Path3 Default Router2 Default",
+                    "operationId": "path3_default_router2_default_default3_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level3", "type": "string"},
+                            "name": "level3",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-0": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+            "/level3/level4/override5": {
+                "get": {
+                    "tags": [
+                        "level3a",
+                        "level3b",
+                        "level4a",
+                        "level4b",
+                        "path5a",
+                        "path5b",
+                    ],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level3_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level3/level4/default5": {
+                "get": {
+                    "tags": ["level3a", "level3b", "level4a", "level4b"],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level3_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "403": {"description": "Client error level 3"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "503": {"description": "Server error level 3"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level3/override5": {
+                "get": {
+                    "tags": ["level3a", "level3b", "path5a", "path5b"],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_level3_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "403": {"description": "Client error level 3"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "503": {"description": "Server error level 3"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level3/default5": {
+                "get": {
+                    "tags": ["level3a", "level3b"],
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_level3_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-3": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "403": {"description": "Client error level 3"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "503": {"description": "Server error level 3"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback3": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback3",
+                                    "operationId": "callback3__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level3",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level3",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                }
+            },
+            "/level4/override5": {
+                "get": {
+                    "tags": ["level4a", "level4b", "path5a", "path5b"],
+                    "summary": "Path5 Override Router4 Override",
+                    "operationId": "path5_override_router4_override_level4_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "404": {"description": "Client error level 4"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "504": {"description": "Server error level 4"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/level4/default5": {
+                "get": {
+                    "tags": ["level4a", "level4b"],
+                    "summary": "Path5 Default Router4 Override",
+                    "operationId": "path5_default_router4_override_level4_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-4": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "404": {"description": "Client error level 4"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "504": {"description": "Server error level 4"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback4": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback4",
+                                    "operationId": "callback4__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level4",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level4",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/override5": {
+                "get": {
+                    "tags": ["path5a", "path5b"],
+                    "summary": "Path5 Override Router4 Default",
+                    "operationId": "path5_override_router4_default_override5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-5": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "405": {"description": "Client error level 5"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                        "505": {"description": "Server error level 5"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "callback5": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback5",
+                                    "operationId": "callback5__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level5",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level5",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    },
+                    "deprecated": True,
+                }
+            },
+            "/default5": {
+                "get": {
+                    "summary": "Path5 Default Router4 Default",
+                    "operationId": "path5_default_router4_default_default5_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Level5", "type": "string"},
+                            "name": "level5",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/x-level-0": {"schema": {}}},
+                        },
+                        "400": {"description": "Client error level 0"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                        "500": {"description": "Server error level 0"},
+                    },
+                    "callbacks": {
+                        "callback0": {
+                            "/": {
+                                "get": {
+                                    "summary": "Callback0",
+                                    "operationId": "callback0__get",
+                                    "parameters": [
+                                        {
+                                            "name": "level0",
+                                            "in": "query",
+                                            "required": True,
+                                            "schema": {
+                                                "title": "Level0",
+                                                "type": "string",
+                                            },
+                                        }
+                                    ],
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {"schema": {}}
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_modules_same_name_body/test_main.py
+++ b/tests/test_modules_same_name_body/test_main.py
@@ -4,130 +4,6 @@ from .app.main import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a/compute": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Compute",
-                "operationId": "compute_a_compute_post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_compute_a_compute_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/b/compute/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Compute",
-                "operationId": "compute_b_compute__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_compute_b_compute__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_compute_b_compute__post": {
-                "title": "Body_compute_b_compute__post",
-                "required": ["a", "b"],
-                "type": "object",
-                "properties": {
-                    "a": {"title": "A", "type": "integer"},
-                    "b": {"title": "B", "type": "string"},
-                },
-            },
-            "Body_compute_a_compute_post": {
-                "title": "Body_compute_a_compute_post",
-                "required": ["a", "b"],
-                "type": "object",
-                "properties": {
-                    "a": {"title": "A", "type": "integer"},
-                    "b": {"title": "B", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_a():
     data = {"a": 2, "b": "foo"}
@@ -153,3 +29,127 @@ def test_post_b_invalid():
     data = {"a": "bar", "b": "foo"}
     response = client.post("/b/compute/", json=data)
     assert response.status_code == 422, response.text
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a/compute": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Compute",
+                    "operationId": "compute_a_compute_post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_compute_a_compute_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/b/compute/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Compute",
+                    "operationId": "compute_b_compute__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_compute_b_compute__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_compute_b_compute__post": {
+                    "title": "Body_compute_b_compute__post",
+                    "required": ["a", "b"],
+                    "type": "object",
+                    "properties": {
+                        "a": {"title": "A", "type": "integer"},
+                        "b": {"title": "B", "type": "string"},
+                    },
+                },
+                "Body_compute_a_compute_post": {
+                    "title": "Body_compute_a_compute_post",
+                    "required": ["a", "b"],
+                    "type": "object",
+                    "properties": {
+                        "a": {"title": "A", "type": "integer"},
+                        "b": {"title": "B", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -21,85 +21,6 @@ def save_item_no_body(item: List[Item]):
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Save Item No Body",
-                "operationId": "save_item_no_body_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "title": "Item",
-                                "type": "array",
-                                "items": {"$ref": "#/components/schemas/Item"},
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "age"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "age": {"title": "Age", "exclusiveMinimum": 0.0, "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 single_error = {
     "detail": [
         {
@@ -137,12 +58,6 @@ multiple_errors = {
 }
 
 
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_put_correct_body():
     response = client.post("/items/", json=[{"name": "Foo", "age": 5}])
     assert response.status_code == 200, response.text
@@ -159,3 +74,92 @@ def test_put_incorrect_body_multiple():
     response = client.post("/items/", json=[{"age": "five"}, {"age": "six"}])
     assert response.status_code == 422, response.text
     assert response.json() == multiple_errors
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Save Item No Body",
+                    "operationId": "save_item_no_body_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Item",
+                                    "type": "array",
+                                    "items": {"$ref": "#/components/schemas/Item"},
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "age"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "age": {
+                            "title": "Age",
+                            "exclusiveMinimum": 0.0,
+                            "type": "number",
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_multi_query_errors.py
+++ b/tests/test_multi_query_errors.py
@@ -14,76 +14,6 @@ def read_items(q: List[int] = Query(default=None)):
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "integer"},
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 multiple_errors = {
     "detail": [
         {
@@ -100,12 +30,6 @@ multiple_errors = {
 }
 
 
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_multi_query():
     response = client.get("/items/?q=5&q=6")
     assert response.status_code == 200, response.text
@@ -116,3 +40,79 @@ def test_multi_query_incorrect():
     response = client.get("/items/?q=five&q=six")
     assert response.status_code == 422, response.text
     assert response.json() == multiple_errors
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "integer"},
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_openapi_query_parameter_extension.py
+++ b/tests/test_openapi_query_parameter_extension.py
@@ -32,96 +32,95 @@ def route_with_extra_query_parameters(standard_query_param: Optional[int] = 50):
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "summary": "Route With Extra Query Parameters",
-                "operationId": "route_with_extra_query_parameters__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Standard Query Param",
-                            "type": "integer",
-                            "default": 50,
-                        },
-                        "name": "standard_query_param",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Extra Param 1"},
-                        "name": "extra_param_1",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Extra Param 2"},
-                        "name": "extra_param_2",
-                        "in": "query",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
+def test_get_route():
+    response = client.get("/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {}
 
 
 def test_openapi():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_get_route():
-    response = client.get("/")
-    assert response.status_code == 200, response.text
-    assert response.json() == {}
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "summary": "Route With Extra Query Parameters",
+                    "operationId": "route_with_extra_query_parameters__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Standard Query Param",
+                                "type": "integer",
+                                "default": 50,
+                            },
+                            "name": "standard_query_param",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Extra Param 1"},
+                            "name": "extra_param_1",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Extra Param 2"},
+                            "name": "extra_param_2",
+                            "in": "query",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_openapi_route_extensions.py
+++ b/tests/test_openapi_route_extensions.py
@@ -12,34 +12,31 @@ def route_with_extras():
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "Route With Extras",
-                "operationId": "route_with_extras__get",
-                "x-custom-extension": "value",
-            }
-        },
-    },
-}
+def test_get_route():
+    response = client.get("/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {}
 
 
 def test_openapi():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_get_route():
-    response = client.get("/")
-    assert response.status_code == 200, response.text
-    assert response.json() == {}
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "Route With Extras",
+                    "operationId": "route_with_extras__get",
+                    "x-custom-extension": "value",
+                }
+            },
+        },
+    }

--- a/tests/test_openapi_servers.py
+++ b/tests/test_openapi_servers.py
@@ -21,40 +21,37 @@ def foo():
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "servers": [
-        {"url": "/", "description": "Default, relative server"},
-        {
-            "url": "http://staging.localhost.tiangolo.com:8000",
-            "description": "Staging but actually localhost still",
-        },
-        {"url": "https://prod.example.com"},
-    ],
-    "paths": {
-        "/foo": {
-            "get": {
-                "summary": "Foo",
-                "operationId": "foo_foo_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_servers():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_app():
     response = client.get("/foo")
     assert response.status_code == 200, response.text
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "servers": [
+            {"url": "/", "description": "Default, relative server"},
+            {
+                "url": "http://staging.localhost.tiangolo.com:8000",
+                "description": "Staging but actually localhost still",
+            },
+            {"url": "https://prod.example.com"},
+        ],
+        "paths": {
+            "/foo": {
+                "get": {
+                    "summary": "Foo",
+                    "operationId": "foo_foo_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_param_in_path_and_dependency.py
+++ b/tests/test_param_in_path_and_dependency.py
@@ -15,79 +15,79 @@ async def read_users(user_id: int):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/{user_id}": {
-            "get": {
-                "summary": "Read Users",
-                "operationId": "read_users_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_reused_param():
-    response = client.get("/openapi.json")
-    data = response.json()
-    assert data == openapi_schema
-
 
 def test_read_users():
     response = client.get("/users/42")
     assert response.status_code == 200, response.text
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    data = response.json()
+    assert data == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/{user_id}": {
+                "get": {
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_put_no_body.py
+++ b/tests/test_put_no_body.py
@@ -12,79 +12,6 @@ def save_item_no_body(item_id: str):
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Save Item No Body",
-                "operationId": "save_item_no_body_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_put_no_body():
     response = client.put("/items/foo")
     assert response.status_code == 200, response.text
@@ -95,3 +22,75 @@ def test_put_no_body_with_body():
     response = client.put("/items/foo", json={"name": "Foo"})
     assert response.status_code == 200, response.text
     assert response.json() == {"item_id": "foo"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Save Item No Body",
+                    "operationId": "save_item_no_body_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_repeated_parameter_alias.py
+++ b/tests/test_repeated_parameter_alias.py
@@ -14,87 +14,87 @@ def get_parameters_with_repeated_aliases(
 
 client = TestClient(app)
 
-openapi_schema = {
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "properties": {
-                    "detail": {
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                        "title": "Detail",
-                        "type": "array",
-                    }
-                },
-                "title": "HTTPValidationError",
-                "type": "object",
-            },
-            "ValidationError": {
-                "properties": {
-                    "loc": {
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                        "title": "Location",
-                        "type": "array",
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-                "required": ["loc", "msg", "type"],
-                "title": "ValidationError",
-                "type": "object",
-            },
-        }
-    },
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "openapi": "3.0.2",
-    "paths": {
-        "/{repeated_alias}": {
-            "get": {
-                "operationId": "get_parameters_with_repeated_aliases__repeated_alias__get",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "repeated_alias",
-                        "required": True,
-                        "schema": {"title": "Repeated Alias", "type": "string"},
-                    },
-                    {
-                        "in": "query",
-                        "name": "repeated_alias",
-                        "required": True,
-                        "schema": {"title": "Repeated Alias", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {"application/json": {"schema": {}}},
-                        "description": "Successful Response",
-                    },
-                    "422": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                        "description": "Validation Error",
-                    },
-                },
-                "summary": "Get Parameters With Repeated Aliases",
-            }
-        }
-    },
-}
+
+def test_get_parameters():
+    response = client.get("/test_path", params={"repeated_alias": "test_query"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"path": "test_path", "query": "test_query"}
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == status.HTTP_200_OK
     actual_schema = response.json()
-    assert actual_schema == openapi_schema
-
-
-def test_get_parameters():
-    response = client.get("/test_path", params={"repeated_alias": "test_query"})
-    assert response.status_code == 200, response.text
-    assert response.json() == {"path": "test_path", "query": "test_query"}
+    assert actual_schema == {
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "properties": {
+                        "detail": {
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                            "title": "Detail",
+                            "type": "array",
+                        }
+                    },
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                },
+                "ValidationError": {
+                    "properties": {
+                        "loc": {
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                            "title": "Location",
+                            "type": "array",
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                    "required": ["loc", "msg", "type"],
+                    "title": "ValidationError",
+                    "type": "object",
+                },
+            }
+        },
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "openapi": "3.0.2",
+        "paths": {
+            "/{repeated_alias}": {
+                "get": {
+                    "operationId": "get_parameters_with_repeated_aliases__repeated_alias__get",
+                    "parameters": [
+                        {
+                            "in": "path",
+                            "name": "repeated_alias",
+                            "required": True,
+                            "schema": {"title": "Repeated Alias", "type": "string"},
+                        },
+                        {
+                            "in": "query",
+                            "name": "repeated_alias",
+                            "required": True,
+                            "schema": {"title": "Repeated Alias", "type": "string"},
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "content": {"application/json": {"schema": {}}},
+                            "description": "Successful Response",
+                        },
+                        "422": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                            "description": "Validation Error",
+                        },
+                    },
+                    "summary": "Get Parameters With Repeated Aliases",
+                }
+            }
+        },
+    }

--- a/tests/test_reponse_set_reponse_code_empty.py
+++ b/tests/test_reponse_set_reponse_code_empty.py
@@ -22,77 +22,76 @@ async def delete_deployment(
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/{id}": {
-            "delete": {
-                "summary": "Delete Deployment",
-                "operationId": "delete_deployment__id__delete",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Id", "type": "integer"},
-                        "name": "id",
-                        "in": "path",
-                    }
-                ],
-                "responses": {
-                    "204": {"description": "Successful Response"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
+def test_dependency_set_status_code():
+    response = client.delete("/1")
+    assert response.status_code == 400 and response.content
+    assert response.json() == {"msg": "Status overwritten", "id": 1}
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_dependency_set_status_code():
-    response = client.delete("/1")
-    assert response.status_code == 400 and response.content
-    assert response.json() == {"msg": "Status overwritten", "id": 1}
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/{id}": {
+                "delete": {
+                    "summary": "Delete Deployment",
+                    "operationId": "delete_deployment__id__delete",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Id", "type": "integer"},
+                            "name": "id",
+                            "in": "path",
+                        }
+                    ],
+                    "responses": {
+                        "204": {"description": "Successful Response"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_response_by_alias.py
+++ b/tests/test_response_by_alias.py
@@ -68,196 +68,7 @@ def no_alias_list():
     return [{"name": "Foo"}, {"name": "Bar"}]
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/dict": {
-            "get": {
-                "summary": "Read Dict",
-                "operationId": "read_dict_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Model"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/model": {
-            "get": {
-                "summary": "Read Model",
-                "operationId": "read_model_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Model"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/list": {
-            "get": {
-                "summary": "Read List",
-                "operationId": "read_list_list_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read List List Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Model"},
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/by-alias/dict": {
-            "get": {
-                "summary": "By Alias Dict",
-                "operationId": "by_alias_dict_by_alias_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Model"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/by-alias/model": {
-            "get": {
-                "summary": "By Alias Model",
-                "operationId": "by_alias_model_by_alias_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Model"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/by-alias/list": {
-            "get": {
-                "summary": "By Alias List",
-                "operationId": "by_alias_list_by_alias_list_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response By Alias List By Alias List Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Model"},
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no-alias/dict": {
-            "get": {
-                "summary": "No Alias Dict",
-                "operationId": "no_alias_dict_no_alias_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/ModelNoAlias"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no-alias/model": {
-            "get": {
-                "summary": "No Alias Model",
-                "operationId": "no_alias_model_no_alias_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/ModelNoAlias"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no-alias/list": {
-            "get": {
-                "summary": "No Alias List",
-                "operationId": "no_alias_list_no_alias_list_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response No Alias List No Alias List Get",
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ModelNoAlias"
-                                    },
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Model": {
-                "title": "Model",
-                "required": ["alias"],
-                "type": "object",
-                "properties": {"alias": {"title": "Alias", "type": "string"}},
-            },
-            "ModelNoAlias": {
-                "title": "ModelNoAlias",
-                "required": ["name"],
-                "type": "object",
-                "properties": {"name": {"title": "Name", "type": "string"}},
-                "description": "response_model_by_alias=False is basically a quick hack, to support proper OpenAPI use another model with the correct field names",
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_read_dict():
@@ -321,3 +132,193 @@ def test_read_list_no_alias():
         {"name": "Foo"},
         {"name": "Bar"},
     ]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/dict": {
+                "get": {
+                    "summary": "Read Dict",
+                    "operationId": "read_dict_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Model"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/model": {
+                "get": {
+                    "summary": "Read Model",
+                    "operationId": "read_model_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Model"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/list": {
+                "get": {
+                    "summary": "Read List",
+                    "operationId": "read_list_list_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read List List Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Model"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/by-alias/dict": {
+                "get": {
+                    "summary": "By Alias Dict",
+                    "operationId": "by_alias_dict_by_alias_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Model"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/by-alias/model": {
+                "get": {
+                    "summary": "By Alias Model",
+                    "operationId": "by_alias_model_by_alias_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Model"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/by-alias/list": {
+                "get": {
+                    "summary": "By Alias List",
+                    "operationId": "by_alias_list_by_alias_list_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response By Alias List By Alias List Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Model"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no-alias/dict": {
+                "get": {
+                    "summary": "No Alias Dict",
+                    "operationId": "no_alias_dict_no_alias_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/ModelNoAlias"
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no-alias/model": {
+                "get": {
+                    "summary": "No Alias Model",
+                    "operationId": "no_alias_model_no_alias_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/ModelNoAlias"
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no-alias/list": {
+                "get": {
+                    "summary": "No Alias List",
+                    "operationId": "no_alias_list_no_alias_list_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response No Alias List No Alias List Get",
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/ModelNoAlias"
+                                        },
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Model": {
+                    "title": "Model",
+                    "required": ["alias"],
+                    "type": "object",
+                    "properties": {"alias": {"title": "Alias", "type": "string"}},
+                },
+                "ModelNoAlias": {
+                    "title": "ModelNoAlias",
+                    "required": ["name"],
+                    "type": "object",
+                    "properties": {"name": {"title": "Name", "type": "string"}},
+                    "description": "response_model_by_alias=False is basically a quick hack, to support proper OpenAPI use another model with the correct field names",
+                },
+            }
+        },
+    }

--- a/tests/test_response_class_no_mediatype.py
+++ b/tests/test_response_class_no_mediatype.py
@@ -35,80 +35,79 @@ async def b():
     pass  # pragma: no cover
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a": {
-            "get": {
-                "responses": {
-                    "500": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/JsonApiError"}
-                            }
-                        },
-                    },
-                    "200": {"description": "Successful Response"},
-                },
-                "summary": "A",
-                "operationId": "a_a_get",
-            }
-        },
-        "/b": {
-            "get": {
-                "responses": {
-                    "500": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Error"}
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "B",
-                "operationId": "b_b_get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Error": {
-                "title": "Error",
-                "required": ["status", "title"],
-                "type": "object",
-                "properties": {
-                    "status": {"title": "Status", "type": "string"},
-                    "title": {"title": "Title", "type": "string"},
-                },
-            },
-            "JsonApiError": {
-                "title": "JsonApiError",
-                "required": ["errors"],
-                "type": "object",
-                "properties": {
-                    "errors": {
-                        "title": "Errors",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Error"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a": {
+                "get": {
+                    "responses": {
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/JsonApiError"
+                                    }
+                                }
+                            },
+                        },
+                        "200": {"description": "Successful Response"},
+                    },
+                    "summary": "A",
+                    "operationId": "a_a_get",
+                }
+            },
+            "/b": {
+                "get": {
+                    "responses": {
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Error"}
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "B",
+                    "operationId": "b_b_get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Error": {
+                    "title": "Error",
+                    "required": ["status", "title"],
+                    "type": "object",
+                    "properties": {
+                        "status": {"title": "Status", "type": "string"},
+                        "title": {"title": "Title", "type": "string"},
+                    },
+                },
+                "JsonApiError": {
+                    "title": "JsonApiError",
+                    "required": ["errors"],
+                    "type": "object",
+                    "properties": {
+                        "errors": {
+                            "title": "Errors",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Error"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -36,76 +36,7 @@ async def b():
     pass  # pragma: no cover
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/a": {
-            "get": {
-                "responses": {
-                    "500": {
-                        "description": "Error",
-                        "content": {
-                            "application/vnd.api+json": {
-                                "schema": {"$ref": "#/components/schemas/JsonApiError"}
-                            }
-                        },
-                    },
-                    "204": {"description": "Successful Response"},
-                },
-                "summary": "A",
-                "operationId": "a_a_get",
-            }
-        },
-        "/b": {
-            "get": {
-                "responses": {
-                    "204": {"description": "No Content"},
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                },
-                "summary": "B",
-                "operationId": "b_b_get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Error": {
-                "title": "Error",
-                "required": ["status", "title"],
-                "type": "object",
-                "properties": {
-                    "status": {"title": "Status", "type": "string"},
-                    "title": {"title": "Title", "type": "string"},
-                },
-            },
-            "JsonApiError": {
-                "title": "JsonApiError",
-                "required": ["errors"],
-                "type": "object",
-                "properties": {
-                    "errors": {
-                        "title": "Errors",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Error"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_get_response():
@@ -113,3 +44,71 @@ def test_get_response():
     assert response.status_code == 204, response.text
     assert "content-length" not in response.headers
     assert response.content == b""
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/a": {
+                "get": {
+                    "responses": {
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/vnd.api+json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/JsonApiError"
+                                    }
+                                }
+                            },
+                        },
+                        "204": {"description": "Successful Response"},
+                    },
+                    "summary": "A",
+                    "operationId": "a_a_get",
+                }
+            },
+            "/b": {
+                "get": {
+                    "responses": {
+                        "204": {"description": "No Content"},
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                    },
+                    "summary": "B",
+                    "operationId": "b_b_get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Error": {
+                    "title": "Error",
+                    "required": ["status", "title"],
+                    "type": "object",
+                    "properties": {
+                        "status": {"title": "Status", "type": "string"},
+                        "title": {"title": "Title", "type": "string"},
+                    },
+                },
+                "JsonApiError": {
+                    "title": "JsonApiError",
+                    "required": ["errors"],
+                    "type": "object",
+                    "properties": {
+                        "errors": {
+                            "title": "Errors",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Error"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_response_model_as_return_annotation.py
+++ b/tests/test_response_model_as_return_annotation.py
@@ -249,615 +249,7 @@ def no_response_model_annotation_json_response_class() -> JSONResponse:
     return JSONResponse(content={"foo": "bar"})
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/no_response_model-no_annotation-return_model": {
-            "get": {
-                "summary": "No Response Model No Annotation Return Model",
-                "operationId": "no_response_model_no_annotation_return_model_no_response_model_no_annotation_return_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/no_response_model-no_annotation-return_dict": {
-            "get": {
-                "summary": "No Response Model No Annotation Return Dict",
-                "operationId": "no_response_model_no_annotation_return_dict_no_response_model_no_annotation_return_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/response_model-no_annotation-return_same_model": {
-            "get": {
-                "summary": "Response Model No Annotation Return Same Model",
-                "operationId": "response_model_no_annotation_return_same_model_response_model_no_annotation_return_same_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model-no_annotation-return_exact_dict": {
-            "get": {
-                "summary": "Response Model No Annotation Return Exact Dict",
-                "operationId": "response_model_no_annotation_return_exact_dict_response_model_no_annotation_return_exact_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model-no_annotation-return_invalid_dict": {
-            "get": {
-                "summary": "Response Model No Annotation Return Invalid Dict",
-                "operationId": "response_model_no_annotation_return_invalid_dict_response_model_no_annotation_return_invalid_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model-no_annotation-return_invalid_model": {
-            "get": {
-                "summary": "Response Model No Annotation Return Invalid Model",
-                "operationId": "response_model_no_annotation_return_invalid_model_response_model_no_annotation_return_invalid_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model-no_annotation-return_dict_with_extra_data": {
-            "get": {
-                "summary": "Response Model No Annotation Return Dict With Extra Data",
-                "operationId": "response_model_no_annotation_return_dict_with_extra_data_response_model_no_annotation_return_dict_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model-no_annotation-return_submodel_with_extra_data": {
-            "get": {
-                "summary": "Response Model No Annotation Return Submodel With Extra Data",
-                "operationId": "response_model_no_annotation_return_submodel_with_extra_data_response_model_no_annotation_return_submodel_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation-return_same_model": {
-            "get": {
-                "summary": "No Response Model Annotation Return Same Model",
-                "operationId": "no_response_model_annotation_return_same_model_no_response_model_annotation_return_same_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation-return_exact_dict": {
-            "get": {
-                "summary": "No Response Model Annotation Return Exact Dict",
-                "operationId": "no_response_model_annotation_return_exact_dict_no_response_model_annotation_return_exact_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation-return_invalid_dict": {
-            "get": {
-                "summary": "No Response Model Annotation Return Invalid Dict",
-                "operationId": "no_response_model_annotation_return_invalid_dict_no_response_model_annotation_return_invalid_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation-return_invalid_model": {
-            "get": {
-                "summary": "No Response Model Annotation Return Invalid Model",
-                "operationId": "no_response_model_annotation_return_invalid_model_no_response_model_annotation_return_invalid_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation-return_dict_with_extra_data": {
-            "get": {
-                "summary": "No Response Model Annotation Return Dict With Extra Data",
-                "operationId": "no_response_model_annotation_return_dict_with_extra_data_no_response_model_annotation_return_dict_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation-return_submodel_with_extra_data": {
-            "get": {
-                "summary": "No Response Model Annotation Return Submodel With Extra Data",
-                "operationId": "no_response_model_annotation_return_submodel_with_extra_data_no_response_model_annotation_return_submodel_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_none-annotation-return_same_model": {
-            "get": {
-                "summary": "Response Model None Annotation Return Same Model",
-                "operationId": "response_model_none_annotation_return_same_model_response_model_none_annotation_return_same_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/response_model_none-annotation-return_exact_dict": {
-            "get": {
-                "summary": "Response Model None Annotation Return Exact Dict",
-                "operationId": "response_model_none_annotation_return_exact_dict_response_model_none_annotation_return_exact_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/response_model_none-annotation-return_invalid_dict": {
-            "get": {
-                "summary": "Response Model None Annotation Return Invalid Dict",
-                "operationId": "response_model_none_annotation_return_invalid_dict_response_model_none_annotation_return_invalid_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/response_model_none-annotation-return_invalid_model": {
-            "get": {
-                "summary": "Response Model None Annotation Return Invalid Model",
-                "operationId": "response_model_none_annotation_return_invalid_model_response_model_none_annotation_return_invalid_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/response_model_none-annotation-return_dict_with_extra_data": {
-            "get": {
-                "summary": "Response Model None Annotation Return Dict With Extra Data",
-                "operationId": "response_model_none_annotation_return_dict_with_extra_data_response_model_none_annotation_return_dict_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/response_model_none-annotation-return_submodel_with_extra_data": {
-            "get": {
-                "summary": "Response Model None Annotation Return Submodel With Extra Data",
-                "operationId": "response_model_none_annotation_return_submodel_with_extra_data_response_model_none_annotation_return_submodel_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/response_model_model1-annotation_model2-return_same_model": {
-            "get": {
-                "summary": "Response Model Model1 Annotation Model2 Return Same Model",
-                "operationId": "response_model_model1_annotation_model2_return_same_model_response_model_model1_annotation_model2_return_same_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_model1-annotation_model2-return_exact_dict": {
-            "get": {
-                "summary": "Response Model Model1 Annotation Model2 Return Exact Dict",
-                "operationId": "response_model_model1_annotation_model2_return_exact_dict_response_model_model1_annotation_model2_return_exact_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_model1-annotation_model2-return_invalid_dict": {
-            "get": {
-                "summary": "Response Model Model1 Annotation Model2 Return Invalid Dict",
-                "operationId": "response_model_model1_annotation_model2_return_invalid_dict_response_model_model1_annotation_model2_return_invalid_dict_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_model1-annotation_model2-return_invalid_model": {
-            "get": {
-                "summary": "Response Model Model1 Annotation Model2 Return Invalid Model",
-                "operationId": "response_model_model1_annotation_model2_return_invalid_model_response_model_model1_annotation_model2_return_invalid_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_model1-annotation_model2-return_dict_with_extra_data": {
-            "get": {
-                "summary": "Response Model Model1 Annotation Model2 Return Dict With Extra Data",
-                "operationId": "response_model_model1_annotation_model2_return_dict_with_extra_data_response_model_model1_annotation_model2_return_dict_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_model1-annotation_model2-return_submodel_with_extra_data": {
-            "get": {
-                "summary": "Response Model Model1 Annotation Model2 Return Submodel With Extra Data",
-                "operationId": "response_model_model1_annotation_model2_return_submodel_with_extra_data_response_model_model1_annotation_model2_return_submodel_with_extra_data_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_filtering_model-annotation_submodel-return_submodel": {
-            "get": {
-                "summary": "Response Model Filtering Model Annotation Submodel Return Submodel",
-                "operationId": "response_model_filtering_model_annotation_submodel_return_submodel_response_model_filtering_model_annotation_submodel_return_submodel_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_list_of_model-no_annotation": {
-            "get": {
-                "summary": "Response Model List Of Model No Annotation",
-                "operationId": "response_model_list_of_model_no_annotation_response_model_list_of_model_no_annotation_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Response Model List Of Model No Annotation Response Model List Of Model No Annotation Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation_list_of_model": {
-            "get": {
-                "summary": "No Response Model Annotation List Of Model",
-                "operationId": "no_response_model_annotation_list_of_model_no_response_model_annotation_list_of_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response No Response Model Annotation List Of Model No Response Model Annotation List Of Model Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation_forward_ref_list_of_model": {
-            "get": {
-                "summary": "No Response Model Annotation Forward Ref List Of Model",
-                "operationId": "no_response_model_annotation_forward_ref_list_of_model_no_response_model_annotation_forward_ref_list_of_model_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response No Response Model Annotation Forward Ref List Of Model No Response Model Annotation Forward Ref List Of Model Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_union-no_annotation-return_model1": {
-            "get": {
-                "summary": "Response Model Union No Annotation Return Model1",
-                "operationId": "response_model_union_no_annotation_return_model1_response_model_union_no_annotation_return_model1_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Response Model Union No Annotation Return Model1 Response Model Union No Annotation Return Model1 Get",
-                                    "anyOf": [
-                                        {"$ref": "#/components/schemas/User"},
-                                        {"$ref": "#/components/schemas/Item"},
-                                    ],
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/response_model_union-no_annotation-return_model2": {
-            "get": {
-                "summary": "Response Model Union No Annotation Return Model2",
-                "operationId": "response_model_union_no_annotation_return_model2_response_model_union_no_annotation_return_model2_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Response Model Union No Annotation Return Model2 Response Model Union No Annotation Return Model2 Get",
-                                    "anyOf": [
-                                        {"$ref": "#/components/schemas/User"},
-                                        {"$ref": "#/components/schemas/Item"},
-                                    ],
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation_union-return_model1": {
-            "get": {
-                "summary": "No Response Model Annotation Union Return Model1",
-                "operationId": "no_response_model_annotation_union_return_model1_no_response_model_annotation_union_return_model1_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response No Response Model Annotation Union Return Model1 No Response Model Annotation Union Return Model1 Get",
-                                    "anyOf": [
-                                        {"$ref": "#/components/schemas/User"},
-                                        {"$ref": "#/components/schemas/Item"},
-                                    ],
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation_union-return_model2": {
-            "get": {
-                "summary": "No Response Model Annotation Union Return Model2",
-                "operationId": "no_response_model_annotation_union_return_model2_no_response_model_annotation_union_return_model2_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response No Response Model Annotation Union Return Model2 No Response Model Annotation Union Return Model2 Get",
-                                    "anyOf": [
-                                        {"$ref": "#/components/schemas/User"},
-                                        {"$ref": "#/components/schemas/Item"},
-                                    ],
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation_response_class": {
-            "get": {
-                "summary": "No Response Model Annotation Response Class",
-                "operationId": "no_response_model_annotation_response_class_no_response_model_annotation_response_class_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/no_response_model-annotation_json_response_class": {
-            "get": {
-                "summary": "No Response Model Annotation Json Response Class",
-                "operationId": "no_response_model_annotation_json_response_class_no_response_model_annotation_json_response_class_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["name", "surname"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "surname": {"title": "Surname", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
 client = TestClient(app)
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_no_response_model_no_annotation_return_model():
@@ -1109,3 +501,608 @@ def test_invalid_response_model_field():
 
     assert "valid Pydantic field type" in e.value.args[0]
     assert "parameter response_model=None" in e.value.args[0]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/no_response_model-no_annotation-return_model": {
+                "get": {
+                    "summary": "No Response Model No Annotation Return Model",
+                    "operationId": "no_response_model_no_annotation_return_model_no_response_model_no_annotation_return_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/no_response_model-no_annotation-return_dict": {
+                "get": {
+                    "summary": "No Response Model No Annotation Return Dict",
+                    "operationId": "no_response_model_no_annotation_return_dict_no_response_model_no_annotation_return_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/response_model-no_annotation-return_same_model": {
+                "get": {
+                    "summary": "Response Model No Annotation Return Same Model",
+                    "operationId": "response_model_no_annotation_return_same_model_response_model_no_annotation_return_same_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model-no_annotation-return_exact_dict": {
+                "get": {
+                    "summary": "Response Model No Annotation Return Exact Dict",
+                    "operationId": "response_model_no_annotation_return_exact_dict_response_model_no_annotation_return_exact_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model-no_annotation-return_invalid_dict": {
+                "get": {
+                    "summary": "Response Model No Annotation Return Invalid Dict",
+                    "operationId": "response_model_no_annotation_return_invalid_dict_response_model_no_annotation_return_invalid_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model-no_annotation-return_invalid_model": {
+                "get": {
+                    "summary": "Response Model No Annotation Return Invalid Model",
+                    "operationId": "response_model_no_annotation_return_invalid_model_response_model_no_annotation_return_invalid_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model-no_annotation-return_dict_with_extra_data": {
+                "get": {
+                    "summary": "Response Model No Annotation Return Dict With Extra Data",
+                    "operationId": "response_model_no_annotation_return_dict_with_extra_data_response_model_no_annotation_return_dict_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model-no_annotation-return_submodel_with_extra_data": {
+                "get": {
+                    "summary": "Response Model No Annotation Return Submodel With Extra Data",
+                    "operationId": "response_model_no_annotation_return_submodel_with_extra_data_response_model_no_annotation_return_submodel_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation-return_same_model": {
+                "get": {
+                    "summary": "No Response Model Annotation Return Same Model",
+                    "operationId": "no_response_model_annotation_return_same_model_no_response_model_annotation_return_same_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation-return_exact_dict": {
+                "get": {
+                    "summary": "No Response Model Annotation Return Exact Dict",
+                    "operationId": "no_response_model_annotation_return_exact_dict_no_response_model_annotation_return_exact_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation-return_invalid_dict": {
+                "get": {
+                    "summary": "No Response Model Annotation Return Invalid Dict",
+                    "operationId": "no_response_model_annotation_return_invalid_dict_no_response_model_annotation_return_invalid_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation-return_invalid_model": {
+                "get": {
+                    "summary": "No Response Model Annotation Return Invalid Model",
+                    "operationId": "no_response_model_annotation_return_invalid_model_no_response_model_annotation_return_invalid_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation-return_dict_with_extra_data": {
+                "get": {
+                    "summary": "No Response Model Annotation Return Dict With Extra Data",
+                    "operationId": "no_response_model_annotation_return_dict_with_extra_data_no_response_model_annotation_return_dict_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation-return_submodel_with_extra_data": {
+                "get": {
+                    "summary": "No Response Model Annotation Return Submodel With Extra Data",
+                    "operationId": "no_response_model_annotation_return_submodel_with_extra_data_no_response_model_annotation_return_submodel_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_none-annotation-return_same_model": {
+                "get": {
+                    "summary": "Response Model None Annotation Return Same Model",
+                    "operationId": "response_model_none_annotation_return_same_model_response_model_none_annotation_return_same_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/response_model_none-annotation-return_exact_dict": {
+                "get": {
+                    "summary": "Response Model None Annotation Return Exact Dict",
+                    "operationId": "response_model_none_annotation_return_exact_dict_response_model_none_annotation_return_exact_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/response_model_none-annotation-return_invalid_dict": {
+                "get": {
+                    "summary": "Response Model None Annotation Return Invalid Dict",
+                    "operationId": "response_model_none_annotation_return_invalid_dict_response_model_none_annotation_return_invalid_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/response_model_none-annotation-return_invalid_model": {
+                "get": {
+                    "summary": "Response Model None Annotation Return Invalid Model",
+                    "operationId": "response_model_none_annotation_return_invalid_model_response_model_none_annotation_return_invalid_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/response_model_none-annotation-return_dict_with_extra_data": {
+                "get": {
+                    "summary": "Response Model None Annotation Return Dict With Extra Data",
+                    "operationId": "response_model_none_annotation_return_dict_with_extra_data_response_model_none_annotation_return_dict_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/response_model_none-annotation-return_submodel_with_extra_data": {
+                "get": {
+                    "summary": "Response Model None Annotation Return Submodel With Extra Data",
+                    "operationId": "response_model_none_annotation_return_submodel_with_extra_data_response_model_none_annotation_return_submodel_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/response_model_model1-annotation_model2-return_same_model": {
+                "get": {
+                    "summary": "Response Model Model1 Annotation Model2 Return Same Model",
+                    "operationId": "response_model_model1_annotation_model2_return_same_model_response_model_model1_annotation_model2_return_same_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_model1-annotation_model2-return_exact_dict": {
+                "get": {
+                    "summary": "Response Model Model1 Annotation Model2 Return Exact Dict",
+                    "operationId": "response_model_model1_annotation_model2_return_exact_dict_response_model_model1_annotation_model2_return_exact_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_model1-annotation_model2-return_invalid_dict": {
+                "get": {
+                    "summary": "Response Model Model1 Annotation Model2 Return Invalid Dict",
+                    "operationId": "response_model_model1_annotation_model2_return_invalid_dict_response_model_model1_annotation_model2_return_invalid_dict_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_model1-annotation_model2-return_invalid_model": {
+                "get": {
+                    "summary": "Response Model Model1 Annotation Model2 Return Invalid Model",
+                    "operationId": "response_model_model1_annotation_model2_return_invalid_model_response_model_model1_annotation_model2_return_invalid_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_model1-annotation_model2-return_dict_with_extra_data": {
+                "get": {
+                    "summary": "Response Model Model1 Annotation Model2 Return Dict With Extra Data",
+                    "operationId": "response_model_model1_annotation_model2_return_dict_with_extra_data_response_model_model1_annotation_model2_return_dict_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_model1-annotation_model2-return_submodel_with_extra_data": {
+                "get": {
+                    "summary": "Response Model Model1 Annotation Model2 Return Submodel With Extra Data",
+                    "operationId": "response_model_model1_annotation_model2_return_submodel_with_extra_data_response_model_model1_annotation_model2_return_submodel_with_extra_data_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_filtering_model-annotation_submodel-return_submodel": {
+                "get": {
+                    "summary": "Response Model Filtering Model Annotation Submodel Return Submodel",
+                    "operationId": "response_model_filtering_model_annotation_submodel_return_submodel_response_model_filtering_model_annotation_submodel_return_submodel_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_list_of_model-no_annotation": {
+                "get": {
+                    "summary": "Response Model List Of Model No Annotation",
+                    "operationId": "response_model_list_of_model_no_annotation_response_model_list_of_model_no_annotation_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Response Model List Of Model No Annotation Response Model List Of Model No Annotation Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation_list_of_model": {
+                "get": {
+                    "summary": "No Response Model Annotation List Of Model",
+                    "operationId": "no_response_model_annotation_list_of_model_no_response_model_annotation_list_of_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response No Response Model Annotation List Of Model No Response Model Annotation List Of Model Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation_forward_ref_list_of_model": {
+                "get": {
+                    "summary": "No Response Model Annotation Forward Ref List Of Model",
+                    "operationId": "no_response_model_annotation_forward_ref_list_of_model_no_response_model_annotation_forward_ref_list_of_model_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response No Response Model Annotation Forward Ref List Of Model No Response Model Annotation Forward Ref List Of Model Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_union-no_annotation-return_model1": {
+                "get": {
+                    "summary": "Response Model Union No Annotation Return Model1",
+                    "operationId": "response_model_union_no_annotation_return_model1_response_model_union_no_annotation_return_model1_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Response Model Union No Annotation Return Model1 Response Model Union No Annotation Return Model1 Get",
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/User"},
+                                            {"$ref": "#/components/schemas/Item"},
+                                        ],
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/response_model_union-no_annotation-return_model2": {
+                "get": {
+                    "summary": "Response Model Union No Annotation Return Model2",
+                    "operationId": "response_model_union_no_annotation_return_model2_response_model_union_no_annotation_return_model2_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Response Model Union No Annotation Return Model2 Response Model Union No Annotation Return Model2 Get",
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/User"},
+                                            {"$ref": "#/components/schemas/Item"},
+                                        ],
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation_union-return_model1": {
+                "get": {
+                    "summary": "No Response Model Annotation Union Return Model1",
+                    "operationId": "no_response_model_annotation_union_return_model1_no_response_model_annotation_union_return_model1_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response No Response Model Annotation Union Return Model1 No Response Model Annotation Union Return Model1 Get",
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/User"},
+                                            {"$ref": "#/components/schemas/Item"},
+                                        ],
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation_union-return_model2": {
+                "get": {
+                    "summary": "No Response Model Annotation Union Return Model2",
+                    "operationId": "no_response_model_annotation_union_return_model2_no_response_model_annotation_union_return_model2_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response No Response Model Annotation Union Return Model2 No Response Model Annotation Union Return Model2 Get",
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/User"},
+                                            {"$ref": "#/components/schemas/Item"},
+                                        ],
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation_response_class": {
+                "get": {
+                    "summary": "No Response Model Annotation Response Class",
+                    "operationId": "no_response_model_annotation_response_class_no_response_model_annotation_response_class_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/no_response_model-annotation_json_response_class": {
+                "get": {
+                    "summary": "No Response Model Annotation Json Response Class",
+                    "operationId": "no_response_model_annotation_json_response_class_no_response_model_annotation_json_response_class_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["name", "surname"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "surname": {"title": "Surname", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_response_model_sub_types.py
+++ b/tests/test_response_model_sub_types.py
@@ -32,121 +32,7 @@ def valid4():
     pass
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/valid1": {
-            "get": {
-                "summary": "Valid1",
-                "operationId": "valid1_valid1_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response 500 Valid1 Valid1 Get",
-                                    "type": "integer",
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/valid2": {
-            "get": {
-                "summary": "Valid2",
-                "operationId": "valid2_valid2_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response 500 Valid2 Valid2 Get",
-                                    "type": "array",
-                                    "items": {"type": "integer"},
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/valid3": {
-            "get": {
-                "summary": "Valid3",
-                "operationId": "valid3_valid3_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Model"}
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/valid4": {
-            "get": {
-                "summary": "Valid4",
-                "operationId": "valid4_valid4_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response 500 Valid4 Valid4 Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Model"},
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Model": {
-                "title": "Model",
-                "required": ["name"],
-                "type": "object",
-                "properties": {"name": {"title": "Name", "type": "string"}},
-            }
-        }
-    },
-}
-
 client = TestClient(app)
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_path_operations():
@@ -158,3 +44,115 @@ def test_path_operations():
     assert response.status_code == 200, response.text
     response = client.get("/valid4")
     assert response.status_code == 200, response.text
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/valid1": {
+                "get": {
+                    "summary": "Valid1",
+                    "operationId": "valid1_valid1_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "500": {
+                            "description": "Internal Server Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response 500 Valid1 Valid1 Get",
+                                        "type": "integer",
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/valid2": {
+                "get": {
+                    "summary": "Valid2",
+                    "operationId": "valid2_valid2_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "500": {
+                            "description": "Internal Server Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response 500 Valid2 Valid2 Get",
+                                        "type": "array",
+                                        "items": {"type": "integer"},
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/valid3": {
+                "get": {
+                    "summary": "Valid3",
+                    "operationId": "valid3_valid3_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "500": {
+                            "description": "Internal Server Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Model"}
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/valid4": {
+                "get": {
+                    "summary": "Valid4",
+                    "operationId": "valid4_valid4_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "500": {
+                            "description": "Internal Server Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response 500 Valid4 Valid4 Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Model"},
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Model": {
+                    "title": "Model",
+                    "required": ["name"],
+                    "type": "object",
+                    "properties": {"name": {"title": "Name", "type": "string"}},
+                }
+            }
+        },
+    }

--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -234,623 +234,6 @@ def cookie_example_examples(
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/schema_extra/": {
-            "post": {
-                "summary": "Schema Extra",
-                "operationId": "schema_extra_schema_extra__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/example/": {
-            "post": {
-                "summary": "Example",
-                "operationId": "example_example__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "example": {"data": "Data in Body example"},
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/examples/": {
-            "post": {
-                "summary": "Examples",
-                "operationId": "examples_examples__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "examples": {
-                                "example1": {
-                                    "summary": "example1 summary",
-                                    "value": {
-                                        "data": "Data in Body examples, example1"
-                                    },
-                                },
-                                "example2": {
-                                    "value": {"data": "Data in Body examples, example2"}
-                                },
-                            },
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/example_examples/": {
-            "post": {
-                "summary": "Example Examples",
-                "operationId": "example_examples_example_examples__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "examples": {
-                                "example1": {
-                                    "value": {"data": "examples example_examples 1"}
-                                },
-                                "example2": {
-                                    "value": {"data": "examples example_examples 2"}
-                                },
-                            },
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/path_example/{item_id}": {
-            "get": {
-                "summary": "Path Example",
-                "operationId": "path_example_path_example__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "example": "item_1",
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/path_examples/{item_id}": {
-            "get": {
-                "summary": "Path Examples",
-                "operationId": "path_examples_path_examples__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "item ID summary",
-                                "value": "item_1",
-                            },
-                            "example2": {"value": "item_2"},
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/path_example_examples/{item_id}": {
-            "get": {
-                "summary": "Path Example Examples",
-                "operationId": "path_example_examples_path_example_examples__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "item ID summary",
-                                "value": "item_1",
-                            },
-                            "example2": {"value": "item_2"},
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/query_example/": {
-            "get": {
-                "summary": "Query Example",
-                "operationId": "query_example_query_example__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "example": "query1",
-                        "name": "data",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/query_examples/": {
-            "get": {
-                "summary": "Query Examples",
-                "operationId": "query_examples_query_examples__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "Query example 1",
-                                "value": "query1",
-                            },
-                            "example2": {"value": "query2"},
-                        },
-                        "name": "data",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/query_example_examples/": {
-            "get": {
-                "summary": "Query Example Examples",
-                "operationId": "query_example_examples_query_example_examples__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "Query example 1",
-                                "value": "query1",
-                            },
-                            "example2": {"value": "query2"},
-                        },
-                        "name": "data",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/header_example/": {
-            "get": {
-                "summary": "Header Example",
-                "operationId": "header_example_header_example__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "example": "header1",
-                        "name": "data",
-                        "in": "header",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/header_examples/": {
-            "get": {
-                "summary": "Header Examples",
-                "operationId": "header_examples_header_examples__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "header example 1",
-                                "value": "header1",
-                            },
-                            "example2": {"value": "header2"},
-                        },
-                        "name": "data",
-                        "in": "header",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/header_example_examples/": {
-            "get": {
-                "summary": "Header Example Examples",
-                "operationId": "header_example_examples_header_example_examples__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "Query example 1",
-                                "value": "header1",
-                            },
-                            "example2": {"value": "header2"},
-                        },
-                        "name": "data",
-                        "in": "header",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/cookie_example/": {
-            "get": {
-                "summary": "Cookie Example",
-                "operationId": "cookie_example_cookie_example__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "example": "cookie1",
-                        "name": "data",
-                        "in": "cookie",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/cookie_examples/": {
-            "get": {
-                "summary": "Cookie Examples",
-                "operationId": "cookie_examples_cookie_examples__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "cookie example 1",
-                                "value": "cookie1",
-                            },
-                            "example2": {"value": "cookie2"},
-                        },
-                        "name": "data",
-                        "in": "cookie",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/cookie_example_examples/": {
-            "get": {
-                "summary": "Cookie Example Examples",
-                "operationId": "cookie_example_examples_cookie_example_examples__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Data", "type": "string"},
-                        "examples": {
-                            "example1": {
-                                "summary": "Query example 1",
-                                "value": "cookie1",
-                            },
-                            "example2": {"value": "cookie2"},
-                        },
-                        "name": "data",
-                        "in": "cookie",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["data"],
-                "type": "object",
-                "properties": {"data": {"title": "Data", "type": "string"}},
-                "example": {"data": "Data in schema_extra"},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    """
-    Test that example overrides work:
-
-    * pydantic model schema_extra is included
-    * Body(example={}) overrides schema_extra in pydantic model
-    * Body(examples{}) overrides Body(example={}) and schema_extra in pydantic model
-    """
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_call_api():
     response = client.post("/schema_extra/", json={"data": "Foo"})
     assert response.status_code == 200, response.text
@@ -884,3 +267,621 @@ def test_call_api():
     assert response.status_code == 200, response.text
     response = client.get("/cookie_example_examples/")
     assert response.status_code == 200, response.text
+
+
+def test_openapi_schema():
+    """
+    Test that example overrides work:
+
+    * pydantic model schema_extra is included
+    * Body(example={}) overrides schema_extra in pydantic model
+    * Body(examples{}) overrides Body(example={}) and schema_extra in pydantic model
+    """
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/schema_extra/": {
+                "post": {
+                    "summary": "Schema Extra",
+                    "operationId": "schema_extra_schema_extra__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/example/": {
+                "post": {
+                    "summary": "Example",
+                    "operationId": "example_example__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "example": {"data": "Data in Body example"},
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/examples/": {
+                "post": {
+                    "summary": "Examples",
+                    "operationId": "examples_examples__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "examples": {
+                                    "example1": {
+                                        "summary": "example1 summary",
+                                        "value": {
+                                            "data": "Data in Body examples, example1"
+                                        },
+                                    },
+                                    "example2": {
+                                        "value": {
+                                            "data": "Data in Body examples, example2"
+                                        }
+                                    },
+                                },
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/example_examples/": {
+                "post": {
+                    "summary": "Example Examples",
+                    "operationId": "example_examples_example_examples__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "examples": {
+                                    "example1": {
+                                        "value": {"data": "examples example_examples 1"}
+                                    },
+                                    "example2": {
+                                        "value": {"data": "examples example_examples 2"}
+                                    },
+                                },
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/path_example/{item_id}": {
+                "get": {
+                    "summary": "Path Example",
+                    "operationId": "path_example_path_example__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "example": "item_1",
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/path_examples/{item_id}": {
+                "get": {
+                    "summary": "Path Examples",
+                    "operationId": "path_examples_path_examples__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "item ID summary",
+                                    "value": "item_1",
+                                },
+                                "example2": {"value": "item_2"},
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/path_example_examples/{item_id}": {
+                "get": {
+                    "summary": "Path Example Examples",
+                    "operationId": "path_example_examples_path_example_examples__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "item ID summary",
+                                    "value": "item_1",
+                                },
+                                "example2": {"value": "item_2"},
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/query_example/": {
+                "get": {
+                    "summary": "Query Example",
+                    "operationId": "query_example_query_example__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "example": "query1",
+                            "name": "data",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/query_examples/": {
+                "get": {
+                    "summary": "Query Examples",
+                    "operationId": "query_examples_query_examples__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "Query example 1",
+                                    "value": "query1",
+                                },
+                                "example2": {"value": "query2"},
+                            },
+                            "name": "data",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/query_example_examples/": {
+                "get": {
+                    "summary": "Query Example Examples",
+                    "operationId": "query_example_examples_query_example_examples__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "Query example 1",
+                                    "value": "query1",
+                                },
+                                "example2": {"value": "query2"},
+                            },
+                            "name": "data",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/header_example/": {
+                "get": {
+                    "summary": "Header Example",
+                    "operationId": "header_example_header_example__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "example": "header1",
+                            "name": "data",
+                            "in": "header",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/header_examples/": {
+                "get": {
+                    "summary": "Header Examples",
+                    "operationId": "header_examples_header_examples__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "header example 1",
+                                    "value": "header1",
+                                },
+                                "example2": {"value": "header2"},
+                            },
+                            "name": "data",
+                            "in": "header",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/header_example_examples/": {
+                "get": {
+                    "summary": "Header Example Examples",
+                    "operationId": "header_example_examples_header_example_examples__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "Query example 1",
+                                    "value": "header1",
+                                },
+                                "example2": {"value": "header2"},
+                            },
+                            "name": "data",
+                            "in": "header",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/cookie_example/": {
+                "get": {
+                    "summary": "Cookie Example",
+                    "operationId": "cookie_example_cookie_example__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "example": "cookie1",
+                            "name": "data",
+                            "in": "cookie",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/cookie_examples/": {
+                "get": {
+                    "summary": "Cookie Examples",
+                    "operationId": "cookie_examples_cookie_examples__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "cookie example 1",
+                                    "value": "cookie1",
+                                },
+                                "example2": {"value": "cookie2"},
+                            },
+                            "name": "data",
+                            "in": "cookie",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/cookie_example_examples/": {
+                "get": {
+                    "summary": "Cookie Example Examples",
+                    "operationId": "cookie_example_examples_cookie_example_examples__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Data", "type": "string"},
+                            "examples": {
+                                "example1": {
+                                    "summary": "Query example 1",
+                                    "value": "cookie1",
+                                },
+                                "example2": {"value": "cookie2"},
+                            },
+                            "name": "data",
+                            "in": "cookie",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["data"],
+                    "type": "object",
+                    "properties": {"data": {"title": "Data", "type": "string"}},
+                    "example": {"data": "Data in schema_extra"},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_security_api_key_cookie.py
+++ b/tests/test_security_api_key_cookie.py
@@ -22,39 +22,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
     return current_user
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyCookie": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyCookie": {"type": "apiKey", "name": "key", "in": "cookie"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    client = TestClient(app)
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_security_api_key():
     client = TestClient(app, cookies={"key": "secret"})
     response = client.get("/users/me")
@@ -67,3 +34,33 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyCookie": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyCookie": {"type": "apiKey", "name": "key", "in": "cookie"}
+            }
+        },
+    }

--- a/tests/test_security_api_key_cookie_description.py
+++ b/tests/test_security_api_key_cookie_description.py
@@ -22,44 +22,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
     return current_user
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyCookie": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyCookie": {
-                "type": "apiKey",
-                "name": "key",
-                "in": "cookie",
-                "description": "An API Cookie Key",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    client = TestClient(app)
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_security_api_key():
     client = TestClient(app, cookies={"key": "secret"})
     response = client.get("/users/me")
@@ -72,3 +34,38 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyCookie": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyCookie": {
+                    "type": "apiKey",
+                    "name": "key",
+                    "in": "cookie",
+                    "description": "An API Cookie Key",
+                }
+            }
+        },
+    }

--- a/tests/test_security_api_key_cookie_optional.py
+++ b/tests/test_security_api_key_cookie_optional.py
@@ -29,39 +29,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
         return current_user
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyCookie": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyCookie": {"type": "apiKey", "name": "key", "in": "cookie"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    client = TestClient(app)
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_security_api_key():
     client = TestClient(app, cookies={"key": "secret"})
     response = client.get("/users/me")
@@ -74,3 +41,33 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyCookie": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyCookie": {"type": "apiKey", "name": "key", "in": "cookie"}
+            }
+        },
+    }

--- a/tests/test_security_api_key_header.py
+++ b/tests/test_security_api_key_header.py
@@ -24,37 +24,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyHeader": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyHeader": {"type": "apiKey", "name": "key", "in": "header"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_api_key():
     response = client.get("/users/me", headers={"key": "secret"})
@@ -66,3 +35,32 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyHeader": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyHeader": {"type": "apiKey", "name": "key", "in": "header"}
+            }
+        },
+    }

--- a/tests/test_security_api_key_header_description.py
+++ b/tests/test_security_api_key_header_description.py
@@ -24,42 +24,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyHeader": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyHeader": {
-                "type": "apiKey",
-                "name": "key",
-                "in": "header",
-                "description": "An API Key Header",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_api_key():
     response = client.get("/users/me", headers={"key": "secret"})
@@ -71,3 +35,37 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyHeader": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyHeader": {
+                    "type": "apiKey",
+                    "name": "key",
+                    "in": "header",
+                    "description": "An API Key Header",
+                }
+            }
+        },
+    }

--- a/tests/test_security_api_key_header_optional.py
+++ b/tests/test_security_api_key_header_optional.py
@@ -30,37 +30,6 @@ def read_current_user(current_user: Optional[User] = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyHeader": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyHeader": {"type": "apiKey", "name": "key", "in": "header"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_api_key():
     response = client.get("/users/me", headers={"key": "secret"})
@@ -72,3 +41,32 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyHeader": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyHeader": {"type": "apiKey", "name": "key", "in": "header"}
+            }
+        },
+    }

--- a/tests/test_security_api_key_query.py
+++ b/tests/test_security_api_key_query.py
@@ -24,37 +24,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyQuery": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyQuery": {"type": "apiKey", "name": "key", "in": "query"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_api_key():
     response = client.get("/users/me?key=secret")
@@ -66,3 +35,32 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyQuery": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyQuery": {"type": "apiKey", "name": "key", "in": "query"}
+            }
+        },
+    }

--- a/tests/test_security_api_key_query_description.py
+++ b/tests/test_security_api_key_query_description.py
@@ -24,42 +24,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyQuery": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyQuery": {
-                "type": "apiKey",
-                "name": "key",
-                "in": "query",
-                "description": "API Key Query",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_api_key():
     response = client.get("/users/me?key=secret")
@@ -71,3 +35,37 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyQuery": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyQuery": {
+                    "type": "apiKey",
+                    "name": "key",
+                    "in": "query",
+                    "description": "API Key Query",
+                }
+            }
+        },
+    }

--- a/tests/test_security_api_key_query_optional.py
+++ b/tests/test_security_api_key_query_optional.py
@@ -30,37 +30,6 @@ def read_current_user(current_user: Optional[User] = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"APIKeyQuery": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "APIKeyQuery": {"type": "apiKey", "name": "key", "in": "query"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_api_key():
     response = client.get("/users/me?key=secret")
@@ -72,3 +41,32 @@ def test_security_api_key_no_key():
     response = client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"APIKeyQuery": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "APIKeyQuery": {"type": "apiKey", "name": "key", "in": "query"}
+            }
+        },
+    }

--- a/tests/test_security_http_base.py
+++ b/tests/test_security_http_base.py
@@ -14,35 +14,6 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBase": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBase": {"type": "http", "scheme": "Other"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_base():
     response = client.get("/users/me", headers={"Authorization": "Other foobar"})
@@ -54,3 +25,30 @@ def test_security_http_base_no_credentials():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBase": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBase": {"type": "http", "scheme": "Other"}}
+        },
+    }

--- a/tests/test_security_http_base_description.py
+++ b/tests/test_security_http_base_description.py
@@ -14,41 +14,6 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBase": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "HTTPBase": {
-                "type": "http",
-                "scheme": "Other",
-                "description": "Other Security Scheme",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_base():
     response = client.get("/users/me", headers={"Authorization": "Other foobar"})
@@ -60,3 +25,36 @@ def test_security_http_base_no_credentials():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBase": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "HTTPBase": {
+                    "type": "http",
+                    "scheme": "Other",
+                    "description": "Other Security Scheme",
+                }
+            }
+        },
+    }

--- a/tests/test_security_http_base_optional.py
+++ b/tests/test_security_http_base_optional.py
@@ -20,35 +20,6 @@ def read_current_user(
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBase": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBase": {"type": "http", "scheme": "Other"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_base():
     response = client.get("/users/me", headers={"Authorization": "Other foobar"})
@@ -60,3 +31,30 @@ def test_security_http_base_no_credentials():
     response = client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBase": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBase": {"type": "http", "scheme": "Other"}}
+        },
+    }

--- a/tests/test_security_http_basic_optional.py
+++ b/tests/test_security_http_basic_optional.py
@@ -19,35 +19,6 @@ def read_current_user(credentials: Optional[HTTPBasicCredentials] = Security(sec
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBasic": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_basic():
     response = client.get("/users/me", auth=("john", "secret"))
@@ -77,3 +48,30 @@ def test_security_http_basic_non_basic_credentials():
     assert response.status_code == 401, response.text
     assert response.headers["WWW-Authenticate"] == "Basic"
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBasic": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
+        },
+    }

--- a/tests/test_security_http_basic_realm.py
+++ b/tests/test_security_http_basic_realm.py
@@ -16,35 +16,6 @@ def read_current_user(credentials: HTTPBasicCredentials = Security(security)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBasic": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_basic():
     response = client.get("/users/me", auth=("john", "secret"))
@@ -75,3 +46,30 @@ def test_security_http_basic_non_basic_credentials():
     assert response.status_code == 401, response.text
     assert response.headers["WWW-Authenticate"] == 'Basic realm="simple"'
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBasic": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
+        },
+    }

--- a/tests/test_security_http_basic_realm_description.py
+++ b/tests/test_security_http_basic_realm_description.py
@@ -16,41 +16,6 @@ def read_current_user(credentials: HTTPBasicCredentials = Security(security)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBasic": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "HTTPBasic": {
-                "type": "http",
-                "scheme": "basic",
-                "description": "HTTPBasic scheme",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_basic():
     response = client.get("/users/me", auth=("john", "secret"))
@@ -81,3 +46,36 @@ def test_security_http_basic_non_basic_credentials():
     assert response.status_code == 401, response.text
     assert response.headers["WWW-Authenticate"] == 'Basic realm="simple"'
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBasic": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "HTTPBasic": {
+                    "type": "http",
+                    "scheme": "basic",
+                    "description": "HTTPBasic scheme",
+                }
+            }
+        },
+    }

--- a/tests/test_security_http_bearer.py
+++ b/tests/test_security_http_bearer.py
@@ -14,35 +14,6 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBearer": {"type": "http", "scheme": "bearer"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_bearer():
     response = client.get("/users/me", headers={"Authorization": "Bearer foobar"})
@@ -60,3 +31,30 @@ def test_security_http_bearer_incorrect_scheme_credentials():
     response = client.get("/users/me", headers={"Authorization": "Basic notreally"})
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBearer": {"type": "http", "scheme": "bearer"}}
+        },
+    }

--- a/tests/test_security_http_bearer_description.py
+++ b/tests/test_security_http_bearer_description.py
@@ -14,41 +14,6 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "HTTPBearer": {
-                "type": "http",
-                "scheme": "bearer",
-                "description": "HTTP Bearer token scheme",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_bearer():
     response = client.get("/users/me", headers={"Authorization": "Bearer foobar"})
@@ -66,3 +31,36 @@ def test_security_http_bearer_incorrect_scheme_credentials():
     response = client.get("/users/me", headers={"Authorization": "Basic notreally"})
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "HTTPBearer": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "description": "HTTP Bearer token scheme",
+                }
+            }
+        },
+    }

--- a/tests/test_security_http_bearer_optional.py
+++ b/tests/test_security_http_bearer_optional.py
@@ -20,35 +20,6 @@ def read_current_user(
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBearer": {"type": "http", "scheme": "bearer"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_bearer():
     response = client.get("/users/me", headers={"Authorization": "Bearer foobar"})
@@ -66,3 +37,30 @@ def test_security_http_bearer_incorrect_scheme_credentials():
     response = client.get("/users/me", headers={"Authorization": "Basic notreally"})
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBearer": {"type": "http", "scheme": "bearer"}}
+        },
+    }

--- a/tests/test_security_http_digest.py
+++ b/tests/test_security_http_digest.py
@@ -14,35 +14,6 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPDigest": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPDigest": {"type": "http", "scheme": "digest"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_digest():
     response = client.get("/users/me", headers={"Authorization": "Digest foobar"})
@@ -62,3 +33,30 @@ def test_security_http_digest_incorrect_scheme_credentials():
     )
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPDigest": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPDigest": {"type": "http", "scheme": "digest"}}
+        },
+    }

--- a/tests/test_security_http_digest_description.py
+++ b/tests/test_security_http_digest_description.py
@@ -14,41 +14,6 @@ def read_current_user(credentials: HTTPAuthorizationCredentials = Security(secur
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPDigest": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "HTTPDigest": {
-                "type": "http",
-                "scheme": "digest",
-                "description": "HTTPDigest scheme",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_digest():
     response = client.get("/users/me", headers={"Authorization": "Digest foobar"})
@@ -68,3 +33,36 @@ def test_security_http_digest_incorrect_scheme_credentials():
     )
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPDigest": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "HTTPDigest": {
+                    "type": "http",
+                    "scheme": "digest",
+                    "description": "HTTPDigest scheme",
+                }
+            }
+        },
+    }

--- a/tests/test_security_http_digest_optional.py
+++ b/tests/test_security_http_digest_optional.py
@@ -20,35 +20,6 @@ def read_current_user(
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPDigest": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPDigest": {"type": "http", "scheme": "digest"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_digest():
     response = client.get("/users/me", headers={"Authorization": "Digest foobar"})
@@ -68,3 +39,30 @@ def test_security_http_digest_incorrect_scheme_credentials():
     )
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPDigest": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPDigest": {"type": "http", "scheme": "digest"}}
+        },
+    }

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -40,124 +40,6 @@ def read_current_user(current_user: "User" = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/login": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_login_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_login_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"OAuth2": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_login_post": {
-                "title": "Body_login_login_post",
-                "required": ["grant_type", "username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "read:users": "Read the users",
-                            "write:users": "Create users",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_oauth2():
     response = client.get("/users/me", headers={"Authorization": "Bearer footokenbar"})
@@ -247,3 +129,121 @@ def test_strict_login(data, expected_status, expected_response):
     response = client.post("/login", data=data)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/login": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_login_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_login_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"OAuth2": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_login_post": {
+                    "title": "Body_login_login_post",
+                    "required": ["grant_type", "username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "read:users": "Read the users",
+                                "write:users": "Create users",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_security_oauth2_authorization_code_bearer.py
+++ b/tests/test_security_oauth2_authorization_code_bearer.py
@@ -18,46 +18,6 @@ async def read_items(token: Optional[str] = Security(oauth2_scheme)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "security": [{"OAuth2AuthorizationCodeBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OAuth2AuthorizationCodeBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "authorizationCode": {
-                        "authorizationUrl": "authorize",
-                        "tokenUrl": "token",
-                        "scopes": {},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_no_token():
     response = client.get("/items")
@@ -75,3 +35,41 @@ def test_token():
     response = client.get("/items", headers={"Authorization": "Bearer testtoken"})
     assert response.status_code == 200, response.text
     assert response.json() == {"token": "testtoken"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "security": [{"OAuth2AuthorizationCodeBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OAuth2AuthorizationCodeBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "authorizationCode": {
+                            "authorizationUrl": "authorize",
+                            "tokenUrl": "token",
+                            "scopes": {},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_security_oauth2_authorization_code_bearer_description.py
+++ b/tests/test_security_oauth2_authorization_code_bearer_description.py
@@ -21,47 +21,6 @@ async def read_items(token: Optional[str] = Security(oauth2_scheme)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "security": [{"OAuth2AuthorizationCodeBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OAuth2AuthorizationCodeBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "authorizationCode": {
-                        "authorizationUrl": "authorize",
-                        "tokenUrl": "token",
-                        "scopes": {},
-                    }
-                },
-                "description": "OAuth2 Code Bearer",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_no_token():
     response = client.get("/items")
@@ -79,3 +38,42 @@ def test_token():
     response = client.get("/items", headers={"Authorization": "Bearer testtoken"})
     assert response.status_code == 200, response.text
     assert response.json() == {"token": "testtoken"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "security": [{"OAuth2AuthorizationCodeBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OAuth2AuthorizationCodeBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "authorizationCode": {
+                            "authorizationUrl": "authorize",
+                            "tokenUrl": "token",
+                            "scopes": {},
+                        }
+                    },
+                    "description": "OAuth2 Code Bearer",
+                }
+            }
+        },
+    }

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -44,124 +44,6 @@ def read_users_me(current_user: Optional[User] = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/login": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_login_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_login_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me_get",
-                "security": [{"OAuth2": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_login_post": {
-                "title": "Body_login_login_post",
-                "required": ["grant_type", "username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "read:users": "Read the users",
-                            "write:users": "Create users",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_oauth2():
     response = client.get("/users/me", headers={"Authorization": "Bearer footokenbar"})
@@ -251,3 +133,121 @@ def test_strict_login(data, expected_status, expected_response):
     response = client.post("/login", data=data)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/login": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_login_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_login_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me_get",
+                    "security": [{"OAuth2": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_login_post": {
+                    "title": "Body_login_login_post",
+                    "required": ["grant_type", "username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "read:users": "Read the users",
+                                "write:users": "Create users",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_security_oauth2_optional_description.py
+++ b/tests/test_security_oauth2_optional_description.py
@@ -45,125 +45,6 @@ def read_users_me(current_user: Optional[User] = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/login": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_login_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_login_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me_get",
-                "security": [{"OAuth2": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_login_post": {
-                "title": "Body_login_login_post",
-                "required": ["grant_type", "username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "read:users": "Read the users",
-                            "write:users": "Create users",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-                "description": "OAuth2 security scheme",
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_oauth2():
     response = client.get("/users/me", headers={"Authorization": "Bearer footokenbar"})
@@ -253,3 +134,122 @@ def test_strict_login(data, expected_status, expected_response):
     response = client.post("/login", data=data)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/login": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_login_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_login_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me_get",
+                    "security": [{"OAuth2": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_login_post": {
+                    "title": "Body_login_login_post",
+                    "required": ["grant_type", "username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "read:users": "Read the users",
+                                "write:users": "Create users",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                    "description": "OAuth2 security scheme",
+                }
+            },
+        },
+    }

--- a/tests/test_security_oauth2_password_bearer_optional.py
+++ b/tests/test_security_oauth2_password_bearer_optional.py
@@ -18,40 +18,6 @@ async def read_items(token: Optional[str] = Security(oauth2_scheme)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "/token"}},
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_no_token():
     response = client.get("/items")
@@ -69,3 +35,35 @@ def test_incorrect_token():
     response = client.get("/items", headers={"Authorization": "Notexistent testtoken"})
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "/token"}},
+                }
+            }
+        },
+    }

--- a/tests/test_security_oauth2_password_bearer_optional_description.py
+++ b/tests/test_security_oauth2_password_bearer_optional_description.py
@@ -22,41 +22,6 @@ async def read_items(token: Optional[str] = Security(oauth2_scheme)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "/token"}},
-                "description": "OAuth2PasswordBearer security scheme",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_no_token():
     response = client.get("/items")
@@ -74,3 +39,36 @@ def test_incorrect_token():
     response = client.get("/items", headers={"Authorization": "Notexistent testtoken"})
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "/token"}},
+                    "description": "OAuth2PasswordBearer security scheme",
+                }
+            }
+        },
+    }

--- a/tests/test_security_openid_connect.py
+++ b/tests/test_security_openid_connect.py
@@ -24,37 +24,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"OpenIdConnect": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OpenIdConnect": {"type": "openIdConnect", "openIdConnectUrl": "/openid"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_oauth2():
     response = client.get("/users/me", headers={"Authorization": "Bearer footokenbar"})
@@ -72,3 +41,35 @@ def test_security_oauth2_password_bearer_no_header():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"OpenIdConnect": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OpenIdConnect": {
+                    "type": "openIdConnect",
+                    "openIdConnectUrl": "/openid",
+                }
+            }
+        },
+    }

--- a/tests/test_security_openid_connect_description.py
+++ b/tests/test_security_openid_connect_description.py
@@ -26,41 +26,6 @@ def read_current_user(current_user: User = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"OpenIdConnect": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OpenIdConnect": {
-                "type": "openIdConnect",
-                "openIdConnectUrl": "/openid",
-                "description": "OpenIdConnect security scheme",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_oauth2():
     response = client.get("/users/me", headers={"Authorization": "Bearer footokenbar"})
@@ -78,3 +43,36 @@ def test_security_oauth2_password_bearer_no_header():
     response = client.get("/users/me")
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"OpenIdConnect": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OpenIdConnect": {
+                    "type": "openIdConnect",
+                    "openIdConnectUrl": "/openid",
+                    "description": "OpenIdConnect security scheme",
+                }
+            }
+        },
+    }

--- a/tests/test_security_openid_connect_optional.py
+++ b/tests/test_security_openid_connect_optional.py
@@ -30,37 +30,6 @@ def read_current_user(current_user: Optional[User] = Depends(get_current_user)):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"OpenIdConnect": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OpenIdConnect": {"type": "openIdConnect", "openIdConnectUrl": "/openid"}
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_oauth2():
     response = client.get("/users/me", headers={"Authorization": "Bearer footokenbar"})
@@ -78,3 +47,35 @@ def test_security_oauth2_password_bearer_no_header():
     response = client.get("/users/me")
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Create an account first"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"OpenIdConnect": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OpenIdConnect": {
+                    "type": "openIdConnect",
+                    "openIdConnectUrl": "/openid",
+                }
+            }
+        },
+    }

--- a/tests/test_starlette_exception.py
+++ b/tests/test_starlette_exception.py
@@ -37,132 +37,6 @@ async def read_starlette_item(item_id: str):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/http-no-body-statuscode-exception": {
-            "get": {
-                "operationId": "no_body_status_code_exception_http_no_body_statuscode_exception_get",
-                "responses": {
-                    "200": {
-                        "content": {"application/json": {"schema": {}}},
-                        "description": "Successful Response",
-                    }
-                },
-                "summary": "No Body Status Code Exception",
-            }
-        },
-        "/http-no-body-statuscode-with-detail-exception": {
-            "get": {
-                "operationId": "no_body_status_code_with_detail_exception_http_no_body_statuscode_with_detail_exception_get",
-                "responses": {
-                    "200": {
-                        "content": {"application/json": {"schema": {}}},
-                        "description": "Successful Response",
-                    }
-                },
-                "summary": "No Body Status Code With Detail Exception",
-            }
-        },
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/starlette-items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Starlette Item",
-                "operationId": "read_starlette_item_starlette_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_item():
     response = client.get("/items/foo")
@@ -200,3 +74,129 @@ def test_no_body_status_code_with_detail_exception_handlers():
     response = client.get("/http-no-body-statuscode-with-detail-exception")
     assert response.status_code == 204
     assert not response.content
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/http-no-body-statuscode-exception": {
+                "get": {
+                    "operationId": "no_body_status_code_exception_http_no_body_statuscode_exception_get",
+                    "responses": {
+                        "200": {
+                            "content": {"application/json": {"schema": {}}},
+                            "description": "Successful Response",
+                        }
+                    },
+                    "summary": "No Body Status Code Exception",
+                }
+            },
+            "/http-no-body-statuscode-with-detail-exception": {
+                "get": {
+                    "operationId": "no_body_status_code_with_detail_exception_http_no_body_statuscode_with_detail_exception_get",
+                    "responses": {
+                        "200": {
+                            "content": {"application/json": {"schema": {}}},
+                            "description": "Successful Response",
+                        }
+                    },
+                    "summary": "No Body Status Code With Detail Exception",
+                }
+            },
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/starlette-items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Starlette Item",
+                    "operationId": "read_starlette_item_starlette_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_sub_callbacks.py
+++ b/tests/test_sub_callbacks.py
@@ -74,205 +74,6 @@ app.include_router(subrouter, callbacks=events_callback_router.routes)
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/invoices/": {
-            "post": {
-                "summary": "Create Invoice",
-                "description": 'Create an invoice.\n\nThis will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
-                "operationId": "create_invoice_invoices__post",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Callback Url",
-                            "maxLength": 2083,
-                            "minLength": 1,
-                            "type": "string",
-                            "format": "uri",
-                        },
-                        "name": "callback_url",
-                        "in": "query",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Invoice"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "callbacks": {
-                    "event_callback": {
-                        "{$callback_url}/events/{$request.body.title}": {
-                            "get": {
-                                "summary": "Event Callback",
-                                "operationId": "event_callback__callback_url__events___request_body_title__get",
-                                "requestBody": {
-                                    "required": True,
-                                    "content": {
-                                        "application/json": {
-                                            "schema": {
-                                                "$ref": "#/components/schemas/Event"
-                                            }
-                                        }
-                                    },
-                                },
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {"application/json": {"schema": {}}},
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "invoice_notification": {
-                        "{$callback_url}/invoices/{$request.body.id}": {
-                            "post": {
-                                "summary": "Invoice Notification",
-                                "operationId": "invoice_notification__callback_url__invoices___request_body_id__post",
-                                "requestBody": {
-                                    "required": True,
-                                    "content": {
-                                        "application/json": {
-                                            "schema": {
-                                                "$ref": "#/components/schemas/InvoiceEvent"
-                                            }
-                                        }
-                                    },
-                                },
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/InvoiceEventReceived"
-                                                }
-                                            }
-                                        },
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Event": {
-                "title": "Event",
-                "required": ["name", "total"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "total": {"title": "Total", "type": "number"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Invoice": {
-                "title": "Invoice",
-                "required": ["id", "customer", "total"],
-                "type": "object",
-                "properties": {
-                    "id": {"title": "Id", "type": "string"},
-                    "title": {"title": "Title", "type": "string"},
-                    "customer": {"title": "Customer", "type": "string"},
-                    "total": {"title": "Total", "type": "number"},
-                },
-            },
-            "InvoiceEvent": {
-                "title": "InvoiceEvent",
-                "required": ["description", "paid"],
-                "type": "object",
-                "properties": {
-                    "description": {"title": "Description", "type": "string"},
-                    "paid": {"title": "Paid", "type": "boolean"},
-                },
-            },
-            "InvoiceEventReceived": {
-                "title": "InvoiceEventReceived",
-                "required": ["ok"],
-                "type": "object",
-                "properties": {"ok": {"title": "Ok", "type": "boolean"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi():
-    with client:
-        response = client.get("/openapi.json")
-
-        assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.post(
@@ -280,3 +81,205 @@ def test_get():
     )
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "Invoice received"}
+
+
+def test_openapi_schema():
+    with client:
+        response = client.get("/openapi.json")
+        assert response.json() == {
+            "openapi": "3.0.2",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/invoices/": {
+                    "post": {
+                        "summary": "Create Invoice",
+                        "description": 'Create an invoice.\n\nThis will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
+                        "operationId": "create_invoice_invoices__post",
+                        "parameters": [
+                            {
+                                "required": False,
+                                "schema": {
+                                    "title": "Callback Url",
+                                    "maxLength": 2083,
+                                    "minLength": 1,
+                                    "type": "string",
+                                    "format": "uri",
+                                },
+                                "name": "callback_url",
+                                "in": "query",
+                            }
+                        ],
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Invoice"}
+                                }
+                            },
+                            "required": True,
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
+                        },
+                        "callbacks": {
+                            "event_callback": {
+                                "{$callback_url}/events/{$request.body.title}": {
+                                    "get": {
+                                        "summary": "Event Callback",
+                                        "operationId": "event_callback__callback_url__events___request_body_title__get",
+                                        "requestBody": {
+                                            "required": True,
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/Event"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                        "responses": {
+                                            "200": {
+                                                "description": "Successful Response",
+                                                "content": {
+                                                    "application/json": {"schema": {}}
+                                                },
+                                            },
+                                            "422": {
+                                                "description": "Validation Error",
+                                                "content": {
+                                                    "application/json": {
+                                                        "schema": {
+                                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                                        }
+                                                    }
+                                                },
+                                            },
+                                        },
+                                    }
+                                }
+                            },
+                            "invoice_notification": {
+                                "{$callback_url}/invoices/{$request.body.id}": {
+                                    "post": {
+                                        "summary": "Invoice Notification",
+                                        "operationId": "invoice_notification__callback_url__invoices___request_body_id__post",
+                                        "requestBody": {
+                                            "required": True,
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/InvoiceEvent"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                        "responses": {
+                                            "200": {
+                                                "description": "Successful Response",
+                                                "content": {
+                                                    "application/json": {
+                                                        "schema": {
+                                                            "$ref": "#/components/schemas/InvoiceEventReceived"
+                                                        }
+                                                    }
+                                                },
+                                            },
+                                            "422": {
+                                                "description": "Validation Error",
+                                                "content": {
+                                                    "application/json": {
+                                                        "schema": {
+                                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                                        }
+                                                    }
+                                                },
+                                            },
+                                        },
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Event": {
+                        "title": "Event",
+                        "required": ["name", "total"],
+                        "type": "object",
+                        "properties": {
+                            "name": {"title": "Name", "type": "string"},
+                            "total": {"title": "Total", "type": "number"},
+                        },
+                    },
+                    "HTTPValidationError": {
+                        "title": "HTTPValidationError",
+                        "type": "object",
+                        "properties": {
+                            "detail": {
+                                "title": "Detail",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                },
+                            }
+                        },
+                    },
+                    "Invoice": {
+                        "title": "Invoice",
+                        "required": ["id", "customer", "total"],
+                        "type": "object",
+                        "properties": {
+                            "id": {"title": "Id", "type": "string"},
+                            "title": {"title": "Title", "type": "string"},
+                            "customer": {"title": "Customer", "type": "string"},
+                            "total": {"title": "Total", "type": "number"},
+                        },
+                    },
+                    "InvoiceEvent": {
+                        "title": "InvoiceEvent",
+                        "required": ["description", "paid"],
+                        "type": "object",
+                        "properties": {
+                            "description": {"title": "Description", "type": "string"},
+                            "paid": {"title": "Paid", "type": "boolean"},
+                        },
+                    },
+                    "InvoiceEventReceived": {
+                        "title": "InvoiceEventReceived",
+                        "required": ["ok"],
+                        "type": "object",
+                        "properties": {"ok": {"title": "Ok", "type": "boolean"}},
+                    },
+                    "ValidationError": {
+                        "title": "ValidationError",
+                        "required": ["loc", "msg", "type"],
+                        "type": "object",
+                        "properties": {
+                            "loc": {
+                                "title": "Location",
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [{"type": "string"}, {"type": "integer"}]
+                                },
+                            },
+                            "msg": {"title": "Message", "type": "string"},
+                            "type": {"title": "Error Type", "type": "string"},
+                        },
+                    },
+                }
+            },
+        }

--- a/tests/test_tuples.py
+++ b/tests/test_tuples.py
@@ -33,189 +33,6 @@ def hello(values: Tuple[int, int] = Form()):
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/model-with-tuple/": {
-            "post": {
-                "summary": "Post Model With Tuple",
-                "operationId": "post_model_with_tuple_model_with_tuple__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemGroup"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/tuple-of-models/": {
-            "post": {
-                "summary": "Post Tuple Of Models",
-                "operationId": "post_tuple_of_models_tuple_of_models__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "title": "Square",
-                                "maxItems": 2,
-                                "minItems": 2,
-                                "type": "array",
-                                "items": [
-                                    {"$ref": "#/components/schemas/Coordinate"},
-                                    {"$ref": "#/components/schemas/Coordinate"},
-                                ],
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/tuple-form/": {
-            "post": {
-                "summary": "Hello",
-                "operationId": "hello_tuple_form__post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_hello_tuple_form__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_hello_tuple_form__post": {
-                "title": "Body_hello_tuple_form__post",
-                "required": ["values"],
-                "type": "object",
-                "properties": {
-                    "values": {
-                        "title": "Values",
-                        "maxItems": 2,
-                        "minItems": 2,
-                        "type": "array",
-                        "items": [{"type": "integer"}, {"type": "integer"}],
-                    }
-                },
-            },
-            "Coordinate": {
-                "title": "Coordinate",
-                "required": ["x", "y"],
-                "type": "object",
-                "properties": {
-                    "x": {"title": "X", "type": "number"},
-                    "y": {"title": "Y", "type": "number"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ItemGroup": {
-                "title": "ItemGroup",
-                "required": ["items"],
-                "type": "object",
-                "properties": {
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "type": "array",
-                            "items": [{"type": "string"}, {"type": "string"}],
-                        },
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_model_with_tuple_valid():
     data = {"items": [["foo", "bar"], ["baz", "whatelse"]]}
@@ -263,3 +80,186 @@ def test_tuple_form_invalid():
 
     response = client.post("/tuple-form/", data={"values": ("1")})
     assert response.status_code == 422, response.text
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/model-with-tuple/": {
+                "post": {
+                    "summary": "Post Model With Tuple",
+                    "operationId": "post_model_with_tuple_model_with_tuple__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemGroup"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/tuple-of-models/": {
+                "post": {
+                    "summary": "Post Tuple Of Models",
+                    "operationId": "post_tuple_of_models_tuple_of_models__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Square",
+                                    "maxItems": 2,
+                                    "minItems": 2,
+                                    "type": "array",
+                                    "items": [
+                                        {"$ref": "#/components/schemas/Coordinate"},
+                                        {"$ref": "#/components/schemas/Coordinate"},
+                                    ],
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/tuple-form/": {
+                "post": {
+                    "summary": "Hello",
+                    "operationId": "hello_tuple_form__post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_hello_tuple_form__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_hello_tuple_form__post": {
+                    "title": "Body_hello_tuple_form__post",
+                    "required": ["values"],
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "title": "Values",
+                            "maxItems": 2,
+                            "minItems": 2,
+                            "type": "array",
+                            "items": [{"type": "integer"}, {"type": "integer"}],
+                        }
+                    },
+                },
+                "Coordinate": {
+                    "title": "Coordinate",
+                    "required": ["x", "y"],
+                    "type": "object",
+                    "properties": {
+                        "x": {"title": "X", "type": "number"},
+                        "y": {"title": "Y", "type": "number"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ItemGroup": {
+                    "title": "ItemGroup",
+                    "required": ["items"],
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array",
+                                "items": [{"type": "string"}, {"type": "string"}],
+                            },
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_additional_responses/test_tutorial001.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial001.py
@@ -4,105 +4,6 @@ from docs_src.additional_responses.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Message"}
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["id", "value"],
-                "type": "object",
-                "properties": {
-                    "id": {"title": "Id", "type": "string"},
-                    "value": {"title": "Value", "type": "string"},
-                },
-            },
-            "Message": {
-                "title": "Message",
-                "required": ["message"],
-                "type": "object",
-                "properties": {"message": {"title": "Message", "type": "string"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_path_operation():
     response = client.get("/items/foo")
@@ -114,3 +15,102 @@ def test_path_operation_not_found():
     response = client.get("/items/bar")
     assert response.status_code == 404, response.text
     assert response.json() == {"message": "Item not found"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "404": {
+                            "description": "Not Found",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Message"}
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["id", "value"],
+                    "type": "object",
+                    "properties": {
+                        "id": {"title": "Id", "type": "string"},
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                },
+                "Message": {
+                    "title": "Message",
+                    "required": ["message"],
+                    "type": "object",
+                    "properties": {"message": {"title": "Message", "type": "string"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_additional_responses/test_tutorial002.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial002.py
@@ -7,98 +7,6 @@ from docs_src.additional_responses.tutorial002 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Return the JSON item or an image.",
-                        "content": {
-                            "image/png": {},
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            },
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Img", "type": "boolean"},
-                        "name": "img",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["id", "value"],
-                "type": "object",
-                "properties": {
-                    "id": {"title": "Id", "type": "string"},
-                    "value": {"title": "Value", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_path_operation():
     response = client.get("/items/foo")
@@ -113,3 +21,95 @@ def test_path_operation_img():
     assert response.headers["Content-Type"] == "image/png"
     assert len(response.content)
     os.remove("./image.png")
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Return the JSON item or an image.",
+                            "content": {
+                                "image/png": {},
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                },
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Img", "type": "boolean"},
+                            "name": "img",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["id", "value"],
+                    "type": "object",
+                    "properties": {
+                        "id": {"title": "Id", "type": "string"},
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_additional_responses/test_tutorial003.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial003.py
@@ -4,106 +4,6 @@ from docs_src.additional_responses.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "404": {
-                        "description": "The item was not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Message"}
-                            }
-                        },
-                    },
-                    "200": {
-                        "description": "Item requested by ID",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"},
-                                "example": {"id": "bar", "value": "The bar tenders"},
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["id", "value"],
-                "type": "object",
-                "properties": {
-                    "id": {"title": "Id", "type": "string"},
-                    "value": {"title": "Value", "type": "string"},
-                },
-            },
-            "Message": {
-                "title": "Message",
-                "required": ["message"],
-                "type": "object",
-                "properties": {"message": {"title": "Message", "type": "string"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_path_operation():
     response = client.get("/items/foo")
@@ -115,3 +15,106 @@ def test_path_operation_not_found():
     response = client.get("/items/bar")
     assert response.status_code == 404, response.text
     assert response.json() == {"message": "Item not found"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "404": {
+                            "description": "The item was not found",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Message"}
+                                }
+                            },
+                        },
+                        "200": {
+                            "description": "Item requested by ID",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"},
+                                    "example": {
+                                        "id": "bar",
+                                        "value": "The bar tenders",
+                                    },
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["id", "value"],
+                    "type": "object",
+                    "properties": {
+                        "id": {"title": "Id", "type": "string"},
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                },
+                "Message": {
+                    "title": "Message",
+                    "required": ["message"],
+                    "type": "object",
+                    "properties": {"message": {"title": "Message", "type": "string"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_additional_responses/test_tutorial004.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial004.py
@@ -7,101 +7,6 @@ from docs_src.additional_responses.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "404": {"description": "Item not found"},
-                    "302": {"description": "The item was moved"},
-                    "403": {"description": "Not enough privileges"},
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "image/png": {},
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            },
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Img", "type": "boolean"},
-                        "name": "img",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["id", "value"],
-                "type": "object",
-                "properties": {
-                    "id": {"title": "Id", "type": "string"},
-                    "value": {"title": "Value", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_path_operation():
     response = client.get("/items/foo")
@@ -116,3 +21,98 @@ def test_path_operation_img():
     assert response.headers["Content-Type"] == "image/png"
     assert len(response.content)
     os.remove("./image.png")
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "404": {"description": "Item not found"},
+                        "302": {"description": "The item was moved"},
+                        "403": {"description": "Not enough privileges"},
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "image/png": {},
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                },
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Img", "type": "boolean"},
+                            "name": "img",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["id", "value"],
+                    "type": "object",
+                    "properties": {
+                        "id": {"title": "Id", "type": "string"},
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -2,120 +2,6 @@ from fastapi.testclient import TestClient
 
 from docs_src.async_sql_databases.tutorial001 import app
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/notes/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Notes Notes  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Note"},
-                                }
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Notes",
-                "operationId": "read_notes_notes__get",
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Note"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Note",
-                "operationId": "create_note_notes__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/NoteIn"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        }
-    },
-    "components": {
-        "schemas": {
-            "NoteIn": {
-                "title": "NoteIn",
-                "required": ["text", "completed"],
-                "type": "object",
-                "properties": {
-                    "text": {"title": "Text", "type": "string"},
-                    "completed": {"title": "Completed", "type": "boolean"},
-                },
-            },
-            "Note": {
-                "title": "Note",
-                "required": ["id", "text", "completed"],
-                "type": "object",
-                "properties": {
-                    "id": {"title": "Id", "type": "integer"},
-                    "text": {"title": "Text", "type": "string"},
-                    "completed": {"title": "Completed", "type": "boolean"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    with TestClient(app) as client:
-        response = client.get("/openapi.json")
-        assert response.status_code == 200, response.text
-        assert response.json() == openapi_schema
-
 
 def test_create_read():
     with TestClient(app) as client:
@@ -129,3 +15,121 @@ def test_create_read():
         response = client.get("/notes/")
         assert response.status_code == 200, response.text
         assert data in response.json()
+
+
+def test_openapi_schema():
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "openapi": "3.0.2",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/notes/": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "title": "Response Read Notes Notes  Get",
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Note"
+                                            },
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                        "summary": "Read Notes",
+                        "operationId": "read_notes_notes__get",
+                    },
+                    "post": {
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Note"}
+                                    }
+                                },
+                            },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
+                        },
+                        "summary": "Create Note",
+                        "operationId": "create_note_notes__post",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/NoteIn"}
+                                }
+                            },
+                            "required": True,
+                        },
+                    },
+                }
+            },
+            "components": {
+                "schemas": {
+                    "NoteIn": {
+                        "title": "NoteIn",
+                        "required": ["text", "completed"],
+                        "type": "object",
+                        "properties": {
+                            "text": {"title": "Text", "type": "string"},
+                            "completed": {"title": "Completed", "type": "boolean"},
+                        },
+                    },
+                    "Note": {
+                        "title": "Note",
+                        "required": ["id", "text", "completed"],
+                        "type": "object",
+                        "properties": {
+                            "id": {"title": "Id", "type": "integer"},
+                            "text": {"title": "Text", "type": "string"},
+                            "completed": {"title": "Completed", "type": "boolean"},
+                        },
+                    },
+                    "ValidationError": {
+                        "title": "ValidationError",
+                        "required": ["loc", "msg", "type"],
+                        "type": "object",
+                        "properties": {
+                            "loc": {
+                                "title": "Location",
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [{"type": "string"}, {"type": "integer"}]
+                                },
+                            },
+                            "msg": {"title": "Message", "type": "string"},
+                            "type": {"title": "Error Type", "type": "string"},
+                        },
+                    },
+                    "HTTPValidationError": {
+                        "title": "HTTPValidationError",
+                        "type": "object",
+                        "properties": {
+                            "detail": {
+                                "title": "Detail",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                },
+                            }
+                        },
+                    },
+                }
+            },
+        }

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial001.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial001.py
@@ -4,34 +4,32 @@ from docs_src.behind_a_proxy.tutorial001 import app
 
 client = TestClient(app, root_path="/api/v1")
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/app": {
-            "get": {
-                "summary": "Read Main",
-                "operationId": "read_main_app_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-    "servers": [{"url": "/api/v1"}],
-}
-
-
-def test_openapi():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
-
 
 def test_main():
     response = client.get("/app")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World", "root_path": "/api/v1"}
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/app": {
+                "get": {
+                    "summary": "Read Main",
+                    "operationId": "read_main_app_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+        "servers": [{"url": "/api/v1"}],
+    }

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial002.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial002.py
@@ -4,34 +4,32 @@ from docs_src.behind_a_proxy.tutorial002 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/app": {
-            "get": {
-                "summary": "Read Main",
-                "operationId": "read_main_app_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-    "servers": [{"url": "/api/v1"}],
-}
-
-
-def test_openapi():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
-
 
 def test_main():
     response = client.get("/app")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World", "root_path": "/api/v1"}
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/app": {
+                "get": {
+                    "summary": "Read Main",
+                    "operationId": "read_main_app_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+        "servers": [{"url": "/api/v1"}],
+    }

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial003.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial003.py
@@ -4,38 +4,39 @@ from docs_src.behind_a_proxy.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "servers": [
-        {"url": "/api/v1"},
-        {"url": "https://stag.example.com", "description": "Staging environment"},
-        {"url": "https://prod.example.com", "description": "Production environment"},
-    ],
-    "paths": {
-        "/app": {
-            "get": {
-                "summary": "Read Main",
-                "operationId": "read_main_app_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
-
 
 def test_main():
     response = client.get("/app")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World", "root_path": "/api/v1"}
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "servers": [
+            {"url": "/api/v1"},
+            {"url": "https://stag.example.com", "description": "Staging environment"},
+            {
+                "url": "https://prod.example.com",
+                "description": "Production environment",
+            },
+        ],
+        "paths": {
+            "/app": {
+                "get": {
+                    "summary": "Read Main",
+                    "operationId": "read_main_app_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_behind_a_proxy/test_tutorial004.py
+++ b/tests/test_tutorial/test_behind_a_proxy/test_tutorial004.py
@@ -4,37 +4,38 @@ from docs_src.behind_a_proxy.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "servers": [
-        {"url": "https://stag.example.com", "description": "Staging environment"},
-        {"url": "https://prod.example.com", "description": "Production environment"},
-    ],
-    "paths": {
-        "/app": {
-            "get": {
-                "summary": "Read Main",
-                "operationId": "read_main_app_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
-
 
 def test_main():
     response = client.get("/app")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World", "root_path": "/api/v1"}
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "servers": [
+            {"url": "https://stag.example.com", "description": "Staging environment"},
+            {
+                "url": "https://prod.example.com",
+                "description": "Production environment",
+            },
+        ],
+        "paths": {
+            "/app": {
+                "get": {
+                    "summary": "Read Main",
+                    "operationId": "read_main_app_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_bigger_applications/test_main.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main.py
@@ -5,334 +5,6 @@ from docs_src.bigger_applications.app.main import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read User Me",
-                "operationId": "read_user_me_users_me_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/{username}": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read User",
-                "operationId": "read_user_users__username__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Username", "type": "string"},
-                        "name": "username",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/items/{item_id}": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-            "put": {
-                "tags": ["items", "custom"],
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "403": {"description": "Operation forbidden"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-        },
-        "/admin/": {
-            "post": {
-                "tags": ["admin"],
-                "summary": "Update Admin",
-                "operationId": "update_admin_admin__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "418": {"description": "I'm a teapot"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Root",
-                "operationId": "root__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 no_jessica = {
     "detail": [
@@ -427,7 +99,6 @@ no_jessica = {
         ),
         ("/?token=jessica", 200, {"message": "Hello Bigger Applications!"}, {}),
         ("/", 422, no_jessica, {}),
-        ("/openapi.json", 200, openapi_schema, {}),
     ],
 )
 def test_get_path(path, expected_status, expected_response, headers):
@@ -489,3 +160,337 @@ def test_admin_invalid_header():
     response = client.post("/admin/", headers={"X-Token": "invalid"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "X-Token header invalid"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read User Me",
+                    "operationId": "read_user_me_users_me_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/{username}": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read User",
+                    "operationId": "read_user_users__username__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Username", "type": "string"},
+                            "name": "username",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/items/{item_id}": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+                "put": {
+                    "tags": ["items", "custom"],
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "403": {"description": "Operation forbidden"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+            "/admin/": {
+                "post": {
+                    "tags": ["admin"],
+                    "summary": "Update Admin",
+                    "operationId": "update_admin_admin__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "418": {"description": "I'm a teapot"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "summary": "Root",
+                    "operationId": "root__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_bigger_applications/test_main_an.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main_an.py
@@ -5,334 +5,6 @@ from docs_src.bigger_applications.app_an.main import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read User Me",
-                "operationId": "read_user_me_users_me_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/{username}": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read User",
-                "operationId": "read_user_users__username__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Username", "type": "string"},
-                        "name": "username",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/items/{item_id}": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-            "put": {
-                "tags": ["items", "custom"],
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "403": {"description": "Operation forbidden"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-        },
-        "/admin/": {
-            "post": {
-                "tags": ["admin"],
-                "summary": "Update Admin",
-                "operationId": "update_admin_admin__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "418": {"description": "I'm a teapot"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Root",
-                "operationId": "root__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 no_jessica = {
     "detail": [
@@ -427,7 +99,6 @@ no_jessica = {
         ),
         ("/?token=jessica", 200, {"message": "Hello Bigger Applications!"}, {}),
         ("/", 422, no_jessica, {}),
-        ("/openapi.json", 200, openapi_schema, {}),
     ],
 )
 def test_get_path(path, expected_status, expected_response, headers):
@@ -489,3 +160,337 @@ def test_admin_invalid_header():
     response = client.post("/admin/", headers={"X-Token": "invalid"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "X-Token header invalid"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read User Me",
+                    "operationId": "read_user_me_users_me_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/{username}": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read User",
+                    "operationId": "read_user_users__username__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Username", "type": "string"},
+                            "name": "username",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/items/{item_id}": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+                "put": {
+                    "tags": ["items", "custom"],
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "403": {"description": "Operation forbidden"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+            "/admin/": {
+                "post": {
+                    "tags": ["admin"],
+                    "summary": "Update Admin",
+                    "operationId": "update_admin_admin__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "418": {"description": "I'm a teapot"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "summary": "Root",
+                    "operationId": "root__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_bigger_applications/test_main_an_py39.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main_an_py39.py
@@ -3,335 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read User Me",
-                "operationId": "read_user_me_users_me_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/{username}": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read User",
-                "operationId": "read_user_users__username__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Username", "type": "string"},
-                        "name": "username",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/items/{item_id}": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-            "put": {
-                "tags": ["items", "custom"],
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "404": {"description": "Not found"},
-                    "403": {"description": "Operation forbidden"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-        },
-        "/admin/": {
-            "post": {
-                "tags": ["admin"],
-                "summary": "Update Admin",
-                "operationId": "update_admin_admin__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "418": {"description": "I'm a teapot"},
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Root",
-                "operationId": "root__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Token", "type": "string"},
-                        "name": "token",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
 no_jessica = {
     "detail": [
         {
@@ -434,7 +105,6 @@ def get_client():
         ),
         ("/?token=jessica", 200, {"message": "Hello Bigger Applications!"}, {}),
         ("/", 422, no_jessica, {}),
-        ("/openapi.json", 200, openapi_schema, {}),
     ],
 )
 def test_get_path(
@@ -504,3 +174,338 @@ def test_admin_invalid_header(client: TestClient):
     response = client.post("/admin/", headers={"X-Token": "invalid"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "X-Token header invalid"}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read User Me",
+                    "operationId": "read_user_me_users_me_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/{username}": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read User",
+                    "operationId": "read_user_users__username__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Username", "type": "string"},
+                            "name": "username",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/items/{item_id}": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+                "put": {
+                    "tags": ["items", "custom"],
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "404": {"description": "Not found"},
+                        "403": {"description": "Operation forbidden"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+            "/admin/": {
+                "post": {
+                    "tags": ["admin"],
+                    "summary": "Update Admin",
+                    "operationId": "update_admin_admin__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "418": {"description": "I'm a teapot"},
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "summary": "Root",
+                    "operationId": "root__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Token", "type": "string"},
+                            "name": "token",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -7,89 +7,6 @@ from docs_src.body.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 price_missing = {
     "detail": [
@@ -277,3 +194,86 @@ def test_other_exceptions():
     with patch("json.loads", side_effect=Exception):
         response = client.post("/items/", json={"test": "test2"})
         assert response.status_code == 400, response.text
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body/test_tutorial001_py310.py
@@ -5,83 +5,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture
 def client():
@@ -89,13 +12,6 @@ def client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 price_missing = {
@@ -292,3 +208,87 @@ def test_other_exceptions(client: TestClient):
     with patch("json.loads", side_effect=Exception):
         response = client.post("/items/", json={"test": "test2"})
         assert response.status_code == 400, response.text
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001.py
@@ -6,115 +6,6 @@ from docs_src.body_fields.tutorial001 import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {
-                        "title": "The description of the item",
-                        "maxLength": 300,
-                        "type": "string",
-                    },
-                    "price": {
-                        "title": "Price",
-                        "exclusiveMinimum": 0.0,
-                        "type": "number",
-                        "description": "The price must be greater than zero",
-                    },
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item"],
-                "type": "object",
-                "properties": {"item": {"$ref": "#/components/schemas/Item"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 price_not_greater = {
     "detail": [
         {
@@ -167,3 +58,111 @@ def test(path, body, expected_status, expected_response):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {
+                            "title": "The description of the item",
+                            "maxLength": 300,
+                            "type": "string",
+                        },
+                        "price": {
+                            "title": "Price",
+                            "exclusiveMinimum": 0.0,
+                            "type": "number",
+                            "description": "The price must be greater than zero",
+                        },
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item"],
+                    "type": "object",
+                    "properties": {"item": {"$ref": "#/components/schemas/Item"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_an.py
@@ -6,115 +6,6 @@ from docs_src.body_fields.tutorial001_an import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {
-                        "title": "The description of the item",
-                        "maxLength": 300,
-                        "type": "string",
-                    },
-                    "price": {
-                        "title": "Price",
-                        "exclusiveMinimum": 0.0,
-                        "type": "number",
-                        "description": "The price must be greater than zero",
-                    },
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item"],
-                "type": "object",
-                "properties": {"item": {"$ref": "#/components/schemas/Item"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 price_not_greater = {
     "detail": [
         {
@@ -167,3 +58,111 @@ def test(path, body, expected_status, expected_response):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {
+                            "title": "The description of the item",
+                            "maxLength": 300,
+                            "type": "string",
+                        },
+                        "price": {
+                            "title": "Price",
+                            "exclusiveMinimum": 0.0,
+                            "type": "number",
+                            "description": "The price must be greater than zero",
+                        },
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item"],
+                    "type": "object",
+                    "properties": {"item": {"$ref": "#/components/schemas/Item"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_an_py310.py
@@ -3,108 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {
-                        "title": "The description of the item",
-                        "maxLength": 300,
-                        "type": "string",
-                    },
-                    "price": {
-                        "title": "Price",
-                        "exclusiveMinimum": 0.0,
-                        "type": "number",
-                        "description": "The price must be greater than zero",
-                    },
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item"],
-                "type": "object",
-                "properties": {"item": {"$ref": "#/components/schemas/Item"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -112,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 price_not_greater = {
@@ -174,3 +65,112 @@ def test(path, body, expected_status, expected_response, client: TestClient):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {
+                            "title": "The description of the item",
+                            "maxLength": 300,
+                            "type": "string",
+                        },
+                        "price": {
+                            "title": "Price",
+                            "exclusiveMinimum": 0.0,
+                            "type": "number",
+                            "description": "The price must be greater than zero",
+                        },
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item"],
+                    "type": "object",
+                    "properties": {"item": {"$ref": "#/components/schemas/Item"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_an_py39.py
@@ -3,108 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {
-                        "title": "The description of the item",
-                        "maxLength": 300,
-                        "type": "string",
-                    },
-                    "price": {
-                        "title": "Price",
-                        "exclusiveMinimum": 0.0,
-                        "type": "number",
-                        "description": "The price must be greater than zero",
-                    },
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item"],
-                "type": "object",
-                "properties": {"item": {"$ref": "#/components/schemas/Item"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -112,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 price_not_greater = {
@@ -174,3 +65,112 @@ def test(path, body, expected_status, expected_response, client: TestClient):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {
+                            "title": "The description of the item",
+                            "maxLength": 300,
+                            "type": "string",
+                        },
+                        "price": {
+                            "title": "Price",
+                            "exclusiveMinimum": 0.0,
+                            "type": "number",
+                            "description": "The price must be greater than zero",
+                        },
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item"],
+                    "type": "object",
+                    "properties": {"item": {"$ref": "#/components/schemas/Item"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_py310.py
@@ -3,108 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {
-                        "title": "The description of the item",
-                        "maxLength": 300,
-                        "type": "string",
-                    },
-                    "price": {
-                        "title": "Price",
-                        "exclusiveMinimum": 0.0,
-                        "type": "number",
-                        "description": "The price must be greater than zero",
-                    },
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item"],
-                "type": "object",
-                "properties": {"item": {"$ref": "#/components/schemas/Item"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -112,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 price_not_greater = {
@@ -174,3 +65,112 @@ def test(path, body, expected_status, expected_response, client: TestClient):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {
+                            "title": "The description of the item",
+                            "maxLength": 300,
+                            "type": "string",
+                        },
+                        "price": {
+                            "title": "Price",
+                            "exclusiveMinimum": 0.0,
+                            "type": "number",
+                            "description": "The price must be greater than zero",
+                        },
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item"],
+                    "type": "object",
+                    "properties": {"item": {"$ref": "#/components/schemas/Item"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
@@ -5,107 +5,6 @@ from docs_src.body_multiple_params.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "The ID of the item to get",
-                            "maximum": 1000.0,
-                            "minimum": 0.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 item_id_not_int = {
     "detail": [
@@ -145,3 +44,104 @@ def test_post_body(path, body, expected_status, expected_response):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "The ID of the item to get",
+                                "maximum": 1000.0,
+                                "minimum": 0.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an.py
@@ -5,107 +5,6 @@ from docs_src.body_multiple_params.tutorial001_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "The ID of the item to get",
-                            "maximum": 1000.0,
-                            "minimum": 0.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 item_id_not_int = {
     "detail": [
@@ -145,3 +44,104 @@ def test_post_body(path, body, expected_status, expected_response):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "The ID of the item to get",
+                                "maximum": 1000.0,
+                                "minimum": 0.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py310.py
@@ -3,101 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "The ID of the item to get",
-                            "maximum": 1000.0,
-                            "minimum": 0.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -105,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 item_id_not_int = {
@@ -153,3 +51,105 @@ def test_post_body(path, body, expected_status, expected_response, client: TestC
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "The ID of the item to get",
+                                "maximum": 1000.0,
+                                "minimum": 0.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py39.py
@@ -3,101 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "The ID of the item to get",
-                            "maximum": 1000.0,
-                            "minimum": 0.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -105,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 item_id_not_int = {
@@ -153,3 +51,105 @@ def test_post_body(path, body, expected_status, expected_response, client: TestC
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "The ID of the item to get",
+                                "maximum": 1000.0,
+                                "minimum": 0.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_py310.py
@@ -3,101 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "The ID of the item to get",
-                            "maximum": 1000.0,
-                            "minimum": 0.0,
-                            "type": "integer",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -105,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 item_id_not_int = {
@@ -153,3 +51,105 @@ def test_post_body(path, body, expected_status, expected_response, client: TestC
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "The ID of the item to get",
+                                "maximum": 1000.0,
+                                "minimum": 0.0,
+                                "type": "integer",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -5,118 +5,6 @@ from docs_src.body_multiple_params.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item", "user", "importance"],
-                "type": "object",
-                "properties": {
-                    "item": {"$ref": "#/components/schemas/Item"},
-                    "user": {"$ref": "#/components/schemas/User"},
-                    "importance": {"title": "Importance", "type": "integer"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 # Test required and embedded body parameters with no bodies sent
 @pytest.mark.parametrize(
@@ -196,3 +84,115 @@ def test_post_body(path, body, expected_status, expected_response):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item", "user", "importance"],
+                    "type": "object",
+                    "properties": {
+                        "item": {"$ref": "#/components/schemas/Item"},
+                        "user": {"$ref": "#/components/schemas/User"},
+                        "importance": {"title": "Importance", "type": "integer"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an.py
@@ -5,118 +5,6 @@ from docs_src.body_multiple_params.tutorial003_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item", "user", "importance"],
-                "type": "object",
-                "properties": {
-                    "item": {"$ref": "#/components/schemas/Item"},
-                    "user": {"$ref": "#/components/schemas/User"},
-                    "importance": {"title": "Importance", "type": "integer"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 # Test required and embedded body parameters with no bodies sent
 @pytest.mark.parametrize(
@@ -196,3 +84,115 @@ def test_post_body(path, body, expected_status, expected_response):
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item", "user", "importance"],
+                    "type": "object",
+                    "properties": {
+                        "item": {"$ref": "#/components/schemas/Item"},
+                        "user": {"$ref": "#/components/schemas/User"},
+                        "importance": {"title": "Importance", "type": "integer"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py310.py
@@ -3,112 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item", "user", "importance"],
-                "type": "object",
-                "properties": {
-                    "item": {"$ref": "#/components/schemas/Item"},
-                    "user": {"$ref": "#/components/schemas/User"},
-                    "importance": {"title": "Importance", "type": "integer"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -116,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 # Test required and embedded body parameters with no bodies sent
@@ -204,3 +91,116 @@ def test_post_body(path, body, expected_status, expected_response, client: TestC
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item", "user", "importance"],
+                    "type": "object",
+                    "properties": {
+                        "item": {"$ref": "#/components/schemas/Item"},
+                        "user": {"$ref": "#/components/schemas/User"},
+                        "importance": {"title": "Importance", "type": "integer"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py39.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py39.py
@@ -3,112 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item", "user", "importance"],
-                "type": "object",
-                "properties": {
-                    "item": {"$ref": "#/components/schemas/Item"},
-                    "user": {"$ref": "#/components/schemas/User"},
-                    "importance": {"title": "Importance", "type": "integer"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -116,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 # Test required and embedded body parameters with no bodies sent
@@ -204,3 +91,116 @@ def test_post_body(path, body, expected_status, expected_response, client: TestC
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item", "user", "importance"],
+                    "type": "object",
+                    "properties": {
+                        "item": {"$ref": "#/components/schemas/Item"},
+                        "user": {"$ref": "#/components/schemas/User"},
+                        "importance": {"title": "Importance", "type": "integer"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_py310.py
@@ -3,112 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "Body_update_item_items__item_id__put": {
-                "title": "Body_update_item_items__item_id__put",
-                "required": ["item", "user", "importance"],
-                "type": "object",
-                "properties": {
-                    "item": {"$ref": "#/components/schemas/Item"},
-                    "user": {"$ref": "#/components/schemas/User"},
-                    "importance": {"title": "Importance", "type": "integer"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -116,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 # Test required and embedded body parameters with no bodies sent
@@ -204,3 +91,116 @@ def test_post_body(path, body, expected_status, expected_response, client: TestC
     response = client.put(path, json=body)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "Body_update_item_items__item_id__put": {
+                    "title": "Body_update_item_items__item_id__put",
+                    "required": ["item", "user", "importance"],
+                    "type": "object",
+                    "properties": {
+                        "item": {"$ref": "#/components/schemas/Item"},
+                        "user": {"$ref": "#/components/schemas/User"},
+                        "importance": {"title": "Importance", "type": "integer"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
@@ -4,82 +4,6 @@ from docs_src.body_nested_models.tutorial009 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/index-weights/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Index Weights",
-                "operationId": "create_index_weights_index_weights__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "title": "Weights",
-                                "type": "object",
-                                "additionalProperties": {"type": "number"},
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_body():
     data = {"2": 2.2, "3": 3.3}
@@ -100,4 +24,80 @@ def test_post_invalid_body():
                 "type": "type_error.integer",
             }
         ]
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/index-weights/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Index Weights",
+                    "operationId": "create_index_weights_index_weights__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Weights",
+                                    "type": "object",
+                                    "additionalProperties": {"type": "number"},
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009_py39.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009_py39.py
@@ -3,76 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/index-weights/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Index Weights",
-                "operationId": "create_index_weights_index_weights__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "title": "Weights",
-                                "type": "object",
-                                "additionalProperties": {"type": "number"},
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -80,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -110,4 +33,81 @@ def test_post_invalid_body(client: TestClient):
                 "type": "type_error.integer",
             }
         ]
+    }
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/index-weights/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Index Weights",
+                    "operationId": "create_index_weights_index_weights__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Weights",
+                                    "type": "object",
+                                    "additionalProperties": {"type": "number"},
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_body_updates/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001.py
@@ -4,138 +4,6 @@ from docs_src.body_updates.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            },
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                    "tags": {
-                        "title": "Tags",
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.get("/items/baz")
@@ -159,4 +27,136 @@ def test_put():
         "price": 3,
         "tax": 10.5,
         "tags": [],
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                },
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                        "tags": {
+                            "title": "Tags",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_body_updates/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001_py310.py
@@ -3,132 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            },
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                    "tags": {
-                        "title": "Tags",
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -136,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -169,4 +36,137 @@ def test_put(client: TestClient):
         "price": 3,
         "tax": 10.5,
         "tags": [],
+    }
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                },
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                        "tags": {
+                            "title": "Tags",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_body_updates/test_tutorial001_py39.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001_py39.py
@@ -3,132 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            },
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                    "tags": {
-                        "title": "Tags",
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -136,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -169,4 +36,137 @@ def test_put(client: TestClient):
         "price": 3,
         "tax": 10.5,
         "tags": [],
+    }
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                },
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                        "tags": {
+                            "title": "Tags",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
@@ -25,6 +25,7 @@ def test_root():
 
 
 def test_default_openapi():
+    importlib.reload(tutorial001)
     client = TestClient(tutorial001.app)
     response = client.get("/docs")
     assert response.status_code == 200, response.text

--- a/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_conditional_openapi/test_tutorial001.py
@@ -4,35 +4,6 @@ from fastapi.testclient import TestClient
 
 from docs_src.conditional_openapi import tutorial001
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "summary": "Root",
-                "operationId": "root__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_default_openapi():
-    client = TestClient(tutorial001.app)
-    response = client.get("/openapi.json")
-    assert response.json() == openapi_schema
-    response = client.get("/docs")
-    assert response.status_code == 200, response.text
-    response = client.get("/redoc")
-    assert response.status_code == 200, response.text
-
 
 def test_disable_openapi(monkeypatch):
     monkeypatch.setenv("OPENAPI_URL", "")
@@ -51,3 +22,30 @@ def test_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Hello World"}
+
+
+def test_default_openapi():
+    client = TestClient(tutorial001.app)
+    response = client.get("/docs")
+    assert response.status_code == 200, response.text
+    response = client.get("/redoc")
+    assert response.status_code == 200, response.text
+    response = client.get("/openapi.json")
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "summary": "Root",
+                    "operationId": "root__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001.py
@@ -3,77 +3,10 @@ from fastapi.testclient import TestClient
 
 from docs_src.cookie_params.tutorial001 import app
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Ads Id", "type": "string"},
-                        "name": "ads_id",
-                        "in": "cookie",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.mark.parametrize(
     "path,cookies,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"ads_id": None}),
         ("/items", {"ads_id": "ads_track"}, 200, {"ads_id": "ads_track"}),
         (
@@ -90,3 +23,76 @@ def test(path, cookies, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Ads Id", "type": "string"},
+                            "name": "ads_id",
+                            "in": "cookie",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001_an.py
@@ -3,77 +3,10 @@ from fastapi.testclient import TestClient
 
 from docs_src.cookie_params.tutorial001_an import app
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Ads Id", "type": "string"},
-                        "name": "ads_id",
-                        "in": "cookie",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.mark.parametrize(
     "path,cookies,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"ads_id": None}),
         ("/items", {"ads_id": "ads_track"}, 200, {"ads_id": "ads_track"}),
         (
@@ -90,3 +23,76 @@ def test(path, cookies, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Ads Id", "type": "string"},
+                            "name": "ads_id",
+                            "in": "cookie",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001_an_py310.py
@@ -3,78 +3,11 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Ads Id", "type": "string"},
-                        "name": "ads_id",
-                        "in": "cookie",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @needs_py310
 @pytest.mark.parametrize(
     "path,cookies,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"ads_id": None}),
         ("/items", {"ads_id": "ads_track"}, 200, {"ads_id": "ads_track"}),
         (
@@ -93,3 +26,79 @@ def test(path, cookies, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema():
+    from docs_src.cookie_params.tutorial001_an_py310 import app
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Ads Id", "type": "string"},
+                            "name": "ads_id",
+                            "in": "cookie",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001_an_py39.py
@@ -3,78 +3,11 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Ads Id", "type": "string"},
-                        "name": "ads_id",
-                        "in": "cookie",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @needs_py39
 @pytest.mark.parametrize(
     "path,cookies,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"ads_id": None}),
         ("/items", {"ads_id": "ads_track"}, 200, {"ads_id": "ads_track"}),
         (
@@ -93,3 +26,79 @@ def test(path, cookies, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema():
+    from docs_src.cookie_params.tutorial001_an_py39 import app
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Ads Id", "type": "string"},
+                            "name": "ads_id",
+                            "in": "cookie",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001_py310.py
@@ -3,78 +3,11 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Ads Id", "type": "string"},
-                        "name": "ads_id",
-                        "in": "cookie",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @needs_py310
 @pytest.mark.parametrize(
     "path,cookies,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"ads_id": None}),
         ("/items", {"ads_id": "ads_track"}, 200, {"ads_id": "ads_track"}),
         (
@@ -93,3 +26,79 @@ def test(path, cookies, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema():
+    from docs_src.cookie_params.tutorial001_py310 import app
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Ads Id", "type": "string"},
+                            "name": "ads_id",
+                            "in": "cookie",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_custom_response/test_tutorial001.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial001.py
@@ -4,33 +4,31 @@ from docs_src.custom_response.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_custom_response():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == [{"item_id": "Foo"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_custom_response/test_tutorial001b.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial001b.py
@@ -4,33 +4,31 @@ from docs_src.custom_response.tutorial001b import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_custom_response():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == [{"item_id": "Foo"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_custom_response/test_tutorial004.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial004.py
@@ -4,24 +4,6 @@ from docs_src.custom_response.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"text/html": {"schema": {"type": "string"}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        }
-    },
-}
 
 html_contents = """
     <html>
@@ -35,13 +17,30 @@ html_contents = """
     """
 
 
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_get_custom_response():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.text == html_contents
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"text/html": {"schema": {"type": "string"}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_custom_response/test_tutorial005.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial005.py
@@ -4,33 +4,31 @@ from docs_src.custom_response.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "summary": "Main",
-                "operationId": "main__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"text/plain": {"schema": {"type": "string"}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert response.text == "Hello World"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "summary": "Main",
+                    "operationId": "main__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_custom_response/test_tutorial006.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006.py
@@ -5,33 +5,30 @@ from docs_src.custom_response.tutorial006 import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/typer": {
-            "get": {
-                "summary": "Redirect Typer",
-                "operationId": "redirect_typer_typer_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
+def test_get():
+    response = client.get("/typer", follow_redirects=False)
+    assert response.status_code == 307, response.text
+    assert response.headers["location"] == "https://typer.tiangolo.com"
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_get():
-    response = client.get("/typer", follow_redirects=False)
-    assert response.status_code == 307, response.text
-    assert response.headers["location"] == "https://typer.tiangolo.com"
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/typer": {
+                "get": {
+                    "summary": "Redirect Typer",
+                    "operationId": "redirect_typer_typer_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_custom_response/test_tutorial006b.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006b.py
@@ -5,28 +5,25 @@ from docs_src.custom_response.tutorial006b import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/fastapi": {
-            "get": {
-                "summary": "Redirect Fastapi",
-                "operationId": "redirect_fastapi_fastapi_get",
-                "responses": {"307": {"description": "Successful Response"}},
-            }
-        }
-    },
-}
+def test_redirect_response_class():
+    response = client.get("/fastapi", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://fastapi.tiangolo.com"
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_redirect_response_class():
-    response = client.get("/fastapi", follow_redirects=False)
-    assert response.status_code == 307
-    assert response.headers["location"] == "https://fastapi.tiangolo.com"
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/fastapi": {
+                "get": {
+                    "summary": "Redirect Fastapi",
+                    "operationId": "redirect_fastapi_fastapi_get",
+                    "responses": {"307": {"description": "Successful Response"}},
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_custom_response/test_tutorial006c.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006c.py
@@ -5,28 +5,25 @@ from docs_src.custom_response.tutorial006c import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/pydantic": {
-            "get": {
-                "summary": "Redirect Pydantic",
-                "operationId": "redirect_pydantic_pydantic_get",
-                "responses": {"302": {"description": "Successful Response"}},
-            }
-        }
-    },
-}
+def test_redirect_status_code():
+    response = client.get("/pydantic", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "https://pydantic-docs.helpmanual.io/"
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_redirect_status_code():
-    response = client.get("/pydantic", follow_redirects=False)
-    assert response.status_code == 302
-    assert response.headers["location"] == "https://pydantic-docs.helpmanual.io/"
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/pydantic": {
+                "get": {
+                    "summary": "Redirect Pydantic",
+                    "operationId": "redirect_pydantic_pydantic_get",
+                    "responses": {"302": {"description": "Successful Response"}},
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dataclasses/test_tutorial001.py
+++ b/tests/test_tutorial/test_dataclasses/test_tutorial001.py
@@ -4,89 +4,6 @@ from docs_src.dataclasses.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "summary": "Create Item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
-
 
 def test_post_item():
     response = client.post("/items/", json={"name": "Foo", "price": 3})
@@ -110,4 +27,87 @@ def test_post_invalid_item():
                 "type": "type_error.float",
             }
         ]
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "summary": "Create Item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_dataclasses/test_tutorial003.py
+++ b/tests/test_tutorial/test_dataclasses/test_tutorial003.py
@@ -4,136 +4,6 @@ from docs_src.dataclasses.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/authors/{author_id}/items/": {
-            "post": {
-                "summary": "Create Author Items",
-                "operationId": "create_author_items_authors__author_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Author Id", "type": "string"},
-                        "name": "author_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "title": "Items",
-                                "type": "array",
-                                "items": {"$ref": "#/components/schemas/Item"},
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Author"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/authors/": {
-            "get": {
-                "summary": "Get Authors",
-                "operationId": "get_authors_authors__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Get Authors Authors  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Author"},
-                                }
-                            }
-                        },
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Author": {
-                "title": "Author",
-                "required": ["name"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                    },
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200
-    assert response.json() == openapi_schema
-
 
 def test_post_authors_item():
     response = client.post(
@@ -179,3 +49,135 @@ def test_get_authors():
             ],
         },
     ]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/authors/{author_id}/items/": {
+                "post": {
+                    "summary": "Create Author Items",
+                    "operationId": "create_author_items_authors__author_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Author Id", "type": "string"},
+                            "name": "author_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Items",
+                                    "type": "array",
+                                    "items": {"$ref": "#/components/schemas/Item"},
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Author"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/authors/": {
+                "get": {
+                    "summary": "Get Authors",
+                    "operationId": "get_authors_authors__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Get Authors Authors  Get",
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/components/schemas/Author"
+                                        },
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Author": {
+                    "title": "Author",
+                    "required": ["name"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                        },
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial001.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001.py
@@ -5,132 +5,6 @@ from docs_src.dependencies.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -140,10 +14,151 @@ def test_openapi_schema():
         ("/items?q=foo&skip=5", 200, {"q": "foo", "skip": 5, "limit": 100}),
         ("/items?q=foo&skip=5&limit=30", 200, {"q": "foo", "skip": 5, "limit": 30}),
         ("/users", 200, {"q": None, "skip": 0, "limit": 100}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001_an.py
@@ -5,132 +5,6 @@ from docs_src.dependencies.tutorial001_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -140,10 +14,151 @@ def test_openapi_schema():
         ("/items?q=foo&skip=5", 200, {"q": "foo", "skip": 5, "limit": 100}),
         ("/items?q=foo&skip=5&limit=30", 200, {"q": "foo", "skip": 5, "limit": 30}),
         ("/users", 200, {"q": None, "skip": 0, "limit": 100}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001_an_py310.py
@@ -3,126 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -130,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -148,10 +21,152 @@ def test_openapi_schema(client: TestClient):
         ("/items?q=foo&skip=5", 200, {"q": "foo", "skip": 5, "limit": 100}),
         ("/items?q=foo&skip=5&limit=30", 200, {"q": "foo", "skip": 5, "limit": 30}),
         ("/users", 200, {"q": None, "skip": 0, "limit": 100}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get(path, expected_status, expected_response, client: TestClient):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001_an_py39.py
@@ -3,126 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -130,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -148,10 +21,152 @@ def test_openapi_schema(client: TestClient):
         ("/items?q=foo&skip=5", 200, {"q": "foo", "skip": 5, "limit": 100}),
         ("/items?q=foo&skip=5&limit=30", 200, {"q": "foo", "skip": 5, "limit": 30}),
         ("/users", 200, {"q": None, "skip": 0, "limit": 100}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get(path, expected_status, expected_response, client: TestClient):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001_py310.py
@@ -3,126 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -130,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -148,10 +21,152 @@ def test_openapi_schema(client: TestClient):
         ("/items?q=foo&skip=5", 200, {"q": "foo", "skip": 5, "limit": 100}),
         ("/items?q=foo&skip=5&limit=30", 200, {"q": "foo", "skip": 5, "limit": 30}),
         ("/users", 200, {"q": None, "skip": 0, "limit": 100}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get(path, expected_status, expected_response, client: TestClient):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial004.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004.py
@@ -5,90 +5,6 @@ from docs_src.dependencies.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -142,3 +58,95 @@ def test_get(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial004_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004_an.py
@@ -5,90 +5,6 @@ from docs_src.dependencies.tutorial004_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -142,3 +58,95 @@ def test_get(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial004_an_py310.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004_an_py310.py
@@ -3,84 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -88,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -150,3 +65,96 @@ def test_get(path, expected_status, expected_response, client: TestClient):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial004_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004_an_py39.py
@@ -3,84 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -88,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -150,3 +65,96 @@ def test_get(path, expected_status, expected_response, client: TestClient):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial004_py310.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial004_py310.py
@@ -3,84 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Q", "type": "string"},
-                        "name": "q",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -88,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -150,3 +65,96 @@ def test_get(path, expected_status, expected_response, client: TestClient):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Q", "type": "string"},
+                            "name": "q",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial006.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006.py
@@ -4,84 +4,6 @@ from docs_src.dependencies.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_no_headers():
     response = client.get("/items/")
@@ -126,3 +48,81 @@ def test_get_valid_headers():
     )
     assert response.status_code == 200, response.text
     assert response.json() == [{"item": "Foo"}, {"item": "Bar"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial006_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006_an.py
@@ -4,84 +4,6 @@ from docs_src.dependencies.tutorial006_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_no_headers():
     response = client.get("/items/")
@@ -126,3 +48,81 @@ def test_get_valid_headers():
     )
     assert response.status_code == 200, response.text
     assert response.json() == [{"item": "Foo"}, {"item": "Bar"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial006_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006_an_py39.py
@@ -3,78 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -82,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -138,3 +59,82 @@ def test_get_valid_headers(client: TestClient):
     )
     assert response.status_code == 200, response.text
     assert response.json() == [{"item": "Foo"}, {"item": "Bar"}]
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial012.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012.py
@@ -4,120 +4,6 @@ from docs_src.dependencies.tutorial012 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/": {
-            "get": {
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_no_headers_items():
     response = client.get("/items/")
@@ -207,3 +93,117 @@ def test_get_valid_headers_users():
     )
     assert response.status_code == 200, response.text
     assert response.json() == [{"username": "Rick"}, {"username": "Morty"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/": {
+                "get": {
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial012_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012_an.py
@@ -4,120 +4,6 @@ from docs_src.dependencies.tutorial012_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/": {
-            "get": {
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_no_headers_items():
     response = client.get("/items/")
@@ -207,3 +93,117 @@ def test_get_valid_headers_users():
     )
     assert response.status_code == 200, response.text
     assert response.json() == [{"username": "Rick"}, {"username": "Morty"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/": {
+                "get": {
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_dependencies/test_tutorial012_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012_an_py39.py
@@ -3,114 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/": {
-            "get": {
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Token", "type": "string"},
-                        "name": "x-token",
-                        "in": "header",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "X-Key", "type": "string"},
-                        "name": "x-key",
-                        "in": "header",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -118,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -223,3 +108,118 @@ def test_get_valid_headers_users(client: TestClient):
     )
     assert response.status_code == 200, response.text
     assert response.json() == [{"username": "Rick"}, {"username": "Morty"}]
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/": {
+                "get": {
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Token", "type": "string"},
+                            "name": "x-token",
+                            "in": "header",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "X-Key", "type": "string"},
+                            "name": "x-key",
+                            "in": "header",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_events/test_tutorial001.py
+++ b/tests/test_tutorial/test_events/test_tutorial001.py
@@ -2,78 +2,84 @@ from fastapi.testclient import TestClient
 
 from docs_src.events.tutorial001 import app
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 def test_events():
     with TestClient(app) as client:
-        response = client.get("/openapi.json")
-        assert response.status_code == 200, response.text
-        assert response.json() == openapi_schema
         response = client.get("/items/foo")
         assert response.status_code == 200, response.text
         assert response.json() == {"name": "Fighters"}
+
+
+def test_openapi_schema():
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "openapi": "3.0.2",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/items/{item_id}": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
+                        },
+                        "summary": "Read Items",
+                        "operationId": "read_items_items__item_id__get",
+                        "parameters": [
+                            {
+                                "required": True,
+                                "schema": {"title": "Item Id", "type": "string"},
+                                "name": "item_id",
+                                "in": "path",
+                            }
+                        ],
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "ValidationError": {
+                        "title": "ValidationError",
+                        "required": ["loc", "msg", "type"],
+                        "type": "object",
+                        "properties": {
+                            "loc": {
+                                "title": "Location",
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [{"type": "string"}, {"type": "integer"}]
+                                },
+                            },
+                            "msg": {"title": "Message", "type": "string"},
+                            "type": {"title": "Error Type", "type": "string"},
+                        },
+                    },
+                    "HTTPValidationError": {
+                        "title": "HTTPValidationError",
+                        "type": "object",
+                        "properties": {
+                            "detail": {
+                                "title": "Detail",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                },
+                            }
+                        },
+                    },
+                }
+            },
+        }

--- a/tests/test_tutorial/test_events/test_tutorial002.py
+++ b/tests/test_tutorial/test_events/test_tutorial002.py
@@ -2,33 +2,35 @@ from fastapi.testclient import TestClient
 
 from docs_src.events.tutorial002 import app
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        }
-    },
-}
-
 
 def test_events():
     with TestClient(app) as client:
-        response = client.get("/openapi.json")
-        assert response.status_code == 200, response.text
-        assert response.json() == openapi_schema
         response = client.get("/items/")
         assert response.status_code == 200, response.text
         assert response.json() == [{"name": "Foo"}]
     with open("log.txt") as log:
         assert "Application shutdown" in log.read()
+
+
+def test_openapi_schema():
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "openapi": "3.0.2",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/items/": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            }
+                        },
+                        "summary": "Read Items",
+                        "operationId": "read_items_items__get",
+                    }
+                }
+            },
+        }

--- a/tests/test_tutorial/test_events/test_tutorial003.py
+++ b/tests/test_tutorial/test_events/test_tutorial003.py
@@ -6,81 +6,87 @@ from docs_src.events.tutorial003 import (
     ml_models,
 )
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/predict": {
-            "get": {
-                "summary": "Predict",
-                "operationId": "predict_predict_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "X", "type": "number"},
-                        "name": "x",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 def test_events():
     assert not ml_models, "ml_models should be empty"
     with TestClient(app) as client:
         assert ml_models["answer_to_everything"] == fake_answer_to_everything_ml_model
-        response = client.get("/openapi.json")
-        assert response.status_code == 200, response.text
-        assert response.json() == openapi_schema
         response = client.get("/predict", params={"x": 2})
         assert response.status_code == 200, response.text
         assert response.json() == {"result": 84.0}
     assert not ml_models, "ml_models should be empty"
+
+
+def test_openapi_schema():
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "openapi": "3.0.2",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/predict": {
+                    "get": {
+                        "summary": "Predict",
+                        "operationId": "predict_predict_get",
+                        "parameters": [
+                            {
+                                "required": True,
+                                "schema": {"title": "X", "type": "number"},
+                                "name": "x",
+                                "in": "query",
+                            }
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
+                        },
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "HTTPValidationError": {
+                        "title": "HTTPValidationError",
+                        "type": "object",
+                        "properties": {
+                            "detail": {
+                                "title": "Detail",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                },
+                            }
+                        },
+                    },
+                    "ValidationError": {
+                        "title": "ValidationError",
+                        "required": ["loc", "msg", "type"],
+                        "type": "object",
+                        "properties": {
+                            "loc": {
+                                "title": "Location",
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [{"type": "string"}, {"type": "integer"}]
+                                },
+                            },
+                            "msg": {"title": "Message", "type": "string"},
+                            "type": {"title": "Error Type", "type": "string"},
+                        },
+                    },
+                }
+            },
+        }

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
@@ -4,41 +4,38 @@ from docs_src.extending_openapi.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {
-        "title": "Custom title",
-        "version": "2.5.0",
-        "description": "This is a very custom OpenAPI schema",
-        "x-logo": {"url": "https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png"},
-    },
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == [{"name": "Foo"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {
+            "title": "Custom title",
+            "version": "2.5.0",
+            "description": "This is a very custom OpenAPI schema",
+            "x-logo": {
+                "url": "https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png"
+            },
+        },
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
+++ b/tests/test_tutorial/test_extending_openapi/test_tutorial001.py
@@ -39,3 +39,8 @@ def test_openapi_schema():
             }
         },
     }
+    openapi_schema = response.json()
+    # Request again to test the custom cache
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == openapi_schema

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
@@ -5,118 +5,6 @@ from docs_src.extra_data_types.tutorial001 import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "type": "string",
-                            "format": "uuid",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_read_items_items__item_id__put": {
-                "title": "Body_read_items_items__item_id__put",
-                "type": "object",
-                "properties": {
-                    "start_datetime": {
-                        "title": "Start Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "end_datetime": {
-                        "title": "End Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "repeat_at": {
-                        "title": "Repeat At",
-                        "type": "string",
-                        "format": "time",
-                    },
-                    "process_after": {
-                        "title": "Process After",
-                        "type": "number",
-                        "format": "time-delta",
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_extra_types():
     item_id = "ff97dd87-a4a5-4a12-b412-cde99f33e00e"
     data = {
@@ -136,3 +24,114 @@ def test_extra_types():
     response = client.put(f"/items/{item_id}", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "type": "string",
+                                "format": "uuid",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_read_items_items__item_id__put": {
+                    "title": "Body_read_items_items__item_id__put",
+                    "type": "object",
+                    "properties": {
+                        "start_datetime": {
+                            "title": "Start Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "end_datetime": {
+                            "title": "End Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "repeat_at": {
+                            "title": "Repeat At",
+                            "type": "string",
+                            "format": "time",
+                        },
+                        "process_after": {
+                            "title": "Process After",
+                            "type": "number",
+                            "format": "time-delta",
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001_an.py
@@ -5,118 +5,6 @@ from docs_src.extra_data_types.tutorial001_an import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "type": "string",
-                            "format": "uuid",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_read_items_items__item_id__put": {
-                "title": "Body_read_items_items__item_id__put",
-                "type": "object",
-                "properties": {
-                    "start_datetime": {
-                        "title": "Start Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "end_datetime": {
-                        "title": "End Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "repeat_at": {
-                        "title": "Repeat At",
-                        "type": "string",
-                        "format": "time",
-                    },
-                    "process_after": {
-                        "title": "Process After",
-                        "type": "number",
-                        "format": "time-delta",
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_extra_types():
     item_id = "ff97dd87-a4a5-4a12-b412-cde99f33e00e"
     data = {
@@ -136,3 +24,114 @@ def test_extra_types():
     response = client.put(f"/items/{item_id}", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "type": "string",
+                                "format": "uuid",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_read_items_items__item_id__put": {
+                    "title": "Body_read_items_items__item_id__put",
+                    "type": "object",
+                    "properties": {
+                        "start_datetime": {
+                            "title": "Start Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "end_datetime": {
+                            "title": "End Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "repeat_at": {
+                            "title": "Repeat At",
+                            "type": "string",
+                            "format": "time",
+                        },
+                        "process_after": {
+                            "title": "Process After",
+                            "type": "number",
+                            "format": "time-delta",
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001_an_py310.py
@@ -3,111 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "type": "string",
-                            "format": "uuid",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_read_items_items__item_id__put": {
-                "title": "Body_read_items_items__item_id__put",
-                "type": "object",
-                "properties": {
-                    "start_datetime": {
-                        "title": "Start Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "end_datetime": {
-                        "title": "End Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "repeat_at": {
-                        "title": "Repeat At",
-                        "type": "string",
-                        "format": "time",
-                    },
-                    "process_after": {
-                        "title": "Process After",
-                        "type": "number",
-                        "format": "time-delta",
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -115,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -144,3 +32,115 @@ def test_extra_types(client: TestClient):
     response = client.put(f"/items/{item_id}", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "type": "string",
+                                "format": "uuid",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_read_items_items__item_id__put": {
+                    "title": "Body_read_items_items__item_id__put",
+                    "type": "object",
+                    "properties": {
+                        "start_datetime": {
+                            "title": "Start Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "end_datetime": {
+                            "title": "End Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "repeat_at": {
+                            "title": "Repeat At",
+                            "type": "string",
+                            "format": "time",
+                        },
+                        "process_after": {
+                            "title": "Process After",
+                            "type": "number",
+                            "format": "time-delta",
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001_an_py39.py
@@ -3,111 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "type": "string",
-                            "format": "uuid",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_read_items_items__item_id__put": {
-                "title": "Body_read_items_items__item_id__put",
-                "type": "object",
-                "properties": {
-                    "start_datetime": {
-                        "title": "Start Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "end_datetime": {
-                        "title": "End Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "repeat_at": {
-                        "title": "Repeat At",
-                        "type": "string",
-                        "format": "time",
-                    },
-                    "process_after": {
-                        "title": "Process After",
-                        "type": "number",
-                        "format": "time-delta",
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -115,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -144,3 +32,115 @@ def test_extra_types(client: TestClient):
     response = client.put(f"/items/{item_id}", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "type": "string",
+                                "format": "uuid",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_read_items_items__item_id__put": {
+                    "title": "Body_read_items_items__item_id__put",
+                    "type": "object",
+                    "properties": {
+                        "start_datetime": {
+                            "title": "Start Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "end_datetime": {
+                            "title": "End Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "repeat_at": {
+                            "title": "Repeat At",
+                            "type": "string",
+                            "format": "time",
+                        },
+                        "process_after": {
+                            "title": "Process After",
+                            "type": "number",
+                            "format": "time-delta",
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001_py310.py
@@ -3,111 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Item Id",
-                            "type": "string",
-                            "format": "uuid",
-                        },
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_read_items_items__item_id__put": {
-                "title": "Body_read_items_items__item_id__put",
-                "type": "object",
-                "properties": {
-                    "start_datetime": {
-                        "title": "Start Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "end_datetime": {
-                        "title": "End Datetime",
-                        "type": "string",
-                        "format": "date-time",
-                    },
-                    "repeat_at": {
-                        "title": "Repeat At",
-                        "type": "string",
-                        "format": "time",
-                    },
-                    "process_after": {
-                        "title": "Process After",
-                        "type": "number",
-                        "format": "time-delta",
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -115,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -144,3 +32,115 @@ def test_extra_types(client: TestClient):
     response = client.put(f"/items/{item_id}", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {
+                                "title": "Item Id",
+                                "type": "string",
+                                "format": "uuid",
+                            },
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_read_items_items__item_id__put": {
+                    "title": "Body_read_items_items__item_id__put",
+                    "type": "object",
+                    "properties": {
+                        "start_datetime": {
+                            "title": "Start Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "end_datetime": {
+                            "title": "End Datetime",
+                            "type": "string",
+                            "format": "date-time",
+                        },
+                        "repeat_at": {
+                            "title": "Repeat At",
+                            "type": "string",
+                            "format": "time",
+                        },
+                        "process_after": {
+                            "title": "Process After",
+                            "type": "number",
+                            "format": "time-delta",
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial003.py
@@ -4,107 +4,6 @@ from docs_src.extra_models.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Item Items  Item Id  Get",
-                                    "anyOf": [
-                                        {"$ref": "#/components/schemas/PlaneItem"},
-                                        {"$ref": "#/components/schemas/CarItem"},
-                                    ],
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "PlaneItem": {
-                "title": "PlaneItem",
-                "required": ["description", "size"],
-                "type": "object",
-                "properties": {
-                    "description": {"title": "Description", "type": "string"},
-                    "type": {"title": "Type", "type": "string", "default": "plane"},
-                    "size": {"title": "Size", "type": "integer"},
-                },
-            },
-            "CarItem": {
-                "title": "CarItem",
-                "required": ["description"],
-                "type": "object",
-                "properties": {
-                    "description": {"title": "Description", "type": "string"},
-                    "type": {"title": "Type", "type": "string", "default": "car"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_car():
     response = client.get("/items/item1")
@@ -122,4 +21,105 @@ def test_get_plane():
         "description": "Music is my aeroplane, it's my aeroplane",
         "type": "plane",
         "size": 5,
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Item Items  Item Id  Get",
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/PlaneItem"},
+                                            {"$ref": "#/components/schemas/CarItem"},
+                                        ],
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "PlaneItem": {
+                    "title": "PlaneItem",
+                    "required": ["description", "size"],
+                    "type": "object",
+                    "properties": {
+                        "description": {"title": "Description", "type": "string"},
+                        "type": {"title": "Type", "type": "string", "default": "plane"},
+                        "size": {"title": "Size", "type": "integer"},
+                    },
+                },
+                "CarItem": {
+                    "title": "CarItem",
+                    "required": ["description"],
+                    "type": "object",
+                    "properties": {
+                        "description": {"title": "Description", "type": "string"},
+                        "type": {"title": "Type", "type": "string", "default": "car"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_extra_models/test_tutorial003_py310.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial003_py310.py
@@ -3,101 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Item Items  Item Id  Get",
-                                    "anyOf": [
-                                        {"$ref": "#/components/schemas/PlaneItem"},
-                                        {"$ref": "#/components/schemas/CarItem"},
-                                    ],
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "PlaneItem": {
-                "title": "PlaneItem",
-                "required": ["description", "size"],
-                "type": "object",
-                "properties": {
-                    "description": {"title": "Description", "type": "string"},
-                    "type": {"title": "Type", "type": "string", "default": "plane"},
-                    "size": {"title": "Size", "type": "integer"},
-                },
-            },
-            "CarItem": {
-                "title": "CarItem",
-                "required": ["description"],
-                "type": "object",
-                "properties": {
-                    "description": {"title": "Description", "type": "string"},
-                    "type": {"title": "Type", "type": "string", "default": "car"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -105,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -132,4 +30,106 @@ def test_get_plane(client: TestClient):
         "description": "Music is my aeroplane, it's my aeroplane",
         "type": "plane",
         "size": 5,
+    }
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Item Items  Item Id  Get",
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/PlaneItem"},
+                                            {"$ref": "#/components/schemas/CarItem"},
+                                        ],
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "PlaneItem": {
+                    "title": "PlaneItem",
+                    "required": ["description", "size"],
+                    "type": "object",
+                    "properties": {
+                        "description": {"title": "Description", "type": "string"},
+                        "type": {"title": "Type", "type": "string", "default": "plane"},
+                        "size": {"title": "Size", "type": "integer"},
+                    },
+                },
+                "CarItem": {
+                    "title": "CarItem",
+                    "required": ["description"],
+                    "type": "object",
+                    "properties": {
+                        "description": {"title": "Description", "type": "string"},
+                        "type": {"title": "Type", "type": "string", "default": "car"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_extra_models/test_tutorial004.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial004.py
@@ -4,52 +4,6 @@ from docs_src.extra_models.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "description"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_items():
     response = client.get("/items/")
@@ -58,3 +12,47 @@ def test_get_items():
         {"name": "Foo", "description": "There comes my hero"},
         {"name": "Red", "description": "It's my aeroplane"},
     ]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "description"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_models/test_tutorial004_py39.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial004_py39.py
@@ -3,46 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "description"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            }
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -53,13 +13,6 @@ def get_client():
 
 
 @needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-@needs_py39
 def test_get_items(client: TestClient):
     response = client.get("/items/")
     assert response.status_code == 200, response.text
@@ -67,3 +20,48 @@ def test_get_items(client: TestClient):
         {"name": "Foo", "description": "There comes my hero"},
         {"name": "Red", "description": "It's my aeroplane"},
     ]
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "description"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_models/test_tutorial005.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial005.py
@@ -4,41 +4,39 @@ from docs_src.extra_models.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/keyword-weights/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Keyword Weights Keyword Weights  Get",
-                                    "type": "object",
-                                    "additionalProperties": {"type": "number"},
-                                }
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Keyword Weights",
-                "operationId": "read_keyword_weights_keyword_weights__get",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_items():
     response = client.get("/keyword-weights/")
     assert response.status_code == 200, response.text
     assert response.json() == {"foo": 2.3, "bar": 3.4}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/keyword-weights/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Keyword Weights Keyword Weights  Get",
+                                        "type": "object",
+                                        "additionalProperties": {"type": "number"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Keyword Weights",
+                    "operationId": "read_keyword_weights_keyword_weights__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_extra_models/test_tutorial005_py39.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial005_py39.py
@@ -3,33 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/keyword-weights/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Keyword Weights Keyword Weights  Get",
-                                    "type": "object",
-                                    "additionalProperties": {"type": "number"},
-                                }
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Keyword Weights",
-                "operationId": "read_keyword_weights_keyword_weights__get",
-            }
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -40,14 +13,39 @@ def get_client():
 
 
 @needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-@needs_py39
 def test_get_items(client: TestClient):
     response = client.get("/keyword-weights/")
     assert response.status_code == 200, response.text
     assert response.json() == {"foo": 2.3, "bar": 3.4}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/keyword-weights/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Keyword Weights Keyword Weights  Get",
+                                        "type": "object",
+                                        "additionalProperties": {"type": "number"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Keyword Weights",
+                    "operationId": "read_keyword_weights_keyword_weights__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_first_steps/test_tutorial001.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial001.py
@@ -5,35 +5,38 @@ from docs_src.first_steps.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Root",
-                "operationId": "root__get",
-            }
-        }
-    },
-}
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
     [
         ("/", 200, {"message": "Hello World"}),
         ("/nonexistent", 404, {"detail": "Not Found"}),
-        ("/openapi.json", 200, openapi_schema),
     ],
 )
 def test_get_path(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Root",
+                    "operationId": "root__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_generate_clients/test_tutorial003.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial003.py
@@ -4,166 +4,6 @@ from docs_src.generate_clients.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Get Items",
-                "operationId": "items-get_items",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Items-Get Items",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    }
-                },
-            },
-            "post": {
-                "tags": ["items"],
-                "summary": "Create Item",
-                "operationId": "items-create_item",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ResponseMessage"
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-        },
-        "/users/": {
-            "post": {
-                "tags": ["users"],
-                "summary": "Create User",
-                "operationId": "users-create_user",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/User"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ResponseMessage"
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                },
-            },
-            "ResponseMessage": {
-                "title": "ResponseMessage",
-                "required": ["message"],
-                "type": "object",
-                "properties": {"message": {"title": "Message", "type": "string"}},
-            },
-            "User": {
-                "title": "User",
-                "required": ["username", "email"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi():
-    with client:
-        response = client.get("/openapi.json")
-
-        assert response.json() == openapi_schema
-
 
 def test_post_items():
     response = client.post("/items/", json={"name": "Foo", "price": 5})
@@ -186,3 +26,162 @@ def test_get_items():
         {"name": "Plumbus", "price": 3},
         {"name": "Portal Gun", "price": 9001},
     ]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Get Items",
+                    "operationId": "items-get_items",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Items-Get Items",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        }
+                    },
+                },
+                "post": {
+                    "tags": ["items"],
+                    "summary": "Create Item",
+                    "operationId": "items-create_item",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/ResponseMessage"
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+            "/users/": {
+                "post": {
+                    "tags": ["users"],
+                    "summary": "Create User",
+                    "operationId": "users-create_user",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/User"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/ResponseMessage"
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                    },
+                },
+                "ResponseMessage": {
+                    "title": "ResponseMessage",
+                    "required": ["message"],
+                    "type": "object",
+                    "properties": {"message": {"title": "Message", "type": "string"}},
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["username", "email"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {"title": "Email", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial001.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial001.py
@@ -4,78 +4,6 @@ from docs_src.handling_errors.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_item():
     response = client.get("/items/foo")
@@ -88,3 +16,75 @@ def test_get_item_not_found():
     assert response.status_code == 404, response.text
     assert response.headers.get("x-error") is None
     assert response.json() == {"detail": "Item not found"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial002.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial002.py
@@ -4,78 +4,6 @@ from docs_src.handling_errors.tutorial002 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items-header/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Header",
-                "operationId": "read_item_header_items_header__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_item_header():
     response = client.get("/items-header/foo")
@@ -88,3 +16,75 @@ def test_get_item_not_found_header():
     assert response.status_code == 404, response.text
     assert response.headers.get("x-error") == "There goes my error"
     assert response.json() == {"detail": "Item not found"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items-header/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Header",
+                    "operationId": "read_item_header_items_header__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial003.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial003.py
@@ -4,78 +4,6 @@ from docs_src.handling_errors.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/unicorns/{name}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Unicorn",
-                "operationId": "read_unicorn_unicorns__name__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Name", "type": "string"},
-                        "name": "name",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.get("/unicorns/shinny")
@@ -88,4 +16,76 @@ def test_get_exception():
     assert response.status_code == 418, response.text
     assert response.json() == {
         "message": "Oops! yolo did something. There goes a rainbow..."
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/unicorns/{name}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Unicorn",
+                    "operationId": "read_unicorn_unicorns__name__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Name", "type": "string"},
+                            "name": "name",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial004.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial004.py
@@ -4,78 +4,6 @@ from docs_src.handling_errors.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_validation_error():
     response = client.get("/items/foo")
@@ -98,3 +26,75 @@ def test_get():
     response = client.get("/items/2")
     assert response.status_code == 200, response.text
     assert response.json() == {"item_id": 2}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial005.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial005.py
@@ -4,87 +4,6 @@ from docs_src.handling_errors.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "summary": "Create Item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "size"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "size": {"title": "Size", "type": "integer"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_validation_error():
     response = client.post("/items/", json={"title": "towel", "size": "XL"})
@@ -106,3 +25,84 @@ def test_post():
     response = client.post("/items/", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == data
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "summary": "Create Item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "size"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "size": {"title": "Size", "type": "integer"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial006.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial006.py
@@ -4,78 +4,6 @@ from docs_src.handling_errors.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_validation_error():
     response = client.get("/items/foo")
@@ -101,3 +29,75 @@ def test_get():
     response = client.get("/items/2")
     assert response.status_code == 200, response.text
     assert response.json() == {"item_id": 2}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001.py
@@ -6,77 +6,9 @@ from docs_src.header_params.tutorial001 import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "User-Agent", "type": "string"},
-                        "name": "user-agent",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"User-Agent": "testclient"}),
         ("/items", {"X-Header": "notvalid"}, 200, {"User-Agent": "testclient"}),
         ("/items", {"User-Agent": "FastAPI test"}, 200, {"User-Agent": "FastAPI test"}),
@@ -86,3 +18,75 @@ def test(path, headers, expected_status, expected_response):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "User-Agent", "type": "string"},
+                            "name": "user-agent",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001_an.py
@@ -6,77 +6,9 @@ from docs_src.header_params.tutorial001_an import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "User-Agent", "type": "string"},
-                        "name": "user-agent",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"User-Agent": "testclient"}),
         ("/items", {"X-Header": "notvalid"}, 200, {"User-Agent": "testclient"}),
         ("/items", {"User-Agent": "FastAPI test"}, 200, {"User-Agent": "FastAPI test"}),
@@ -86,3 +18,75 @@ def test(path, headers, expected_status, expected_response):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "User-Agent", "type": "string"},
+                            "name": "user-agent",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001_an_py310.py
@@ -12,6 +12,7 @@ def get_client():
     return client
 
 
+@needs_py310
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [

--- a/tests/test_tutorial/test_header_params/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001_an_py310.py
@@ -3,72 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "User-Agent", "type": "string"},
-                        "name": "user-agent",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -78,11 +12,9 @@ def get_client():
     return client
 
 
-@needs_py310
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"User-Agent": "testclient"}),
         ("/items", {"X-Header": "notvalid"}, 200, {"User-Agent": "testclient"}),
         ("/items", {"User-Agent": "FastAPI test"}, 200, {"User-Agent": "FastAPI test"}),
@@ -92,3 +24,76 @@ def test(path, headers, expected_status, expected_response, client: TestClient):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "User-Agent", "type": "string"},
+                            "name": "user-agent",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001_py310.py
@@ -3,72 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "User-Agent", "type": "string"},
-                        "name": "user-agent",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -82,7 +16,6 @@ def get_client():
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"User-Agent": "testclient"}),
         ("/items", {"X-Header": "notvalid"}, 200, {"User-Agent": "testclient"}),
         ("/items", {"User-Agent": "FastAPI test"}, 200, {"User-Agent": "FastAPI test"}),
@@ -92,3 +25,76 @@ def test(path, headers, expected_status, expected_response, client: TestClient):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "User-Agent", "type": "string"},
+                            "name": "user-agent",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial002.py
@@ -6,77 +6,9 @@ from docs_src.header_params.tutorial002 import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Strange Header", "type": "string"},
-                        "name": "strange_header",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"strange_header": None}),
         ("/items", {"X-Header": "notvalid"}, 200, {"strange_header": None}),
         (
@@ -97,3 +29,75 @@ def test(path, headers, expected_status, expected_response):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Strange Header", "type": "string"},
+                            "name": "strange_header",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial002_an.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial002_an.py
@@ -6,77 +6,9 @@ from docs_src.header_params.tutorial002_an import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Strange Header", "type": "string"},
-                        "name": "strange_header",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"strange_header": None}),
         ("/items", {"X-Header": "notvalid"}, 200, {"strange_header": None}),
         (
@@ -97,3 +29,75 @@ def test(path, headers, expected_status, expected_response):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Strange Header", "type": "string"},
+                            "name": "strange_header",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial002_an_py310.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial002_an_py310.py
@@ -3,72 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Strange Header", "type": "string"},
-                        "name": "strange_header",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -82,7 +16,6 @@ def get_client():
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"strange_header": None}),
         ("/items", {"X-Header": "notvalid"}, 200, {"strange_header": None}),
         (
@@ -103,3 +36,76 @@ def test(path, headers, expected_status, expected_response, client: TestClient):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Strange Header", "type": "string"},
+                            "name": "strange_header",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial002_an_py39.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial002_an_py39.py
@@ -3,72 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Strange Header", "type": "string"},
-                        "name": "strange_header",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -82,7 +16,6 @@ def get_client():
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"strange_header": None}),
         ("/items", {"X-Header": "notvalid"}, 200, {"strange_header": None}),
         (
@@ -103,3 +36,79 @@ def test(path, headers, expected_status, expected_response, client: TestClient):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema():
+    from docs_src.header_params.tutorial002_an_py39 import app
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Strange Header", "type": "string"},
+                            "name": "strange_header",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_header_params/test_tutorial002_py310.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial002_py310.py
@@ -3,72 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Strange Header", "type": "string"},
-                        "name": "strange_header",
-                        "in": "header",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -82,7 +16,6 @@ def get_client():
 @pytest.mark.parametrize(
     "path,headers,expected_status,expected_response",
     [
-        ("/openapi.json", None, 200, openapi_schema),
         ("/items", None, 200, {"strange_header": None}),
         ("/items", {"X-Header": "notvalid"}, 200, {"strange_header": None}),
         (
@@ -103,3 +36,79 @@ def test(path, headers, expected_status, expected_response, client: TestClient):
     response = client.get(path, headers=headers)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema():
+    from docs_src.header_params.tutorial002_py310 import app
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {"title": "Strange Header", "type": "string"},
+                            "name": "strange_header",
+                            "in": "header",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_metadata/test_tutorial001.py
+++ b/tests/test_tutorial/test_metadata/test_tutorial001.py
@@ -4,47 +4,45 @@ from docs_src.metadata.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {
-        "title": "ChimichangApp",
-        "description": "\nChimichangApp API helps you do awesome stuff. 🚀\n\n## Items\n\nYou can **read items**.\n\n## Users\n\nYou will be able to:\n\n* **Create users** (_not implemented_).\n* **Read users** (_not implemented_).\n",
-        "termsOfService": "http://example.com/terms/",
-        "contact": {
-            "name": "Deadpoolio the Amazing",
-            "url": "http://x-force.example.com/contact/",
-            "email": "dp@x-force.example.com",
-        },
-        "license": {
-            "name": "Apache 2.0",
-            "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
-        },
-        "version": "0.0.1",
-    },
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_items():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == [{"name": "Katana"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {
+            "title": "ChimichangApp",
+            "description": "\nChimichangApp API helps you do awesome stuff. 🚀\n\n## Items\n\nYou can **read items**.\n\n## Users\n\nYou will be able to:\n\n* **Create users** (_not implemented_).\n* **Read users** (_not implemented_).\n",
+            "termsOfService": "http://example.com/terms/",
+            "contact": {
+                "name": "Deadpoolio the Amazing",
+                "url": "http://x-force.example.com/contact/",
+                "email": "dp@x-force.example.com",
+            },
+            "license": {
+                "name": "Apache 2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+            },
+            "version": "0.0.1",
+        },
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_metadata/test_tutorial004.py
+++ b/tests/test_tutorial/test_metadata/test_tutorial004.py
@@ -4,62 +4,60 @@ from docs_src.metadata.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Get Users",
-                "operationId": "get_users_users__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Get Items",
-                "operationId": "get_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-    },
-    "tags": [
-        {
-            "name": "users",
-            "description": "Operations with users. The **login** logic is also here.",
-        },
-        {
-            "name": "items",
-            "description": "Manage items. So _fancy_ they have their own docs.",
-            "externalDocs": {
-                "description": "Items external docs",
-                "url": "https://fastapi.tiangolo.com/",
-            },
-        },
-    ],
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_path_operations():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     response = client.get("/users/")
     assert response.status_code == 200, response.text
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Get Users",
+                    "operationId": "get_users_users__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Get Items",
+                    "operationId": "get_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+        },
+        "tags": [
+            {
+                "name": "users",
+                "description": "Operations with users. The **login** logic is also here.",
+            },
+            {
+                "name": "items",
+                "description": "Manage items. So _fancy_ they have their own docs.",
+                "externalDocs": {
+                    "description": "Items external docs",
+                    "url": "https://fastapi.tiangolo.com/",
+                },
+            },
+        ],
+    }

--- a/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
+++ b/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
@@ -4,162 +4,6 @@ from docs_src.openapi_callbacks.tutorial001 import app, invoice_notification
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/invoices/": {
-            "post": {
-                "summary": "Create Invoice",
-                "description": 'Create an invoice.\n\nThis will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
-                "operationId": "create_invoice_invoices__post",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Callback Url",
-                            "maxLength": 2083,
-                            "minLength": 1,
-                            "type": "string",
-                            "format": "uri",
-                        },
-                        "name": "callback_url",
-                        "in": "query",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Invoice"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "callbacks": {
-                    "invoice_notification": {
-                        "{$callback_url}/invoices/{$request.body.id}": {
-                            "post": {
-                                "summary": "Invoice Notification",
-                                "operationId": "invoice_notification__callback_url__invoices___request_body_id__post",
-                                "requestBody": {
-                                    "required": True,
-                                    "content": {
-                                        "application/json": {
-                                            "schema": {
-                                                "$ref": "#/components/schemas/InvoiceEvent"
-                                            }
-                                        }
-                                    },
-                                },
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful Response",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/InvoiceEventReceived"
-                                                }
-                                            }
-                                        },
-                                    },
-                                    "422": {
-                                        "description": "Validation Error",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                                }
-                                            }
-                                        },
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Invoice": {
-                "title": "Invoice",
-                "required": ["id", "customer", "total"],
-                "type": "object",
-                "properties": {
-                    "id": {"title": "Id", "type": "string"},
-                    "title": {"title": "Title", "type": "string"},
-                    "customer": {"title": "Customer", "type": "string"},
-                    "total": {"title": "Total", "type": "number"},
-                },
-            },
-            "InvoiceEvent": {
-                "title": "InvoiceEvent",
-                "required": ["description", "paid"],
-                "type": "object",
-                "properties": {
-                    "description": {"title": "Description", "type": "string"},
-                    "paid": {"title": "Paid", "type": "boolean"},
-                },
-            },
-            "InvoiceEventReceived": {
-                "title": "InvoiceEventReceived",
-                "required": ["ok"],
-                "type": "object",
-                "properties": {"ok": {"title": "Ok", "type": "boolean"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi():
-    with client:
-        response = client.get("/openapi.json")
-
-        assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.post(
@@ -172,3 +16,158 @@ def test_get():
 def test_dummy_callback():
     # Just for coverage
     invoice_notification({})
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/invoices/": {
+                "post": {
+                    "summary": "Create Invoice",
+                    "description": 'Create an invoice.\n\nThis will (let\'s imagine) let the API user (some external developer) create an\ninvoice.\n\nAnd this path operation will:\n\n* Send the invoice to the client.\n* Collect the money from the client.\n* Send a notification back to the API user (the external developer), as a callback.\n    * At this point is that the API will somehow send a POST request to the\n        external API with the notification of the invoice event\n        (e.g. "payment successful").',
+                    "operationId": "create_invoice_invoices__post",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Callback Url",
+                                "maxLength": 2083,
+                                "minLength": 1,
+                                "type": "string",
+                                "format": "uri",
+                            },
+                            "name": "callback_url",
+                            "in": "query",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Invoice"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "callbacks": {
+                        "invoice_notification": {
+                            "{$callback_url}/invoices/{$request.body.id}": {
+                                "post": {
+                                    "summary": "Invoice Notification",
+                                    "operationId": "invoice_notification__callback_url__invoices___request_body_id__post",
+                                    "requestBody": {
+                                        "required": True,
+                                        "content": {
+                                            "application/json": {
+                                                "schema": {
+                                                    "$ref": "#/components/schemas/InvoiceEvent"
+                                                }
+                                            }
+                                        },
+                                    },
+                                    "responses": {
+                                        "200": {
+                                            "description": "Successful Response",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/InvoiceEventReceived"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                        "422": {
+                                            "description": "Validation Error",
+                                            "content": {
+                                                "application/json": {
+                                                    "schema": {
+                                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                                    }
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Invoice": {
+                    "title": "Invoice",
+                    "required": ["id", "customer", "total"],
+                    "type": "object",
+                    "properties": {
+                        "id": {"title": "Id", "type": "string"},
+                        "title": {"title": "Title", "type": "string"},
+                        "customer": {"title": "Customer", "type": "string"},
+                        "total": {"title": "Total", "type": "number"},
+                    },
+                },
+                "InvoiceEvent": {
+                    "title": "InvoiceEvent",
+                    "required": ["description", "paid"],
+                    "type": "object",
+                    "properties": {
+                        "description": {"title": "Description", "type": "string"},
+                        "paid": {"title": "Paid", "type": "boolean"},
+                    },
+                },
+                "InvoiceEventReceived": {
+                    "title": "InvoiceEventReceived",
+                    "required": ["ok"],
+                    "type": "object",
+                    "properties": {"ok": {"title": "Ok", "type": "boolean"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial001.py
@@ -4,33 +4,31 @@ from docs_src.path_operation_advanced_configuration.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "some_specific_id_you_define",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == [{"item_id": "Foo"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "some_specific_id_you_define",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial002.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial002.py
@@ -4,33 +4,31 @@ from docs_src.path_operation_advanced_configuration.tutorial002 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items",
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == [{"item_id": "Foo"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial003.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial003.py
@@ -4,20 +4,18 @@ from docs_src.path_operation_advanced_configuration.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {},
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get():
     response = client.get("/items/")
     assert response.status_code == 200, response.text
     assert response.json() == [{"item_id": "Foo"}]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {},
+    }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
@@ -4,101 +4,6 @@ from docs_src.path_operation_advanced_configuration.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create an item",
-                "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                    "tags": {
-                        "title": "Tags",
-                        "uniqueItems": True,
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_query_params_str_validations():
     response = client.post("/items/", json={"name": "Foo", "price": 42})
@@ -109,4 +14,99 @@ def test_query_params_str_validations():
         "description": None,
         "tax": None,
         "tags": [],
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create an item",
+                    "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                        "tags": {
+                            "title": "Tags",
+                            "uniqueItems": True,
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial005.py
@@ -4,33 +4,31 @@ from docs_src.path_operation_advanced_configuration.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "x-aperture-labs-portal": "blue",
-            }
-        }
-    },
-}
+
+def test_get():
+    response = client.get("/items/")
+    assert response.status_code == 200, response.text
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_get():
-    response = client.get("/items/")
-    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "x-aperture-labs-portal": "blue",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial006.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial006.py
@@ -4,47 +4,6 @@ from docs_src.path_operation_advanced_configuration.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "summary": "Create Item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "required": ["name", "price"],
-                                "type": "object",
-                                "properties": {
-                                    "name": {"type": "string"},
-                                    "price": {"type": "number"},
-                                    "description": {"type": "string"},
-                                },
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post():
     response = client.post("/items/", content=b"this is actually not validated")
@@ -55,5 +14,44 @@ def test_post():
             "name": "Maaaagic",
             "price": 42,
             "description": "Just kiddin', no magic here. ✨",
+        },
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "summary": "Create Item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": ["name", "price"],
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "price": {"type": "number"},
+                                        "description": {"type": "string"},
+                                    },
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
         },
     }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial007.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial007.py
@@ -4,51 +4,6 @@ from docs_src.path_operation_advanced_configuration.tutorial007 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "summary": "Create Item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/x-yaml": {
-                            "schema": {
-                                "title": "Item",
-                                "required": ["name", "tags"],
-                                "type": "object",
-                                "properties": {
-                                    "name": {"title": "Name", "type": "string"},
-                                    "tags": {
-                                        "title": "Tags",
-                                        "type": "array",
-                                        "items": {"type": "string"},
-                                    },
-                                },
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post():
     yaml_data = """
@@ -94,4 +49,47 @@ def test_post_invalid():
         "detail": [
             {"loc": ["tags", 3], "msg": "str type expected", "type": "type_error.str"}
         ]
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "summary": "Create Item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-yaml": {
+                                "schema": {
+                                    "title": "Item",
+                                    "required": ["name", "tags"],
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"title": "Name", "type": "string"},
+                                        "tags": {
+                                            "title": "Tags",
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
     }

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial002b.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial002b.py
@@ -4,45 +4,6 @@ from docs_src.path_operation_configuration.tutorial002b import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "tags": ["items"],
-                "summary": "Get Items",
-                "operationId": "get_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-        "/users/": {
-            "get": {
-                "tags": ["users"],
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_items():
     response = client.get("/items/")
@@ -54,3 +15,40 @@ def test_get_users():
     response = client.get("/users/")
     assert response.status_code == 200, response.text
     assert response.json() == ["Rick", "Morty"]
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "tags": ["items"],
+                    "summary": "Get Items",
+                    "operationId": "get_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+            "/users/": {
+                "get": {
+                    "tags": ["users"],
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
@@ -4,101 +4,6 @@ from docs_src.path_operation_configuration.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "The created item",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create an item",
-                "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                    "tags": {
-                        "title": "Tags",
-                        "uniqueItems": True,
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_query_params_str_validations():
     response = client.post("/items/", json={"name": "Foo", "price": 42})
@@ -109,4 +14,99 @@ def test_query_params_str_validations():
         "description": None,
         "tax": None,
         "tags": [],
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "The created item",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create an item",
+                    "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                        "tags": {
+                            "title": "Tags",
+                            "uniqueItems": True,
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial005_py310.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial005_py310.py
@@ -3,95 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "The created item",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create an item",
-                "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                    "tags": {
-                        "title": "Tags",
-                        "uniqueItems": True,
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -99,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -118,4 +22,100 @@ def test_query_params_str_validations(client: TestClient):
         "description": None,
         "tax": None,
         "tags": [],
+    }
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "The created item",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create an item",
+                    "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                        "tags": {
+                            "title": "Tags",
+                            "uniqueItems": True,
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial005_py39.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial005_py39.py
@@ -3,95 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "The created item",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create an item",
-                "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
-                "operationId": "create_item_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number"},
-                    "tags": {
-                        "title": "Tags",
-                        "uniqueItems": True,
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -99,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -118,4 +22,100 @@ def test_query_params_str_validations(client: TestClient):
         "description": None,
         "tax": None,
         "tags": [],
+    }
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "The created item",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create an item",
+                    "description": "Create an item with all the information:\n\n- **name**: each item must have a name\n- **description**: a long description\n- **price**: required\n- **tax**: if the item doesn't have tax, you can omit this\n- **tags**: a set of unique tag strings for this item",
+                    "operationId": "create_item_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number"},
+                        "tags": {
+                            "title": "Tags",
+                            "uniqueItems": True,
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial006.py
@@ -5,59 +5,6 @@ from docs_src.path_operation_configuration.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "tags": ["items"],
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-            }
-        },
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "tags": ["users"],
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-            }
-        },
-        "/elements/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "tags": ["items"],
-                "summary": "Read Elements",
-                "operationId": "read_elements_elements__get",
-                "deprecated": True,
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
@@ -71,3 +18,54 @@ def test_query_params_str_validations(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "tags": ["items"],
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                }
+            },
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "tags": ["users"],
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                }
+            },
+            "/elements/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "tags": ["items"],
+                    "summary": "Read Elements",
+                    "operationId": "read_elements_elements__get",
+                    "deprecated": True,
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_path_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial004.py
@@ -4,78 +4,6 @@ from docs_src.path_params.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/{file_path}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read File",
-                "operationId": "read_file_files__file_path__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "File Path", "type": "string"},
-                        "name": "file_path",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_file_path():
     response = client.get("/files/home/johndoe/myfile.txt")
@@ -89,3 +17,75 @@ def test_root_file_path():
     print(response.content)
     assert response.status_code == 200, response.text
     assert response.json() == {"file_path": "/home/johndoe/myfile.txt"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/{file_path}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read File",
+                    "operationId": "read_file_files__file_path__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "File Path", "type": "string"},
+                            "name": "file_path",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -5,156 +5,6 @@ from docs_src.path_params.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/models/{model_name}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Get Model",
-                "operationId": "get_model_models__model_name__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {
-                            "title": "Model Name",
-                            "enum": ["alexnet", "resnet", "lenet"],
-                            "type": "string",
-                        },
-                        "name": "model_name",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-openapi_schema2 = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/models/{model_name}": {
-            "get": {
-                "summary": "Get Model",
-                "operationId": "get_model_models__model_name__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"$ref": "#/components/schemas/ModelName"},
-                        "name": "model_name",
-                        "in": "path",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ModelName": {
-                "title": "ModelName",
-                "enum": ["alexnet", "resnet", "lenet"],
-                "type": "string",
-                "description": "An enumeration.",
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    data = response.json()
-    assert data == openapi_schema or data == openapi_schema2
-
 
 @pytest.mark.parametrize(
     "url,status_code,expected",
@@ -194,3 +44,82 @@ def test_get_enums(url, status_code, expected):
     response = client.get(url)
     assert response.status_code == status_code
     assert response.json() == expected
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/models/{model_name}": {
+                "get": {
+                    "summary": "Get Model",
+                    "operationId": "get_model_models__model_name__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"$ref": "#/components/schemas/ModelName"},
+                            "name": "model_name",
+                            "in": "path",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ModelName": {
+                    "title": "ModelName",
+                    "enum": ["alexnet", "resnet", "lenet"],
+                    "type": "string",
+                    "description": "An enumeration.",
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial005.py
@@ -5,78 +5,6 @@ from docs_src.query_params.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User Item",
-                "operationId": "read_user_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Needy", "type": "string"},
-                        "name": "needy",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 query_required = {
     "detail": [
@@ -92,7 +20,6 @@ query_required = {
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
     [
-        ("/openapi.json", 200, openapi_schema),
         ("/items/foo?needy=very", 200, {"item_id": "foo", "needy": "very"}),
         ("/items/foo", 422, query_required),
         ("/items/foo", 422, query_required),
@@ -102,3 +29,81 @@ def test(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User Item",
+                    "operationId": "read_user_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Needy", "type": "string"},
+                            "name": "needy",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006.py
@@ -5,90 +5,6 @@ from docs_src.query_params.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User Item",
-                "operationId": "read_user_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Needy", "type": "string"},
-                        "name": "needy",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer"},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 query_required = {
     "detail": [
@@ -104,7 +20,6 @@ query_required = {
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
     [
-        ("/openapi.json", 200, openapi_schema),
         (
             "/items/foo?needy=very",
             200,
@@ -139,3 +54,97 @@ def test(path, expected_status, expected_response):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User Item",
+                    "operationId": "read_user_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Needy", "type": "string"},
+                            "name": "needy",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Limit", "type": "integer"},
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params/test_tutorial006_py310.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006_py310.py
@@ -3,91 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User Item",
-                "operationId": "read_user_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    },
-                    {
-                        "required": True,
-                        "schema": {"title": "Needy", "type": "string"},
-                        "name": "needy",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer"},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
 query_required = {
     "detail": [
         {
@@ -111,7 +26,6 @@ def get_client():
 @pytest.mark.parametrize(
     "path,expected_status,expected_response",
     [
-        ("/openapi.json", 200, openapi_schema),
         (
             "/items/foo?needy=very",
             200,
@@ -146,3 +60,98 @@ def test(path, expected_status, expected_response, client: TestClient):
     response = client.get(path)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User Item",
+                    "operationId": "read_user_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        },
+                        {
+                            "required": True,
+                            "schema": {"title": "Needy", "type": "string"},
+                            "name": "needy",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {"title": "Limit", "type": "integer"},
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
@@ -5,87 +5,6 @@ from docs_src.query_params_str_validations.tutorial010 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "description": "Query string for the items to search in the database that have a good match",
-                        "required": False,
-                        "deprecated": True,
-                        "schema": {
-                            "title": "Query string",
-                            "maxLength": 50,
-                            "minLength": 3,
-                            "pattern": "^fixedquery$",
-                            "type": "string",
-                            "description": "Query string for the items to search in the database that have a good match",
-                        },
-                        "name": "item-query",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 regex_error = {
     "detail": [
@@ -120,3 +39,84 @@ def test_query_params_str_validations(q_name, q, expected_status, expected_respo
     response = client.get(url)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "description": "Query string for the items to search in the database that have a good match",
+                            "required": False,
+                            "deprecated": True,
+                            "schema": {
+                                "title": "Query string",
+                                "maxLength": 50,
+                                "minLength": 3,
+                                "pattern": "^fixedquery$",
+                                "type": "string",
+                                "description": "Query string for the items to search in the database that have a good match",
+                            },
+                            "name": "item-query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an.py
@@ -5,87 +5,6 @@ from docs_src.query_params_str_validations.tutorial010_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "description": "Query string for the items to search in the database that have a good match",
-                        "required": False,
-                        "deprecated": True,
-                        "schema": {
-                            "title": "Query string",
-                            "maxLength": 50,
-                            "minLength": 3,
-                            "pattern": "^fixedquery$",
-                            "type": "string",
-                            "description": "Query string for the items to search in the database that have a good match",
-                        },
-                        "name": "item-query",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 regex_error = {
     "detail": [
@@ -120,3 +39,84 @@ def test_query_params_str_validations(q_name, q, expected_status, expected_respo
     response = client.get(url)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "description": "Query string for the items to search in the database that have a good match",
+                            "required": False,
+                            "deprecated": True,
+                            "schema": {
+                                "title": "Query string",
+                                "maxLength": 50,
+                                "minLength": 3,
+                                "pattern": "^fixedquery$",
+                                "type": "string",
+                                "description": "Query string for the items to search in the database that have a good match",
+                            },
+                            "name": "item-query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py310.py
@@ -3,81 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "description": "Query string for the items to search in the database that have a good match",
-                        "required": False,
-                        "deprecated": True,
-                        "schema": {
-                            "title": "Query string",
-                            "maxLength": 50,
-                            "minLength": 3,
-                            "pattern": "^fixedquery$",
-                            "type": "string",
-                            "description": "Query string for the items to search in the database that have a good match",
-                        },
-                        "name": "item-query",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -85,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 regex_error = {
@@ -130,3 +48,85 @@ def test_query_params_str_validations(
     response = client.get(url)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "description": "Query string for the items to search in the database that have a good match",
+                            "required": False,
+                            "deprecated": True,
+                            "schema": {
+                                "title": "Query string",
+                                "maxLength": 50,
+                                "minLength": 3,
+                                "pattern": "^fixedquery$",
+                                "type": "string",
+                                "description": "Query string for the items to search in the database that have a good match",
+                            },
+                            "name": "item-query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py39.py
@@ -3,81 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "description": "Query string for the items to search in the database that have a good match",
-                        "required": False,
-                        "deprecated": True,
-                        "schema": {
-                            "title": "Query string",
-                            "maxLength": 50,
-                            "minLength": 3,
-                            "pattern": "^fixedquery$",
-                            "type": "string",
-                            "description": "Query string for the items to search in the database that have a good match",
-                        },
-                        "name": "item-query",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -85,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 regex_error = {
@@ -130,3 +48,85 @@ def test_query_params_str_validations(
     response = client.get(url)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "description": "Query string for the items to search in the database that have a good match",
+                            "required": False,
+                            "deprecated": True,
+                            "schema": {
+                                "title": "Query string",
+                                "maxLength": 50,
+                                "minLength": 3,
+                                "pattern": "^fixedquery$",
+                                "type": "string",
+                                "description": "Query string for the items to search in the database that have a good match",
+                            },
+                            "name": "item-query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_py310.py
@@ -3,81 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "description": "Query string for the items to search in the database that have a good match",
-                        "required": False,
-                        "deprecated": True,
-                        "schema": {
-                            "title": "Query string",
-                            "maxLength": 50,
-                            "minLength": 3,
-                            "pattern": "^fixedquery$",
-                            "type": "string",
-                            "description": "Query string for the items to search in the database that have a good match",
-                        },
-                        "name": "item-query",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -85,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 regex_error = {
@@ -130,3 +48,85 @@ def test_query_params_str_validations(
     response = client.get(url)
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "description": "Query string for the items to search in the database that have a good match",
+                            "required": False,
+                            "deprecated": True,
+                            "schema": {
+                                "title": "Query string",
+                                "maxLength": 50,
+                                "minLength": 3,
+                                "pattern": "^fixedquery$",
+                                "type": "string",
+                                "description": "Query string for the items to search in the database that have a good match",
+                            },
+                            "name": "item-query",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
@@ -4,82 +4,6 @@ from docs_src.query_params_str_validations.tutorial011 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_multi_query_values():
     url = "/items/?q=foo&q=bar"
@@ -93,3 +17,79 @@ def test_query_no_values():
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": None}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_an.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_an.py
@@ -4,82 +4,6 @@ from docs_src.query_params_str_validations.tutorial011_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_multi_query_values():
     url = "/items/?q=foo&q=bar"
@@ -93,3 +17,79 @@ def test_query_no_values():
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": None}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_an_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_an_py310.py
@@ -3,76 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -80,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -103,3 +26,80 @@ def test_query_no_values(client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": None}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_an_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_an_py39.py
@@ -3,76 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -80,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -103,3 +26,80 @@ def test_query_no_values(client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": None}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_py310.py
@@ -3,76 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -80,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -103,3 +26,80 @@ def test_query_no_values(client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": None}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011_py39.py
@@ -3,76 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -80,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -103,3 +26,80 @@ def test_query_no_values(client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": None}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
@@ -4,83 +4,6 @@ from docs_src.query_params_str_validations.tutorial012 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "default": ["foo", "bar"],
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_default_query_values():
     url = "/items/"
@@ -94,3 +17,80 @@ def test_multi_query_values():
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": ["baz", "foobar"]}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "default": ["foo", "bar"],
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012_an.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012_an.py
@@ -4,83 +4,6 @@ from docs_src.query_params_str_validations.tutorial012_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "default": ["foo", "bar"],
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_default_query_values():
     url = "/items/"
@@ -94,3 +17,80 @@ def test_multi_query_values():
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": ["baz", "foobar"]}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "default": ["foo", "bar"],
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012_an_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012_an_py39.py
@@ -3,77 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "default": ["foo", "bar"],
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -81,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -104,3 +26,81 @@ def test_multi_query_values(client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": ["baz", "foobar"]}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "default": ["foo", "bar"],
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012_py39.py
@@ -3,77 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "default": ["foo", "bar"],
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -81,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -104,3 +26,81 @@ def test_multi_query_values(client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": ["baz", "foobar"]}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "default": ["foo", "bar"],
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
@@ -4,83 +4,6 @@ from docs_src.query_params_str_validations.tutorial013 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {},
-                            "default": [],
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_multi_query_values():
     url = "/items/?q=foo&q=bar"
@@ -94,3 +17,80 @@ def test_query_no_values():
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": []}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {},
+                                "default": [],
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013_an.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013_an.py
@@ -4,83 +4,6 @@ from docs_src.query_params_str_validations.tutorial013_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {},
-                            "default": [],
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_multi_query_values():
     url = "/items/?q=foo&q=bar"
@@ -94,3 +17,80 @@ def test_query_no_values():
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": []}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {},
+                                "default": [],
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013_an_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013_an_py39.py
@@ -3,77 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Q",
-                            "type": "array",
-                            "items": {},
-                            "default": [],
-                        },
-                        "name": "q",
-                        "in": "query",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -81,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -104,3 +26,81 @@ def test_query_no_values(client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == {"q": []}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Q",
+                                "type": "array",
+                                "items": {},
+                                "default": [],
+                            },
+                            "name": "q",
+                            "in": "query",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial014.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial014.py
@@ -5,71 +5,6 @@ from docs_src.query_params_str_validations.tutorial014 import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_hidden_query():
     response = client.get("/items?hidden_query=somevalue")
     assert response.status_code == 200, response.text
@@ -80,3 +15,67 @@ def test_no_hidden_query():
     response = client.get("/items")
     assert response.status_code == 200, response.text
     assert response.json() == {"hidden_query": "Not found"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_an.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_an.py
@@ -5,71 +5,6 @@ from docs_src.query_params_str_validations.tutorial014_an import app
 client = TestClient(app)
 
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
 def test_hidden_query():
     response = client.get("/items?hidden_query=somevalue")
     assert response.status_code == 200, response.text
@@ -80,3 +15,67 @@ def test_no_hidden_query():
     response = client.get("/items")
     assert response.status_code == 200, response.text
     assert response.json() == {"hidden_query": "Not found"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_an_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_an_py310.py
@@ -3,64 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -68,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -89,3 +24,68 @@ def test_no_hidden_query(client: TestClient):
     response = client.get("/items")
     assert response.status_code == 200, response.text
     assert response.json() == {"hidden_query": "Not found"}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_an_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_an_py39.py
@@ -3,64 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -68,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -89,3 +24,68 @@ def test_no_hidden_query(client: TestClient):
     response = client.get("/items")
     assert response.status_code == 200, response.text
     assert response.json() == {"hidden_query": "Not found"}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial014_py310.py
@@ -3,64 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -68,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -89,3 +24,68 @@ def test_no_hidden_query(client: TestClient):
     response = client.get("/items")
     assert response.status_code == 200, response.text
     assert response.json() == {"hidden_query": "Not found"}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -4,128 +4,6 @@ from docs_src.request_files.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 file_required = {
     "detail": [
@@ -182,3 +60,125 @@ def test_post_upload_file(tmp_path):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_02.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_02.py
@@ -4,124 +4,6 @@ from docs_src.request_files.tutorial001_02 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_form_no_body():
     response = client.post("/files/")
@@ -155,3 +37,121 @@ def test_post_upload_file(tmp_path):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_02_an.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_02_an.py
@@ -4,124 +4,6 @@ from docs_src.request_files.tutorial001_02_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_form_no_body():
     response = client.post("/files/")
@@ -155,3 +37,121 @@ def test_post_upload_file(tmp_path):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_02_an_py310.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_02_an_py310.py
@@ -5,118 +5,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -124,13 +12,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -167,3 +48,122 @@ def test_post_upload_file(tmp_path: Path, client: TestClient):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_02_an_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_02_an_py39.py
@@ -5,118 +5,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -124,13 +12,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -167,3 +48,122 @@ def test_post_upload_file(tmp_path: Path, client: TestClient):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_02_py310.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_02_py310.py
@@ -5,118 +5,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -124,13 +12,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -167,3 +48,122 @@ def test_post_upload_file(tmp_path: Path, client: TestClient):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_03.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_03.py
@@ -4,138 +4,6 @@ from docs_src.request_files.tutorial001_03 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "title": "File",
-                        "type": "string",
-                        "description": "A file read as bytes",
-                        "format": "binary",
-                    }
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "title": "File",
-                        "type": "string",
-                        "description": "A file read as UploadFile",
-                        "format": "binary",
-                    }
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_file(tmp_path):
     path = tmp_path / "test.txt"
@@ -157,3 +25,135 @@ def test_post_upload_file(tmp_path):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {
+                            "title": "File",
+                            "type": "string",
+                            "description": "A file read as bytes",
+                            "format": "binary",
+                        }
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {
+                            "title": "File",
+                            "type": "string",
+                            "description": "A file read as UploadFile",
+                            "format": "binary",
+                        }
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_03_an.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_03_an.py
@@ -4,138 +4,6 @@ from docs_src.request_files.tutorial001_03_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "title": "File",
-                        "type": "string",
-                        "description": "A file read as bytes",
-                        "format": "binary",
-                    }
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "title": "File",
-                        "type": "string",
-                        "description": "A file read as UploadFile",
-                        "format": "binary",
-                    }
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_file(tmp_path):
     path = tmp_path / "test.txt"
@@ -157,3 +25,135 @@ def test_post_upload_file(tmp_path):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {
+                            "title": "File",
+                            "type": "string",
+                            "description": "A file read as bytes",
+                            "format": "binary",
+                        }
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {
+                            "title": "File",
+                            "type": "string",
+                            "description": "A file read as UploadFile",
+                            "format": "binary",
+                        }
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_03_an_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_03_an_py39.py
@@ -3,132 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "title": "File",
-                        "type": "string",
-                        "description": "A file read as bytes",
-                        "format": "binary",
-                    }
-                },
-            },
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "title": "File",
-                        "type": "string",
-                        "description": "A file read as UploadFile",
-                        "format": "binary",
-                    }
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -136,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -165,3 +32,136 @@ def test_post_upload_file(tmp_path, client: TestClient):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {
+                            "title": "File",
+                            "type": "string",
+                            "description": "A file read as bytes",
+                            "format": "binary",
+                        }
+                    },
+                },
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {
+                            "title": "File",
+                            "type": "string",
+                            "description": "A file read as UploadFile",
+                            "format": "binary",
+                        }
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_an.py
@@ -4,128 +4,6 @@ from docs_src.request_files.tutorial001_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 file_required = {
     "detail": [
@@ -182,3 +60,125 @@ def test_post_upload_file(tmp_path):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_an_py39.py
@@ -3,122 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/uploadfile/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Upload File",
-                "operationId": "create_upload_file_uploadfile__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_upload_file_uploadfile__post": {
-                "title": "Body_create_upload_file_uploadfile__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"}
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -126,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 file_required = {
@@ -192,3 +69,126 @@ def test_post_upload_file(tmp_path, client: TestClient):
         response = client.post("/uploadfile/", files={"file": file})
     assert response.status_code == 200, response.text
     assert response.json() == {"filename": "test.txt"}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/uploadfile/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Upload File",
+                    "operationId": "create_upload_file_uploadfile__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_file_uploadfile__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_upload_file_uploadfile__post": {
+                    "title": "Body_create_upload_file_uploadfile__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"}
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002.py
@@ -4,148 +4,6 @@ from docs_src.request_files.tutorial002 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Main",
-                "operationId": "main__get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 file_required = {
     "detail": [
@@ -213,3 +71,145 @@ def test_get_root():
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Main",
+                    "operationId": "main__get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial002_an.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002_an.py
@@ -4,148 +4,6 @@ from docs_src.request_files.tutorial002_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Main",
-                "operationId": "main__get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 file_required = {
     "detail": [
@@ -213,3 +71,145 @@ def test_get_root():
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Main",
+                    "operationId": "main__get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial002_an_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002_an_py39.py
@@ -4,142 +4,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Main",
-                "operationId": "main__get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="app")
 def get_app():
@@ -152,13 +16,6 @@ def get_app():
 def get_client(app: FastAPI):
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 file_required = {
@@ -232,3 +89,146 @@ def test_get_root(app: FastAPI):
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Main",
+                    "operationId": "main__get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial002_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002_py39.py
@@ -4,142 +4,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Main",
-                "operationId": "main__get",
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="app")
 def get_app():
@@ -152,13 +16,6 @@ def get_app():
 def get_client(app: FastAPI):
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 file_required = {
@@ -232,3 +89,146 @@ def test_get_root(app: FastAPI):
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Main",
+                    "operationId": "main__get",
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial003.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial003.py
@@ -4,150 +4,6 @@ from docs_src.request_files.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Main",
-                "operationId": "main__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as bytes",
-                    }
-                },
-            },
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as UploadFile",
-                    }
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_files(tmp_path):
     path = tmp_path / "test.txt"
@@ -192,3 +48,147 @@ def test_get_root():
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "summary": "Main",
+                    "operationId": "main__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as bytes",
+                        }
+                    },
+                },
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as UploadFile",
+                        }
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial003_an.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial003_an.py
@@ -4,150 +4,6 @@ from docs_src.request_files.tutorial003_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Main",
-                "operationId": "main__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as bytes",
-                    }
-                },
-            },
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as UploadFile",
-                    }
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_files(tmp_path):
     path = tmp_path / "test.txt"
@@ -192,3 +48,147 @@ def test_get_root():
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "summary": "Main",
+                    "operationId": "main__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as bytes",
+                        }
+                    },
+                },
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as UploadFile",
+                        }
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial003_an_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial003_an_py39.py
@@ -4,144 +4,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Main",
-                "operationId": "main__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as bytes",
-                    }
-                },
-            },
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as UploadFile",
-                    }
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="app")
 def get_app():
@@ -154,13 +16,6 @@ def get_app():
 def get_client(app: FastAPI):
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 file_required = {
@@ -220,3 +75,148 @@ def test_get_root(app: FastAPI):
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "summary": "Main",
+                    "operationId": "main__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as bytes",
+                        }
+                    },
+                },
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as UploadFile",
+                        }
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_files/test_tutorial003_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial003_py39.py
@@ -4,144 +4,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "summary": "Create Files",
-                "operationId": "create_files_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_files_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/uploadfiles/": {
-            "post": {
-                "summary": "Create Upload Files",
-                "operationId": "create_upload_files_uploadfiles__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Main",
-                "operationId": "main__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_create_files_files__post": {
-                "title": "Body_create_files_files__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as bytes",
-                    }
-                },
-            },
-            "Body_create_upload_files_uploadfiles__post": {
-                "title": "Body_create_upload_files_uploadfiles__post",
-                "required": ["files"],
-                "type": "object",
-                "properties": {
-                    "files": {
-                        "title": "Files",
-                        "type": "array",
-                        "items": {"type": "string", "format": "binary"},
-                        "description": "Multiple files as UploadFile",
-                    }
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="app")
 def get_app():
@@ -154,13 +16,6 @@ def get_app():
 def get_client(app: FastAPI):
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 file_required = {
@@ -220,3 +75,148 @@ def test_get_root(app: FastAPI):
     response = client.get("/")
     assert response.status_code == 200, response.text
     assert b"<form" in response.content
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "summary": "Create Files",
+                    "operationId": "create_files_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_files_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/uploadfiles/": {
+                "post": {
+                    "summary": "Create Upload Files",
+                    "operationId": "create_upload_files_uploadfiles__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_upload_files_uploadfiles__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/": {
+                "get": {
+                    "summary": "Main",
+                    "operationId": "main__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_create_files_files__post": {
+                    "title": "Body_create_files_files__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as bytes",
+                        }
+                    },
+                },
+                "Body_create_upload_files_uploadfiles__post": {
+                    "title": "Body_create_upload_files_uploadfiles__post",
+                    "required": ["files"],
+                    "type": "object",
+                    "properties": {
+                        "files": {
+                            "title": "Files",
+                            "type": "array",
+                            "items": {"type": "string", "format": "binary"},
+                            "description": "Multiple files as UploadFile",
+                        }
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -5,89 +5,6 @@ from docs_src.request_forms.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/login/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_login__post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_login__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_login_login__post": {
-                "title": "Body_login_login__post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 password_required = {
     "detail": [
@@ -147,3 +64,86 @@ def test_post_body_json():
     response = client.post("/login/", json={"username": "Foo", "password": "secret"})
     assert response.status_code == 422, response.text
     assert response.json() == username_and_password_required
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/login/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_login__post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_login__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_login_login__post": {
+                    "title": "Body_login_login__post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_forms/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001_an.py
@@ -5,89 +5,6 @@ from docs_src.request_forms.tutorial001_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/login/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_login__post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_login__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_login_login__post": {
-                "title": "Body_login_login__post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 password_required = {
     "detail": [
@@ -147,3 +64,86 @@ def test_post_body_json():
     response = client.post("/login/", json={"username": "Foo", "password": "secret"})
     assert response.status_code == 422, response.text
     assert response.json() == username_and_password_required
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/login/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_login__post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_login__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_login_login__post": {
+                    "title": "Body_login_login__post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_forms/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001_an_py39.py
@@ -3,83 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/login/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_login__post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_login__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_login_login__post": {
-                "title": "Body_login_login__post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -87,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 password_required = {
@@ -158,3 +74,87 @@ def test_post_body_json(client: TestClient):
     response = client.post("/login/", json={"username": "Foo", "password": "secret"})
     assert response.status_code == 422, response.text
     assert response.json() == username_and_password_required
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/login/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_login__post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_login__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_login_login__post": {
+                    "title": "Body_login_login__post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -4,90 +4,6 @@ from docs_src.request_forms_and_files.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file", "fileb", "token"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"},
-                    "fileb": {"title": "Fileb", "type": "string", "format": "binary"},
-                    "token": {"title": "Token", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 file_required = {
     "detail": [
@@ -189,4 +105,92 @@ def test_post_files_and_token(tmp_path):
         "file_size": 14,
         "token": "foo",
         "fileb_content_type": "text/plain",
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file", "fileb", "token"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"},
+                        "fileb": {
+                            "title": "Fileb",
+                            "type": "string",
+                            "format": "binary",
+                        },
+                        "token": {"title": "Token", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an.py
@@ -4,90 +4,6 @@ from docs_src.request_forms_and_files.tutorial001_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file", "fileb", "token"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"},
-                    "fileb": {"title": "Fileb", "type": "string", "format": "binary"},
-                    "token": {"title": "Token", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 file_required = {
     "detail": [
@@ -189,4 +105,92 @@ def test_post_files_and_token(tmp_path):
         "file_size": 14,
         "token": "foo",
         "fileb_content_type": "text/plain",
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file", "fileb", "token"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"},
+                        "fileb": {
+                            "title": "Fileb",
+                            "type": "string",
+                            "format": "binary",
+                        },
+                        "token": {"title": "Token", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an_py39.py
@@ -4,84 +4,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/files/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create File",
-                "operationId": "create_file_files__post",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_create_file_files__post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Body_create_file_files__post": {
-                "title": "Body_create_file_files__post",
-                "required": ["file", "fileb", "token"],
-                "type": "object",
-                "properties": {
-                    "file": {"title": "File", "type": "string", "format": "binary"},
-                    "fileb": {"title": "Fileb", "type": "string", "format": "binary"},
-                    "token": {"title": "Token", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="app")
 def get_app():
@@ -94,13 +16,6 @@ def get_app():
 def get_client(app: FastAPI):
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 file_required = {
@@ -208,4 +123,93 @@ def test_post_files_and_token(tmp_path, app: FastAPI):
         "file_size": 14,
         "token": "foo",
         "fileb_content_type": "text/plain",
+    }
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/files/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create File",
+                    "operationId": "create_file_files__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_create_file_files__post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Body_create_file_files__post": {
+                    "title": "Body_create_file_files__post",
+                    "required": ["file", "fileb", "token"],
+                    "type": "object",
+                    "properties": {
+                        "file": {"title": "File", "type": "string", "format": "binary"},
+                        "fileb": {
+                            "title": "Fileb",
+                            "type": "string",
+                            "format": "binary",
+                        },
+                        "token": {"title": "Token", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial003.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003.py
@@ -4,103 +4,6 @@ from docs_src.response_model.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/user/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/UserOut"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_user__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserIn"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "UserOut": {
-                "title": "UserOut",
-                "required": ["username", "email"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "UserIn": {
-                "title": "UserIn",
-                "required": ["username", "password", "email"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_user():
     response = client.post(
@@ -117,4 +20,109 @@ def test_post_user():
         "username": "foo",
         "email": "foo@example.com",
         "full_name": "Grave Dohl",
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/user/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/UserOut"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_user__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserIn"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "UserOut": {
+                    "title": "UserOut",
+                    "required": ["username", "email"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "UserIn": {
+                    "title": "UserIn",
+                    "required": ["username", "password", "email"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_01.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_01.py
@@ -4,103 +4,6 @@ from docs_src.response_model.tutorial003_01 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/user/": {
-            "post": {
-                "summary": "Create User",
-                "operationId": "create_user_user__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserIn"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/BaseUser"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "BaseUser": {
-                "title": "BaseUser",
-                "required": ["username", "email"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "UserIn": {
-                "title": "UserIn",
-                "required": ["username", "email", "password"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_post_user():
     response = client.post(
@@ -117,4 +20,109 @@ def test_post_user():
         "username": "foo",
         "email": "foo@example.com",
         "full_name": "Grave Dohl",
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/user/": {
+                "post": {
+                    "summary": "Create User",
+                    "operationId": "create_user_user__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserIn"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/BaseUser"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "BaseUser": {
+                    "title": "BaseUser",
+                    "required": ["username", "email"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "UserIn": {
+                    "title": "UserIn",
+                    "required": ["username", "email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_01_py310.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_01_py310.py
@@ -3,97 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/user/": {
-            "post": {
-                "summary": "Create User",
-                "operationId": "create_user_user__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserIn"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/BaseUser"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "BaseUser": {
-                "title": "BaseUser",
-                "required": ["username", "email"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "UserIn": {
-                "title": "UserIn",
-                "required": ["username", "email", "password"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -101,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -126,4 +28,110 @@ def test_post_user(client: TestClient):
         "username": "foo",
         "email": "foo@example.com",
         "full_name": "Grave Dohl",
+    }
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/user/": {
+                "post": {
+                    "summary": "Create User",
+                    "operationId": "create_user_user__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserIn"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/BaseUser"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "BaseUser": {
+                    "title": "BaseUser",
+                    "required": ["username", "email"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "UserIn": {
+                    "title": "UserIn",
+                    "required": ["username", "email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_02.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_02.py
@@ -4,82 +4,6 @@ from docs_src.response_model.tutorial003_02 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/portal": {
-            "get": {
-                "summary": "Get Portal",
-                "operationId": "get_portal_portal_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Teleport",
-                            "type": "boolean",
-                            "default": False,
-                        },
-                        "name": "teleport",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_portal():
     response = client.get("/portal")
@@ -91,3 +15,79 @@ def test_get_redirect():
     response = client.get("/portal", params={"teleport": True}, follow_redirects=False)
     assert response.status_code == 307, response.text
     assert response.headers["location"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/portal": {
+                "get": {
+                    "summary": "Get Portal",
+                    "operationId": "get_portal_portal_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Teleport",
+                                "type": "boolean",
+                                "default": False,
+                            },
+                            "name": "teleport",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_03.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_03.py
@@ -4,33 +4,31 @@ from docs_src.response_model.tutorial003_03 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/teleport": {
-            "get": {
-                "summary": "Get Teleport",
-                "operationId": "get_teleport_teleport_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_portal():
     response = client.get("/teleport", follow_redirects=False)
     assert response.status_code == 307, response.text
     assert response.headers["location"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/teleport": {
+                "get": {
+                    "summary": "Get Teleport",
+                    "operationId": "get_teleport_teleport_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_05.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_05.py
@@ -4,82 +4,6 @@ from docs_src.response_model.tutorial003_05 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/portal": {
-            "get": {
-                "summary": "Get Portal",
-                "operationId": "get_portal_portal_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Teleport",
-                            "type": "boolean",
-                            "default": False,
-                        },
-                        "name": "teleport",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_get_portal():
     response = client.get("/portal")
@@ -91,3 +15,79 @@ def test_get_redirect():
     response = client.get("/portal", params={"teleport": True}, follow_redirects=False)
     assert response.status_code == 307, response.text
     assert response.headers["location"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/portal": {
+                "get": {
+                    "summary": "Get Portal",
+                    "operationId": "get_portal_portal_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Teleport",
+                                "type": "boolean",
+                                "default": False,
+                            },
+                            "name": "teleport",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_05_py310.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_05_py310.py
@@ -3,76 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/portal": {
-            "get": {
-                "summary": "Get Portal",
-                "operationId": "get_portal_portal_get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {
-                            "title": "Teleport",
-                            "type": "boolean",
-                            "default": False,
-                        },
-                        "name": "teleport",
-                        "in": "query",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -80,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -101,3 +24,80 @@ def test_get_redirect(client: TestClient):
     response = client.get("/portal", params={"teleport": True}, follow_redirects=False)
     assert response.status_code == 307, response.text
     assert response.headers["location"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/portal": {
+                "get": {
+                    "summary": "Get Portal",
+                    "operationId": "get_portal_portal_get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Teleport",
+                                "type": "boolean",
+                                "default": False,
+                            },
+                            "name": "teleport",
+                            "in": "query",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_py310.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_py310.py
@@ -3,97 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/user/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/UserOut"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_user__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserIn"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "UserOut": {
-                "title": "UserOut",
-                "required": ["username", "email"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "UserIn": {
-                "title": "UserIn",
-                "required": ["username", "password", "email"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "email": {"title": "Email", "type": "string", "format": "email"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -101,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -126,4 +28,110 @@ def test_post_user(client: TestClient):
         "username": "foo",
         "email": "foo@example.com",
         "full_name": "Grave Dohl",
+    }
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/user/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/UserOut"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_user__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserIn"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "UserOut": {
+                    "title": "UserOut",
+                    "required": ["username", "email"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "UserIn": {
+                    "title": "UserIn",
+                    "required": ["username", "password", "email"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "email": {
+                            "title": "Email",
+                            "type": "string",
+                            "format": "email",
+                        },
+                        "full_name": {"title": "Full Name", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial004.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial004.py
@@ -5,99 +5,6 @@ from docs_src.response_model.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                    "tags": {
-                        "title": "Tags",
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 @pytest.mark.parametrize(
     "url,data",
@@ -123,3 +30,96 @@ def test_get(url, data):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == data
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                        "tags": {
+                            "title": "Tags",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_response_model/test_tutorial004_py310.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial004_py310.py
@@ -3,93 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                    "tags": {
-                        "title": "Tags",
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -97,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -131,3 +37,97 @@ def test_get(url, data, client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == data
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                        "tags": {
+                            "title": "Tags",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_response_model/test_tutorial004_py39.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial004_py39.py
@@ -3,93 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item",
-                "operationId": "read_item_items__item_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                    "tags": {
-                        "title": "Tags",
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "default": [],
-                    },
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -97,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -131,3 +37,97 @@ def test_get(url, data, client: TestClient):
     response = client.get(url)
     assert response.status_code == 200, response.text
     assert response.json() == data
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item",
+                    "operationId": "read_item_items__item_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                        "tags": {
+                            "title": "Tags",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "default": [],
+                        },
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_response_model/test_tutorial005.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial005.py
@@ -4,127 +4,6 @@ from docs_src.response_model.tutorial005 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}/name": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Name",
-                "operationId": "read_item_name_items__item_id__name_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/items/{item_id}/public": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Public Data",
-                "operationId": "read_item_public_data_items__item_id__public_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_read_item_name():
     response = client.get("/items/bar/name")
@@ -139,4 +18,125 @@ def test_read_item_public_data():
         "name": "Bar",
         "description": "The Bar fighters",
         "price": 62,
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}/name": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Name",
+                    "operationId": "read_item_name_items__item_id__name_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/items/{item_id}/public": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Public Data",
+                    "operationId": "read_item_public_data_items__item_id__public_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial005_py310.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial005_py310.py
@@ -3,121 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}/name": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Name",
-                "operationId": "read_item_name_items__item_id__name_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/items/{item_id}/public": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Public Data",
-                "operationId": "read_item_public_data_items__item_id__public_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -125,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -149,4 +27,126 @@ def test_read_item_public_data(client: TestClient):
         "name": "Bar",
         "description": "The Bar fighters",
         "price": 62,
+    }
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}/name": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Name",
+                    "operationId": "read_item_name_items__item_id__name_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/items/{item_id}/public": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Public Data",
+                    "operationId": "read_item_public_data_items__item_id__public_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial006.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial006.py
@@ -4,127 +4,6 @@ from docs_src.response_model.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}/name": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Name",
-                "operationId": "read_item_name_items__item_id__name_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/items/{item_id}/public": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Public Data",
-                "operationId": "read_item_public_data_items__item_id__public_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_read_item_name():
     response = client.get("/items/bar/name")
@@ -139,4 +18,125 @@ def test_read_item_public_data():
         "name": "Bar",
         "description": "The Bar fighters",
         "price": 62,
+    }
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}/name": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Name",
+                    "operationId": "read_item_name_items__item_id__name_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/items/{item_id}/public": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Public Data",
+                    "operationId": "read_item_public_data_items__item_id__public_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_response_model/test_tutorial006_py310.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial006_py310.py
@@ -3,121 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}/name": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Name",
-                "operationId": "read_item_name_items__item_id__name_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/items/{item_id}/public": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Item Public Data",
-                "operationId": "read_item_public_data_items__item_id__public_get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "string"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "description": {"title": "Description", "type": "string"},
-                    "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -125,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -149,4 +27,126 @@ def test_read_item_public_data(client: TestClient):
         "name": "Bar",
         "description": "The Bar fighters",
         "price": 62,
+    }
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}/name": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Name",
+                    "operationId": "read_item_name_items__item_id__name_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/items/{item_id}/public": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Item Public Data",
+                    "operationId": "read_item_public_data_items__item_id__public_get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "string"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "description": {"title": "Description", "type": "string"},
+                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
     }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial004.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial004.py
@@ -4,121 +4,6 @@ from docs_src.schema_extra_example.tutorial004 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "examples": {
-                                "normal": {
-                                    "summary": "A normal example",
-                                    "description": "A **normal** item works correctly.",
-                                    "value": {
-                                        "name": "Foo",
-                                        "description": "A very nice Item",
-                                        "price": 35.4,
-                                        "tax": 3.2,
-                                    },
-                                },
-                                "converted": {
-                                    "summary": "An example with converted data",
-                                    "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
-                                    "value": {"name": "Bar", "price": "35.4"},
-                                },
-                                "invalid": {
-                                    "summary": "Invalid data is rejected with an error",
-                                    "value": {
-                                        "name": "Baz",
-                                        "price": "thirty five point four",
-                                    },
-                                },
-                            },
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 # Test required and embedded body parameters with no bodies sent
 def test_post_body_example():
@@ -132,3 +17,118 @@ def test_post_body_example():
         },
     )
     assert response.status_code == 200
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "examples": {
+                                    "normal": {
+                                        "summary": "A normal example",
+                                        "description": "A **normal** item works correctly.",
+                                        "value": {
+                                            "name": "Foo",
+                                            "description": "A very nice Item",
+                                            "price": 35.4,
+                                            "tax": 3.2,
+                                        },
+                                    },
+                                    "converted": {
+                                        "summary": "An example with converted data",
+                                        "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
+                                        "value": {"name": "Bar", "price": "35.4"},
+                                    },
+                                    "invalid": {
+                                        "summary": "Invalid data is rejected with an error",
+                                        "value": {
+                                            "name": "Baz",
+                                            "price": "thirty five point four",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial004_an.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial004_an.py
@@ -4,121 +4,6 @@ from docs_src.schema_extra_example.tutorial004_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "examples": {
-                                "normal": {
-                                    "summary": "A normal example",
-                                    "description": "A **normal** item works correctly.",
-                                    "value": {
-                                        "name": "Foo",
-                                        "description": "A very nice Item",
-                                        "price": 35.4,
-                                        "tax": 3.2,
-                                    },
-                                },
-                                "converted": {
-                                    "summary": "An example with converted data",
-                                    "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
-                                    "value": {"name": "Bar", "price": "35.4"},
-                                },
-                                "invalid": {
-                                    "summary": "Invalid data is rejected with an error",
-                                    "value": {
-                                        "name": "Baz",
-                                        "price": "thirty five point four",
-                                    },
-                                },
-                            },
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 # Test required and embedded body parameters with no bodies sent
 def test_post_body_example():
@@ -132,3 +17,118 @@ def test_post_body_example():
         },
     )
     assert response.status_code == 200
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "examples": {
+                                    "normal": {
+                                        "summary": "A normal example",
+                                        "description": "A **normal** item works correctly.",
+                                        "value": {
+                                            "name": "Foo",
+                                            "description": "A very nice Item",
+                                            "price": 35.4,
+                                            "tax": 3.2,
+                                        },
+                                    },
+                                    "converted": {
+                                        "summary": "An example with converted data",
+                                        "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
+                                        "value": {"name": "Bar", "price": "35.4"},
+                                    },
+                                    "invalid": {
+                                        "summary": "Invalid data is rejected with an error",
+                                        "value": {
+                                            "name": "Baz",
+                                            "price": "thirty five point four",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial004_an_py310.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial004_an_py310.py
@@ -3,115 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "examples": {
-                                "normal": {
-                                    "summary": "A normal example",
-                                    "description": "A **normal** item works correctly.",
-                                    "value": {
-                                        "name": "Foo",
-                                        "description": "A very nice Item",
-                                        "price": 35.4,
-                                        "tax": 3.2,
-                                    },
-                                },
-                                "converted": {
-                                    "summary": "An example with converted data",
-                                    "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
-                                    "value": {"name": "Bar", "price": "35.4"},
-                                },
-                                "invalid": {
-                                    "summary": "Invalid data is rejected with an error",
-                                    "value": {
-                                        "name": "Baz",
-                                        "price": "thirty five point four",
-                                    },
-                                },
-                            },
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -119,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 # Test required and embedded body parameters with no bodies sent
@@ -141,3 +25,119 @@ def test_post_body_example(client: TestClient):
         },
     )
     assert response.status_code == 200
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "examples": {
+                                    "normal": {
+                                        "summary": "A normal example",
+                                        "description": "A **normal** item works correctly.",
+                                        "value": {
+                                            "name": "Foo",
+                                            "description": "A very nice Item",
+                                            "price": 35.4,
+                                            "tax": 3.2,
+                                        },
+                                    },
+                                    "converted": {
+                                        "summary": "An example with converted data",
+                                        "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
+                                        "value": {"name": "Bar", "price": "35.4"},
+                                    },
+                                    "invalid": {
+                                        "summary": "Invalid data is rejected with an error",
+                                        "value": {
+                                            "name": "Baz",
+                                            "price": "thirty five point four",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial004_an_py39.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial004_an_py39.py
@@ -3,115 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "examples": {
-                                "normal": {
-                                    "summary": "A normal example",
-                                    "description": "A **normal** item works correctly.",
-                                    "value": {
-                                        "name": "Foo",
-                                        "description": "A very nice Item",
-                                        "price": 35.4,
-                                        "tax": 3.2,
-                                    },
-                                },
-                                "converted": {
-                                    "summary": "An example with converted data",
-                                    "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
-                                    "value": {"name": "Bar", "price": "35.4"},
-                                },
-                                "invalid": {
-                                    "summary": "Invalid data is rejected with an error",
-                                    "value": {
-                                        "name": "Baz",
-                                        "price": "thirty five point four",
-                                    },
-                                },
-                            },
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -119,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 # Test required and embedded body parameters with no bodies sent
@@ -141,3 +25,119 @@ def test_post_body_example(client: TestClient):
         },
     )
     assert response.status_code == 200
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "examples": {
+                                    "normal": {
+                                        "summary": "A normal example",
+                                        "description": "A **normal** item works correctly.",
+                                        "value": {
+                                            "name": "Foo",
+                                            "description": "A very nice Item",
+                                            "price": 35.4,
+                                            "tax": 3.2,
+                                        },
+                                    },
+                                    "converted": {
+                                        "summary": "An example with converted data",
+                                        "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
+                                        "value": {"name": "Bar", "price": "35.4"},
+                                    },
+                                    "invalid": {
+                                        "summary": "Invalid data is rejected with an error",
+                                        "value": {
+                                            "name": "Baz",
+                                            "price": "thirty five point four",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial004_py310.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial004_py310.py
@@ -3,115 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/{item_id}": {
-            "put": {
-                "summary": "Update Item",
-                "operationId": "update_item_items__item_id__put",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "Item Id", "type": "integer"},
-                        "name": "item_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/Item"},
-                            "examples": {
-                                "normal": {
-                                    "summary": "A normal example",
-                                    "description": "A **normal** item works correctly.",
-                                    "value": {
-                                        "name": "Foo",
-                                        "description": "A very nice Item",
-                                        "price": 35.4,
-                                        "tax": 3.2,
-                                    },
-                                },
-                                "converted": {
-                                    "summary": "An example with converted data",
-                                    "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
-                                    "value": {"name": "Bar", "price": "35.4"},
-                                },
-                                "invalid": {
-                                    "summary": "Invalid data is rejected with an error",
-                                    "value": {
-                                        "name": "Baz",
-                                        "price": "thirty five point four",
-                                    },
-                                },
-                            },
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["name", "price"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "price": {"title": "Price", "type": "number"},
-                    "tax": {"title": "Tax", "type": "number"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -119,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 # Test required and embedded body parameters with no bodies sent
@@ -141,3 +25,119 @@ def test_post_body_example(client: TestClient):
         },
     )
     assert response.status_code == 200
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/{item_id}": {
+                "put": {
+                    "summary": "Update Item",
+                    "operationId": "update_item_items__item_id__put",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "Item Id", "type": "integer"},
+                            "name": "item_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Item"},
+                                "examples": {
+                                    "normal": {
+                                        "summary": "A normal example",
+                                        "description": "A **normal** item works correctly.",
+                                        "value": {
+                                            "name": "Foo",
+                                            "description": "A very nice Item",
+                                            "price": 35.4,
+                                            "tax": 3.2,
+                                        },
+                                    },
+                                    "converted": {
+                                        "summary": "An example with converted data",
+                                        "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
+                                        "value": {"name": "Bar", "price": "35.4"},
+                                    },
+                                    "invalid": {
+                                        "summary": "Invalid data is rejected with an error",
+                                        "value": {
+                                            "name": "Baz",
+                                            "price": "thirty five point four",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["name", "price"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "price": {"title": "Price", "type": "number"},
+                        "tax": {"title": "Tax", "type": "number"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial001.py
+++ b/tests/test_tutorial/test_security/test_tutorial001.py
@@ -4,40 +4,6 @@ from docs_src.security.tutorial001 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_no_token():
     response = client.get("/items")
@@ -57,3 +23,35 @@ def test_incorrect_token():
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_security/test_tutorial001_an.py
@@ -4,40 +4,6 @@ from docs_src.security.tutorial001_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        }
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_no_token():
     response = client.get("/items")
@@ -57,3 +23,35 @@ def test_incorrect_token():
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_security/test_tutorial001_an_py39.py
@@ -3,34 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        }
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -38,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -68,3 +33,36 @@ def test_incorrect_token(client: TestClient):
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -4,116 +4,6 @@ from docs_src.security.tutorial003 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me_get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_token_post": {
-                "title": "Body_login_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_login():
     response = client.post("/token", data={"username": "johndoe", "password": "secret"})
@@ -174,3 +64,113 @@ def test_inactive_user():
     response = client.get("/users/me", headers={"Authorization": "Bearer alice"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "Inactive user"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me_get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_token_post": {
+                    "title": "Body_login_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial003_an.py
+++ b/tests/test_tutorial/test_security/test_tutorial003_an.py
@@ -4,116 +4,6 @@ from docs_src.security.tutorial003_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me_get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_token_post": {
-                "title": "Body_login_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_login():
     response = client.post("/token", data={"username": "johndoe", "password": "secret"})
@@ -174,3 +64,113 @@ def test_inactive_user():
     response = client.get("/users/me", headers={"Authorization": "Bearer alice"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "Inactive user"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me_get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_token_post": {
+                    "title": "Body_login_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial003_an_py310.py
+++ b/tests/test_tutorial/test_security/test_tutorial003_an_py310.py
@@ -3,110 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me_get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_token_post": {
-                "title": "Body_login_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        },
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -114,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -190,3 +79,114 @@ def test_inactive_user(client: TestClient):
     response = client.get("/users/me", headers={"Authorization": "Bearer alice"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "Inactive user"}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me_get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_token_post": {
+                    "title": "Body_login_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial003_an_py39.py
+++ b/tests/test_tutorial/test_security/test_tutorial003_an_py39.py
@@ -3,110 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me_get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_token_post": {
-                "title": "Body_login_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        },
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -114,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -190,3 +79,114 @@ def test_inactive_user(client: TestClient):
     response = client.get("/users/me", headers={"Authorization": "Bearer alice"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "Inactive user"}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me_get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_token_post": {
+                    "title": "Body_login_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial003_py310.py
+++ b/tests/test_tutorial/test_security/test_tutorial003_py310.py
@@ -3,110 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login",
-                "operationId": "login_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me_get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "Body_login_token_post": {
-                "title": "Body_login_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
-            }
-        },
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -114,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -190,3 +79,114 @@ def test_inactive_user(client: TestClient):
     response = client.get("/users/me", headers={"Authorization": "Bearer alice"})
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "Inactive user"}
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login",
+                    "operationId": "login_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me_get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Body_login_token_post": {
+                    "title": "Body_login_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {"password": {"scopes": {}, "tokenUrl": "token"}},
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -10,178 +10,6 @@ from docs_src.security.tutorial005 import (
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Token"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login For Access Token",
-                "operationId": "login_for_access_token_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me__get",
-                "security": [{"OAuth2PasswordBearer": ["me"]}],
-            }
-        },
-        "/users/me/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Own Items",
-                "operationId": "read_own_items_users_me_items__get",
-                "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
-            }
-        },
-        "/status/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read System Status",
-                "operationId": "read_system_status_status__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "disabled": {"title": "Disabled", "type": "boolean"},
-                },
-            },
-            "Token": {
-                "title": "Token",
-                "required": ["access_token", "token_type"],
-                "type": "object",
-                "properties": {
-                    "access_token": {"title": "Access Token", "type": "string"},
-                    "token_type": {"title": "Token Type", "type": "string"},
-                },
-            },
-            "Body_login_for_access_token_token_post": {
-                "title": "Body_login_for_access_token_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "me": "Read information about the current user.",
-                            "items": "Read items.",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def get_access_token(username="johndoe", password="secret", scope=None):
     data = {"username": username, "password": password}
@@ -345,3 +173,175 @@ def test_read_system_status_no_token():
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Token"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login For Access Token",
+                    "operationId": "login_for_access_token_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me__get",
+                    "security": [{"OAuth2PasswordBearer": ["me"]}],
+                }
+            },
+            "/users/me/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Own Items",
+                    "operationId": "read_own_items_users_me_items__get",
+                    "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
+                }
+            },
+            "/status/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read System Status",
+                    "operationId": "read_system_status_status__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {"title": "Email", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "disabled": {"title": "Disabled", "type": "boolean"},
+                    },
+                },
+                "Token": {
+                    "title": "Token",
+                    "required": ["access_token", "token_type"],
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"title": "Access Token", "type": "string"},
+                        "token_type": {"title": "Token Type", "type": "string"},
+                    },
+                },
+                "Body_login_for_access_token_token_post": {
+                    "title": "Body_login_for_access_token_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "me": "Read information about the current user.",
+                                "items": "Read items.",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial005_an.py
+++ b/tests/test_tutorial/test_security/test_tutorial005_an.py
@@ -10,178 +10,6 @@ from docs_src.security.tutorial005_an import (
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Token"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login For Access Token",
-                "operationId": "login_for_access_token_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me__get",
-                "security": [{"OAuth2PasswordBearer": ["me"]}],
-            }
-        },
-        "/users/me/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Own Items",
-                "operationId": "read_own_items_users_me_items__get",
-                "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
-            }
-        },
-        "/status/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read System Status",
-                "operationId": "read_system_status_status__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "disabled": {"title": "Disabled", "type": "boolean"},
-                },
-            },
-            "Token": {
-                "title": "Token",
-                "required": ["access_token", "token_type"],
-                "type": "object",
-                "properties": {
-                    "access_token": {"title": "Access Token", "type": "string"},
-                    "token_type": {"title": "Token Type", "type": "string"},
-                },
-            },
-            "Body_login_for_access_token_token_post": {
-                "title": "Body_login_for_access_token_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "me": "Read information about the current user.",
-                            "items": "Read items.",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def get_access_token(username="johndoe", password="secret", scope=None):
     data = {"username": username, "password": password}
@@ -345,3 +173,175 @@ def test_read_system_status_no_token():
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Token"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login For Access Token",
+                    "operationId": "login_for_access_token_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me__get",
+                    "security": [{"OAuth2PasswordBearer": ["me"]}],
+                }
+            },
+            "/users/me/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Own Items",
+                    "operationId": "read_own_items_users_me_items__get",
+                    "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
+                }
+            },
+            "/status/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read System Status",
+                    "operationId": "read_system_status_status__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {"title": "Email", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "disabled": {"title": "Disabled", "type": "boolean"},
+                    },
+                },
+                "Token": {
+                    "title": "Token",
+                    "required": ["access_token", "token_type"],
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"title": "Access Token", "type": "string"},
+                        "token_type": {"title": "Token Type", "type": "string"},
+                    },
+                },
+                "Body_login_for_access_token_token_post": {
+                    "title": "Body_login_for_access_token_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "me": "Read information about the current user.",
+                                "items": "Read items.",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial005_an_py310.py
+++ b/tests/test_tutorial/test_security/test_tutorial005_an_py310.py
@@ -3,172 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Token"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login For Access Token",
-                "operationId": "login_for_access_token_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me__get",
-                "security": [{"OAuth2PasswordBearer": ["me"]}],
-            }
-        },
-        "/users/me/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Own Items",
-                "operationId": "read_own_items_users_me_items__get",
-                "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
-            }
-        },
-        "/status/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read System Status",
-                "operationId": "read_system_status_status__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "disabled": {"title": "Disabled", "type": "boolean"},
-                },
-            },
-            "Token": {
-                "title": "Token",
-                "required": ["access_token", "token_type"],
-                "type": "object",
-                "properties": {
-                    "access_token": {"title": "Access Token", "type": "string"},
-                    "token_type": {"title": "Token Type", "type": "string"},
-                },
-            },
-            "Body_login_for_access_token_token_post": {
-                "title": "Body_login_for_access_token_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "me": "Read information about the current user.",
-                            "items": "Read items.",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -176,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def get_access_token(
@@ -373,3 +200,176 @@ def test_read_system_status_no_token(client: TestClient):
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Token"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login For Access Token",
+                    "operationId": "login_for_access_token_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me__get",
+                    "security": [{"OAuth2PasswordBearer": ["me"]}],
+                }
+            },
+            "/users/me/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Own Items",
+                    "operationId": "read_own_items_users_me_items__get",
+                    "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
+                }
+            },
+            "/status/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read System Status",
+                    "operationId": "read_system_status_status__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {"title": "Email", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "disabled": {"title": "Disabled", "type": "boolean"},
+                    },
+                },
+                "Token": {
+                    "title": "Token",
+                    "required": ["access_token", "token_type"],
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"title": "Access Token", "type": "string"},
+                        "token_type": {"title": "Token Type", "type": "string"},
+                    },
+                },
+                "Body_login_for_access_token_token_post": {
+                    "title": "Body_login_for_access_token_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "me": "Read information about the current user.",
+                                "items": "Read items.",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial005_an_py39.py
+++ b/tests/test_tutorial/test_security/test_tutorial005_an_py39.py
@@ -3,172 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Token"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login For Access Token",
-                "operationId": "login_for_access_token_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me__get",
-                "security": [{"OAuth2PasswordBearer": ["me"]}],
-            }
-        },
-        "/users/me/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Own Items",
-                "operationId": "read_own_items_users_me_items__get",
-                "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
-            }
-        },
-        "/status/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read System Status",
-                "operationId": "read_system_status_status__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "disabled": {"title": "Disabled", "type": "boolean"},
-                },
-            },
-            "Token": {
-                "title": "Token",
-                "required": ["access_token", "token_type"],
-                "type": "object",
-                "properties": {
-                    "access_token": {"title": "Access Token", "type": "string"},
-                    "token_type": {"title": "Token Type", "type": "string"},
-                },
-            },
-            "Body_login_for_access_token_token_post": {
-                "title": "Body_login_for_access_token_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "me": "Read information about the current user.",
-                            "items": "Read items.",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -176,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def get_access_token(
@@ -373,3 +200,176 @@ def test_read_system_status_no_token(client: TestClient):
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Token"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login For Access Token",
+                    "operationId": "login_for_access_token_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me__get",
+                    "security": [{"OAuth2PasswordBearer": ["me"]}],
+                }
+            },
+            "/users/me/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Own Items",
+                    "operationId": "read_own_items_users_me_items__get",
+                    "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
+                }
+            },
+            "/status/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read System Status",
+                    "operationId": "read_system_status_status__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {"title": "Email", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "disabled": {"title": "Disabled", "type": "boolean"},
+                    },
+                },
+                "Token": {
+                    "title": "Token",
+                    "required": ["access_token", "token_type"],
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"title": "Access Token", "type": "string"},
+                        "token_type": {"title": "Token Type", "type": "string"},
+                    },
+                },
+                "Body_login_for_access_token_token_post": {
+                    "title": "Body_login_for_access_token_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "me": "Read information about the current user.",
+                                "items": "Read items.",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial005_py310.py
+++ b/tests/test_tutorial/test_security/test_tutorial005_py310.py
@@ -3,172 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Token"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login For Access Token",
-                "operationId": "login_for_access_token_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me__get",
-                "security": [{"OAuth2PasswordBearer": ["me"]}],
-            }
-        },
-        "/users/me/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Own Items",
-                "operationId": "read_own_items_users_me_items__get",
-                "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
-            }
-        },
-        "/status/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read System Status",
-                "operationId": "read_system_status_status__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "disabled": {"title": "Disabled", "type": "boolean"},
-                },
-            },
-            "Token": {
-                "title": "Token",
-                "required": ["access_token", "token_type"],
-                "type": "object",
-                "properties": {
-                    "access_token": {"title": "Access Token", "type": "string"},
-                    "token_type": {"title": "Token Type", "type": "string"},
-                },
-            },
-            "Body_login_for_access_token_token_post": {
-                "title": "Body_login_for_access_token_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "me": "Read information about the current user.",
-                            "items": "Read items.",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -176,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py310
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def get_access_token(
@@ -373,3 +200,176 @@ def test_read_system_status_no_token(client: TestClient):
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+@needs_py310
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Token"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login For Access Token",
+                    "operationId": "login_for_access_token_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me__get",
+                    "security": [{"OAuth2PasswordBearer": ["me"]}],
+                }
+            },
+            "/users/me/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Own Items",
+                    "operationId": "read_own_items_users_me_items__get",
+                    "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
+                }
+            },
+            "/status/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read System Status",
+                    "operationId": "read_system_status_status__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {"title": "Email", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "disabled": {"title": "Disabled", "type": "boolean"},
+                    },
+                },
+                "Token": {
+                    "title": "Token",
+                    "required": ["access_token", "token_type"],
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"title": "Access Token", "type": "string"},
+                        "token_type": {"title": "Token Type", "type": "string"},
+                    },
+                },
+                "Body_login_for_access_token_token_post": {
+                    "title": "Body_login_for_access_token_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "me": "Read information about the current user.",
+                                "items": "Read items.",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial005_py39.py
+++ b/tests/test_tutorial/test_security/test_tutorial005_py39.py
@@ -3,172 +3,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/token": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Token"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Login For Access Token",
-                "operationId": "login_for_access_token_token_post",
-                "requestBody": {
-                    "content": {
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/users/me/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    }
-                },
-                "summary": "Read Users Me",
-                "operationId": "read_users_me_users_me__get",
-                "security": [{"OAuth2PasswordBearer": ["me"]}],
-            }
-        },
-        "/users/me/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Own Items",
-                "operationId": "read_own_items_users_me_items__get",
-                "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
-            }
-        },
-        "/status/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read System Status",
-                "operationId": "read_system_status_status__get",
-                "security": [{"OAuth2PasswordBearer": []}],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "User": {
-                "title": "User",
-                "required": ["username"],
-                "type": "object",
-                "properties": {
-                    "username": {"title": "Username", "type": "string"},
-                    "email": {"title": "Email", "type": "string"},
-                    "full_name": {"title": "Full Name", "type": "string"},
-                    "disabled": {"title": "Disabled", "type": "boolean"},
-                },
-            },
-            "Token": {
-                "title": "Token",
-                "required": ["access_token", "token_type"],
-                "type": "object",
-                "properties": {
-                    "access_token": {"title": "Access Token", "type": "string"},
-                    "token_type": {"title": "Token Type", "type": "string"},
-                },
-            },
-            "Body_login_for_access_token_token_post": {
-                "title": "Body_login_for_access_token_token_post",
-                "required": ["username", "password"],
-                "type": "object",
-                "properties": {
-                    "grant_type": {
-                        "title": "Grant Type",
-                        "pattern": "password",
-                        "type": "string",
-                    },
-                    "username": {"title": "Username", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                    "scope": {"title": "Scope", "type": "string", "default": ""},
-                    "client_id": {"title": "Client Id", "type": "string"},
-                    "client_secret": {"title": "Client Secret", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        },
-        "securitySchemes": {
-            "OAuth2PasswordBearer": {
-                "type": "oauth2",
-                "flows": {
-                    "password": {
-                        "scopes": {
-                            "me": "Read information about the current user.",
-                            "items": "Read items.",
-                        },
-                        "tokenUrl": "token",
-                    }
-                },
-            }
-        },
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -176,13 +10,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def get_access_token(
@@ -373,3 +200,176 @@ def test_read_system_status_no_token(client: TestClient):
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Not authenticated"}
     assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/token": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Token"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Login For Access Token",
+                    "operationId": "login_for_access_token_token_post",
+                    "requestBody": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Body_login_for_access_token_token_post"
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/users/me/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        }
+                    },
+                    "summary": "Read Users Me",
+                    "operationId": "read_users_me_users_me__get",
+                    "security": [{"OAuth2PasswordBearer": ["me"]}],
+                }
+            },
+            "/users/me/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Own Items",
+                    "operationId": "read_own_items_users_me_items__get",
+                    "security": [{"OAuth2PasswordBearer": ["items", "me"]}],
+                }
+            },
+            "/status/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read System Status",
+                    "operationId": "read_system_status_status__get",
+                    "security": [{"OAuth2PasswordBearer": []}],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "title": "User",
+                    "required": ["username"],
+                    "type": "object",
+                    "properties": {
+                        "username": {"title": "Username", "type": "string"},
+                        "email": {"title": "Email", "type": "string"},
+                        "full_name": {"title": "Full Name", "type": "string"},
+                        "disabled": {"title": "Disabled", "type": "boolean"},
+                    },
+                },
+                "Token": {
+                    "title": "Token",
+                    "required": ["access_token", "token_type"],
+                    "type": "object",
+                    "properties": {
+                        "access_token": {"title": "Access Token", "type": "string"},
+                        "token_type": {"title": "Token Type", "type": "string"},
+                    },
+                },
+                "Body_login_for_access_token_token_post": {
+                    "title": "Body_login_for_access_token_token_post",
+                    "required": ["username", "password"],
+                    "type": "object",
+                    "properties": {
+                        "grant_type": {
+                            "title": "Grant Type",
+                            "pattern": "password",
+                            "type": "string",
+                        },
+                        "username": {"title": "Username", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                        "scope": {"title": "Scope", "type": "string", "default": ""},
+                        "client_id": {"title": "Client Id", "type": "string"},
+                        "client_secret": {"title": "Client Secret", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            },
+            "securitySchemes": {
+                "OAuth2PasswordBearer": {
+                    "type": "oauth2",
+                    "flows": {
+                        "password": {
+                            "scopes": {
+                                "me": "Read information about the current user.",
+                                "items": "Read items.",
+                            },
+                            "tokenUrl": "token",
+                        }
+                    },
+                }
+            },
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial006.py
+++ b/tests/test_tutorial/test_security/test_tutorial006.py
@@ -6,35 +6,6 @@ from docs_src.security.tutorial006 import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBasic": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_basic():
     response = client.get("/users/me", auth=("john", "secret"))
@@ -65,3 +36,30 @@ def test_security_http_basic_non_basic_credentials():
     assert response.status_code == 401, response.text
     assert response.headers["WWW-Authenticate"] == "Basic"
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBasic": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial006_an.py
+++ b/tests/test_tutorial/test_security/test_tutorial006_an.py
@@ -6,35 +6,6 @@ from docs_src.security.tutorial006_an import app
 
 client = TestClient(app)
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBasic": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
-    },
-}
-
-
-def test_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
 
 def test_security_http_basic():
     response = client.get("/users/me", auth=("john", "secret"))
@@ -65,3 +36,30 @@ def test_security_http_basic_non_basic_credentials():
     assert response.status_code == 401, response.text
     assert response.headers["WWW-Authenticate"] == "Basic"
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBasic": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
+        },
+    }

--- a/tests/test_tutorial/test_security/test_tutorial006_an_py39.py
+++ b/tests/test_tutorial/test_security/test_tutorial006_an_py39.py
@@ -5,29 +5,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/me": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Current User",
-                "operationId": "read_current_user_users_me_get",
-                "security": [{"HTTPBasic": []}],
-            }
-        }
-    },
-    "components": {
-        "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
-    },
-}
-
 
 @pytest.fixture(name="client")
 def get_client():
@@ -35,13 +12,6 @@ def get_client():
 
     client = TestClient(app)
     return client
-
-
-@needs_py39
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -77,3 +47,31 @@ def test_security_http_basic_non_basic_credentials(client: TestClient):
     assert response.status_code == 401, response.text
     assert response.headers["WWW-Authenticate"] == "Basic"
     assert response.json() == {"detail": "Invalid authentication credentials"}
+
+
+@needs_py39
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/me": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Current User",
+                    "operationId": "read_current_user_users_me_get",
+                    "security": [{"HTTPBasic": []}],
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
+        },
+    }

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases.py
@@ -5,283 +5,6 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Users Users  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_users__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        },
-        "/users/{user_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User",
-                "operationId": "read_user_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/users/{user_id}/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item For User",
-                "operationId": "create_item_for_user_users__user_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ItemCreate": {
-                "title": "ItemCreate",
-                "required": ["title"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "id", "owner_id"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "owner_id": {"title": "Owner Id", "type": "integer"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["email", "id", "is_active"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "is_active": {"title": "Is Active", "type": "boolean"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                        "default": [],
-                    },
-                },
-            },
-            "UserCreate": {
-                "title": "UserCreate",
-                "required": ["email", "password"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(scope="module")
 def client(tmp_path_factory: pytest.TempPathFactory):
@@ -301,12 +24,6 @@ def client(tmp_path_factory: pytest.TempPathFactory):
     if test_db.is_file():  # pragma: nocover
         test_db.unlink()
     os.chdir(cwd)
-
-
-def test_openapi_schema(client):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_create_user(client):
@@ -366,3 +83,302 @@ def test_read_items(client):
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+def test_openapi_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Users Users  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                },
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            },
+            "/users/{user_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User",
+                    "operationId": "read_user_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/users/{user_id}/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item For User",
+                    "operationId": "create_item_for_user_users__user_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ItemCreate": {
+                    "title": "ItemCreate",
+                    "required": ["title"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "id", "owner_id"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "owner_id": {"title": "Owner Id", "type": "integer"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["email", "id", "is_active"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "is_active": {"title": "Is Active", "type": "boolean"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                            "default": [],
+                        },
+                    },
+                },
+                "UserCreate": {
+                    "title": "UserCreate",
+                    "required": ["email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware.py
@@ -4,283 +4,6 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Users Users  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_users__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        },
-        "/users/{user_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User",
-                "operationId": "read_user_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/users/{user_id}/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item For User",
-                "operationId": "create_item_for_user_users__user_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ItemCreate": {
-                "title": "ItemCreate",
-                "required": ["title"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "id", "owner_id"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "owner_id": {"title": "Owner Id", "type": "integer"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["email", "id", "is_active"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "is_active": {"title": "Is Active", "type": "boolean"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                        "default": [],
-                    },
-                },
-            },
-            "UserCreate": {
-                "title": "UserCreate",
-                "required": ["email", "password"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(scope="module")
 def client():
@@ -297,12 +20,6 @@ def client():
         yield c
     if test_db.is_file():  # pragma: nocover
         test_db.unlink()
-
-
-def test_openapi_schema(client):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_create_user(client):
@@ -368,3 +85,302 @@ def test_read_items(client):
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+def test_openapi_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Users Users  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                },
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            },
+            "/users/{user_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User",
+                    "operationId": "read_user_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/users/{user_id}/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item For User",
+                    "operationId": "create_item_for_user_users__user_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ItemCreate": {
+                    "title": "ItemCreate",
+                    "required": ["title"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "id", "owner_id"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "owner_id": {"title": "Owner Id", "type": "integer"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["email", "id", "is_active"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "is_active": {"title": "Is Active", "type": "boolean"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                            "default": [],
+                        },
+                    },
+                },
+                "UserCreate": {
+                    "title": "UserCreate",
+                    "required": ["email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware_py310.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware_py310.py
@@ -7,283 +7,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Users Users  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_users__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        },
-        "/users/{user_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User",
-                "operationId": "read_user_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/users/{user_id}/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item For User",
-                "operationId": "create_item_for_user_users__user_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ItemCreate": {
-                "title": "ItemCreate",
-                "required": ["title"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "id", "owner_id"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "owner_id": {"title": "Owner Id", "type": "integer"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["email", "id", "is_active"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "is_active": {"title": "Is Active", "type": "boolean"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                        "default": [],
-                    },
-                },
-            },
-            "UserCreate": {
-                "title": "UserCreate",
-                "required": ["email", "password"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(scope="module")
 def client(tmp_path_factory: pytest.TempPathFactory):
@@ -304,13 +27,6 @@ def client(tmp_path_factory: pytest.TempPathFactory):
     if test_db.is_file():  # pragma: nocover
         test_db.unlink()
     os.chdir(cwd)
-
-
-@needs_py310
-def test_openapi_schema(client):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -382,3 +98,303 @@ def test_read_items(client):
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+@needs_py310
+def test_openapi_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Users Users  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                },
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            },
+            "/users/{user_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User",
+                    "operationId": "read_user_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/users/{user_id}/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item For User",
+                    "operationId": "create_item_for_user_users__user_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ItemCreate": {
+                    "title": "ItemCreate",
+                    "required": ["title"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "id", "owner_id"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "owner_id": {"title": "Owner Id", "type": "integer"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["email", "id", "is_active"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "is_active": {"title": "Is Active", "type": "boolean"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                            "default": [],
+                        },
+                    },
+                },
+                "UserCreate": {
+                    "title": "UserCreate",
+                    "required": ["email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware_py39.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases_middleware_py39.py
@@ -7,283 +7,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Users Users  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_users__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        },
-        "/users/{user_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User",
-                "operationId": "read_user_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/users/{user_id}/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item For User",
-                "operationId": "create_item_for_user_users__user_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ItemCreate": {
-                "title": "ItemCreate",
-                "required": ["title"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "id", "owner_id"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "owner_id": {"title": "Owner Id", "type": "integer"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["email", "id", "is_active"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "is_active": {"title": "Is Active", "type": "boolean"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                        "default": [],
-                    },
-                },
-            },
-            "UserCreate": {
-                "title": "UserCreate",
-                "required": ["email", "password"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(scope="module")
 def client(tmp_path_factory: pytest.TempPathFactory):
@@ -304,13 +27,6 @@ def client(tmp_path_factory: pytest.TempPathFactory):
     if test_db.is_file():  # pragma: nocover
         test_db.unlink()
     os.chdir(cwd)
-
-
-@needs_py39
-def test_openapi_schema(client):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -382,3 +98,303 @@ def test_read_items(client):
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+@needs_py39
+def test_openapi_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Users Users  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                },
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            },
+            "/users/{user_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User",
+                    "operationId": "read_user_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/users/{user_id}/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item For User",
+                    "operationId": "create_item_for_user_users__user_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ItemCreate": {
+                    "title": "ItemCreate",
+                    "required": ["title"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "id", "owner_id"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "owner_id": {"title": "Owner Id", "type": "integer"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["email", "id", "is_active"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "is_active": {"title": "Is Active", "type": "boolean"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                            "default": [],
+                        },
+                    },
+                },
+                "UserCreate": {
+                    "title": "UserCreate",
+                    "required": ["email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases_py310.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases_py310.py
@@ -7,283 +7,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py310
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Users Users  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_users__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        },
-        "/users/{user_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User",
-                "operationId": "read_user_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/users/{user_id}/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item For User",
-                "operationId": "create_item_for_user_users__user_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ItemCreate": {
-                "title": "ItemCreate",
-                "required": ["title"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "id", "owner_id"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "owner_id": {"title": "Owner Id", "type": "integer"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["email", "id", "is_active"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "is_active": {"title": "Is Active", "type": "boolean"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                        "default": [],
-                    },
-                },
-            },
-            "UserCreate": {
-                "title": "UserCreate",
-                "required": ["email", "password"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(scope="module", name="client")
 def get_client(tmp_path_factory: pytest.TempPathFactory):
@@ -303,13 +26,6 @@ def get_client(tmp_path_factory: pytest.TempPathFactory):
     if test_db.is_file():  # pragma: nocover
         test_db.unlink()
     os.chdir(cwd)
-
-
-@needs_py310
-def test_openapi_schema(client):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py310
@@ -381,3 +97,303 @@ def test_read_items(client):
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+@needs_py310
+def test_openapi_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Users Users  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                },
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            },
+            "/users/{user_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User",
+                    "operationId": "read_user_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/users/{user_id}/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item For User",
+                    "operationId": "create_item_for_user_users__user_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ItemCreate": {
+                    "title": "ItemCreate",
+                    "required": ["title"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "id", "owner_id"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "owner_id": {"title": "Owner Id", "type": "integer"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["email", "id", "is_active"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "is_active": {"title": "Is Active", "type": "boolean"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                            "default": [],
+                        },
+                    },
+                },
+                "UserCreate": {
+                    "title": "UserCreate",
+                    "required": ["email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_sql_databases/test_sql_databases_py39.py
+++ b/tests/test_tutorial/test_sql_databases/test_sql_databases_py39.py
@@ -7,283 +7,6 @@ from fastapi.testclient import TestClient
 
 from ...utils import needs_py39
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Users Users  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            },
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create User",
-                "operationId": "create_user_users__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            },
-        },
-        "/users/{user_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read User",
-                "operationId": "read_user_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-            }
-        },
-        "/users/{user_id}/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Create Item For User",
-                "operationId": "create_item_for_user_users__user_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "ItemCreate": {
-                "title": "ItemCreate",
-                "required": ["title"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "id", "owner_id"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "owner_id": {"title": "Owner Id", "type": "integer"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["email", "id", "is_active"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "is_active": {"title": "Is Active", "type": "boolean"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                        "default": [],
-                    },
-                },
-            },
-            "UserCreate": {
-                "title": "UserCreate",
-                "required": ["email", "password"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(scope="module", name="client")
 def get_client(tmp_path_factory: pytest.TempPathFactory):
@@ -303,13 +26,6 @@ def get_client(tmp_path_factory: pytest.TempPathFactory):
     if test_db.is_file():  # pragma: nocover
         test_db.unlink()
     os.chdir(cwd)
-
-
-@needs_py39
-def test_openapi_schema(client):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 @needs_py39
@@ -381,3 +97,303 @@ def test_read_items(client):
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+@needs_py39
+def test_openapi_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Users Users  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                },
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create User",
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            },
+            "/users/{user_id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read User",
+                    "operationId": "read_user_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                }
+            },
+            "/users/{user_id}/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Create Item For User",
+                    "operationId": "create_item_for_user_users__user_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "ItemCreate": {
+                    "title": "ItemCreate",
+                    "required": ["title"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "id", "owner_id"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "owner_id": {"title": "Owner Id", "type": "integer"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["email", "id", "is_active"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "is_active": {"title": "Is Active", "type": "boolean"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                            "default": [],
+                        },
+                    },
+                },
+                "UserCreate": {
+                    "title": "UserCreate",
+                    "required": ["email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_sql_databases_peewee/test_sql_databases_peewee.py
+++ b/tests/test_tutorial/test_sql_databases_peewee/test_sql_databases_peewee.py
@@ -5,327 +5,6 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/users/": {
-            "get": {
-                "summary": "Read Users",
-                "operationId": "read_users_users__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Users Users  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-            "post": {
-                "summary": "Create User",
-                "operationId": "create_user_users__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/UserCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            },
-        },
-        "/users/{user_id}": {
-            "get": {
-                "summary": "Read User",
-                "operationId": "read_user_users__user_id__get",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/User"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/users/{user_id}/items/": {
-            "post": {
-                "summary": "Create Item For User",
-                "operationId": "create_item_for_user_users__user_id__items__post",
-                "parameters": [
-                    {
-                        "required": True,
-                        "schema": {"title": "User Id", "type": "integer"},
-                        "name": "user_id",
-                        "in": "path",
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/ItemCreate"}
-                        }
-                    },
-                    "required": True,
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/items/": {
-            "get": {
-                "summary": "Read Items",
-                "operationId": "read_items_items__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Items Items  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/Item"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-        "/slowusers/": {
-            "get": {
-                "summary": "Read Slow Users",
-                "operationId": "read_slow_users_slowusers__get",
-                "parameters": [
-                    {
-                        "required": False,
-                        "schema": {"title": "Skip", "type": "integer", "default": 0},
-                        "name": "skip",
-                        "in": "query",
-                    },
-                    {
-                        "required": False,
-                        "schema": {"title": "Limit", "type": "integer", "default": 100},
-                        "name": "limit",
-                        "in": "query",
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Response Read Slow Users Slowusers  Get",
-                                    "type": "array",
-                                    "items": {"$ref": "#/components/schemas/User"},
-                                }
-                            }
-                        },
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-            }
-        },
-    },
-    "components": {
-        "schemas": {
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-            "Item": {
-                "title": "Item",
-                "required": ["title", "id", "owner_id"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "owner_id": {"title": "Owner Id", "type": "integer"},
-                },
-            },
-            "ItemCreate": {
-                "title": "ItemCreate",
-                "required": ["title"],
-                "type": "object",
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "description": {"title": "Description", "type": "string"},
-                },
-            },
-            "User": {
-                "title": "User",
-                "required": ["email", "id", "is_active"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "is_active": {"title": "Is Active", "type": "boolean"},
-                    "items": {
-                        "title": "Items",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/Item"},
-                        "default": [],
-                    },
-                },
-            },
-            "UserCreate": {
-                "title": "UserCreate",
-                "required": ["email", "password"],
-                "type": "object",
-                "properties": {
-                    "email": {"title": "Email", "type": "string"},
-                    "password": {"title": "Password", "type": "string"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-        }
-    },
-}
-
 
 @pytest.fixture(scope="module")
 def client():
@@ -336,12 +15,6 @@ def client():
     with TestClient(app) as c:
         yield c
     test_db.unlink()
-
-
-def test_openapi_schema(client):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
 
 
 def test_create_user(client):
@@ -418,3 +91,354 @@ def test_read_items(client):
     first_item = data[0]
     assert "title" in first_item
     assert "description" in first_item
+
+
+def test_openapi_schema(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/users/": {
+                "get": {
+                    "summary": "Read Users",
+                    "operationId": "read_users_users__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Users Users  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+                "post": {
+                    "summary": "Create User",
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/UserCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+            "/users/{user_id}": {
+                "get": {
+                    "summary": "Read User",
+                    "operationId": "read_user_users__user_id__get",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/User"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/users/{user_id}/items/": {
+                "post": {
+                    "summary": "Create Item For User",
+                    "operationId": "create_item_for_user_users__user_id__items__post",
+                    "parameters": [
+                        {
+                            "required": True,
+                            "schema": {"title": "User Id", "type": "integer"},
+                            "name": "user_id",
+                            "in": "path",
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/ItemCreate"}
+                            }
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Item"}
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/items/": {
+                "get": {
+                    "summary": "Read Items",
+                    "operationId": "read_items_items__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Items Items  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Item"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+            "/slowusers/": {
+                "get": {
+                    "summary": "Read Slow Users",
+                    "operationId": "read_slow_users_slowusers__get",
+                    "parameters": [
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Skip",
+                                "type": "integer",
+                                "default": 0,
+                            },
+                            "name": "skip",
+                            "in": "query",
+                        },
+                        {
+                            "required": False,
+                            "schema": {
+                                "title": "Limit",
+                                "type": "integer",
+                                "default": 100,
+                            },
+                            "name": "limit",
+                            "in": "query",
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "title": "Response Read Slow Users Slowusers  Get",
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/User"},
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+                "Item": {
+                    "title": "Item",
+                    "required": ["title", "id", "owner_id"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "owner_id": {"title": "Owner Id", "type": "integer"},
+                    },
+                },
+                "ItemCreate": {
+                    "title": "ItemCreate",
+                    "required": ["title"],
+                    "type": "object",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "description": {"title": "Description", "type": "string"},
+                    },
+                },
+                "User": {
+                    "title": "User",
+                    "required": ["email", "id", "is_active"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "id": {"title": "Id", "type": "integer"},
+                        "is_active": {"title": "Is Active", "type": "boolean"},
+                        "items": {
+                            "title": "Items",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Item"},
+                            "default": [],
+                        },
+                    },
+                },
+                "UserCreate": {
+                    "title": "UserCreate",
+                    "required": ["email", "password"],
+                    "type": "object",
+                    "properties": {
+                        "email": {"title": "Email", "type": "string"},
+                        "password": {"title": "Password", "type": "string"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_tutorial/test_testing/test_main.py
+++ b/tests/test_tutorial/test_testing/test_main.py
@@ -1,30 +1,28 @@
 from docs_src.app_testing.test_main import client, test_read_main
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Main",
-                "operationId": "read_main__get",
-            }
-        }
-    },
-}
+
+def test_main():
+    test_read_main()
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_main():
-    test_read_main()
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Main",
+                    "operationId": "read_main__get",
+                }
+            }
+        },
+    }

--- a/tests/test_tutorial/test_testing/test_tutorial001.py
+++ b/tests/test_tutorial/test_testing/test_tutorial001.py
@@ -1,30 +1,28 @@
 from docs_src.app_testing.tutorial001 import client, test_read_main
 
-openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    }
-                },
-                "summary": "Read Main",
-                "operationId": "read_main__get",
-            }
-        }
-    },
-}
+
+def test_main():
+    test_read_main()
 
 
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
-    assert response.json() == openapi_schema
-
-
-def test_main():
-    test_read_main()
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        }
+                    },
+                    "summary": "Read Main",
+                    "operationId": "read_main__get",
+                }
+            }
+        },
+    }

--- a/tests/test_union_body.py
+++ b/tests/test_union_body.py
@@ -22,95 +22,6 @@ def save_union_body(item: Union[OtherItem, Item]):
 
 client = TestClient(app)
 
-item_openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Save Union Body",
-                "operationId": "save_union_body_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "title": "Item",
-                                "anyOf": [
-                                    {"$ref": "#/components/schemas/OtherItem"},
-                                    {"$ref": "#/components/schemas/Item"},
-                                ],
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "OtherItem": {
-                "title": "OtherItem",
-                "required": ["price"],
-                "type": "object",
-                "properties": {"price": {"title": "Price", "type": "integer"}},
-            },
-            "Item": {
-                "title": "Item",
-                "type": "object",
-                "properties": {"name": {"title": "Name", "type": "string"}},
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_item_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == item_openapi_schema
-
 
 def test_post_other_item():
     response = client.post("/items/", json={"price": 100})
@@ -122,3 +33,92 @@ def test_post_item():
     response = client.post("/items/", json={"name": "Foo"})
     assert response.status_code == 200, response.text
     assert response.json() == {"item": {"name": "Foo"}}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Save Union Body",
+                    "operationId": "save_union_body_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Item",
+                                    "anyOf": [
+                                        {"$ref": "#/components/schemas/OtherItem"},
+                                        {"$ref": "#/components/schemas/Item"},
+                                    ],
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "OtherItem": {
+                    "title": "OtherItem",
+                    "required": ["price"],
+                    "type": "object",
+                    "properties": {"price": {"title": "Price", "type": "integer"}},
+                },
+                "Item": {
+                    "title": "Item",
+                    "type": "object",
+                    "properties": {"name": {"title": "Name", "type": "string"}},
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }

--- a/tests/test_union_inherited_body.py
+++ b/tests/test_union_inherited_body.py
@@ -23,99 +23,6 @@ def save_union_different_body(item: Union[ExtendedItem, Item]):
 client = TestClient(app)
 
 
-inherited_item_openapi_schema = {
-    "openapi": "3.0.2",
-    "info": {"title": "FastAPI", "version": "0.1.0"},
-    "paths": {
-        "/items/": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {"application/json": {"schema": {}}},
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        },
-                    },
-                },
-                "summary": "Save Union Different Body",
-                "operationId": "save_union_different_body_items__post",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "title": "Item",
-                                "anyOf": [
-                                    {"$ref": "#/components/schemas/ExtendedItem"},
-                                    {"$ref": "#/components/schemas/Item"},
-                                ],
-                            }
-                        }
-                    },
-                    "required": True,
-                },
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Item": {
-                "title": "Item",
-                "type": "object",
-                "properties": {"name": {"title": "Name", "type": "string"}},
-            },
-            "ExtendedItem": {
-                "title": "ExtendedItem",
-                "required": ["age"],
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "age": {"title": "Age", "type": "integer"},
-                },
-            },
-            "ValidationError": {
-                "title": "ValidationError",
-                "required": ["loc", "msg", "type"],
-                "type": "object",
-                "properties": {
-                    "loc": {
-                        "title": "Location",
-                        "type": "array",
-                        "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
-                    },
-                    "msg": {"title": "Message", "type": "string"},
-                    "type": {"title": "Error Type", "type": "string"},
-                },
-            },
-            "HTTPValidationError": {
-                "title": "HTTPValidationError",
-                "type": "object",
-                "properties": {
-                    "detail": {
-                        "title": "Detail",
-                        "type": "array",
-                        "items": {"$ref": "#/components/schemas/ValidationError"},
-                    }
-                },
-            },
-        }
-    },
-}
-
-
-def test_inherited_item_openapi_schema():
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == inherited_item_openapi_schema
-
-
 def test_post_extended_item():
     response = client.post("/items/", json={"name": "Foo", "age": 5})
     assert response.status_code == 200, response.text
@@ -126,3 +33,95 @@ def test_post_item():
     response = client.post("/items/", json={"name": "Foo"})
     assert response.status_code == 200, response.text
     assert response.json() == {"item": {"name": "Foo"}}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.0.2",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/items/": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {"application/json": {"schema": {}}},
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    "summary": "Save Union Different Body",
+                    "operationId": "save_union_different_body_items__post",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Item",
+                                    "anyOf": [
+                                        {"$ref": "#/components/schemas/ExtendedItem"},
+                                        {"$ref": "#/components/schemas/Item"},
+                                    ],
+                                }
+                            }
+                        },
+                        "required": True,
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "title": "Item",
+                    "type": "object",
+                    "properties": {"name": {"title": "Name", "type": "string"}},
+                },
+                "ExtendedItem": {
+                    "title": "ExtendedItem",
+                    "required": ["age"],
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "age": {"title": "Age", "type": "integer"},
+                    },
+                },
+                "ValidationError": {
+                    "title": "ValidationError",
+                    "required": ["loc", "msg", "type"],
+                    "type": "object",
+                    "properties": {
+                        "loc": {
+                            "title": "Location",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                        },
+                        "msg": {"title": "Message", "type": "string"},
+                        "type": {"title": "Error Type", "type": "string"},
+                    },
+                },
+                "HTTPValidationError": {
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "title": "Detail",
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                        }
+                    },
+                },
+            }
+        },
+    }


### PR DESCRIPTION
✅ Refactor OpenAPI tests, prepare for Pydantic v2

During the migration, it will be very useful to check the tests with `insert_assert` from https://github.com/samuelcolvin/python-devtools

This prepares the code for that.

---

Before this change, there was normally a variable with `openapi_schema`, containing all the OpenAPI schema for each app tested. Then that was checked in a test for that.

But this doesn't allow easily inlining the result with `insert_assert`. By moving that schema to inside of the test, I'll be able to explore with `insert_assert` and verify in the diff what is wrong (later during the migration to Pydantic v2).

This needed to be done here, before that, because it only moves code/data around. But the diff is gigantic, so it shouldn't be mixed with code changing actual logic.

I also wanted to do it, to be able to keep using `insert_assert`, but that needed many consecutive hours of work, and a reason to go through all that work. But now this is a good reason to do it. :nerd_face: 