### PR TITLE
Add `response_model_schema_mode` option

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -43,6 +43,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import BaseRoute
 from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
+from typing_extensions import Literal
 
 AppType = TypeVar("AppType", bound="FastAPI")
 
@@ -310,6 +311,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Union[Type[Response], DefaultPlaceholder] = Default(
             JSONResponse
@@ -340,6 +344,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -368,6 +373,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -397,6 +405,7 @@ class FastAPI(Starlette):
                 response_model_exclude_unset=response_model_exclude_unset,
                 response_model_exclude_defaults=response_model_exclude_defaults,
                 response_model_exclude_none=response_model_exclude_none,
+                response_model_schema_mode=response_model_schema_mode,
                 include_in_schema=include_in_schema,
                 response_class=response_class,
                 name=name,
@@ -489,6 +498,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -516,6 +528,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -544,6 +557,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -571,6 +587,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -599,6 +616,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -654,6 +674,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -681,6 +704,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -709,6 +733,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -736,6 +763,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -764,6 +792,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -791,6 +822,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -819,6 +851,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -846,6 +881,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -874,6 +910,9 @@ class FastAPI(Starlette):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -901,6 +940,7 @@ class FastAPI(Starlette):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -69,6 +69,7 @@ from starlette.routing import (
 from starlette.routing import Mount as Mount  # noqa
 from starlette.types import ASGIApp, Lifespan, Scope
 from starlette.websockets import WebSocket
+from typing_extensions import Literal
 
 
 def _prepare_response_content(
@@ -386,6 +387,9 @@ class APIRoute(routing.Route):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Union[Type[Response], DefaultPlaceholder] = Default(
             JSONResponse
@@ -448,9 +452,7 @@ class APIRoute(routing.Route):
             self.response_field = create_response_field(
                 name=response_name,
                 type_=self.response_model,
-                # TODO: This should actually set mode='serialization', just, that changes the schemas
-                # mode="serialization",
-                mode="validation",
+                mode=response_model_schema_mode,
             )
             # Create a clone of the field, so that a Pydantic submodel is not returned
             # as is just because it's an instance of a subclass of a more limited class
@@ -612,6 +614,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Union[Type[Response], DefaultPlaceholder] = Default(
             JSONResponse
@@ -662,6 +667,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema and self.include_in_schema,
             response_class=current_response_class,
             name=name,
@@ -693,6 +699,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -723,6 +732,7 @@ class APIRouter(routing.Router):
                 response_model_exclude_unset=response_model_exclude_unset,
                 response_model_exclude_defaults=response_model_exclude_defaults,
                 response_model_exclude_none=response_model_exclude_none,
+                response_model_schema_mode=response_model_schema_mode,
                 include_in_schema=include_in_schema,
                 response_class=response_class,
                 name=name,
@@ -920,6 +930,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -948,6 +961,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -976,6 +990,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -1004,6 +1021,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -1032,6 +1050,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -1060,6 +1081,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -1088,6 +1110,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -1116,6 +1141,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -1144,6 +1170,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -1172,6 +1201,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -1200,6 +1230,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -1228,6 +1261,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -1256,6 +1290,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -1284,6 +1321,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,
@@ -1312,6 +1350,9 @@ class APIRouter(routing.Router):
         response_model_exclude_unset: bool = False,
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
+        response_model_schema_mode: Literal[
+            "validation", "serialization"
+        ] = "validation",
         include_in_schema: bool = True,
         response_class: Type[Response] = Default(JSONResponse),
         name: Optional[str] = None,
@@ -1340,6 +1381,7 @@ class APIRouter(routing.Router):
             response_model_exclude_unset=response_model_exclude_unset,
             response_model_exclude_defaults=response_model_exclude_defaults,
             response_model_exclude_none=response_model_exclude_none,
+            response_model_schema_mode=response_model_schema_mode,
             include_in_schema=include_in_schema,
             response_class=response_class,
             name=name,


### PR DESCRIPTION
At the moment the schema mode for the response model is not configurable. This adds an option for it.