### PR TITLE
Allow httpx 0.24.x for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = [
     "ruff ==0.0.138",
     "black == 23.1.0",
     "isort >=5.0.6,<6.0.0",
-    "httpx >=0.23.0,<0.24.0",
+    "httpx >=0.23.0,<0.25.0",
     "email_validator >=1.1.1,<2.0.0",
     # TODO: once removing databases from tutorial, upgrade SQLAlchemy
     # probably when including SQLModel


### PR DESCRIPTION
Changes in 0.24.0: https://github.com/encode/httpx/releases/tag/0.24.0

Additions and fixes in 0.24.1: https://github.com/encode/httpx/releases/tag/0.24.1

No regressions appear in the test suite.