### PR TITLE
fix: Annotated's second args not work

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -355,6 +355,11 @@ def analyze_param(
                 field_info.default = Required
         elif isinstance(fastapi_annotation, params.Depends):
             depends = fastapi_annotation
+        # When there is no `FieldInfo` or `Depends` in annotated_args,
+        # like Annotated[str, StringConstraints(...)]
+        # we need use the `annotation` as the `type_annotation` to keep the metadata.
+        elif fastapi_annotation is None:
+            type_annotation = annotation
     elif annotation is not inspect.Signature.empty:
         type_annotation = annotation
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,10 +1,14 @@
+import pydantic
 import pytest
 from dirty_equals import IsDict
 from fastapi import APIRouter, FastAPI, Query
 from fastapi.testclient import TestClient
 from fastapi.utils import match_pydantic_error_url
-from pydantic import StringConstraints
 from typing_extensions import Annotated
+if pydantic.__version__.startswith("2."):
+    from pydantic import StringConstraints
+else:
+    from pydantic import ConstrainedStr as StringConstraints
 
 app = FastAPI()
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -15,7 +15,7 @@ async def default(foo: Annotated[str, Query()] = "foo"):
 
 
 @app.get("/required")
-async def required(foo: Annotated[str, Query(min_length=1)]):
+async def required(foo: Annotated[str, StringConstraints(min_length=1)]):
     return {"foo": foo}
 
 
@@ -26,11 +26,6 @@ async def multiple(foo: Annotated[str, object(), Query(min_length=1)]):
 
 @app.get("/unrelated")
 async def unrelated(foo: Annotated[str, object()]):
-    return {"foo": foo}
-
-
-@app.get("/other_constrict")
-async def other_constrict(foo: Annotated[str, StringConstraints(min_length=1)]):
     return {"foo": foo}
 
 
@@ -90,7 +85,6 @@ foo_is_short = {
         ("/required?foo=bar", 200, {"foo": "bar"}),
         ("/required", 422, foo_is_missing),
         ("/required?foo=", 422, foo_is_short),
-        ("/other_constrict?foo=", 422, foo_is_short),
         ("/multiple?foo=bar", 200, {"foo": "bar"}),
         ("/multiple", 422, foo_is_missing),
         ("/multiple?foo=", 422, foo_is_short),

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, FastAPI, Query
 from fastapi.testclient import TestClient
 from fastapi.utils import match_pydantic_error_url
 from typing_extensions import Annotated
+
 if pydantic.__version__.startswith("2."):
     from pydantic import StringConstraints
 else:

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -9,7 +9,7 @@ from typing_extensions import Annotated
 if pydantic.__version__.startswith("2."):
     from pydantic import StringConstraints
 else:
-    from pydantic import ConstrainedStr as StringConstraints
+    StringConstraints = Query
 
 app = FastAPI()
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,9 +1,11 @@
 import pytest
 from dirty_equals import IsDict
+from pydantic import StringConstraints
+from typing_extensions import Annotated
+
 from fastapi import APIRouter, FastAPI, Query
 from fastapi.testclient import TestClient
 from fastapi.utils import match_pydantic_error_url
-from typing_extensions import Annotated
 
 app = FastAPI()
 
@@ -25,6 +27,11 @@ async def multiple(foo: Annotated[str, object(), Query(min_length=1)]):
 
 @app.get("/unrelated")
 async def unrelated(foo: Annotated[str, object()]):
+    return {"foo": foo}
+
+
+@app.get("/other_constrict")
+async def other_constrict(foo: Annotated[str, StringConstraints(min_length=1)]):
     return {"foo": foo}
 
 
@@ -84,6 +91,7 @@ foo_is_short = {
         ("/required?foo=bar", 200, {"foo": "bar"}),
         ("/required", 422, foo_is_missing),
         ("/required?foo=", 422, foo_is_short),
+        ("/other_constrict?foo=", 422, foo_is_short),
         ("/multiple?foo=bar", 200, {"foo": "bar"}),
         ("/multiple", 422, foo_is_missing),
         ("/multiple?foo=", 422, foo_is_short),

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,11 +1,10 @@
 import pytest
 from dirty_equals import IsDict
-from pydantic import StringConstraints
-from typing_extensions import Annotated
-
 from fastapi import APIRouter, FastAPI, Query
 from fastapi.testclient import TestClient
 from fastapi.utils import match_pydantic_error_url
+from pydantic import StringConstraints
+from typing_extensions import Annotated
 
 app = FastAPI()
 


### PR DESCRIPTION
Annotated not work when it annotate a pydantic annotated_types