### PR TITLE
Update external link to monitoring post

### DIFF
--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -78,7 +78,7 @@ articles:
     title: FastAPI for Flask Users
   - author: Louis Guitton
     author_link: https://twitter.com/louis_guitton
-    link: https://guitton.co/posts/fastapi-monitoring/
+    link: https://dev.to/louisguitton/how-to-monitor-your-fastapi-service-3mpo
     title: How to monitor your FastAPI service
   - author: Julien Harbulot
     author_link: https://julienharbulot.com/


### PR DESCRIPTION
- The original link redirects with a 308, but redirects to the same URL
- This commit updates the URL to the accessible version of the post available on dev.to