### PR TITLE
Fix `test_get_enums_invalid` test

### DIFF
--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -33,9 +33,9 @@ def test_get_enums_invalid():
                 {
                     "type": "enum",
                     "loc": ["path", "model_name"],
-                    "msg": "Input should be 'alexnet','resnet' or 'lenet'",
+                    "msg": "Input should be 'alexnet', 'resnet' or 'lenet'",
                     "input": "foo",
-                    "ctx": {"expected": "'alexnet','resnet' or 'lenet'"},
+                    "ctx": {"expected": "'alexnet', 'resnet' or 'lenet'"},
                 }
             ]
         }


### PR DESCRIPTION
Hey @tiangolo 👋 

The [test_get_enums_invalid](https://github.com/tiangolo/fastapi/blob/46d1da08da73d8b4100e709edab9d84aa6b6a203/tests/test_tutorial/test_path_params/test_tutorial005.py#L27) will break after `Pydantic` new release because of https://github.com/pydantic/pydantic/commit/02f963cc91e4363c3ebaaa2754c2af3c46999368

Here is the fix.