### PR TITLE
♻️ Simplify `AsyncExitStackMiddleware` as without Python 3.6 `AsyncExitStack` is always available

### DIFF
--- a/fastapi/middleware/asyncexitstack.py
+++ b/fastapi/middleware/asyncexitstack.py
@@ -10,19 +10,16 @@ class AsyncExitStackMiddleware:
         self.context_name = context_name
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if AsyncExitStack:
-            dependency_exception: Optional[Exception] = None
-            async with AsyncExitStack() as stack:
-                scope[self.context_name] = stack
-                try:
-                    await self.app(scope, receive, send)
-                except Exception as e:
-                    dependency_exception = e
-                    raise e
-            if dependency_exception:
-                # This exception was possibly handled by the dependency but it should
-                # still bubble up so that the ServerErrorMiddleware can return a 500
-                # or the ExceptionMiddleware can catch and handle any other exceptions
-                raise dependency_exception
-        else:
-            await self.app(scope, receive, send)  # pragma: no cover
+        dependency_exception: Optional[Exception] = None
+        async with AsyncExitStack() as stack:
+            scope[self.context_name] = stack
+            try:
+                await self.app(scope, receive, send)
+            except Exception as e:
+                dependency_exception = e
+                raise e
+        if dependency_exception:
+            # This exception was possibly handled by the dependency but it should
+            # still bubble up so that the ServerErrorMiddleware can return a 500
+            # or the ExceptionMiddleware can catch and handle any other exceptions
+            raise dependency_exception


### PR DESCRIPTION
♻️ Simplify `AsyncExitStackMiddleware` as without Python 3.6 `AsyncExitStack` is always available