### PR TITLE
Use typing.Optional instead of typing.Union in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ $ pip install "uvicorn[standard]"
 * Create a file `main.py` with:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -171,7 +171,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -181,7 +181,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 If your code uses `async` / `await`, use `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -194,7 +194,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -273,7 +273,7 @@ Now modify the file `main.py` to receive a body from a `PUT` request.
 Declare the body using standard Python types, thanks to Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -284,7 +284,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -293,7 +293,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/em/docs/deployment/docker.md
+++ b/docs/em/docs/deployment/docker.md
@@ -142,7 +142,7 @@ Successfully installed fastapi pydantic uvicorn
 * ✍ `main.py` 📁 ⏮️:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -155,7 +155,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 

--- a/docs/em/docs/index.md
+++ b/docs/em/docs/index.md
@@ -153,7 +153,7 @@ $ pip install "uvicorn[standard]"
 * ✍ 📁 `main.py` ⏮️:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -166,7 +166,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -176,7 +176,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 🚥 👆 📟 ⚙️ `async` / `await`, ⚙️ `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -189,7 +189,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -268,7 +268,7 @@ INFO:     Application startup complete.
 📣 💪 ⚙️ 🐩 🐍 🆎, 👏 Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -279,7 +279,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -288,7 +288,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/en/docs/deployment/docker.md
+++ b/docs/en/docs/deployment/docker.md
@@ -142,7 +142,7 @@ Successfully installed fastapi pydantic uvicorn
 * Create a `main.py` file with:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -155,7 +155,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -162,7 +162,7 @@ $ pip install "uvicorn[standard]"
 * Create a file `main.py` with:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -175,7 +175,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -185,7 +185,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 If your code uses `async` / `await`, use `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -198,7 +198,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -277,7 +277,7 @@ Now modify the file `main.py` to receive a body from a `PUT` request.
 Declare the body using standard Python types, thanks to Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -288,7 +288,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -297,7 +297,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/es/docs/index.md
+++ b/docs/es/docs/index.md
@@ -145,7 +145,7 @@ $ pip install "uvicorn[standard]"
 
 ```Python
 from fastapi import FastAPI
-from typing import Union
+from typing import Optional
 
 app = FastAPI()
 
@@ -156,7 +156,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -167,7 +167,7 @@ Si tu código usa `async` / `await`, usa `async def`:
 
 ```Python hl_lines="7  12"
 from fastapi import FastAPI
-from typing import Union
+from typing import Optional
 
 app = FastAPI()
 
@@ -178,7 +178,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -259,7 +259,7 @@ Declara el body usando las declaraciones de tipo estándares de Python gracias a
 ```Python hl_lines="2  7-10  23-25"
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import Union
+from typing import Optional
 
 app = FastAPI()
 
@@ -267,7 +267,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -276,7 +276,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/fa/docs/index.md
+++ b/docs/fa/docs/index.md
@@ -143,7 +143,7 @@ $ pip install "uvicorn[standard]"
 * فایلی به نام  `main.py` با محتوای زیر ایجاد کنید :
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -156,7 +156,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -270,7 +270,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -279,7 +279,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/fr/docs/index.md
+++ b/docs/fr/docs/index.md
@@ -153,7 +153,7 @@ $ pip install "uvicorn[standard]"
 * Créez un fichier `main.py` avec :
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -166,7 +166,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -176,7 +176,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 Si votre code utilise `async` / `await`, utilisez `async def` :
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -189,7 +189,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -268,7 +268,7 @@ Maintenant, modifiez le fichier `main.py` pour recevoir <abbr title="en anglais 
 Déclarez ce corps en utilisant les types Python standards, grâce à Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -279,7 +279,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -288,7 +288,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/he/docs/index.md
+++ b/docs/he/docs/index.md
@@ -148,7 +148,7 @@ $ pip install "uvicorn[standard]"
 -   צרו קובץ בשם `main.py` עם:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -161,7 +161,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -171,7 +171,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 אם הקוד שלכם משתמש ב - `async` / `await`, השתמשו ב - `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -184,7 +184,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -263,7 +263,7 @@ INFO:     Application startup complete.
 הגדירו את הגוף בעזרת רמזי טיפוסים סטנדרטיים, הודות ל - `Pydantic`.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -274,7 +274,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -283,7 +283,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/ja/docs/deployment/docker.md
+++ b/docs/ja/docs/deployment/docker.md
@@ -151,7 +151,7 @@ Successfully installed fastapi pydantic uvicorn
 * `main.py` ファイルを作成します：
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -164,7 +164,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 

--- a/docs/ko/docs/index.md
+++ b/docs/ko/docs/index.md
@@ -145,7 +145,7 @@ $ pip install "uvicorn[standard]"
 * `main.py` 파일을 만드십시오:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -158,7 +158,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -168,7 +168,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 여러분의 코드가 `async` / `await`을 사용한다면, `async def`를 사용하십시오.
 
 ```Python hl_lines="9 14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -181,7 +181,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -260,7 +260,7 @@ INFO:     Application startup complete.
 Pydantic을 이용해 파이썬 표준 타입으로 본문을 선언합니다.
 
 ```Python hl_lines="4  9 10 11 12  25 26 27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -271,7 +271,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -280,7 +280,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/pl/docs/index.md
+++ b/docs/pl/docs/index.md
@@ -144,7 +144,7 @@ $ pip install "uvicorn[standard]"
 * Utwórz plik o nazwie `main.py` z:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -157,7 +157,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -167,7 +167,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 Jeżeli twój kod korzysta z `async` / `await`, użyj `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -180,7 +180,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -258,7 +258,7 @@ Zmodyfikuj teraz plik `main.py`, aby otrzmywał treść (body) żądania `PUT`.
 Zadeklaruj treść żądania, używając standardowych typów w Pythonie dzięki Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -269,7 +269,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -278,7 +278,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/pt/docs/deployment/docker.md
+++ b/docs/pt/docs/deployment/docker.md
@@ -156,7 +156,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 

--- a/docs/pt/docs/index.md
+++ b/docs/pt/docs/index.md
@@ -138,7 +138,7 @@ $ pip install "uvicorn[standard]"
 * Crie um arquivo `main.py` com:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -151,7 +151,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -161,7 +161,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 Se seu código utiliza `async` / `await`, use `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -174,7 +174,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -253,7 +253,7 @@ Agora modifique o arquivo `main.py` para receber um corpo para uma requisição 
 Declare o corpo utilizando tipos padrão Python, graças ao Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -264,7 +264,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -273,7 +273,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/ru/docs/deployment/docker.md
+++ b/docs/ru/docs/deployment/docker.md
@@ -144,7 +144,7 @@ Successfully installed fastapi pydantic uvicorn
 * Создайте файл `main.py` и заполните его:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -157,7 +157,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 

--- a/docs/ru/docs/index.md
+++ b/docs/ru/docs/index.md
@@ -147,7 +147,7 @@ $ pip install "uvicorn[standard]"
 * Создайте файл `main.py` со следующим содержимым:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -160,7 +160,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -170,7 +170,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 Если ваш код использует `async` / `await`, используйте `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -183,7 +183,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -262,7 +262,7 @@ INFO:     Application startup complete.
 Объявите тело, используя стандартную типизацию Python, спасибо Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -273,7 +273,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -282,7 +282,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/tr/docs/index.md
+++ b/docs/tr/docs/index.md
@@ -153,7 +153,7 @@ $ pip install "uvicorn[standard]"
 * `main.py` adında bir dosya oluştur :
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -166,7 +166,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -176,7 +176,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 Eğer kodunda `async` / `await` var ise, `async def` kullan:
 
 ```Python hl_lines="9 14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -189,7 +189,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -268,7 +268,7 @@ Senin için alternatif olarak (<a href="https://github.com/Rebilly/ReDoc" class=
 Şimdi Pydantic sayesinde, Python'un standart tiplerini kullanarak bir body tanımlayacağız.
 
 ```Python hl_lines="4  9 10 11 12  25 26 27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -279,7 +279,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Union[bool] = None
 
 
 @app.get("/")
@@ -288,7 +288,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/vi/docs/index.md
+++ b/docs/vi/docs/index.md
@@ -154,7 +154,7 @@ $ pip install "uvicorn[standard]"
 * Tạo một tệp tin `main.py` như sau:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -167,7 +167,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -177,7 +177,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 Nếu code của bạn sử dụng `async` / `await`, hãy sử dụng `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -190,7 +190,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -280,7 +280,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -289,7 +289,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/yo/docs/index.md
+++ b/docs/yo/docs/index.md
@@ -152,7 +152,7 @@ $ pip install "uvicorn[standard]"
 * Ṣẹ̀dá fáìlì `main.py (èyí tíí ṣe, akọkọ.py)` pẹ̀lú:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -165,7 +165,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -175,7 +175,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 Tí kóòdù rẹ̀ bá ń lò `async` / `await`, lò `async def`:
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -188,7 +188,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -268,7 +268,7 @@ Ní báyìí ṣe àtúnṣe fáìlì `main.py` láti gba kókó èsì láti in�
 Ní báyìí, ṣe ìkéde kókó èsì API nínú kóòdù rẹ nipa lílo àwọn ìtọ́kasí àmì irúfẹ́ Python, ọpẹ́ pàtàkìsi sí Pydantic.
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -279,7 +279,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -288,7 +288,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 

--- a/docs/zh/docs/index.md
+++ b/docs/zh/docs/index.md
@@ -145,7 +145,7 @@ $ pip install "uvicorn[standard]"
 * 创建一个 `main.py` 文件并写入以下内容:
 
 ```Python
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -158,7 +158,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -168,7 +168,7 @@ def read_item(item_id: int, q: Union[str, None] = None):
 如果你的代码里会出现 `async` / `await`，请使用 `async def`：
 
 ```Python hl_lines="9  14"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -181,7 +181,7 @@ async def read_root():
 
 
 @app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
+async def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 ```
 
@@ -260,7 +260,7 @@ INFO:     Application startup complete.
 我们借助 Pydantic 来使用标准的 Python 类型声明请求体。
 
 ```Python hl_lines="4  9-12  25-27"
-from typing import Union
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -271,7 +271,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     price: float
-    is_offer: Union[bool, None] = None
+    is_offer: Optional[bool] = None
 
 
 @app.get("/")
@@ -280,7 +280,7 @@ def read_root():
 
 
 @app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
+def read_item(item_id: int, q: Optional[str] = None):
     return {"item_id": item_id, "q": q}
 
 


### PR DESCRIPTION
This is a tiny, admittedly pedantic PR to use the more succinct `Optional[<type>] = None` over `Union[<type>, None] = None` syntax in the docs, since:

> Optional[X] is equivalent to X | None (or Union[X, None]).
- [Source](https://docs.python.org/3/library/typing.html#typing.Optional)

I thought that maybe `Union` was a deliberate choice but saw that `Optional` was used liberally throughout the codebase. I made the change in all language-specific files since the code blocks are identical. 