### PR TITLE
Fix duplicated section in menu if a translated file is not mentioned in mkdocs.yaml

### DIFF
--- a/docs/pt/mkdocs.yml
+++ b/docs/pt/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
   - tutorial/encoder.md
   - Segurança:
     - tutorial/security/index.md
+    - tutorial/security/first-steps.md
   - tutorial/background-tasks.md
   - tutorial/static-files.md
   - Guia de Usuário Avançado:

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -166,7 +166,7 @@ def build_lang(
         lang_file_path: Path = build_lang_path / "docs" / file_path
         en_file_path: Path = en_lang_path / "docs" / file_path
         lang_file_path.parent.mkdir(parents=True, exist_ok=True)
-        if not lang_file_path.is_file():
+        if not lang_file_path.is_file() or file not in lang_file_to_nav:
             en_text = en_file_path.read_text(encoding="utf-8")
             lang_text = get_text_with_translate_missing(en_text)
             lang_file_path.write_text(lang_text, encoding="utf-8")


### PR DESCRIPTION
**Context**

In the Portuguese translation, there is a translated file (`tutorial/security/first-steps.md`) that is not in `mkdocs.yaml`.

When building the documentation, the file is still used but ends up with an English section name, which causes a duplicated section to appear in the docs menu.

![image](https://user-images.githubusercontent.com/17676929/236642751-71312f3e-f149-4e78-8d39-90aac949ddec.png)

**What was done**

- Added a check to `./scripts/docs.py lang-build` to confirm that translated files are explicitly mentioned in `mkdocs.yml` and if not treat the case as if the file did not exist, falling back to the English version.
- Included the missing translated file in the PT `mkdocs.yaml`

**How was it tested**

1) Built the docs using `scripts/docs.py build-lang` and verified that the existing translated (`first-steps.md`) that is not mentioned in mkdocs is ignored and replaced by the English version under the appropriate translated section names.

![image](https://github.com/tiangolo/fastapi/assets/17676929/0e4d0d88-d1ef-4249-8f83-402a63d6276b)

2) Added the missing reference to `tutorial/security/first-steps.md` in the PT `mkdocs.yam`l and rebuild the doc to verify that it works as before

![image](https://user-images.githubusercontent.com/17676929/236642994-adbff4e7-e561-4b0c-b605-7b7bd0cc97d8.png)
