### PR TITLE
🔨 Enable linenums in MkDocs Material during local live development to simplify highlighting code

### DIFF
--- a/docs/en/mkdocs.maybe-insiders.yml
+++ b/docs/en/mkdocs.maybe-insiders.yml
@@ -1,3 +1,6 @@
 # Define this here and not in the main mkdocs.yml file because that one is auto
 # updated and written, and the script would remove the env var
 INHERIT: !ENV [INSIDERS_FILE, '../en/mkdocs.no-insiders.yml']
+markdown_extensions:
+  pymdownx.highlight:
+    linenums: !ENV [LINENUMS, false]

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -169,24 +169,24 @@ nav:
 - contributing.md
 - release-notes.md
 markdown_extensions:
-- toc:
+  toc:
     permalink: true
-- markdown.extensions.codehilite:
+  markdown.extensions.codehilite:
     guess_lang: false
-- mdx_include:
+  mdx_include:
     base_path: docs
-- admonition
-- codehilite
-- extra
-- pymdownx.superfences:
+  admonition:
+  codehilite:
+  extra:
+  pymdownx.superfences:
     custom_fences:
     - name: mermaid
       class: mermaid
       format: !!python/name:pymdownx.superfences.fence_code_format ''
-- pymdownx.tabbed:
+  pymdownx.tabbed:
     alternate_style: true
-- attr_list
-- md_in_html
+  attr_list:
+  md_in_html:
 extra:
   analytics:
     provider: google

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -258,6 +258,8 @@ def live(
     Takes an optional LANG argument with the name of the language to serve, by default
     en.
     """
+    # Enable line numbers during local development to make it easier to highlight
+    os.environ["LINENUMS"] = "true"
     if lang is None:
         lang = "en"
     lang_path: Path = docs_path / lang


### PR DESCRIPTION
🔨 Enable linenums in MkDocs Material during local live development to simplify highlighting code