### PR TITLE
fix: Reading List Type Query Parameter with Annotated Type Hints

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -571,6 +571,8 @@ def field_annotation_is_scalar_sequence(annotation: Union[Type[Any], None]) -> b
             elif not field_annotation_is_scalar(arg):
                 return False
         return at_least_one_scalar_sequence
+    elif origin is Annotated:
+        return field_annotation_is_scalar_sequence(get_args(annotation)[0])
     return field_annotation_is_sequence(annotation) and all(
         field_annotation_is_scalar(sub_annotation)
         for sub_annotation in get_args(annotation)

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -299,22 +299,17 @@ def test_openapi_schema():
                             "required": False,
                             "schema": {
                                 "anyOf": [
-                                    {
-                                        "type": "array",
-                                        "items": {"type": "string"}
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
+                                    {"type": "array", "items": {"type": "string"}},
+                                    {"type": "null"},
                                 ],
-                                "title": "Foo"
-                            }
+                                "title": "Foo",
+                            },
                         }
                     ],
                     "responses": {
                         "200": {
                             "description": "Successful Response",
-                            "content": {"application/json": {"schema": {}}}
+                            "content": {"application/json": {"schema": {}}},
                         },
                         "422": {
                             "description": "Validation Error",
@@ -328,7 +323,7 @@ def test_openapi_schema():
                         },
                     },
                 },
-            }
+            },
         },
         "components": {
             "schemas": {

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -297,19 +297,26 @@ def test_openapi_schema():
                             "name": "foo",
                             "in": "query",
                             "required": False,
-                            "schema": {
+                            "schema": IsDict({
                                 "anyOf": [
-                                    {"type": "array", "items": {"type": "string"}},
-                                    {"type": "null"},
+                                    {
+                                        "type": "array",
+                                        "items": {"type": "string"}
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
                                 ],
-                                "title": "Foo",
-                            },
+                                "title": "Foo"
+                            })
+                            # TODO: remove when deprecating Pydantic v1
+                            | IsDict({"items": {"type": "string"}, "type": "array", "title": "Foo"})
                         }
                     ],
                     "responses": {
                         "200": {
                             "description": "Successful Response",
-                            "content": {"application/json": {"schema": {}}},
+                            "content": {"application/json": {"schema": {}}}
                         },
                         "422": {
                             "description": "Validation Error",
@@ -323,7 +330,7 @@ def test_openapi_schema():
                         },
                     },
                 },
-            },
+            }
         },
         "components": {
             "schemas": {

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Union
 
 import pytest
 from dirty_equals import IsDict
@@ -31,7 +31,7 @@ async def unrelated(foo: Annotated[str, object()]):
 
 
 @app.get("/nested-annotated-list")
-async def nested_annotated_list(foo: Union[Annotated[list[str], Query()], None] = None):
+async def nested_annotated_list(foo: Union[Annotated[List[str], Query()], None] = None):
     return {"foo": foo}
 
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -297,26 +297,29 @@ def test_openapi_schema():
                             "name": "foo",
                             "in": "query",
                             "required": False,
-                            "schema": IsDict({
-                                "anyOf": [
-                                    {
-                                        "type": "array",
-                                        "items": {"type": "string"}
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ],
-                                "title": "Foo"
-                            })
+                            "schema": IsDict(
+                                {
+                                    "anyOf": [
+                                        {"type": "array", "items": {"type": "string"}},
+                                        {"type": "null"},
+                                    ],
+                                    "title": "Foo",
+                                }
+                            )
                             # TODO: remove when deprecating Pydantic v1
-                            | IsDict({"items": {"type": "string"}, "type": "array", "title": "Foo"})
+                            | IsDict(
+                                {
+                                    "items": {"type": "string"},
+                                    "type": "array",
+                                    "title": "Foo",
+                                }
+                            ),
                         }
                     ],
                     "responses": {
                         "200": {
                             "description": "Successful Response",
-                            "content": {"application/json": {"schema": {}}}
+                            "content": {"application/json": {"schema": {}}},
                         },
                         "422": {
                             "description": "Validation Error",
@@ -330,7 +333,7 @@ def test_openapi_schema():
                         },
                     },
                 },
-            }
+            },
         },
         "components": {
             "schemas": {


### PR DESCRIPTION
This patch fixes the issue where, when using specific type hints (when `Annotated` type appears within nested type) with list type query parameters, parameter values cannot be read as list.

When I execute the following code, FastAPI returns a 422 response.
(Environment: python version: `3.9.6`, fastapi version: `0.104.1`, pydantic version: `2.4.2`)

```python
from fastapi import FastAPI, Query  
from fastapi.testclient import TestClient  
from pydantic import conlist  
from typing import Optional  
  
  
app = FastAPI()
  
@app.get("/test")  
async def test(  
    tag: Optional[conlist(str, min_length=1, max_length=5)] = Query(None, description="tag")  
):  
    return {"tag": tag}  
  
  
if __name__ == "__main__":  
    with TestClient(app) as client:  
        res = client.get("/test", params={"tag": ["a", "b"]})  
        print(res.json())
```

log:
```
{'detail': [{'type': 'list_type', 'loc': ['query', 'tag'], 'msg': 'Input should be a valid list', 'input': 'b', 'url': 'https://errors.pydantic.dev/2.4/v/list_type'}]}
```


As I read through the code, I found that in `request_params_to_args()`, the result of whether a parameter is a scalar sequence is done with `is_scalar_sequence_field() -> field_annotation_is_scalar_sequence()` and depending on the result, how to read parameter value is changed.
https://github.com/tiangolo/fastapi/blob/0.104.1/fastapi/dependencies/utils.py#L651
https://github.com/tiangolo/fastapi/blob/0.104.1/fastapi/_compat.py#L242
https://github.com/tiangolo/fastapi/blob/0.104.1/fastapi/_compat.py#L563

In the given code execution, type annotation passed to `field_annotation_is_scalar_sequence()` is  `Optional[Annotated[List[str], Len(min_length=1, max_length=5)]]`. But, because there is no implementation to interpret `Annotated` , so it is unable to recognize it as a scalar sequence and returns False.

In this patch, I modified to `field_annotation_is_scalar_sequence()` to be enabled to parse `Annotated`.