### PR TITLE
🌐 Add Spanish translation for `docs/es/docs/learn/index.md`

### DIFF
--- a/docs/es/docs/learn/index.md
+++ b/docs/es/docs/learn/index.md
@@ -1,0 +1,5 @@
+# Aprender
+
+Aquí están las secciones introductorias y los tutoriales para aprender **FastAPI**.
+
+Podrías considerar esto como un **libro**, un **curso**, la forma **oficial** y recomendada de aprender FastAPI. 😎


### PR DESCRIPTION
This is the Spanish translation for the learn page.

Fix Spanish translation structure for docs/es/docs/learn/index.md
- Version >= 0.108.0