### PR TITLE
🌐 Add German translation for `docs/de/docs/reference/openapi/*.md`

### DIFF
--- a/docs/de/docs/reference/openapi/docs.md
+++ b/docs/de/docs/reference/openapi/docs.md
@@ -1,0 +1,11 @@
+# OpenAPI `docs`
+
+Werkzeuge zur Verwaltung der automatischen OpenAPI-UI-Dokumentation, einschließlich Swagger UI (standardmäßig unter `/docs`) und ReDoc (standardmäßig unter `/redoc`).
+
+::: fastapi.openapi.docs.get_swagger_ui_html
+
+::: fastapi.openapi.docs.get_redoc_html
+
+::: fastapi.openapi.docs.get_swagger_ui_oauth2_redirect_html
+
+::: fastapi.openapi.docs.swagger_ui_default_parameters

--- a/docs/de/docs/reference/openapi/index.md
+++ b/docs/de/docs/reference/openapi/index.md
@@ -1,0 +1,5 @@
+# OpenAPI
+
+Es gibt mehrere Werkzeuge zur Handhabung von OpenAPI.
+
+Normalerweise müssen Sie diese nicht verwenden, es sei denn, Sie haben einen bestimmten fortgeschrittenen Anwendungsfall, welcher das erfordert.

--- a/docs/de/docs/reference/openapi/models.md
+++ b/docs/de/docs/reference/openapi/models.md
@@ -1,0 +1,5 @@
+# OpenAPI-`models`
+
+OpenAPI Pydantic-Modelle, werden zum Generieren und Validieren der generierten OpenAPI verwendet.
+
+::: fastapi.openapi.models


### PR DESCRIPTION
All-in-one-PR of three documents, as these are very short.

← `reference/middleware.md` (#10837)
→ `reference/security/index.md` (#10839)

[German translation progress](https://github.com/tiangolo/fastapi/discussions/10582)