### PR TITLE
Add Type to Depends return value

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -549,11 +549,13 @@ def File(  # noqa: N802
     )
 
 
-DependsReturnType = TypeVar('DependsReturnType')
+DependsReturnType = TypeVar("DependsReturnType")
 
 
 def Depends(  # noqa: N802
-    dependency: Optional[Callable[..., DependsReturnType]] = None, *, use_cache: bool = True
+    dependency: Optional[Callable[..., DependsReturnType]] = None,
+    *,
+    use_cache: bool = True,
 ) -> DependsReturnType:
     return params.Depends(dependency=dependency, use_cache=use_cache)
 

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union
 
 from fastapi import params
 from fastapi._compat import Undefined
@@ -549,9 +549,12 @@ def File(  # noqa: N802
     )
 
 
+DependsReturnType = TypeVar('DependsReturnType')
+
+
 def Depends(  # noqa: N802
-    dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
-) -> Any:
+    dependency: Optional[Callable[..., DependsReturnType]] = None, *, use_cache: bool = True
+) -> DependsReturnType:
     return params.Depends(dependency=dependency, use_cache=use_cache)
 
 


### PR DESCRIPTION
Now whenever you use the injection dependency mechanism of fast api you're are getting an Any. This is error prompt.

So instead of that, you can infer the return type given the return type of the provider function. That way the injection mechanism will be more robust.