### PR TITLE
✏️ Fix typo in `docs/en/docs/reference/index.md`

### DIFF
--- a/docs/en/docs/reference/index.md
+++ b/docs/en/docs/reference/index.md
@@ -1,7 +1,7 @@
 # Reference - Code API
 
 Here's the reference or code API, the classes, functions, parameters, attributes, and
-all the FastAPI parts you can use in you applications.
+all the FastAPI parts you can use in your applications.
 
 If you want to **learn FastAPI** you are much better off reading the
 [FastAPI Tutorial](https://fastapi.tiangolo.com/tutorial/).


### PR DESCRIPTION
Just a simple typo @tiangolo, nothing major.