### PR TITLE
Documentation uses deprecated pydantic.utils.GetterDict

### DIFF
--- a/docs/em/docs/how-to/sql-databases-peewee.md
+++ b/docs/em/docs/how-to/sql-databases-peewee.md
@@ -210,7 +210,7 @@ connect_args={"check_same_thread": False}
 
 ✋️ 🎚 ⚫️ 🚫 `list`. &amp; ⚫️ 🚫 ☑ 🐍 <a href="https://docs.python.org/3/glossary.html#term-generator" class="external-link" target="_blank">🚂</a>. ↩️ 👉, Pydantic 🚫 💭 🔢 ❔ 🗜 ⚫️ `list` Pydantic *🏷* / 🔗.
 
-✋️ ⏮️ ⏬ Pydantic ✔ 🚚 🛃 🎓 👈 😖 ⚪️➡️ `pydantic.utils.GetterDict`, 🚚 🛠️ ⚙️ 🕐❔ ⚙️ `orm_mode = True` 🗃 💲 🐜 🏷 🔢.
+✋️ ⏮️ ⏬ Pydantic ✔ 🚚 🛃 🎓 👈 😖 ⚪️➡️ `pydantic.v1.utils.GetterDict`, 🚚 🛠️ ⚙️ 🕐❔ ⚙️ `orm_mode = True` 🗃 💲 🐜 🏷 🔢.
 
 👥 🔜 ✍ 🛃 `PeeweeGetterDict` 🎓 &amp; ⚙️ ⚫️ 🌐 🎏 Pydantic *🏷* / 🔗 👈 ⚙️ `orm_mode`:
 

--- a/docs/en/docs/how-to/sql-databases-peewee.md
+++ b/docs/en/docs/how-to/sql-databases-peewee.md
@@ -219,7 +219,7 @@ It's possible to create a `list` of its items with `list(some_user.items)`.
 
 But the object itself is not a `list`. And it's also not an actual Python <a href="https://docs.python.org/3/glossary.html#term-generator" class="external-link" target="_blank">generator</a>. Because of this, Pydantic doesn't know by default how to convert it to a `list` of Pydantic *models* / schemas.
 
-But recent versions of Pydantic allow providing a custom class that inherits from `pydantic.utils.GetterDict`, to provide the functionality used when using the `orm_mode = True` to retrieve the values for ORM model attributes.
+But recent versions of Pydantic allow providing a custom class that inherits from `pydantic.v1.utils.GetterDict`, to provide the functionality used when using the `orm_mode = True` to retrieve the values for ORM model attributes.
 
 We are going to create a custom `PeeweeGetterDict` class and use it in all the same Pydantic *models* / schemas that use `orm_mode`:
 

--- a/docs_src/sql_databases_peewee/sql_app/schemas.py
+++ b/docs_src/sql_databases_peewee/sql_app/schemas.py
@@ -2,7 +2,7 @@ from typing import Any, List, Union
 
 import peewee
 from pydantic import BaseModel
-from pydantic.utils import GetterDict
+from pydantic.v1.utils import GetterDict
 
 
 class PeeweeGetterDict(GetterDict):


### PR DESCRIPTION
### Why this change?

When following [the current documentation on making the Peewee ORM work with FastAPI](https://fastapi.tiangolo.com/how-to/sql-databases-peewee/), the instructions are using the deprecated `pydantic.utils.GetterDict`.

This leads to this kind of deprecation warning in end-user apps that uses Pydantic v2:

```
/opt/venv/lib/python3.11/site-packages/pydantic/_migration.py:288: UserWarning: `pydantic.utils:GetterDict` has been removed. We are importing from `pydantic.v1.utils:GetterDict` instead.See the migration guide for more details: https://docs.pydantic.dev/latest/migration/
```

The migration guide mentioned: https://docs.pydantic.dev/latest/migration/

### What was changed?

Encourage use of `pydantic.v1.utils.GetterDict` instead, as this does not produce the deprecation warning.