### PR TITLE
🌐 Add German translation for `docs/de/docs/newsletter.md`

### DIFF
--- a/docs/de/docs/newsletter.md
+++ b/docs/de/docs/newsletter.md
@@ -1,0 +1,5 @@
+# FastAPI und Freunde Newsletter
+
+<iframe data-w-type="embedded" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://xr4n4.mjt.lu/wgt/xr4n4/hj5/form?c=40a44fa4" width="100%" style="height: 0;"></iframe>
+
+<script type="text/javascript" src="https://app.mailjet.com/pas-nc-embedded-v1.js"></script>


### PR DESCRIPTION
Short one, just the heading.

← `external-links.md` (#10852)
→ `about/index.md` (#10497)
→ `alternatives.md` (#10855)

[German translation progress](https://github.com/tiangolo/fastapi/discussions/10582)