### PR TITLE
✏️ Fix typo in `docs/en/docs/tutorial/handling-errors.md`

### DIFF
--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -1,6 +1,6 @@
 # Handling Errors
 
-There are many situations in where you need to notify an error to a client that is using your API.
+There are many situations in which you need to notify an error to a client that is using your API.
 
 This client could be a browser with a frontend, a code from someone else, an IoT device, etc.
 


### PR DESCRIPTION
Corrected a simple language error: "There are many situations in **where** you need to (..)" -> "(...) in **which** you need to (...)".

Alternatively just leave out the word "in" in the original sentence.

Disclaimer: I'm not a native English speaker, so I might be wrong here.