### PR TITLE
Fix handling of custom Pydantic V2 types in parameters

### DIFF
--- a/tests/test_custom_types.py
+++ b/tests/test_custom_types.py
@@ -1,0 +1,161 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from .utils import needs_pydanticv2
+
+
+@pytest.fixture(name="client", params=["default", "annotated"])
+def get_client(request) -> TestClient:
+    from typing import Any, Callable
+
+    from fastapi import FastAPI, Query
+    from pydantic import GetJsonSchemaHandler
+    from pydantic.json_schema import JsonSchemaValue
+    from pydantic_core import core_schema
+    from typing_extensions import Annotated
+
+    class WrappedInt:
+        x: int
+
+        def __init__(self, x: int):
+            self.x = x
+
+    class _WrappedIntPydanticAnnotation:
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, _source_type: Any, _handler: Callable[[Any], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
+            from_int_schema = core_schema.chain_schema(
+                [
+                    core_schema.int_schema(),
+                    core_schema.no_info_plain_validator_function(WrappedInt),
+                ]
+            )
+            return core_schema.json_or_python_schema(
+                json_schema=from_int_schema,
+                python_schema=core_schema.union_schema(
+                    [
+                        core_schema.is_instance_schema(WrappedInt),
+                        from_int_schema,
+                    ]
+                ),
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda instance: instance.x
+                ),
+            )
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return handler(core_schema.int_schema())
+
+    PydanticWrappedInt = Annotated[WrappedInt, _WrappedIntPydanticAnnotation]
+
+    app = FastAPI()
+
+    param_style = request.param
+    if param_style == "default":
+
+        @app.get("/echo")
+        def echo(x: PydanticWrappedInt = Query()) -> PydanticWrappedInt:
+            return x
+
+    elif param_style == "annotated":
+
+        @app.get("/echo")
+        def echo(x: Annotated[PydanticWrappedInt, Query()]) -> PydanticWrappedInt:
+            return x
+
+    else:
+        raise ValueError(param_style)  # pragma: nocover
+
+    client = TestClient(app)
+    return client
+
+
+@needs_pydanticv2
+def test_custom_type(client: TestClient):
+    response = client.get("/echo", params={"x": 42})
+    assert response.status_code == 200
+    assert response.json() == 42
+
+
+@needs_pydanticv2
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/echo": {
+                "get": {
+                    "summary": "Echo",
+                    "operationId": "echo_echo_get",
+                    "parameters": [
+                        {
+                            "name": "x",
+                            "in": "query",
+                            "required": True,
+                            "schema": {"type": "integer", "title": "X"},
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "integer",
+                                        "title": "Response Echo Echo Get",
+                                    }
+                                }
+                            },
+                        },
+                        "422": {
+                            "description": "Validation Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError"
+                                    }
+                                }
+                            },
+                        },
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "HTTPValidationError": {
+                    "properties": {
+                        "detail": {
+                            "items": {"$ref": "#/components/schemas/ValidationError"},
+                            "type": "array",
+                            "title": "Detail",
+                        }
+                    },
+                    "type": "object",
+                    "title": "HTTPValidationError",
+                },
+                "ValidationError": {
+                    "properties": {
+                        "loc": {
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "integer"}]
+                            },
+                            "type": "array",
+                            "title": "Location",
+                        },
+                        "msg": {"type": "string", "title": "Message"},
+                        "type": {"type": "string", "title": "Error Type"},
+                    },
+                    "type": "object",
+                    "required": ["loc", "msg", "type"],
+                    "title": "ValidationError",
+                },
+            }
+        },
+    }


### PR DESCRIPTION
Pydantic V2 allows to [add support for third-party types via `typing.Annotated`](https://docs.pydantic.dev/2.2/usage/types/custom/#handling-third-party-types). Unfortunately, this does not work with FastAPI because [FastAPI removes third-party `typing.Annotated` metadata from parameter type hints](https://github.com/tiangolo/fastapi/blob/a6ae5af7d6c9e7e33490307cccff66a49671433b/fastapi/dependencies/utils.py#L332). 

Example:
```python
# example.py

from typing import Any, Callable, Annotated

from pydantic_core import core_schema
from pydantic import GetJsonSchemaHandler
from pydantic.json_schema import JsonSchemaValue

from fastapi import FastAPI, Query


class ThirdPartyType:
    x: int

    def __init__(self, x: int):
        self.x = x


class _ThirdPartyTypePydanticAnnotation:
    @classmethod
    def __get_pydantic_core_schema__(
        cls, _source_type: Any, _handler: Callable[[Any], core_schema.CoreSchema]
    ) -> core_schema.CoreSchema:
        from_int_schema = core_schema.chain_schema(
            [
                core_schema.int_schema(),
                core_schema.no_info_plain_validator_function(ThirdPartyType),
            ]
        )
        return core_schema.json_or_python_schema(
            json_schema=from_int_schema,
            python_schema=core_schema.union_schema(
                [
                    core_schema.is_instance_schema(ThirdPartyType),
                    from_int_schema,
                ]
            ),
            serialization=core_schema.plain_serializer_function_ser_schema(
                lambda instance: instance.x
            ),
        )

    @classmethod
    def __get_pydantic_json_schema__(
        cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
    ) -> JsonSchemaValue:
        # Use the same schema that would be used for `int`
        return handler(core_schema.int_schema())


PydanticThirdPartyType = Annotated[ThirdPartyType, _ThirdPartyTypePydanticAnnotation]

app = FastAPI()


@app.get("/")
def echo(x: PydanticThirdPartyType = Query()) -> PydanticThirdPartyType:
    return x
```

```shell
$ uvicorn example:app
Traceback (most recent call last):
...
fastapi.exceptions.FastAPIError: Invalid args for response field! Hint: check that <class 'example.ThirdPartyType'> is a valid Pydantic field type. If you are using a return type annotation that is not a valid Pydantic field (e.g. Union[Response, dict, None]) you can disable generating the response model from the type annotation with the path operation decorator parameter response_model=None. Read more: https://fastapi.tiangolo.com/tutorial/response-model/
```

This PR modifies FastAPI to preserve third-party `typing.Annotated` metadata, so everything works.