### PR TITLE
Ability to set `openapi_version` from the constructor.

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -59,6 +59,7 @@ class FastAPI(Starlette):
         version: str = "0.1.0",
         openapi_url: Optional[str] = "/openapi.json",
         openapi_tags: Optional[List[Dict[str, Any]]] = None,
+        openapi_version: str = "3.1.0",
         servers: Optional[List[Dict[str, Union[str, Any]]]] = None,
         dependencies: Optional[Sequence[Depends]] = None,
         default_response_class: Type[Response] = Default(JSONResponse),
@@ -112,7 +113,7 @@ class FastAPI(Starlette):
         self.swagger_ui_parameters = swagger_ui_parameters
         self.servers = servers or []
         self.extra = extra
-        self.openapi_version = "3.1.0"
+        self.openapi_version = openapi_version
         self.openapi_schema: Optional[Dict[str, Any]] = None
         if self.openapi_url:
             assert self.title, "A title must be provided for OpenAPI, e.g.: 'My API'"


### PR DESCRIPTION
So it can be editable from a configuration upon creating the object rather than setting them afterward.