### PR TITLE
✏️ Fix Pydantic method name in `docs/en/docs/advanced/path-operation-advanced-configuration.md`

### DIFF
--- a/docs/en/docs/advanced/path-operation-advanced-configuration.md
+++ b/docs/en/docs/advanced/path-operation-advanced-configuration.md
@@ -163,7 +163,7 @@ For example, in this application we don't use FastAPI's integrated functionality
     ```
 
 !!! info
-    In Pydantic version 1 the method to get the JSON Schema for a model was called `Item.schema()`, in Pydantic version 2, the method is called `Item.model_schema_json()`.
+    In Pydantic version 1 the method to get the JSON Schema for a model was called `Item.schema()`, in Pydantic version 2, the method is called `Item.model_json_schema()`.
 
 Nevertheless, although we are not using the default integrated functionality, we are still using a Pydantic model to manually generate the JSON Schema for the data that we want to receive in YAML.
 


### PR DESCRIPTION
## Fixing small typo of pydantic v2 json schema method
![image](https://github.com/tiangolo/fastapi/assets/104530599/aee9a79b-7cf5-4731-88f4-b6422fe1822b)

### Should be `Item.model_json_schema` instead
### [Doc path](https://fastapi.tiangolo.com/advanced/path-operation-advanced-configuration/#custom-openapi-content-type) 