### PR TITLE
This is the Spanish translation for the query-path page.

### DIFF
--- a/docs/es/docs/tutorial/query-params.md
+++ b/docs/es/docs/tutorial/query-params.md
@@ -1,12 +1,12 @@
-# Parámetros de query
+# <abbr title="conocido en inglés como: query parameters">"Parámetros de Consulta"</abbr>
 
-Cuando declaras otros parámetros de la función que no hacen parte de los parámetros de path estos se interpretan automáticamente como parámetros de "query".
+Cuando declaras otros parámetros de la función que no hacen parte de los parámetros de <abbr title="conocido en inglés como: path">"ruta"</abbr> estos se interpretan automáticamente como parámetros de "consulta".
 
 ```Python hl_lines="9"
 {!../../../docs_src/query_params/tutorial001.py!}
 ```
 
-El query es el conjunto de pares de key-value que van después del `?` en la URL, separados por caracteres `&`.
+La consulta o query es el conjunto de pares de <abbr title="conocido en español como: clave-valor o llave-valor">"Parámetros de Consulta"</abbr>key-value que van después del `?` en la URL, separados por caracteres `&`.
 
 Por ejemplo, en la URL:
 
@@ -14,7 +14,7 @@ Por ejemplo, en la URL:
 http://127.0.0.1:8000/items/?skip=0&limit=10
 ```
 
-...los parámetros de query son:
+...los parámetros de consulta son:
 
 * `skip`: con un valor de `0`
 * `limit`: con un valor de `10`
@@ -23,7 +23,7 @@ Dado que son parte de la URL son strings "naturalmente".
 
 Pero cuando los declaras con tipos de Python (en el ejemplo arriba, como `int`) son convertidos a ese tipo y son validados con él.
 
-Todo el proceso que aplicaba a los parámetros de path también aplica a los parámetros de query:
+Todo el proceso que aplicaba a los parámetros de path también aplica a los parámetros de consulta:
 
 * Soporte del editor (obviamente)
 * <abbr title="convertir el string que viene de un HTTP request a datos de Python">"Parsing"</abbr> de datos
@@ -32,7 +32,7 @@ Todo el proceso que aplicaba a los parámetros de path también aplica a los par
 
 ## Configuraciones por defecto
 
-Como los parámetros de query no están fijos en una parte del path pueden ser opcionales y pueden tener valores por defecto.
+Como los parámetros de consulta no están fijos en una parte de la ruta pueden ser opcionales y pueden tener valores por defecto.
 
 El ejemplo arriba tiene `skip=0` y `limit=10` como los valores por defecto.
 
@@ -61,29 +61,40 @@ Los valores de los parámetros en tu función serán:
 
 ## Parámetros opcionales
 
-Del mismo modo puedes declarar parámetros de query opcionales definiendo el valor por defecto como `None`:
+Del mismo modo puedes declarar parámetros de consulta opcionales definiendo el valor por defecto como `None`:
 
-```Python hl_lines="9"
-{!../../../docs_src/query_params/tutorial002.py!}
-```
+=== "Python 3.10+"
+
+    ```Python hl_lines="7"
+    {!> ../../../docs_src/query_params/tutorial002_py310.py!}
+    ```
+
+=== "Python 3.8+"
+
+    ```Python hl_lines="9"
+    {!> ../../../docs_src/query_params/tutorial002.py!}
+    ```
 
 En este caso el parámetro de la función `q` será opcional y será `None` por defecto.
 
 !!! check "Revisa"
-    También puedes notar que **FastAPI** es lo suficientemente inteligente para darse cuenta de que el parámetro de path `item_id` es un parámetro de path y que `q` no lo es, y por lo tanto es un parámetro de query.
+    También puedes notar que **FastAPI** es lo suficientemente inteligente para darse cuenta de que el parámetro de ruta `item_id` es un parámetro de ruta y que `q` no lo es, y por lo tanto es un parámetro de consulta.
 
-!!! note "Nota"
-    FastAPI sabrá que `q` es opcional por el `= None`.
-
-    El `Union` en `Union[str, None]` no es usado por FastAPI (FastAPI solo usará la parte `str`), pero el `Union[str, None]` le permitirá a tu editor ayudarte a encontrar errores en tu código.
-
-## Conversión de tipos de parámetros de query
+## Conversión de tipos de parámetros de consulta
 
 También puedes declarar tipos `bool` y serán convertidos:
 
-```Python hl_lines="9"
-{!../../../docs_src/query_params/tutorial003.py!}
-```
+=== "Python 3.10+"
+
+    ```Python hl_lines="7"
+    {!> ../../../docs_src/query_params/tutorial003_py310.py!}
+    ```
+
+=== "Python 3.8+"
+
+    ```Python hl_lines="9"
+    {!> ../../../docs_src/query_params/tutorial003.py!}
+    ```
 
 En este caso, si vas a:
 
@@ -117,31 +128,40 @@ http://127.0.0.1:8000/items/foo?short=yes
 
 o cualquier otra variación (mayúsculas, primera letra en mayúscula, etc.) tu función verá el parámetro `short` con un valor `bool` de `True`. Si no, lo verá como `False`.
 
-## Múltiples parámetros de path y query
 
-Puedes declarar múltiples parámetros de path y parámetros de query al mismo tiempo. **FastAPI** sabe cuál es cuál.
+## Múltiples parámetros de ruta y consulta
+
+Puedes declarar múltiples parámetros de ruta y parámetros de consulta al mismo tiempo. **FastAPI** sabe cuál es cuál.
 
 No los tienes que declarar en un orden específico.
 
 Serán detectados por nombre:
 
-```Python hl_lines="8  10"
-{!../../../docs_src/query_params/tutorial004.py!}
-```
+=== "Python 3.10+"
 
-## Parámetros de query requeridos
+    ```Python hl_lines="6  8"
+    {!> ../../../docs_src/query_params/tutorial004_py310.py!}
+    ```
 
-Cuando declaras un valor por defecto para los parámetros que no son de path (por ahora solo hemos visto parámetros de query), entonces no es requerido.
+=== "Python 3.8+"
+
+    ```Python hl_lines="8  10"
+    {!> ../../../docs_src/query_params/tutorial004.py!}
+    ```
+
+## Parámetros de consulta requeridos
+
+Cuando declaras un valor por defecto para los parámetros que no son de ruta (por ahora solo hemos visto parámetros de consulta), entonces no es requerido.
 
 Si no quieres añadir un valor específico sino solo hacerlo opcional, pon el valor por defecto como `None`.
 
-Pero cuando quieres hacer que un parámetro de query sea requerido, puedes simplemente no declararle un valor por defecto:
+Pero cuando quieres hacer que un parámetro de consulta sea requerido, puedes simplemente no declararle un valor por defecto:
 
 ```Python hl_lines="6-7"
 {!../../../docs_src/query_params/tutorial005.py!}
 ```
 
-Aquí el parámetro de query `needy` es un parámetro de query requerido, del tipo `str`.
+Aquí el parámetro de consulta `needy` es un parámetro de consulta requerido, del tipo `str`.
 
 Si abres tu navegador en una URL como:
 
@@ -153,16 +173,18 @@ http://127.0.0.1:8000/items/foo-item
 
 ```JSON
 {
-    "detail": [
-        {
-            "loc": [
-                "query",
-                "needy"
-            ],
-            "msg": "field required",
-            "type": "value_error.missing"
-        }
-    ]
+  "detail": [
+    {
+      "type": "missing",
+      "loc": [
+        "query",
+        "needy"
+      ],
+      "msg": "Field required",
+      "input": null,
+      "url": "https://errors.pydantic.dev/2.1/v/missing"
+    }
+  ]
 }
 ```
 
@@ -183,15 +205,23 @@ http://127.0.0.1:8000/items/foo-item?needy=sooooneedy
 
 Por supuesto que también puedes definir algunos parámetros como requeridos, con un valor por defecto y otros completamente opcionales:
 
-```Python hl_lines="10"
-{!../../../docs_src/query_params/tutorial006.py!}
-```
+=== "Python 3.10+"
 
-En este caso hay 3 parámetros de query:
+    ```Python hl_lines="8"
+    {!> ../../../docs_src/query_params/tutorial006_py310.py!}
+    ```
+
+=== "Python 3.8+"
+
+    ```Python hl_lines="10"
+    {!> ../../../docs_src/query_params/tutorial006.py!}
+    ```
+
+En este caso hay 3 parámetros de consulta:
 
 * `needy`, un `str` requerido.
 * `skip`, un `int` con un valor por defecto de `0`.
 * `limit`, un `int` opcional.
 
 !!! tip "Consejo"
-    También podrías usar los `Enum`s de la misma manera que con los [Parámetros de path](path-params.md#predefined-values){.internal-link target=_blank}.
+    También podrías usar los `Enum`s de la misma manera que con los [Parámetros de Ruta](path-params.md#predefined-values){.internal-link target=_blank}.


### PR DESCRIPTION
This is the Spanish translation for the query-path page.

Fix Spanish translation structure for docs/es/docs/tutorial/query-path.md
-  Version >= 0.108.0