### PR TITLE
🌐 Add German translation for `docs/de/docs/reference/testclient.md`

### DIFF
--- a/docs/de/docs/reference/testclient.md
+++ b/docs/de/docs/reference/testclient.md
@@ -1,0 +1,13 @@
+# Testclient – `TestClient`
+
+Sie können die `TestClient`-Klasse verwenden, um FastAPI-Anwendungen zu testen, ohne eine tatsächliche HTTP- und Socket-Verbindung zu erstellen, Sie kommunizieren einfach direkt mit dem FastAPI-Code.
+
+Lesen Sie mehr darüber in der [FastAPI-Dokumentation über Testen](../tutorial/testing.md).
+
+Sie können sie direkt von `fastapi.testclient` importieren:
+
+```python
+from fastapi.testclient import TestClient
+```
+
+::: fastapi.testclient.TestClient


### PR DESCRIPTION
The reference is done. 🎉

← `reference/templating.md` (#10842)
→ `fastapi-people.md` #10285

[German translation progress](https://github.com/tiangolo/fastapi/discussions/10582)