### PR TITLE
✏️ Fix tooltips for light/dark theme toggler in docs

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -11,14 +11,14 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to light mode
+      name: Switch to dark mode
   - media: '(prefers-color-scheme: dark)'
     scheme: slate
     primary: teal
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight


### PR DESCRIPTION
This is a minor fix 😅

When already in dark mode, hovering over the switcher shows "Switch to dark mode" in the tool-tip. Similarly, it shows "Switch to light mode" when its already in light mode.

I have fixed this by swapping the tool-tip texts in `docs/en/mkdocs.yml`.

PS: Please clarify if this needs to be done for every language separately or is it sourced from the *en* directory itself 😅