### PR TITLE
🌐 Remove duplicate line in translation for `docs/pt/docs/tutorial/path-params.md`

### DIFF
--- a/docs/pt/docs/tutorial/path-params.md
+++ b/docs/pt/docs/tutorial/path-params.md
@@ -236,7 +236,6 @@ Então, você poderia usar ele com:
 Com o **FastAPI**, usando as declarações de tipo do Python, você obtém:
 
 * Suporte no editor: verificação de erros, e opção de autocompletar, etc.
-* Parsing de dados
 * "<abbr title="convertendo uma string que vem de um request HTTP em dado Python">Parsing</abbr>" de dados
 * Validação de dados
 * Anotação da API e documentação automática


### PR DESCRIPTION
There was a repeated line in the file path-params.md in the docs/pt.
I only removed this line.