### PR TITLE
✅ Add missing test for OpenAPI examples, it was missing in coverage

### DIFF
--- a/tests/test_openapi_examples.py
+++ b/tests/test_openapi_examples.py
@@ -125,6 +125,9 @@ client = TestClient(app)
 
 
 def test_call_api():
+    response = client.post("/examples/", json={"data": "example1"})
+    assert response.status_code == 200, response.text
+
     response = client.get("/path_examples/foo")
     assert response.status_code == 200, response.text
 


### PR DESCRIPTION
✅ Add missing test for OpenAPI examples, it was missing in coverage, I still don't know why it wasn't visible...

I thought it was the AnyIO upgrade... but now I'm thinking it might be the upgrade to Smokeshow, maybe the coverage was missing from the beginning and I didn't realize.