### PR TITLE
✅ Update tests to import Annotated from typing_extensions for Python < 3.9

### DIFF
--- a/tests/test_regex_deprecated_body.py
+++ b/tests/test_regex_deprecated_body.py
@@ -1,10 +1,9 @@
-from typing import Annotated
-
 import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI, Form
 from fastapi.testclient import TestClient
 from fastapi.utils import match_pydantic_error_url
+from typing_extensions import Annotated
 
 from .utils import needs_py310
 

--- a/tests/test_regex_deprecated_params.py
+++ b/tests/test_regex_deprecated_params.py
@@ -1,10 +1,9 @@
-from typing import Annotated
-
 import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI, Query
 from fastapi.testclient import TestClient
 from fastapi.utils import match_pydantic_error_url
+from typing_extensions import Annotated
 
 from .utils import needs_py310
 


### PR DESCRIPTION
✅ Update tests to import Annotated from typing_extensions for Python < 3.9