### PR TITLE
Fix validation error Optional[list[...]], Union[list[...], ...], Optional[set[...]] and etc in Form

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -228,6 +228,19 @@ if PYDANTIC_V2:
     def is_scalar_sequence_field(field: ModelField) -> bool:
         return field_annotation_is_scalar_sequence(field.field_info.annotation)
 
+
+    def field_annotation_is_optional_sequence(field: ModelField) -> bool:
+        if get_origin(field.field_info.annotation) == Union:
+            args = get_args(field.field_info.annotation)
+            if not args:
+                return False
+            else:
+                first_argument = args[0]
+                if hasattr(first_argument, "__origin__"):
+                    if first_argument.__origin__ in sequence_types:
+                        return True
+        return False
+
     def is_bytes_field(field: ModelField) -> bool:
         return is_bytes_or_nonable_bytes_annotation(field.type_)
 
@@ -465,6 +478,18 @@ else:
     def is_sequence_field(field: ModelField) -> bool:
         return field.shape in sequence_shapes or _annotation_is_sequence(field.type_)  # type: ignore[attr-defined]
 
+    def field_annotation_is_optional_sequence(field: ModelField) -> bool:
+        if get_origin(field.annotation) == Union:
+            args = get_args(field.annotation)
+            if not args:
+                return False
+            else:
+                first_argument = args[0]
+                if hasattr(first_argument, "__origin__"):
+                    if first_argument.__origin__ in sequence_types:
+                        return True
+        return False
+
     def is_scalar_sequence_field(field: ModelField) -> bool:
         return is_pv1_scalar_sequence_field(field)
 
@@ -509,19 +534,6 @@ def _annotation_is_sequence(annotation: Union[Type[Any], None]) -> bool:
     if lenient_issubclass(annotation, (str, bytes)):
         return False
     return lenient_issubclass(annotation, sequence_types)
-
-
-def field_annotation_is_optional_sequence(annotation: Union[Type[Any], None]) -> bool:
-    if get_origin(annotation) == Union:
-        args = get_args(annotation)
-        if not args:
-            return False
-        else:
-            first_argument = args[0]
-            if hasattr(first_argument, "__origin__"):
-                if first_argument.__origin__ in sequence_types:
-                    return True
-    return False
 
 
 def field_annotation_is_sequence(annotation: Union[Type[Any], None]) -> bool:

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -511,6 +511,19 @@ def _annotation_is_sequence(annotation: Union[Type[Any], None]) -> bool:
     return lenient_issubclass(annotation, sequence_types)
 
 
+def field_annotation_is_optional_sequence(annotation: Union[Type[Any], None]) -> bool:
+    if get_origin(annotation) == Union:
+        args = get_args(annotation)
+        if not args:
+            return False
+        else:
+            first_argument = args[0]
+            if hasattr(first_argument, "__origin__"):
+                if first_argument.__origin__ in sequence_types:
+                    return True
+    return False
+
+
 def field_annotation_is_sequence(annotation: Union[Type[Any], None]) -> bool:
     return _annotation_is_sequence(annotation) or _annotation_is_sequence(
         get_origin(annotation)

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -475,8 +475,8 @@ else:
         return field.shape in sequence_shapes or _annotation_is_sequence(field.type_)  # type: ignore[attr-defined]
 
     def field_annotation_is_optional_sequence(field: ModelField) -> bool:
-        if get_origin(field.type_) == Union:
-            args = get_args(field.type_)
+        if get_origin(field.annotation) == Union:
+            args = get_args(field.annotation)
             first_argument = args[0]
             if hasattr(first_argument, "__origin__"):
                 if first_argument.__origin__ in sequence_types:

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -231,13 +231,10 @@ if PYDANTIC_V2:
     def field_annotation_is_optional_sequence(field: ModelField) -> bool:
         if get_origin(field.field_info.annotation) == Union:
             args = get_args(field.field_info.annotation)
-            if not args:
-                return False
-            else:
-                first_argument = args[0]
-                if hasattr(first_argument, "__origin__"):
-                    if first_argument.__origin__ in sequence_types:
-                        return True
+            first_argument = args[0]
+            if hasattr(first_argument, "__origin__"):
+                if first_argument.__origin__ in sequence_types:
+                    return True
         return False
 
     def is_bytes_field(field: ModelField) -> bool:
@@ -480,13 +477,10 @@ else:
     def field_annotation_is_optional_sequence(field: ModelField) -> bool:
         if get_origin(field.type_) == Union:
             args = get_args(field.type_)
-            if not args:
-                return False
-            else:
-                first_argument = args[0]
-                if hasattr(first_argument, "__origin__"):
-                    if first_argument.__origin__ in sequence_types:
-                        return True
+            first_argument = args[0]
+            if hasattr(first_argument, "__origin__"):
+                if first_argument.__origin__ in sequence_types:
+                    return True
         return False
 
     def is_scalar_sequence_field(field: ModelField) -> bool:

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -223,16 +223,16 @@ if PYDANTIC_V2:
         ) and not isinstance(field.field_info, params.Body)
 
     def is_sequence_field(field: ModelField) -> bool:
-        return (
-            field_annotation_is_sequence(field.field_info.annotation)
-            or
-            field_annotation_is_optional_sequence(field.field_info.annotation)
-        )
+        return field_annotation_is_sequence(
+            field.field_info.annotation
+        ) or field_annotation_is_optional_sequence(field.field_info.annotation)
 
     def is_scalar_sequence_field(field: ModelField) -> bool:
         return field_annotation_is_scalar_sequence(field.field_info.annotation)
 
-    def field_annotation_is_optional_sequence(annotation: Union[Type[Any], None]) -> bool:
+    def field_annotation_is_optional_sequence(
+        annotation: Union[Type[Any], None]
+    ) -> bool:
         origin = get_origin(annotation)
         if origin is Union:
             args = get_args(annotation)

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -223,14 +223,19 @@ if PYDANTIC_V2:
         ) and not isinstance(field.field_info, params.Body)
 
     def is_sequence_field(field: ModelField) -> bool:
-        return field_annotation_is_sequence(field.field_info.annotation)
+        return (
+            field_annotation_is_sequence(field.field_info.annotation)
+            or
+            field_annotation_is_optional_sequence(field.field_info.annotation)
+        )
 
     def is_scalar_sequence_field(field: ModelField) -> bool:
         return field_annotation_is_scalar_sequence(field.field_info.annotation)
 
-    def field_annotation_is_optional_sequence(field: ModelField) -> bool:
-        if get_origin(field.field_info.annotation) == Union:
-            args = get_args(field.field_info.annotation)
+    def field_annotation_is_optional_sequence(annotation: Union[Type[Any], None]) -> bool:
+        origin = get_origin(annotation)
+        if origin is Union:
+            args = get_args(annotation)
             first_argument = args[0]
             if hasattr(first_argument, "__origin__"):
                 if first_argument.__origin__ in sequence_types:
@@ -473,15 +478,6 @@ else:
 
     def is_sequence_field(field: ModelField) -> bool:
         return field.shape in sequence_shapes or _annotation_is_sequence(field.type_)  # type: ignore[attr-defined]
-
-    def field_annotation_is_optional_sequence(field: ModelField) -> bool:
-        if get_origin(field.annotation) == Union:
-            args = get_args(field.annotation)
-            first_argument = args[0]
-            if hasattr(first_argument, "__origin__"):
-                if first_argument.__origin__ in sequence_types:
-                    return True
-        return False
 
     def is_scalar_sequence_field(field: ModelField) -> bool:
         return is_pv1_scalar_sequence_field(field)

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -479,8 +479,8 @@ else:
         return field.shape in sequence_shapes or _annotation_is_sequence(field.type_)  # type: ignore[attr-defined]
 
     def field_annotation_is_optional_sequence(field: ModelField) -> bool:
-        if get_origin(field.annotation) == Union:
-            args = get_args(field.annotation)
+        if get_origin(field.type_) == Union:
+            args = get_args(field.type_)
             if not args:
                 return False
             else:

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -228,7 +228,6 @@ if PYDANTIC_V2:
     def is_scalar_sequence_field(field: ModelField) -> bool:
         return field_annotation_is_scalar_sequence(field.field_info.annotation)
 
-
     def field_annotation_is_optional_sequence(field: ModelField) -> bool:
         if get_origin(field.field_info.annotation) == Union:
             args = get_args(field.field_info.annotation)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -29,6 +29,7 @@ from fastapi._compat import (
     copy_field_info,
     create_body_model,
     evaluate_forwardref,
+    field_annotation_is_optional_sequence,
     field_annotation_is_scalar,
     get_annotation_from_field_info,
     get_missing_field_error,
@@ -43,7 +44,6 @@ from fastapi._compat import (
     sequence_types,
     serialize_sequence_value,
     value_is_sequence,
-    field_annotation_is_optional_sequence,
 )
 from fastapi.concurrency import (
     AsyncExitStack,
@@ -693,7 +693,10 @@ async def request_body_to_args(
             value: Optional[Any] = None
             if received_body is not None:
                 if (
-                    is_sequence_field(field) or field_annotation_is_optional_sequence(field.field_info.annotation)
+                    is_sequence_field(field)
+                    or field_annotation_is_optional_sequence(
+                        field.field_info.annotation
+                    )
                 ) and isinstance(received_body, FormData):
                     value = received_body.getlist(field.alias)
                 else:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -29,7 +29,6 @@ from fastapi._compat import (
     copy_field_info,
     create_body_model,
     evaluate_forwardref,
-    field_annotation_is_optional_sequence,
     field_annotation_is_scalar,
     get_annotation_from_field_info,
     get_missing_field_error,
@@ -694,7 +693,6 @@ async def request_body_to_args(
             if received_body is not None:
                 if (
                     is_sequence_field(field)
-                    or field_annotation_is_optional_sequence(field)
                 ) and isinstance(received_body, FormData):
                     value = received_body.getlist(field.alias)
                 else:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -694,9 +694,7 @@ async def request_body_to_args(
             if received_body is not None:
                 if (
                     is_sequence_field(field)
-                    or field_annotation_is_optional_sequence(
-                        field.field_info.annotation
-                    )
+                    or field_annotation_is_optional_sequence(field)
                 ) and isinstance(received_body, FormData):
                     value = received_body.getlist(field.alias)
                 else:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -43,6 +43,7 @@ from fastapi._compat import (
     sequence_types,
     serialize_sequence_value,
     value_is_sequence,
+    field_annotation_is_optional_sequence,
 )
 from fastapi.concurrency import (
     AsyncExitStack,
@@ -691,7 +692,9 @@ async def request_body_to_args(
 
             value: Optional[Any] = None
             if received_body is not None:
-                if (is_sequence_field(field)) and isinstance(received_body, FormData):
+                if (
+                    is_sequence_field(field) or field_annotation_is_optional_sequence(field.field_info.annotation)
+                ) and isinstance(received_body, FormData):
                     value = received_body.getlist(field.alias)
                 else:
                     try:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -693,7 +693,10 @@ async def request_body_to_args(
             value: Optional[Any] = None
             if received_body is not None:
                 if (
-                    is_sequence_field(field) or field_annotation_is_optional_sequence(field.field_info.annotation)
+                    is_sequence_field(field)
+                    or field_annotation_is_optional_sequence(
+                        field.field_info.annotation
+                    )
                 ) and isinstance(received_body, FormData):
                     value = received_body.getlist(field.alias)
                 else:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -691,9 +691,7 @@ async def request_body_to_args(
 
             value: Optional[Any] = None
             if received_body is not None:
-                if (
-                    is_sequence_field(field)
-                ) and isinstance(received_body, FormData):
+                if (is_sequence_field(field)) and isinstance(received_body, FormData):
                     value = received_body.getlist(field.alias)
                 else:
                     try:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,13 +1,13 @@
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
     ModelField,
     Undefined,
     _get_model_config,
+    field_annotation_is_optional_sequence,
     is_bytes_sequence_annotation,
     is_uploadfile_sequence_annotation,
-    field_annotation_is_optional_sequence,
 )
 from fastapi.testclient import TestClient
 from pydantic import BaseConfig, BaseModel, ConfigDict
@@ -102,7 +102,7 @@ def test_model_optional_union():
         Optional[set[int]],
         Union[set[int], set[float]],
         Optional[frozenset[int]],
-        Union[List[int], None]
+        Union[List[int], None],
     ]
     for annotation in types:
         field_info = FieldInfo(annotation=annotation)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -5,9 +5,9 @@ from fastapi._compat import (
     ModelField,
     Undefined,
     _get_model_config,
-    field_annotation_is_optional_sequence,
     is_bytes_sequence_annotation,
     is_uploadfile_sequence_annotation,
+    is_sequence_field,
 )
 from fastapi.testclient import TestClient
 from pydantic import BaseConfig, BaseModel, ConfigDict
@@ -95,7 +95,7 @@ def test_is_uploadfile_sequence_annotation():
 
 
 @needs_pydanticv2
-def test_model_optional_union_v1():
+def test_model_optional_union_v2():
     # For coverage
     types = [
         Optional[List[str]],
@@ -108,41 +108,10 @@ def test_model_optional_union_v1():
     for annotation in types:
         field_info = FieldInfo(annotation=annotation)
         field = ModelField(name="foo", field_info=field_info)
-        assert field_annotation_is_optional_sequence(field) is True
+        assert is_sequence_field(field) is True
 
     field_info_str = FieldInfo(annotation=str)
     field_str = ModelField(name="foo", field_info=field_info_str)
-    assert field_annotation_is_optional_sequence(field_str) is False
+    assert is_sequence_field(field_str) is False
 
 
-@needs_pydanticv1
-def test_model_optional_union_v1():
-    # For coverage
-    types = [
-        Optional[List[str]],
-        Union[List[int], List[float]],
-        Optional[Set[int]],
-        Union[Set[int], Set[float]],
-        Optional[FrozenSet[int]],
-        Union[List[int], None],
-    ]
-    for annotation in types:
-        field_info = FieldInfo()
-        field = ModelField(
-            name="foo",
-            field_info=field_info,
-            type_=annotation,
-            class_validators={},
-            model_config=BaseConfig,
-        )
-        assert field_annotation_is_optional_sequence(field) is True
-
-    field_info_str = FieldInfo()
-    field_str = ModelField(
-        name="foo",
-        field_info=field_info_str,
-        type_=str,
-        class_validators={},
-        model_config=BaseConfig,
-    )
-    assert field_annotation_is_optional_sequence(field_str) is False

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -6,8 +6,8 @@ from fastapi._compat import (
     Undefined,
     _get_model_config,
     is_bytes_sequence_annotation,
-    is_uploadfile_sequence_annotation,
     is_sequence_field,
+    is_uploadfile_sequence_annotation,
 )
 from fastapi.testclient import TestClient
 from pydantic import BaseConfig, BaseModel, ConfigDict
@@ -113,5 +113,3 @@ def test_model_optional_union_v2():
     field_info_str = FieldInfo(annotation=str)
     field_str = ModelField(name="foo", field_info=field_info_str)
     assert is_sequence_field(field_str) is False
-
-

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -116,7 +116,7 @@ def test_model_optional_union_v1():
 
 
 @needs_pydanticv1
-def test_model_optional_union_v2():
+def test_model_optional_union_v1():
     # For coverage
     types = [
         Optional[List[str]],

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Union, Optional
 
 from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
@@ -7,6 +7,7 @@ from fastapi._compat import (
     _get_model_config,
     is_bytes_sequence_annotation,
     is_uploadfile_sequence_annotation,
+    field_annotation_is_optional_sequence,
 )
 from fastapi.testclient import TestClient
 from pydantic import BaseConfig, BaseModel, ConfigDict
@@ -91,3 +92,23 @@ def test_is_uploadfile_sequence_annotation():
     # and other types, but I'm not even sure it's a good idea to support it as a first
     # class "feature"
     assert is_uploadfile_sequence_annotation(Union[List[str], List[UploadFile]])
+
+
+def test_model_optional_union():
+    # For coverage
+    types = [
+        Optional[list[str]],
+        Union[list[int], list[float]],
+        Optional[set[int]],
+        Union[set[int], set[float]],
+        Optional[frozenset[int]],
+        Union[List[int], None]
+    ]
+    for annotation in types:
+        field_info = FieldInfo(annotation=annotation)
+        field = ModelField(name="foo", field_info=field_info)
+        assert field_annotation_is_optional_sequence(field) is True
+
+    field_info_str = FieldInfo(annotation=str)
+    field_str = ModelField(name="foo", field_info=field_info_str)
+    assert field_annotation_is_optional_sequence(field_str) is False

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Set, FrozenSet
 
 from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
@@ -94,14 +94,15 @@ def test_is_uploadfile_sequence_annotation():
     assert is_uploadfile_sequence_annotation(Union[List[str], List[UploadFile]])
 
 
-def test_model_optional_union():
+@needs_pydanticv2
+def test_model_optional_union_v1():
     # For coverage
     types = [
-        Optional[list[str]],
-        Union[list[int], list[float]],
-        Optional[set[int]],
-        Union[set[int], set[float]],
-        Optional[frozenset[int]],
+        Optional[List[str]],
+        Union[List[int], List[float]],
+        Optional[Set[int]],
+        Union[Set[int], Set[float]],
+        Optional[FrozenSet[int]],
         Union[List[int], None]
     ]
     for annotation in types:
@@ -111,4 +112,37 @@ def test_model_optional_union():
 
     field_info_str = FieldInfo(annotation=str)
     field_str = ModelField(name="foo", field_info=field_info_str)
+    assert field_annotation_is_optional_sequence(field_str) is False
+
+
+@needs_pydanticv1
+def test_model_optional_union_v2():
+    # For coverage
+    types = [
+        Optional[List[str]],
+        Union[List[int], List[float]],
+        Optional[Set[int]],
+        Union[Set[int], Set[float]],
+        Optional[FrozenSet[int]],
+        Union[List[int], None]
+    ]
+    for annotation in types:
+        field_info = FieldInfo()
+        field = ModelField(
+            name="foo",
+            field_info=field_info,
+            type_=annotation,
+            class_validators={},
+            model_config=BaseConfig,
+        )
+        assert field_annotation_is_optional_sequence(field) is True
+
+    field_info_str = FieldInfo()
+    field_str = ModelField(
+        name="foo",
+        field_info=field_info_str,
+        type_=str,
+        class_validators={},
+        model_config=BaseConfig,
+    )
     assert field_annotation_is_optional_sequence(field_str) is False

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional, Set, FrozenSet
+from typing import FrozenSet, List, Optional, Set, Union
 
 from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
@@ -103,7 +103,7 @@ def test_model_optional_union_v1():
         Optional[Set[int]],
         Union[Set[int], Set[float]],
         Optional[FrozenSet[int]],
-        Union[List[int], None]
+        Union[List[int], None],
     ]
     for annotation in types:
         field_info = FieldInfo(annotation=annotation)
@@ -124,7 +124,7 @@ def test_model_optional_union_v2():
         Optional[Set[int]],
         Union[Set[int], Set[float]],
         Optional[FrozenSet[int]],
-        Union[List[int], None]
+        Union[List[int], None],
     ]
     for annotation in types:
         field_info = FieldInfo()


### PR DESCRIPTION
## Fix issues with `Optional` and `Union` for `list, set, tuple, etc...` in `Form`:

```python3
a: Optional[list[int]] = Form(None)
b: Union[list[int], list[float]] = Form(None)
```

which lead to a validation error: `"Input should be a valid list"`



## Reproduce the issue:

```python3
from typing import Optional
from fastapi import FastAPI, Form
from fastapi.testclient import TestClient

app = FastAPI()


@app.post("/form")
async def test_form(
    list_int: Optional[list[int]] = Form(None),
):
    return {"elements": list_int}


client = TestClient(app=app)


def test_send_optional_one_element():
    data = {"list_int": "100"}
    response = client.post("/form", data=data)
    assert response.json() == {"elements": [100]}

    # {'detail': [{'input': '100',
    #              'loc': ['body', 'list_int'],
    #              'msg': 'Input should be a valid list',
    #              'type': 'list_type',
    #              'url': 'https://errors.pydantic.dev/2.0.3/v/list_type'}]} != {'elements': [100]}


def test_send_optional_two_list_elements():
    data = {"list_int": ["10", "20"]}
    response = client.post("/form", data=data)
    assert response.json() == {"elements": [10, 20]}
    # {'detail': [{'input': '20',
    #              'loc': ['body', 'list_int'],
    #              'msg': 'Input should be a valid list',
    #              'type': 'list_type',
    #              'url': 'https://errors.pydantic.dev/2.0.3/v/list_type'}]} != {'elements': [10, 20]}


def test_send_optional_list_elements():
    response = client.post("/form")
    assert response.json() == {"elements": []}
    # {'elements': None} != {'elements': []}


```

Previously, the ModelField had a `shape` attribute that said what kind of field it was (list, set, tuple, etc.).
So then the `Optional[list[int]]` shape had `SHAPE_LIST`

In the new version, this field (shape) no longer exists, and for the Form to parse data, FastAPI itself tries to collect values depending on the type.
for `list[int]` iterates through the collection `value=12&value=20` and does `value=[12, 20]`

In the new version, `Optional[list[int]]` does not count as a list when tested with is_sequence_field , which causes the value to be fetched as one element by :
`value = received_body.get(field.alias)`

If we made an annotation like `Optional[list[int]]` then pydantic expects us to pass `[1, 2, 3]` or `[1]`, but we are passing the value directly, which causes a validation error
`"input should be a valid list"`

In simple terms, what is happening:
```python3
class Foo(BaseModel):
      a: Optional[list[int]] = Field(None)

Foo(a="1")  # raise ValidationError
```
And it should happen:
```python3
Foo(a=["1"])  # Ok
```
