### PR TITLE
📌 Pin Swagger UI version to 5.9.0 temporarily to handle a bug crashing it in 5.9.1

### DIFF
--- a/docs/en/docs/how-to/custom-docs-ui-assets.md
+++ b/docs/en/docs/how-to/custom-docs-ui-assets.md
@@ -96,8 +96,8 @@ You can probably right-click each link and select an option similar to `Save lin
 
 **Swagger UI** uses the files:
 
-* <a href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js" class="external-link" target="_blank">`swagger-ui-bundle.js`</a>
-* <a href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" class="external-link" target="_blank">`swagger-ui.css`</a>
+* <a href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui-bundle.js" class="external-link" target="_blank">`swagger-ui-bundle.js`</a>
+* <a href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui.css" class="external-link" target="_blank">`swagger-ui.css`</a>
 
 And **ReDoc** uses the file:
 

--- a/docs_src/custom_docs_ui/tutorial001.py
+++ b/docs_src/custom_docs_ui/tutorial001.py
@@ -14,8 +14,8 @@ async def custom_swagger_ui_html():
         openapi_url=app.openapi_url,
         title=app.title + " - Swagger UI",
         oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
-        swagger_js_url="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js",
-        swagger_css_url="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css",
+        swagger_js_url="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-bundle.js",
+        swagger_css_url="https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui.css",
     )
 
 

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -53,7 +53,7 @@ def get_swagger_ui_html(
             It is normally set to a CDN URL.
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui-bundle.js",
     swagger_css_url: Annotated[
         str,
         Doc(
@@ -63,7 +63,7 @@ def get_swagger_ui_html(
             It is normally set to a CDN URL.
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui.css",
     swagger_favicon_url: Annotated[
         str,
         Doc(

--- a/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py
+++ b/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py
@@ -20,7 +20,9 @@ def client():
 def test_swagger_ui_html(client: TestClient):
     response = client.get("/docs")
     assert response.status_code == 200, response.text
-    assert "https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-bundle.js" in response.text
+    assert (
+        "https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-bundle.js" in response.text
+    )
     assert "https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui.css" in response.text
 
 

--- a/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py
+++ b/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py
@@ -20,8 +20,8 @@ def client():
 def test_swagger_ui_html(client: TestClient):
     response = client.get("/docs")
     assert response.status_code == 200, response.text
-    assert "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" in response.text
-    assert "https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" in response.text
+    assert "https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui-bundle.js" in response.text
+    assert "https://unpkg.com/swagger-ui-dist@5.9.0/swagger-ui.css" in response.text
 
 
 def test_swagger_ui_oauth2_redirect_html(client: TestClient):


### PR DESCRIPTION
swagger-ui version 5.9.1 released on 25/10/2023 (a day ago) has a bug related to recursive schema definitions 
Issue reported at: 
- https://github.com/swagger-api/swagger-ui/issues/9337

Discussion at fastAPI: 
- https://github.com/tiangolo/fastapi/discussions/10525

