### PR TITLE
✨ Add new Pydantic Field param options to Query, Cookie, Body, etc.

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -1,14 +1,22 @@
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, Union
 
 from fastapi import params
 from fastapi._compat import Undefined
 from typing_extensions import Annotated, deprecated
 
+_Unset: Any = Undefined
+
 
 def Path(  # noqa: N802
     default: Any = ...,
     *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
     alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     gt: Optional[float] = None,
@@ -24,6 +32,12 @@ def Path(  # noqa: N802
             "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
         ),
     ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
     examples: Optional[List[Any]] = None,
     example: Annotated[
         Optional[Any],
@@ -31,14 +45,19 @@ def Path(  # noqa: N802
             "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
             "although still supported. Use examples instead."
         ),
-    ] = Undefined,
+    ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
+    json_schema_extra: Union[dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Path(
         default=default,
+        default_factory=default_factory,
         alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         gt=gt,
@@ -49,10 +68,17 @@ def Path(  # noqa: N802
         max_length=max_length,
         pattern=pattern,
         regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
         example=example,
         examples=examples,
         deprecated=deprecated,
         include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
         **extra,
     )
 
@@ -60,7 +86,13 @@ def Path(  # noqa: N802
 def Query(  # noqa: N802
     default: Any = Undefined,
     *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
     alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     gt: Optional[float] = None,
@@ -76,6 +108,12 @@ def Query(  # noqa: N802
             "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
         ),
     ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
     examples: Optional[List[Any]] = None,
     example: Annotated[
         Optional[Any],
@@ -83,14 +121,19 @@ def Query(  # noqa: N802
             "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
             "although still supported. Use examples instead."
         ),
-    ] = Undefined,
+    ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
+    json_schema_extra: Union[dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Query(
         default=default,
+        default_factory=default_factory,
         alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         gt=gt,
@@ -101,10 +144,17 @@ def Query(  # noqa: N802
         max_length=max_length,
         pattern=pattern,
         regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
         example=example,
         examples=examples,
         deprecated=deprecated,
         include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
         **extra,
     )
 
@@ -112,7 +162,13 @@ def Query(  # noqa: N802
 def Header(  # noqa: N802
     default: Any = Undefined,
     *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
     alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
     convert_underscores: bool = True,
     title: Optional[str] = None,
     description: Optional[str] = None,
@@ -129,6 +185,12 @@ def Header(  # noqa: N802
             "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
         ),
     ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
     examples: Optional[List[Any]] = None,
     example: Annotated[
         Optional[Any],
@@ -136,14 +198,19 @@ def Header(  # noqa: N802
             "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
             "although still supported. Use examples instead."
         ),
-    ] = Undefined,
+    ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
+    json_schema_extra: Union[dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Header(
         default=default,
+        default_factory=default_factory,
         alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         convert_underscores=convert_underscores,
         title=title,
         description=description,
@@ -155,10 +222,17 @@ def Header(  # noqa: N802
         max_length=max_length,
         pattern=pattern,
         regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
         example=example,
         examples=examples,
         deprecated=deprecated,
         include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
         **extra,
     )
 
@@ -166,7 +240,13 @@ def Header(  # noqa: N802
 def Cookie(  # noqa: N802
     default: Any = Undefined,
     *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
     alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     gt: Optional[float] = None,
@@ -182,6 +262,12 @@ def Cookie(  # noqa: N802
             "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
         ),
     ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
     examples: Optional[List[Any]] = None,
     example: Annotated[
         Optional[Any],
@@ -189,14 +275,19 @@ def Cookie(  # noqa: N802
             "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
             "although still supported. Use examples instead."
         ),
-    ] = Undefined,
+    ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
+    json_schema_extra: Union[dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Cookie(
         default=default,
+        default_factory=default_factory,
         alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         gt=gt,
@@ -207,10 +298,17 @@ def Cookie(  # noqa: N802
         max_length=max_length,
         pattern=pattern,
         regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
         example=example,
         examples=examples,
         deprecated=deprecated,
         include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
         **extra,
     )
 
@@ -218,9 +316,15 @@ def Cookie(  # noqa: N802
 def Body(  # noqa: N802
     default: Any = Undefined,
     *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
     embed: bool = False,
     media_type: str = "application/json",
     alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     gt: Optional[float] = None,
@@ -236,6 +340,12 @@ def Body(  # noqa: N802
             "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
         ),
     ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
     examples: Optional[List[Any]] = None,
     example: Annotated[
         Optional[Any],
@@ -243,14 +353,21 @@ def Body(  # noqa: N802
             "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
             "although still supported. Use examples instead."
         ),
-    ] = Undefined,
+    ] = _Unset,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Body(
         default=default,
+        default_factory=default_factory,
         embed=embed,
         media_type=media_type,
         alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         gt=gt,
@@ -261,8 +378,17 @@ def Body(  # noqa: N802
         max_length=max_length,
         pattern=pattern,
         regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
         example=example,
         examples=examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
         **extra,
     )
 
@@ -270,8 +396,14 @@ def Body(  # noqa: N802
 def Form(  # noqa: N802
     default: Any = Undefined,
     *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
     media_type: str = "application/x-www-form-urlencoded",
     alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     gt: Optional[float] = None,
@@ -287,6 +419,12 @@ def Form(  # noqa: N802
             "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
         ),
     ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
     examples: Optional[List[Any]] = None,
     example: Annotated[
         Optional[Any],
@@ -294,13 +432,20 @@ def Form(  # noqa: N802
             "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
             "although still supported. Use examples instead."
         ),
-    ] = Undefined,
+    ] = _Unset,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Form(
         default=default,
+        default_factory=default_factory,
         media_type=media_type,
         alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         gt=gt,
@@ -311,8 +456,17 @@ def Form(  # noqa: N802
         max_length=max_length,
         pattern=pattern,
         regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
         example=example,
         examples=examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
         **extra,
     )
 
@@ -320,8 +474,14 @@ def Form(  # noqa: N802
 def File(  # noqa: N802
     default: Any = Undefined,
     *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
     media_type: str = "multipart/form-data",
     alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     gt: Optional[float] = None,
@@ -337,6 +497,12 @@ def File(  # noqa: N802
             "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
         ),
     ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
     examples: Optional[List[Any]] = None,
     example: Annotated[
         Optional[Any],
@@ -344,13 +510,20 @@ def File(  # noqa: N802
             "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
             "although still supported. Use examples instead."
         ),
-    ] = Undefined,
+    ] = _Unset,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.File(
         default=default,
+        default_factory=default_factory,
         media_type=media_type,
         alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         gt=gt,
@@ -361,8 +534,17 @@ def File(  # noqa: N802
         max_length=max_length,
         pattern=pattern,
         regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
         example=example,
         examples=examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
         **extra,
     )
 

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from fastapi import params
 from fastapi._compat import Undefined
@@ -48,7 +48,7 @@ def Path(  # noqa: N802
     ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
-    json_schema_extra: Union[dict[str, Any], None] = None,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Path(
@@ -124,7 +124,7 @@ def Query(  # noqa: N802
     ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
-    json_schema_extra: Union[dict[str, Any], None] = None,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Query(
@@ -201,7 +201,7 @@ def Header(  # noqa: N802
     ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
-    json_schema_extra: Union[dict[str, Any], None] = None,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Header(
@@ -278,7 +278,7 @@ def Cookie(  # noqa: N802
     ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
-    json_schema_extra: Union[dict[str, Any], None] = None,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Cookie(
@@ -356,7 +356,7 @@ def Body(  # noqa: N802
     ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
-    json_schema_extra: Union[dict[str, Any], None] = None,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Body(
@@ -435,7 +435,7 @@ def Form(  # noqa: N802
     ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
-    json_schema_extra: Union[dict[str, Any], None] = None,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.Form(
@@ -513,7 +513,7 @@ def File(  # noqa: N802
     ] = _Unset,
     deprecated: Optional[bool] = None,
     include_in_schema: bool = True,
-    json_schema_extra: Union[dict[str, Any], None] = None,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
     **extra: Any,
 ) -> Any:
     return params.File(

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import Enum
-from typing import Any, Callable, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from pydantic.fields import FieldInfo
 from typing_extensions import Annotated, deprecated
@@ -63,7 +63,7 @@ class Param(FieldInfo):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         self.deprecated = deprecated
@@ -172,7 +172,7 @@ class Path(Param):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         assert default is ..., "Path parameters cannot have a default value"
@@ -256,7 +256,7 @@ class Query(Param):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         super().__init__(
@@ -339,7 +339,7 @@ class Header(Param):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         self.convert_underscores = convert_underscores
@@ -422,7 +422,7 @@ class Cookie(Param):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         super().__init__(
@@ -504,7 +504,7 @@ class Body(FieldInfo):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         self.embed = embed
@@ -615,7 +615,7 @@ class Form(Body):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         super().__init__(
@@ -698,7 +698,7 @@ class File(Form):
         ] = _Unset,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
-        json_schema_extra: Union[dict[str, Any], None] = None,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         super().__init__(


### PR DESCRIPTION
✨ Add new Pydantic Field param options to Query, Cookie, Body, etc.

* default_factory
* alias_priority
* validation_alias
* serialization_alias
* discriminator
* strict
* multiple_of
* allow_inf_nan
* max_digits
* decimal_places
* json_schema_extra