### PR TITLE
🐛 Fix `HTTPException` header type annotations

### DIFF
--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -11,7 +11,7 @@ class HTTPException(StarletteHTTPException):
         self,
         status_code: int,
         detail: Any = None,
-        headers: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
 


### PR DESCRIPTION
🐛 Fix `HTTPException` header type annotations