### PR TITLE
📝 add deployment docs with Granian

### DIFF
--- a/docs/en/docs/advanced/behind-a-proxy.md
+++ b/docs/en/docs/advanced/behind-a-proxy.md
@@ -79,7 +79,7 @@ $ fastapi run main.py --root-path /api/v1
 
 </div>
 
-If you use Hypercorn, it also has the option `--root-path`.
+If you use Hypercorn, it also has the option `--root-path`, while in Granian such option is `--url-path-prefix`.
 
 !!! note "Technical Details"
     The ASGI specification defines a `root_path` for this use case.

--- a/docs/en/docs/alternatives.md
+++ b/docs/en/docs/alternatives.md
@@ -385,7 +385,7 @@ That's one of the main things that **FastAPI** adds on top, all based on Python 
 !!! note "Technical Details"
     ASGI is a new "standard" being developed by Django core team members. It is still not a "Python standard" (a PEP), although they are in the process of doing that.
 
-    Nevertheless, it is already being used as a "standard" by several tools. This greatly improves interoperability, as you could switch Uvicorn for any other ASGI server (like Daphne or Hypercorn), or you could add ASGI compatible tools, like `python-socketio`.
+    Nevertheless, it is already being used as a "standard" by several tools. This greatly improves interoperability, as you could switch Uvicorn for any other ASGI server (like Daphne, Hypercorn or Granian), or you could add ASGI compatible tools, like `python-socketio`.
 
 !!! check "**FastAPI** uses it to"
     Handle all the core web parts. Adding features on top.

--- a/docs/en/docs/benchmarks.md
+++ b/docs/en/docs/benchmarks.md
@@ -21,7 +21,7 @@ The hierarchy is like:
 * **Uvicorn**:
     * Will have the best performance, as it doesn't have much extra code apart from the server itself.
     * You wouldn't write an application in Uvicorn directly. That would mean that your code would have to include more or less, at least, all the code provided by Starlette (or **FastAPI**). And if you did that, your final application would have the same overhead as having used a framework and minimizing your app code and bugs.
-    * If you are comparing Uvicorn, compare it against Daphne, Hypercorn, uWSGI, etc. Application servers.
+    * If you are comparing Uvicorn, compare it against Daphne, Granian, Hypercorn, uWSGI, etc. Application servers.
 * **Starlette**:
     * Will have the next best performance, after Uvicorn. In fact, Starlette uses Uvicorn to run. So, it probably can only get "slower" than Uvicorn by having to execute more code.
     * But it provides you the tools to build simple web applications, with routing based on paths, etc.

--- a/docs/en/docs/deployment/manually.md
+++ b/docs/en/docs/deployment/manually.md
@@ -67,6 +67,7 @@ There are several alternatives, including:
 * <a href="https://www.uvicorn.org/" class="external-link" target="_blank">Uvicorn</a>: a high performance ASGI server.
 * <a href="https://pgjones.gitlab.io/hypercorn/" class="external-link" target="_blank">Hypercorn</a>: an ASGI server compatible with HTTP/2 and Trio among other features.
 * <a href="https://github.com/django/daphne" class="external-link" target="_blank">Daphne</a>: the ASGI server built for Django Channels.
+* <a href="https://github.com/emmett-framework/granian" class="external-link" target="_blank">Granian</a>: A Rust HTTP server for Python applications.
 
 ## Server Machine and Server Program
 
@@ -119,7 +120,21 @@ But you can also install an ASGI server manually:
 
     </div>
 
-    ...or any other ASGI server.
+=== "Granian"
+
+    * <a href="https://github.com/emmett-framework/granian" class="external-link" target="_blank">Granian</a>, a Rust ASGI server also compatible with HTTP/2.
+
+    <div class="termy">
+
+    ```console
+    $ pip install granian
+
+    ---> 100%
+    ```
+
+    </div>
+
+...or any other ASGI server.
 
 ## Run the Server Program
 
@@ -144,7 +159,19 @@ If you installed an ASGI server manually, you would normally need to pass an imp
     ```console
     $ hypercorn main:app --bind 0.0.0.0:80
 
-    Running on 0.0.0.0:8080 over http (CTRL + C to quit)
+    Running on 0.0.0.0:80 over http (CTRL + C to quit)
+    ```
+
+    </div>
+
+=== "Granian"
+
+    <div class="termy">
+
+    ```console
+    $ granian --interface asgi --host 0.0.0.0 --port 80 main:app
+
+    Running on 0.0.0.0:80 over http (CTRL + C to quit)
     ```
 
     </div>
@@ -172,7 +199,7 @@ If you installed an ASGI server manually, you would normally need to pass an imp
 
 Starlette and **FastAPI** are based on <a href="https://anyio.readthedocs.io/en/stable/" class="external-link" target="_blank">AnyIO</a>, which makes them compatible with both Python's standard library <a href="https://docs.python.org/3/library/asyncio-task.html" class="external-link" target="_blank">asyncio</a> and <a href="https://trio.readthedocs.io/en/stable/" class="external-link" target="_blank">Trio</a>.
 
-Nevertheless, Uvicorn is currently only compatible with asyncio, and it normally uses <a href="https://github.com/MagicStack/uvloop" class="external-link" target="_blank">`uvloop`</a>, the high-performance drop-in replacement for `asyncio`.
+Nevertheless, Uvicorn and Granian are currently only compatible with asyncio, and they normally use <a href="https://github.com/MagicStack/uvloop" class="external-link" target="_blank">`uvloop`</a>, the high-performance drop-in replacement for `asyncio`.
 
 But if you want to directly use **Trio**, then you can use **Hypercorn** as it supports it. ✨
 


### PR DESCRIPTION
Granian is a Rust HTTP server for Python applications which supports ASGI and HTTP/2.

It isn't as well known in the FastAPI community as an option - hopefully this will help that.