### PR TITLE
✨ Add Service() annotation

### DIFF
--- a/docs/en/docs/reference/dependencies.md
+++ b/docs/en/docs/reference/dependencies.md
@@ -1,4 +1,4 @@
-# Dependencies - `Depends()` and `Security()`
+# Dependencies - `Depends()`, `Security()` and `Service()`
 
 ## `Depends()`
 
@@ -27,3 +27,18 @@ from fastapi import Security
 ```
 
 ::: fastapi.Security
+
+## `Service()`
+
+`Depends()` is designed to include matching fields of annotated class as body/query params.
+To avoid this, you can annotate class using `Service()` instead of `Depends()`.
+
+Here is the reference for it and its parameters.
+
+You can import it directly from `fastapi`:
+
+```python
+from fastapi import Service
+```
+
+::: fastapi.Service

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -18,6 +18,7 @@ from .param_functions import Header as Header
 from .param_functions import Path as Path
 from .param_functions import Query as Query
 from .param_functions import Security as Security
+from .param_functions import Service as Service
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -32,6 +32,7 @@ class Dependant:
         background_tasks_param_name: Optional[str] = None,
         security_scopes_param_name: Optional[str] = None,
         security_scopes: Optional[List[str]] = None,
+        expose: bool = True,
         use_cache: bool = True,
         path: Optional[str] = None,
     ) -> None:
@@ -51,6 +52,7 @@ class Dependant:
         self.security_scopes_param_name = security_scopes_param_name
         self.name = name
         self.call = call
+        self.expose = expose
         self.use_cache = use_cache
         # Store the path to be able to re-generate a dependable from it in overrides
         self.path = path

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -760,7 +760,10 @@ class File(Form):
 
 class Depends:
     def __init__(
-        self, dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
+        self,
+        dependency: Optional[Callable[..., Any]] = None,
+        *,
+        use_cache: bool = True,
     ):
         self.dependency = dependency
         self.use_cache = use_cache
@@ -781,3 +784,7 @@ class Security(Depends):
     ):
         super().__init__(dependency=dependency, use_cache=use_cache)
         self.scopes = scopes or []
+
+
+class Service(Depends):
+    pass

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -502,7 +502,11 @@ class APIRoute(routing.Route):
                     additional_status_code
                 ), f"Status code {additional_status_code} must not have a response body"
                 response_name = f"Response_{additional_status_code}_{self.unique_id}"
-                response_field = create_response_field(name=response_name, type_=model)
+                response_field = create_response_field(
+                    name=response_name,
+                    type_=model,
+                    mode="serialization",
+                )
                 response_fields[additional_status_code] = response_field
         if response_fields:
             self.response_fields: Dict[Union[int, str], ModelField] = response_fields

--- a/tests/test_dependency_service_overrides.py
+++ b/tests/test_dependency_service_overrides.py
@@ -1,0 +1,223 @@
+from abc import ABC, abstractmethod
+from typing import List, runtime_checkable
+
+import pytest
+from fastapi import APIRouter, FastAPI, Service
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from typing_extensions import Protocol
+
+app = FastAPI()
+
+router = APIRouter()
+
+
+class Item(BaseModel):
+    name: str
+    value: int
+
+
+@runtime_checkable
+class ItemsProtocol(Protocol):
+    def get_items(self) -> List[Item]:
+        ...  # pragma: nocover
+
+
+class ItemsInterface(ABC):
+    @abstractmethod
+    def get_items(self) -> List[Item]:
+        ...  # pragma: nocover
+
+
+class ItemsService(ItemsInterface):
+    def __init__(self, name: str, value: int):
+        self.name = name
+        self.value = value
+
+    def get_items(self) -> List[Item]:
+        return [Item(name=self.name, value=self.value)]
+
+
+class ClassNestedProtocol:
+    def __init__(self, impl: ItemsProtocol = Service()):
+        self.impl = impl
+
+
+class ClassNestedInterface:
+    def __init__(self, impl: ItemsInterface = Service()):
+        self.impl = impl
+
+
+class ClassNested:
+    def __init__(self, impl: ItemsService = Service()):
+        self.impl = impl
+
+
+@app.get("/depends-on-protocol/")
+async def depends_on_protocol(service: ItemsProtocol = Service()):
+    return {"in": "depends-on-protocol", "items": service.get_items()}
+
+
+@app.get("/depends-on-interface/")
+async def depends_on_interface(service: ItemsInterface = Service()):
+    return {"in": "depends-on-interface", "items": service.get_items()}
+
+
+@app.get("/depends-on-class/")
+async def depends_on_class(service: ItemsService = Service()):
+    return {"in": "depends-on-class", "items": service.get_items()}
+
+
+@app.get("/depends-on-nested-protocol/")
+async def depends_on_nested_protocol(service: ClassNestedProtocol = Service()):
+    return {"in": "depends-on-nested-protocol", "items": service.impl.get_items()}
+
+
+@app.get("/depends-on-nested-interface/")
+async def depends_on_nested_interface(service: ClassNestedInterface = Service()):
+    return {"in": "depends-on-nested-interface", "items": service.impl.get_items()}
+
+
+@app.get("/depends-on-nested-class/")
+async def depends_on_nested_class(service: ClassNested = Service()):
+    return {"in": "depends-on-nested-class", "items": service.impl.get_items()}
+
+
+app.include_router(router)
+
+client = TestClient(app)
+
+
+def test_depends_on_protocol_no_override():
+    with pytest.raises(TypeError, match="Protocols cannot be instantiated"):
+        # not 422 error about missing args and kwargs inputs
+        client.get("/depends-on-protocol/")
+
+
+def test_depends_on_protocol_override():
+    app.dependency_overrides[ItemsProtocol] = lambda: ItemsService(name="abc", value=1)
+    response = client.get("/depends-on-protocol/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "in": "depends-on-protocol",
+        "items": [
+            {
+                "name": "abc",
+                "value": 1,
+            },
+        ],
+    }
+    app.dependency_overrides = {}
+
+
+def test_depends_on_interface_no_override():
+    error_msg = "Can't instantiate abstract class ItemsInterface with.*abstract method"
+    with pytest.raises(TypeError, match=error_msg):
+        client.get("/depends-on-interface/")
+
+
+def test_depends_on_interface_override():
+    app.dependency_overrides[ItemsInterface] = lambda: ItemsService(name="abc", value=1)
+    response = client.get("/depends-on-interface/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "in": "depends-on-interface",
+        "items": [
+            {
+                "name": "abc",
+                "value": 1,
+            },
+        ],
+    }
+    app.dependency_overrides = {}
+
+
+def test_depends_on_class_no_override():
+    error_msg = "missing 2 required positional arguments: 'name' and 'value'"
+    with pytest.raises(TypeError, match=error_msg):
+        # not 422 error about missing body fields
+        client.get("/depends-on-class/")
+
+
+def test_depends_on_class_override():
+    app.dependency_overrides[ItemsService] = lambda: ItemsService(name="abc", value=1)
+    response = client.get("/depends-on-class/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "in": "depends-on-class",
+        "items": [
+            {
+                "name": "abc",
+                "value": 1,
+            },
+        ],
+    }
+    app.dependency_overrides = {}
+
+
+def test_depends_on_nested_protocol_no_override():
+    with pytest.raises(TypeError, match="Protocols cannot be instantiated"):
+        client.get("/depends-on-nested-protocol/")
+
+
+def test_depends_on_nested_protocol_override_top_level():
+    service = ClassNestedProtocol(impl=ItemsService(name="abc", value=1))
+    app.dependency_overrides[ClassNestedProtocol] = lambda: service
+    response = client.get("/depends-on-nested-protocol/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "in": "depends-on-nested-protocol",
+        "items": [
+            {
+                "name": "abc",
+                "value": 1,
+            },
+        ],
+    }
+    app.dependency_overrides = {}
+
+
+def test_depends_on_nested_interface_no_override():
+    error_msg = "Can't instantiate abstract class ItemsInterface with.*abstract method"
+    with pytest.raises(TypeError, match=error_msg):
+        client.get("/depends-on-nested-interface/")
+
+
+def test_depends_on_nested_interface_override_top_level():
+    service = ClassNestedInterface(impl=ItemsService(name="abc", value=1))
+    app.dependency_overrides[ClassNestedInterface] = lambda: service
+    response = client.get("/depends-on-nested-interface/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "in": "depends-on-nested-interface",
+        "items": [
+            {
+                "name": "abc",
+                "value": 1,
+            },
+        ],
+    }
+    app.dependency_overrides = {}
+
+
+def test_depends_on_nested_class_no_override():
+    error_msg = "missing 2 required positional arguments: 'name' and 'value'"
+    with pytest.raises(TypeError, match=error_msg):
+        client.get("/depends-on-nested-class/")
+
+
+def test_depends_on_nested_class_override_top_level():
+    service = ClassNested(impl=ItemsService(name="abc", value=1))
+    app.dependency_overrides[ClassNested] = lambda: service
+    response = client.get("/depends-on-nested-class/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "in": "depends-on-nested-class",
+        "items": [
+            {
+                "name": "abc",
+                "value": 1,
+            },
+        ],
+    }
+    app.dependency_overrides = {}


### PR DESCRIPTION
Currently dependency injection mechanism based on `Depends()` can be used for 2 different cases:

1. Move query/body fields from endpoint function annotation to separate class, but avoid making these fields nested in API schema.
2. Create objects of some internal classes (e.g. services) used for business logic, like data validation/creation/bypassing to external applications and so on.


Example application:

```python
from dataclasses import dataclass
from fastapi import FastAPI, Depends

from sqlalchemy import select
from sqlalchemy import Column, Integer, String
from sqlalchemy.ext.declarative import declarative_base
from sqlalchemy.ext.asyncio import AsyncSession


@dataclass
class Item:
    id: int
    name: str


Base = declarative_base()

class DBItem(Base):
    __tablename__ = "items"
    id = Column(Integer, primary_key=True)
    name =  Column(String(50))


class ItemsRepository:
    def __init__(self, session: AsyncSession = Depends()):
        self.session = session

    async def get_items(self, limit: int, offset: int) -> list[DBItem]:
        query = select(DBItem).limit(limit).offset(offset)
        result = await self.session.scalars(query)
        return result.all()


async def session_factory(url: str):
    ...


app = FastAPI()
app.dependency_overrides[AsyncSession] = session_factory(settings.db_url)



@dataclass
class ItemsQuery:
  limit: int = 10
  offset: int = 0

@app.get("/items/")
async def get_items(
  query: ItemsQuery = Depends(),
  repository: ItemsRepository = Depends(),
) -> list[Item]:
    return await repository.get_items(limit=query.limit, offset=query.offset)
```

Here `Depends()` is used to create objects:
1. `query = ItemsQuery(limit=10, offset=0)`
2. `repository = ItemsRepository(session=AsyncSession(...))`

And then pass both of them as `get_items` function arguments.


If both cases `Depends()` traverses annotated class fields to generate dependency tree and so on. But later cases are very different:
1. For `ItemsQuery = Depends()` FastAPI should include `limit` and `offset` as query options in OpenAPI schema, and validate input query against this schema.
4. For `ItemsRepository = Depends()` FastAPI should construct object from values like database URL, engine options and so on, not from user input. And these options are not a part of OpenAPI schema, but a part of some kind of internal documentation (e.g. for DevOps or developer who is going to deploy this service).

So `Depends()` should simultaneously include some fields into OpenAPI schema and perform validation, but exclude others. And this should work recursively on the whole tree of dependencies in application.

This was already mentioned in #8668 - in some cases internal class fields (e.g. repository, auth provider configuration, etc) were included to OpenAPI schema because `Depends()` traverses dependency signature. But it *must* traverse signature to create proper dependency tree.

Some users created wrappers which allowed to make `Depends()` think that class `__init__(...)` method signature does not accept any arguments:
https://github.com/Tishka17/fastapi-template/blob/c5ef8b62d69f04c37ccce40a1cc3f103e9eacdd9/src/app/api/depends_stub.py

But this fails on Protocols and sometimes painful to use.

------------------------

The proposed change is to split `Depends()` functionality to 2 different classes with different behavior:
1. `Depends()` - traverse dependency signatures, build dependency tree, **add mandatory fields** as query/body parameters for schema and validation. During endpoint call substitute all the fields using dependency tree + `app.dependency_overrides`. If some field value is missing, return 422 status code with body marking the exact location of this field.
2. `Service()` - traverse dependency signatures, build dependency tree, but **do nothing with mandatory fields**. During endpoint call substitute all the fields using dependency tree + `app.dependency_overrides`. If some field value is missing, interpreter will raise TypeError exception in some dependency constructor. This means that something wrong with application setup or source code, not the user input, so 500 status code is returned.

<details>
<summary>Why adding one more class?</summary>

Previously I thought about just adding an option `Depends(expose=False)` which disabled handling mandatory fields as body/query params. But `Security()` is subclass of `Depends()`, and it meant to be used to mark some dependencies as adding even more information to OpenAPI schema. So I decided to move this to a separated class.
</details>

Currently annotations look like this:
1. `ItemsQuery = Depends()` - passing valid `limit` or `offset` is up to API user, wrong value == 422. Same as before, nothing is changed.
2. `ItemsRepository = Service()` - passing valid `AsyncSession` is up to application developer, wrong value == 500. Should be used only for internal classes, not user input.


Added tests for new class, including cases like:
```python

# this can be Protocol or abstract class
class BaseItemsRepository(ABC):
    # abstract class with just methods signatures. should be inherited by all implementations of ItemsRepository

    @abstractmethod
    async def get_items(self, limit: int, offset: int) -> list[Item]:
        ...

class InternalItemsRepository(BaseItemsRepository):
    # implementation which stores items in internal database using SQLAlchemy

    def __init__(self, session: AsyncSession = Service()):
        self.session = session

    async def get_items(self, limit: int, offset: int) -> list[Item]:
        # make query to DB here

class ExternalItemsRepository(BaseItemsRepository):
    # implementation which stores items in external service using API

    def __init__(self, client: ExternalAPIClient = Service()):
        self.client = client

    async def get_items(self, limit: int, offset: int) -> list[Item]:
        # make query to external REST API here


def application_factory(settings) -> FastAPI:
    app = FastAPI()
    # change chosen implementation based on application settings
    if settings.items_provider.type == "db":
        app.dependency_overrides[BaseItemsRepository] = InternalItemsRepository
        app.dependency_overrides[AsyncSession] = async_session_factory(settings.items_provider.db_url)

    elif settings.items_provider.type == "api":
        app.dependency_overrides[BaseItemsRepository] = ExternalItemsRepository
        app.dependency_overrides[ExternalAPIClient] = external_client_factory(settings.items_provider.api_url)

    return app
```

I haven't changed documentation much, lets discuss the proposal first.