### PR TITLE
✅ Fix tests for compatibility with pydantic 2.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-pydantic-v2-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}-test-v03
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-pydantic-v2-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}-test-v04
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements-tests.txt
@@ -54,7 +54,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}-test-v03
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}-test-v04
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements-tests.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 dependencies = [
     "starlette>=0.27.0,<0.28.0",
-    "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
+    "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,<3.0.0",
     "typing-extensions>=4.5.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 dependencies = [
     "starlette>=0.27.0,<0.28.0",
-    "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,<3.0.0",
+    "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.5.0",
 ]
 dynamic = ["version"]

--- a/tests/test_filter_pydantic_sub_model_pv2.py
+++ b/tests/test_filter_pydantic_sub_model_pv2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from dirty_equals import IsDict, HasRepr
+from dirty_equals import HasRepr, IsDict
 from fastapi import Depends, FastAPI
 from fastapi.exceptions import ResponseValidationError
 from fastapi.testclient import TestClient

--- a/tests/test_filter_pydantic_sub_model_pv2.py
+++ b/tests/test_filter_pydantic_sub_model_pv2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from dirty_equals import IsDict
+from dirty_equals import IsDict, HasRepr
 from fastapi import Depends, FastAPI
 from fastapi.exceptions import ResponseValidationError
 from fastapi.testclient import TestClient
@@ -66,7 +66,7 @@ def test_validator_is_cloned(client: TestClient):
                 "loc": ("response", "name"),
                 "msg": "Value error, name must end in A",
                 "input": "modelX",
-                "ctx": {"error": "name must end in A"},
+                "ctx": {"error": HasRepr("ValueError('name must end in A')")},
                 "url": match_pydantic_error_url("value_error"),
             }
         )

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -51,7 +51,7 @@ def test_jsonable_encoder_requiring_error():
                     "loc": ["body", 0, "age"],
                     "msg": "Input should be greater than 0",
                     "input": -1.0,
-                    "ctx": {"gt": 0.0},
+                    "ctx": {"gt": '0'},
                     "url": match_pydantic_error_url("greater_than"),
                 }
             ]
@@ -84,9 +84,16 @@ def test_put_incorrect_body_multiple():
                     "input": {"age": "five"},
                     "url": match_pydantic_error_url("missing"),
                 },
+                {'ctx': {'class': 'Decimal'},
+                 'input': 'five',
+                 'loc': ['body', 0, 'age', 'is-instance[Decimal]'],
+                 'msg': 'Input should be an instance of Decimal',
+                 'type': 'is_instance_of',
+                 'url': match_pydantic_error_url("is_instance_of")},
                 {
                     "type": "decimal_parsing",
-                    "loc": ["body", 0, "age"],
+                    "loc": ["body", 0, "age", 'function-after[to_decimal(), '
+                     'union[int,constrained-str,function-plain[str()]]]'],
                     "msg": "Input should be a valid decimal",
                     "input": "five",
                 },
@@ -97,9 +104,16 @@ def test_put_incorrect_body_multiple():
                     "input": {"age": "six"},
                     "url": match_pydantic_error_url("missing"),
                 },
+                {'ctx': {'class': 'Decimal'},
+                 'input': 'six',
+                 'loc': ['body', 1, 'age', 'is-instance[Decimal]'],
+                 'msg': 'Input should be an instance of Decimal',
+                 'type': 'is_instance_of',
+                 'url': match_pydantic_error_url("is_instance_of")},
                 {
                     "type": "decimal_parsing",
-                    "loc": ["body", 1, "age"],
+                    "loc": ["body", 1, "age", 'function-after[to_decimal(), '
+                     'union[int,constrained-str,function-plain[str()]]]'],
                     "msg": "Input should be a valid decimal",
                     "input": "six",
                 },

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -51,7 +51,7 @@ def test_jsonable_encoder_requiring_error():
                     "loc": ["body", 0, "age"],
                     "msg": "Input should be greater than 0",
                     "input": -1.0,
-                    "ctx": {"gt": '0'},
+                    "ctx": {"gt": "0"},
                     "url": match_pydantic_error_url("greater_than"),
                 }
             ]
@@ -84,16 +84,23 @@ def test_put_incorrect_body_multiple():
                     "input": {"age": "five"},
                     "url": match_pydantic_error_url("missing"),
                 },
-                {'ctx': {'class': 'Decimal'},
-                 'input': 'five',
-                 'loc': ['body', 0, 'age', 'is-instance[Decimal]'],
-                 'msg': 'Input should be an instance of Decimal',
-                 'type': 'is_instance_of',
-                 'url': match_pydantic_error_url("is_instance_of")},
+                {
+                    "ctx": {"class": "Decimal"},
+                    "input": "five",
+                    "loc": ["body", 0, "age", "is-instance[Decimal]"],
+                    "msg": "Input should be an instance of Decimal",
+                    "type": "is_instance_of",
+                    "url": match_pydantic_error_url("is_instance_of"),
+                },
                 {
                     "type": "decimal_parsing",
-                    "loc": ["body", 0, "age", 'function-after[to_decimal(), '
-                     'union[int,constrained-str,function-plain[str()]]]'],
+                    "loc": [
+                        "body",
+                        0,
+                        "age",
+                        "function-after[to_decimal(), "
+                        "union[int,constrained-str,function-plain[str()]]]",
+                    ],
                     "msg": "Input should be a valid decimal",
                     "input": "five",
                 },
@@ -104,16 +111,23 @@ def test_put_incorrect_body_multiple():
                     "input": {"age": "six"},
                     "url": match_pydantic_error_url("missing"),
                 },
-                {'ctx': {'class': 'Decimal'},
-                 'input': 'six',
-                 'loc': ['body', 1, 'age', 'is-instance[Decimal]'],
-                 'msg': 'Input should be an instance of Decimal',
-                 'type': 'is_instance_of',
-                 'url': match_pydantic_error_url("is_instance_of")},
+                {
+                    "ctx": {"class": "Decimal"},
+                    "input": "six",
+                    "loc": ["body", 1, "age", "is-instance[Decimal]"],
+                    "msg": "Input should be an instance of Decimal",
+                    "type": "is_instance_of",
+                    "url": match_pydantic_error_url("is_instance_of"),
+                },
                 {
                     "type": "decimal_parsing",
-                    "loc": ["body", 1, "age", 'function-after[to_decimal(), '
-                     'union[int,constrained-str,function-plain[str()]]]'],
+                    "loc": [
+                        "body",
+                        1,
+                        "age",
+                        "function-after[to_decimal(), "
+                        "union[int,constrained-str,function-plain[str()]]]",
+                    ],
                     "msg": "Input should be a valid decimal",
                     "input": "six",
                 },


### PR DESCRIPTION
Pydantic 2.1.1 is not yet released (needs a minor tweak on top of 2.1.0 for fastapi compatibility), but when it is, these tests will fail due to schema generation changes.

I think we really should (on the pydantic side) fix these schemas, specifically the error locs for decimal, but anyway I'm opening this to spare others the hassle of fixing up core schemas that I went through while trying to resolve the incompatibility between fastapi 0.100.0 and pydantic 2.1.0.

@tiangolo feel free to take over this PR, or just steal the commit/changes into a future PR that makes it compatible with the next version of pydantic.