### PR TITLE
Fixed responses model return format to also use serialization mode

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -478,7 +478,11 @@ class APIRoute(routing.Route):
                     additional_status_code
                 ), f"Status code {additional_status_code} must not have a response body"
                 response_name = f"Response_{additional_status_code}_{self.unique_id}"
-                response_field = create_response_field(name=response_name, type_=model)
+                response_field = create_response_field(
+                    name=response_name,
+                    type_=model,
+                    mode="serialization",
+                )
                 response_fields[additional_status_code] = response_field
         if response_fields:
             self.response_fields: Dict[Union[int, str], ModelField] = response_fields


### PR DESCRIPTION
As initially mentioned in https://github.com/tiangolo/fastapi/discussions/10003. 

I discovered even with `0.101.0` this still didn't work when `responses` was used. 
E.g. my example in that discussion still fails if modified such as: 

```Python
import typing as tp
from fastapi import FastAPI
from pydantic import BaseModel, Field

app = FastAPI()

class Foo(BaseModel):
    bar: int
    handler: tp.Callable[[], None] = Field(exclude=True)

@app.post(
    "/check",
    responses={
        200: {"model": Foo},
    } 
)
def validator_check():
    return Foo(handler=lambda: None, bar=1)

app.openapi()
```

Added `mode="serialization"` to the applicable `create_response_field()` and is now working. 