### PR TITLE
🔥 Remove unnecessary duplicated docstrings

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -86,13 +86,6 @@ class FastAPI(Starlette):
                 **Note**: you probably shouldn't use this parameter, it is inherited
                 from Starlette and supported for compatibility.
 
-                In FastAPI, you normally would use the *path operation* decorators,
-                like:
-
-                * `app.get()`
-                * `app.post()`
-                * etc.
-
                 ---
 
                 A list of routes to serve incoming HTTP and WebSocket requests.

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -624,13 +624,6 @@ class APIRouter(routing.Router):
                 **Note**: you probably shouldn't use this parameter, it is inherited
                 from Starlette and supported for compatibility.
 
-                In FastAPI, you normally would use the *path operation* decorators,
-                like:
-
-                * `router.get()`
-                * `router.post()`
-                * etc.
-
                 ---
 
                 A list of routes to serve incoming HTTP and WebSocket requests.


### PR DESCRIPTION
🔥 Remove unnecessary duplicated docstrings

This is covered by the deprecation, and it shows double in the documentation.