### PR TITLE
🐛 Fix File field cannot be defined after Form field

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -713,6 +713,7 @@ async def request_body_to_args(
                     except AttributeError:
                         errors.append(get_missing_field_error(loc))
                         continue
+            field_info = field.field_info
             if (
                 value is None
                 or (isinstance(field_info, params.Form) and value == "")


### PR DESCRIPTION

🐛 If File field is defined after Form field, it will cause a validation error while processing a valid request.

I've added a test case in PR which can test against the issue.

```
# Good
@app.post("/file/")
def create_file(
    file: UploadFile = File(), token: str = Form()
):

# Validation error
@app.post("/files2/")
def create_file_2(
   token: str = Form(), file: UploadFile = File()
):
```