### PR TITLE
📌 Do not allow Pydantic 2.1.0 that breaks (require 2.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 dependencies = [
     "starlette>=0.27.0,<0.28.0",
-    "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,<3.0.0",
+    "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.5.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
📌 Do not allow Pydantic 2.1.0 that breaks (require 2.1.1)