### PR TITLE
📌 Pin AnyIO to < 4.0.0 to handle an incompatibility while upgrading to Starlette 0.31.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
     "starlette>=0.27.0,<0.28.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.5.0",
+    # TODO: remove this pin after upgrading Starlette 0.31.1
+    "anyio>=3.7.1,<4.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
📌 Pin AnyIO to < 4.0.0 to handle an incompatibility while upgrading to Starlette 0.31.1