### PR TITLE
Traceback propagation to allow better logging- concurrency.py

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,8 +1,9 @@
+import sys
 from contextlib import AsyncExitStack as AsyncExitStack  # noqa
 from contextlib import asynccontextmanager as asynccontextmanager
 from typing import AsyncGenerator, ContextManager, TypeVar
 
-import anyio, sys
+import anyio
 from anyio import CapacityLimiter
 from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
 from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -27,13 +27,14 @@ async def contextmanager_in_threadpool(
     try:
         yield await run_in_threadpool(cm.__enter__)
     except Exception as e:
+        _, _, traceback = sys.exc_info()
         ok = bool(
             await anyio.to_thread.run_sync(
                 cm.__exit__, type(e), e, None, limiter=exit_limiter
             )
         )
         if not ok:
-            raise e
+            raise e.with_traceback(traceback)
     else:
         await anyio.to_thread.run_sync(
             cm.__exit__, None, None, None, limiter=exit_limiter

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -35,7 +35,7 @@ async def contextmanager_in_threadpool(
             )
         )
         if not ok:
-            raise e.with_traceback(traceback)
+            raise e.with_traceback(traceback) from e
     else:
         await anyio.to_thread.run_sync(
             cm.__exit__, None, None, None, limiter=exit_limiter

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -2,7 +2,7 @@ from contextlib import AsyncExitStack as AsyncExitStack  # noqa
 from contextlib import asynccontextmanager as asynccontextmanager
 from typing import AsyncGenerator, ContextManager, TypeVar
 
-import anyio
+import anyio, sys
 from anyio import CapacityLimiter
 from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
 from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa


### PR DESCRIPTION
This way we keep the original traceback which can be queried later.

For example when ValidationError happens we can log traceback which is accurate in our exception handlerers.