### PR TITLE
Add option to generate OpenAPI specification by either Pydantic field name or alias

### DIFF
--- a/docs/en/docs/how-to/extending-openapi.md
+++ b/docs/en/docs/how-to/extending-openapi.md
@@ -26,6 +26,7 @@ And that function `get_openapi()` receives as parameters:
 * `summary`: A short summary of the API.
 * `description`: The description of your API, this can include markdown and will be shown in the docs.
 * `routes`: A list of routes, these are each of the registered *path operations*. They are taken from `app.routes`.
+* `field_names_by_alias`: A boolean indicating whether to use the field names or the alias names for the models.
 
 !!! info
     The parameter `summary` is available in OpenAPI 3.1.0 and above, supported by FastAPI 0.99.0 and above.

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -347,6 +347,7 @@ else:
     @dataclass
     class GenerateJsonSchema:  # type: ignore[no-redef]
         ref_template: str
+        by_alias: bool = True
 
     class PydanticSchemaGenerationError(Exception):  # type: ignore[no-redef]
         pass

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -450,6 +450,7 @@ def get_openapi(
     contact: Optional[Dict[str, Union[str, Any]]] = None,
     license_info: Optional[Dict[str, Union[str, Any]]] = None,
     separate_input_output_schemas: bool = True,
+    field_names_by_alias: bool = True,
 ) -> Dict[str, Any]:
     info: Dict[str, Any] = {"title": title, "version": version}
     if summary:
@@ -471,7 +472,9 @@ def get_openapi(
     operation_ids: Set[str] = set()
     all_fields = get_fields_from_routes(list(routes or []) + list(webhooks or []))
     model_name_map = get_compat_model_name_map(all_fields)
-    schema_generator = GenerateJsonSchema(ref_template=REF_TEMPLATE)
+    schema_generator = GenerateJsonSchema(
+        ref_template=REF_TEMPLATE, by_alias=field_names_by_alias
+    )
     field_mapping, definitions = get_definitions(
         fields=all_fields,
         schema_generator=schema_generator,


### PR DESCRIPTION
Hi!

Following the issue raised [here](https://github.com/tiangolo/fastapi/issues/771) and the discussion, I wanted to submit a simple option to the schema generation that I believe solves this problem (thanks @rbuffat for the right code places!).

TL;DR: Some people want to generate their openapi schemas based on the field names in their Models and not the aliases. This was already supported by Pydantic's Schema generation process but not enabled by the FastAPI interface.

I have updated the method overview in the "How To"-Guide but don't think that it's important enough to update the code examples as well. I can update those as well.

**Questions**: 

- [ ] Are there any side-effects to consider (e.g. other types of schema generation)?
- [ ] Does it make more sense to couple this with `response_model_by_alias: bool` in the route handler? That way a user can pass this option for specific routes only and his API spec and return types always match!