### PR TITLE
Removing .dict() method as it is deprecated

### DIFF
--- a/docs/en/docs/tutorial/sql-databases.md
+++ b/docs/en/docs/tutorial/sql-databases.md
@@ -474,11 +474,11 @@ The steps are:
 
     and then we are passing the `dict`'s key-value pairs as the keyword arguments to the SQLAlchemy `Item`, with:
 
-    `Item(**model_dump())`
+    `Item(**item.model_dump())`
 
     And then we pass the extra keyword argument `owner_id` that is not provided by the Pydantic *model*, with:
 
-    `Item(**model_dump(), owner_id=user_id)`
+    `Item(**item.model_dump(), owner_id=user_id)`
 
 ## Main **FastAPI** app
 

--- a/docs/en/docs/tutorial/sql-databases.md
+++ b/docs/en/docs/tutorial/sql-databases.md
@@ -470,15 +470,15 @@ The steps are:
 !!! tip
     Instead of passing each of the keyword arguments to `Item` and reading each one of them from the Pydantic *model*, we are generating a `dict` with the Pydantic *model*'s data with:
 
-    `item.dict()`
+    `model_dump()`
 
     and then we are passing the `dict`'s key-value pairs as the keyword arguments to the SQLAlchemy `Item`, with:
 
-    `Item(**item.dict())`
+    `Item(**model_dump())`
 
     And then we pass the extra keyword argument `owner_id` that is not provided by the Pydantic *model*, with:
 
-    `Item(**item.dict(), owner_id=user_id)`
+    `Item(**model_dump(), owner_id=user_id)`
 
 ## Main **FastAPI** app
 

--- a/docs_src/sql_databases/sql_app/crud.py
+++ b/docs_src/sql_databases/sql_app/crud.py
@@ -29,7 +29,7 @@ def get_items(db: Session, skip: int = 0, limit: int = 100):
 
 
 def create_user_item(db: Session, item: schemas.ItemCreate, user_id: int):
-    db_item = models.Item(**item.dict(), owner_id=user_id)
+    db_item = models.Item(**item.model_dump(), owner_id=user_id)
     db.add(db_item)
     db.commit()
     db.refresh(db_item)

--- a/docs_src/sql_databases/sql_app/crud.py
+++ b/docs_src/sql_databases/sql_app/crud.py
@@ -29,7 +29,7 @@ def get_items(db: Session, skip: int = 0, limit: int = 100):
 
 
 def create_user_item(db: Session, item: schemas.ItemCreate, user_id: int):
-    db_item = models.Item(**item.model_dump()), owner_id=user_id)
+    db_item = models.Item(**item.model_dump(), owner_id=user_id)
     db.add(db_item)
     db.commit()
     db.refresh(db_item)

--- a/docs_src/sql_databases/sql_app/crud.py
+++ b/docs_src/sql_databases/sql_app/crud.py
@@ -29,7 +29,7 @@ def get_items(db: Session, skip: int = 0, limit: int = 100):
 
 
 def create_user_item(db: Session, item: schemas.ItemCreate, user_id: int):
-    db_item = models.Item(**item.model_dump(), owner_id=user_id)
+    db_item = models.Item(**item.model_dump()), owner_id=user_id)
     db.add(db_item)
     db.commit()
     db.refresh(db_item)


### PR DESCRIPTION
.dict() method is deprecated and it is advised to use .model_dump()
To keep the documentation up to date, .dict() needs to be removed and be replaced with .model_dump()