### PR TITLE
[BugFix] Remove additionalProperties from openapi.json

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -60,6 +60,8 @@ def get_model_definitions(
         m_schema, m_definitions, m_nested_models = model_process_schema(
             model, model_name_map=model_name_map, ref_prefix=REF_PREFIX
         )
+        if "additionalProperties" in m_schema.keys() and not m_schema.get("additionalProperties"):
+            del m_schema["additionalProperties"]
         definitions.update(m_definitions)
         model_name = model_name_map[model]
         if "description" in m_schema:

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -66,7 +66,9 @@ def get_model_definitions(
         m_schema, m_definitions, m_nested_models = model_process_schema(
             model, model_name_map=model_name_map, ref_prefix=REF_PREFIX
         )
-        if "additionalProperties" in m_schema.keys() and not m_schema.get("additionalProperties"):
+        if "additionalProperties" in m_schema.keys() and not m_schema.get(
+            "additionalProperties"
+        ):
             del m_schema["additionalProperties"]
         definitions.update(m_definitions)
         model_name = model_name_map[model]

--- a/tests/test_additional_properties_bool.py
+++ b/tests/test_additional_properties_bool.py
@@ -79,7 +79,6 @@ def test_openapi_schema():
             "schemas": {
                 "Foo": {
                     "properties": {},
-                    "additionalProperties": False,
                     "type": "object",
                     "title": "Foo",
                 },


### PR DESCRIPTION
This was branched of the 0.99.1 release.
Essentially, this is a small fix to for [this](https://github.com/tiangolo/fastapi/discussions/9820) issue.

Openapi was bumped to 3.1.0 in 0.99.0. While this is great overall, there's an issue regarding the `additionalProperties` field. Before 3.1.0 if this field was `false`, swagger would ignore it. However, the current behavior adds an `additionalProp1": {}` whenever `extra` is set to `forbid` for any model inheriting from Pydantic's BaseModel. 