### PR TITLE
📝 Add repo link to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dynamic = ["version"]
 [project.urls]
 Homepage = "https://github.com/tiangolo/fastapi"
 Documentation = "https://fastapi.tiangolo.com/"
+Repository = "https://github.com/tiangolo/fastapi"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Currently on PyPI the project repo link is missing.

![image](https://github.com/tiangolo/fastapi/assets/45884264/50a1b663-64d3-4467-8098-6d06f47217e2)

This should add that missing link next time the package is built and published

![image](https://github.com/tiangolo/fastapi/assets/45884264/08a9487c-f3a2-4ee7-9297-ebe8a4b2f648)

