### PR TITLE
Adding new feature - loading/unloading routers

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -469,7 +469,7 @@ class FastAPI(Starlette):
             generate_unique_id_function=generate_unique_id_function,
         )
 
-    def remove_routers(self, *routers: routing.APIRouter) -> None:
+    def exclude_routers(self, *routers: routing.APIRouter) -> None:
         for router in routers:
             for route in router.routes:
                 if route in self.routes:
@@ -503,11 +503,11 @@ class FastAPI(Starlette):
             self.load_router(name, package)
 
     def unload_router(self, name: str, package: str = None) -> None:
-        self.remove_routers(self._get_router(importlib.import_module(name, package), name))
+        self.exclude_routers(self._get_router(importlib.import_module(name, package), name))
 
     def unload_routers(self, *names: str, package: str = None) -> None:
         assert len(names) >= 1
-        self.remove_routers(*(
+        self.exclude_routers(*(
             self._get_router(importlib.import_module(name, package), name) for name in names
         ))
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1,6 +1,5 @@
 import importlib
 import types
-
 from enum import Enum
 from typing import (
     Any,
@@ -265,6 +264,7 @@ class FastAPI(Starlette):
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
 
             if self.swagger_ui_oauth2_redirect_url:
+
                 async def swagger_ui_redirect(req: Request) -> HTMLResponse:
                     return get_swagger_ui_oauth2_redirect_html()
 
@@ -274,6 +274,7 @@ class FastAPI(Starlette):
                     include_in_schema=False,
                 )
         if self.openapi_url and self.redoc_url:
+
             async def redoc_html(req: Request) -> HTMLResponse:
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
@@ -477,12 +478,14 @@ class FastAPI(Starlette):
 
     @staticmethod
     def _get_router(module: types.ModuleType, name: str) -> routing.APIRouter:
-        name = "./" + name.replace('.', '/')
+        name = "./" + name.replace(".", "/")
         if not hasattr(module, "router"):
             raise AttributeError(f"`router` attribute is not present in {name}.py")
 
         if not isinstance(module.router, routing.APIRouter):
-            raise TypeError(f"expected type `{routing.APIRouter}` got `{type(module.router)}` instead in {name}.py")
+            raise TypeError(
+                f"expected type `{routing.APIRouter}` got `{type(module.router)}` instead in {name}.py"
+            )
 
         return module.router
 
@@ -490,26 +493,34 @@ class FastAPI(Starlette):
         router = self._get_router(importlib.import_module(name, package), name)
         self.include_router(router)
 
-    def load_routers(self, *names: str, package: str = None, dirname: str = None) -> None:
+    def load_routers(
+        self, *names: str, package: str = None, dirname: str = None
+    ) -> None:
         if len(names) == 0:
             assert dirname is not None
 
             import os
+
             for filename in os.listdir("./%s" % dirname):
                 if filename.endswith(".py") and "__pycache__" not in filename:
-                    self.load_router("%s.%s" % (dirname, filename[:-3]), package)
+                    self.load_router("{}.{}".format(dirname, filename[:-3]), package)
 
         for name in names:
             self.load_router(name, package)
 
     def unload_router(self, name: str, package: str = None) -> None:
-        self.exclude_routers(self._get_router(importlib.import_module(name, package), name))
+        self.exclude_routers(
+            self._get_router(importlib.import_module(name, package), name)
+        )
 
     def unload_routers(self, *names: str, package: str = None) -> None:
         assert len(names) >= 1
-        self.exclude_routers(*(
-            self._get_router(importlib.import_module(name, package), name) for name in names
-        ))
+        self.exclude_routers(
+            *(
+                self._get_router(importlib.import_module(name, package), name)
+                for name in names
+            )
+        )
 
     def get(
         self,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1,3 +1,6 @@
+import importlib
+import types
+
 from enum import Enum
 from typing import (
     Any,
@@ -54,6 +57,7 @@ class FastAPI(Starlette):
         *,
         debug: bool = False,
         routes: Optional[List[BaseRoute]] = None,
+        routers_dirname: str = None,
         title: str = "FastAPI",
         description: str = "",
         version: str = "0.1.0",
@@ -156,6 +160,11 @@ class FastAPI(Starlette):
             [] if middleware is None else list(middleware)
         )
         self.middleware_stack: Union[ASGIApp, None] = None
+
+        self.routers_dirname = routers_dirname
+        if self.routers_dirname is not None:
+            self.load_routers(dirname=self.routers_dirname)
+
         self.setup()
 
     def build_middleware_stack(self) -> ASGIApp:
@@ -256,7 +265,6 @@ class FastAPI(Starlette):
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
 
             if self.swagger_ui_oauth2_redirect_url:
-
                 async def swagger_ui_redirect(req: Request) -> HTMLResponse:
                     return get_swagger_ui_oauth2_redirect_html()
 
@@ -266,7 +274,6 @@ class FastAPI(Starlette):
                     include_in_schema=False,
                 )
         if self.openapi_url and self.redoc_url:
-
             async def redoc_html(req: Request) -> HTMLResponse:
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
@@ -461,6 +468,48 @@ class FastAPI(Starlette):
             callbacks=callbacks,
             generate_unique_id_function=generate_unique_id_function,
         )
+
+    def remove_routers(self, *routers: routing.APIRouter) -> None:
+        for router in routers:
+            for route in router.routes:
+                if route in self.routes:
+                    self.routes.remove(route)
+
+    @staticmethod
+    def _get_router(module: types.ModuleType, name: str) -> routing.APIRouter:
+        name = "./" + name.replace('.', '/')
+        if not hasattr(module, "router"):
+            raise AttributeError(f"`router` attribute is not present in {name}.py")
+
+        if not isinstance(module.router, routing.APIRouter):
+            raise TypeError(f"expected type `{routing.APIRouter}` got `{type(module.router)}` instead in {name}.py")
+
+        return module.router
+
+    def load_router(self, name: str, package: str = None) -> None:
+        router = self._get_router(importlib.import_module(name, package), name)
+        self.include_router(router)
+
+    def load_routers(self, *names: str, package: str = None, dirname: str = None) -> None:
+        if len(names) == 0:
+            assert dirname is not None
+
+            import os
+            for filename in os.listdir("./%s" % dirname):
+                if filename.endswith(".py") and "__pycache__" not in filename:
+                    self.load_router("%s.%s" % (dirname, filename[:-3]), package)
+
+        for name in names:
+            self.load_router(name, package)
+
+    def unload_router(self, name: str, package: str = None) -> None:
+        self.remove_routers(self._get_router(importlib.import_module(name, package), name))
+
+    def unload_routers(self, *names: str, package: str = None) -> None:
+        assert len(names) >= 1
+        self.remove_routers(*(
+            self._get_router(importlib.import_module(name, package), name) for name in names
+        ))
 
     def get(
         self,


### PR DESCRIPTION
# Adding New Feature to support Multi files support for FastAPI

Changelog (**`Added`**):
- `load_router(...)`
- `load_routers(...)`
- `unload_router(...)`
- `unload_routers(...)`
- `_get_router(...)`
- `exclude_routers(...)`

## How does it work?

here's a example

App Structure
![App Structure](https://i.imgur.com/T9Jp40x.png)

Code in **`routers/sample.py`**
```py
from fastapi import APIRouter

router = APIRouter(tags=["Sample"])


@router.get("/sample")
async def sample():
    return {
        "sample": True
    }
```

## Loading routers

- Method - 1

Code in **`main.py`** file
```py
import os

from fastapi import FastAPI

app = FastAPI()

for file in os.listdir("./routers"):
    if file.endswith(".py") and "__pycache__" not in file:
        filename = file[:-3]

        app.load_router("%s.%s", ("routers", filename))
```

- Method -2
Code in **`main.py`** file
```py
import os

from fastapi import FastAPI

# loads all router's in files of directory `routers`
app = FastAPI(routers_dirname="routers")
```

- Method - 3
Code in **`main.py`** file
```py
import os

from fastapi import FastAPI

app = FastAPI()
app.load_router("routers.sample")  # loads one router
`or` 
app.load_routers(dirname="routers")  # loads all router's in files of directory `routers`
```