### PR TITLE
Printing object failing to encode to json

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -324,6 +324,7 @@ def jsonable_encoder(
         data = dict(obj)
     except Exception as e:
         errors: List[Exception] = []
+        errors.append(Exception(f"Exception while encoding {obj}"))
         errors.append(e)
         try:
             data = vars(obj)


### PR DESCRIPTION
I was using FastAPI on a project an I had to see which object was making fail the json encoding to understand what to change in my code. So I suggest to add an Exception in this case that allow dev to read what object make encoding fails.
In my case it was an object of type numpy.int64, but I couldn't find which one before printing it.