### PR TITLE
`UploadFile` and `EmailStr` class cleanup

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -60,7 +60,7 @@ if PYDANTIC_V2:
     from pydantic_core import PydanticUndefined, PydanticUndefinedType
     from pydantic_core import Url as Url
     from pydantic_core.core_schema import (
-        general_plain_validator_function as general_plain_validator_function,
+        no_info_plain_validator_function as no_info_plain_validator_function,
     )
 
     Required = PydanticUndefined
@@ -340,7 +340,7 @@ else:
     class PydanticSchemaGenerationError(Exception):  # type: ignore[no-redef]
         pass
 
-    def general_plain_validator_function(  # type: ignore[misc]
+    def no_info_plain_validator_function(  # type: ignore[misc]
         function: Callable[..., Any],
         *,
         ref: Union[str, None] = None,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -7,12 +7,20 @@ from fastapi._compat import (
     _get_model_config,
     is_bytes_sequence_annotation,
     is_uploadfile_sequence_annotation,
+    no_info_plain_validator_function,
 )
 from fastapi.testclient import TestClient
 from pydantic import BaseConfig, BaseModel, ConfigDict
 from pydantic.fields import FieldInfo
 
 from .utils import needs_pydanticv1, needs_pydanticv2
+
+
+@needs_pydanticv1
+def test_dummy_no_info_plain_validator_function():
+    # For coverage
+    validator = no_info_plain_validator_function(lambda x: None)
+    assert validator == {}
 
 
 @needs_pydanticv2

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -24,12 +24,6 @@ def test_model_field_default_required():
 
 
 @needs_pydanticv1
-def test_upload_file_dummy_general_plain_validator_function():
-    # For coverage
-    assert UploadFile.__get_pydantic_core_schema__(str, lambda x: None) == {}
-
-
-@needs_pydanticv1
 def test_union_scalar_list():
     # For coverage
     # TODO: there might not be a current valid code path that uses this, it would

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -7,15 +7,9 @@ from fastapi.datastructures import Default
 from fastapi.testclient import TestClient
 
 
-# TODO: remove when deprecating Pydantic v1
 def test_upload_file_invalid():
     with pytest.raises(ValueError):
-        UploadFile.validate("not a Starlette UploadFile")
-
-
-def test_upload_file_invalid_pydantic_v2():
-    with pytest.raises(ValueError):
-        UploadFile._validate("not a Starlette UploadFile", {})
+        UploadFile._validate("not a Starlette UploadFile")
 
 
 def test_default_placeholder_equals():


### PR DESCRIPTION
The definitions became poorly written due to the introduction of glue-code for pydantic@2 in v0.100.0