### PR TITLE
:sparkles: Support HEAD method when GET is supported

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -171,7 +171,7 @@ class FastAPI(Starlette):
         for route in self.routes:
             if isinstance(route, routing.APIRoute) and "GET" in route.methods:
                 new_route = copy(route)
-                new_route.methods = ["HEAD"]
+                new_route.methods = {"HEAD"}
                 new_route.include_in_schema = False
                 self.routes.append(new_route)
 


### PR DESCRIPTION
A third approach towards closing https://github.com/tiangolo/fastapi/issues/1773.

Changes from previous approaches:

- Doesn't add changes to core logic. It uses an startup hook simplifying maintenance
- It doesn't add runtime overhead. The HEAD routes are added at startup
- It doesn't override user defined HEADs. As the routes are added at the end, they have less priority and won't be used unless the HEADs aren't defined

TO DO:

- [ ] Add tests
- [ ] Refactor to match better the project structure? :thinking:  


Code snippet to test the PR:

```python
from fastapi import FastAPI
from fastapi.routing import APIRoute, APIRouter
from fastapi.testclient import TestClient

app = FastAPI()

router = APIRouter(prefix="/router")


@router.get("/")
def read_root():
    return {"Hello": "World"}

@router.head("/")
def modified():
    print("User defined HEAD")
    return {"Hello": "World"}


app.include_router(router)


def test_index_head():
    with TestClient(app) as client:
        response = client.head("/router")
        assert response.status_code == 200
```