### PR TITLE
🔧 Run CI only once on push

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docs/en/docs/release-notes.md'
   pull_request:
     types:
       - opened

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docs/en/docs/release-notes.md'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Description

I noticed the project CI runs "twice" in each commit to the repository (one for the real commit and one for the `latest-changes` job).
Ex.: https://github.com/tiangolo/fastapi/actions/runs/5348732342 and https://github.com/tiangolo/fastapi/actions/runs/5348736904

This PR assures it only runs after `latest-changes` job.

## What has been done to achieve the goal

Run `grep -Iinr 'push' .github/workflows` in the project root to check that all jobs that are run `on push` were updated.

## Testing Instructions

I think there is not a easy to test out github actions (what I usually do before merging them, if I want to test prior to merging, is running it from my fork).

But I do this in my personal projects, so I think it safe :smile: Ex.: If you check the [commits in this repo](https://github.com/mateusoliveira43/cly/commits/main), the CI only run after the `latest-changes` job.

