### PR TITLE
Fix ValidationExceptions missing type annotations after v0.100.0

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -169,7 +169,7 @@ if PYDANTIC_V2:
             if isinstance(error, dict):
                 use_errors.append(error)
             else:
-                raise NotImplementedError(f"Unexpected ErrorWrapper: {error}")
+                raise NotImplementedError(f"Unexpected ErrorWrapper: {repr(error)}")
         return use_errors
 
     def _model_rebuild(model: Type[BaseModel]) -> None:

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-from fastapi.exceptions import RequestErrorModel
+import fastapi
 from fastapi.types import IncEx, ModelNameMap, UnionType
 from pydantic import BaseModel, create_model
 from pydantic.version import VERSION as PYDANTIC_VERSION
@@ -435,7 +435,7 @@ else:
         for error in errors:
             if isinstance(error, ErrorWrapper):
                 new_errors = ValidationError(  # type: ignore[call-arg]
-                    errors=[error], model=RequestErrorModel
+                    errors=[error], model=fastapi.exceptions.RequestErrorModel
                 ).errors()
                 use_errors.extend(new_errors)
             elif isinstance(error, list):
@@ -512,7 +512,9 @@ else:
 
     def get_missing_field_error(loc: Tuple[str, ...]) -> ErrorDetails:
         missing_field_error = ErrorWrapper(MissingError(), loc=loc)  # type: ignore[call-arg]
-        new_error = ValidationError([missing_field_error], RequestErrorModel)
+        new_error = ValidationError(
+            [missing_field_error], fastapi.exceptions.RequestErrorModel
+        )
         return new_error.errors()[0]
 
     def create_body_model(

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -164,7 +164,13 @@ if PYDANTIC_V2:
     def _normalize_errors(
         errors: Sequence[Union[ErrorDetails, ErrorWrapper]]
     ) -> List[ErrorDetails]:
-        return errors  # type: ignore[return-value]
+        use_errors: List[ErrorDetails] = []
+        for error in errors:
+            if isinstance(error, dict):
+                use_errors.append(error)
+            else:
+                raise NotImplementedError(f"Unexpected ErrorWrapper: {error}")
+        return use_errors
 
     def _model_rebuild(model: Type[BaseModel]) -> None:
         model.model_rebuild()
@@ -425,7 +431,7 @@ else:
     def _normalize_errors(
         errors: Sequence[Union[ErrorDetails, ErrorWrapper]]
     ) -> List[ErrorDetails]:
-        use_errors: List[Any] = []
+        use_errors: List[ErrorDetails] = []
         for error in errors:
             if isinstance(error, ErrorWrapper):
                 new_errors = ValidationError(  # type: ignore[call-arg]

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional, Sequence, Type
 
+from fastapi._compat import ErrorDetails
 from pydantic import BaseModel, create_model
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.exceptions import WebSocketException as WebSocketException  # noqa: F401
@@ -26,15 +27,15 @@ class FastAPIError(RuntimeError):
 
 
 class ValidationException(Exception):
-    def __init__(self, errors: Sequence[Any]) -> None:
+    def __init__(self, errors: Sequence[ErrorDetails]) -> None:
         self._errors = errors
 
-    def errors(self) -> Sequence[Any]:
+    def errors(self) -> Sequence[ErrorDetails]:
         return self._errors
 
 
 class RequestValidationError(ValidationException):
-    def __init__(self, errors: Sequence[Any], *, body: Any = None) -> None:
+    def __init__(self, errors: Sequence[ErrorDetails], *, body: Any = None) -> None:
         super().__init__(errors)
         self.body = body
 
@@ -44,6 +45,6 @@ class WebSocketRequestValidationError(ValidationException):
 
 
 class ResponseValidationError(ValidationException):
-    def __init__(self, errors: Sequence[Any], *, body: Any = None) -> None:
+    def __init__(self, errors: Sequence[ErrorDetails], *, body: Any = None) -> None:
         super().__init__(errors)
         self.body = body

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -21,6 +21,8 @@ from typing import (
 
 from fastapi import params
 from fastapi._compat import (
+    ErrorDetails,
+    ErrorWrapper,
     ModelField,
     Undefined,
     _get_model_config,
@@ -131,7 +133,7 @@ async def serialize_response(
     is_coroutine: bool = True,
 ) -> Any:
     if field:
-        errors = []
+        errors: List[Union[ErrorDetails, ErrorWrapper]] = []
         if not hasattr(field, "serialize"):
             # pydantic v1
             response_content = _prepare_response_content(

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,10 +1,13 @@
 from typing import List, Union
 
+import pytest
 from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
+    ErrorWrapper,
     ModelField,
     Undefined,
     _get_model_config,
+    _normalize_errors,
     is_bytes_sequence_annotation,
     is_uploadfile_sequence_annotation,
 )
@@ -57,6 +60,16 @@ def test_get_model_config():
     foo = Foo()
     config = _get_model_config(foo)
     assert config == {"from_attributes": True}
+
+
+@needs_pydanticv2
+def test_normalize_errors_wrapper_not_allowed():
+    # For coverage in Pydantic v2
+    with pytest.raises(
+        NotImplementedError,
+        match="Unexpected ErrorWrapper: ErrorWrapper\\('invalid'\\)",
+    ):
+        _normalize_errors([ErrorWrapper("invalid")])
 
 
 def test_complex():


### PR DESCRIPTION
Type information got lost from `ValidationException`s after v0.100.0. This PR brings them back. `ErrorDetails` is used as is from Pydantic V2. With V1 its compatible with Pydantic V1 `.errors()`.

Related https://github.com/tiangolo/fastapi/discussions/9907