### PR TITLE
Allow multiple swagger css and js

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from fastapi.encoders import jsonable_encoder
 from starlette.responses import HTMLResponse
@@ -45,7 +45,7 @@ def get_swagger_ui_html(
         ),
     ],
     swagger_js_url: Annotated[
-        str,
+        Union[str, list[str]],
         Doc(
             """
             The URL to use to load the Swagger UI JavaScript.
@@ -55,7 +55,7 @@ def get_swagger_ui_html(
         ),
     ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui-bundle.js",
     swagger_css_url: Annotated[
-        str,
+        Union[str, list[str]],
         Doc(
             """
             The URL to use to load the Swagger UI CSS.
@@ -114,19 +114,37 @@ def get_swagger_ui_html(
     if swagger_ui_parameters:
         current_swagger_ui_parameters.update(swagger_ui_parameters)
 
-    html = f"""
+    html = """
     <!DOCTYPE html>
     <html>
-    <head>
-    <link type="text/css" rel="stylesheet" href="{swagger_css_url}">
+    <head>"""
+
+    if isinstance(swagger_css_url, list):
+        html += "\n".join(
+            [
+                f"""<link type="text/css" rel="stylesheet" href="{url}">"""
+                for url in swagger_css_url
+            ]
+        )
+    else:
+        html += f"""<link type="text/css" rel="stylesheet" href="{swagger_css_url}">"""
+
+    html += f"""
     <link rel="shortcut icon" href="{swagger_favicon_url}">
     <title>{title}</title>
     </head>
     <body>
     <div id="swagger-ui">
-    </div>
-    <script src="{swagger_js_url}"></script>
-    <!-- `SwaggerUIBundle` is now available on the page -->
+    </div>"""
+
+    if isinstance(swagger_js_url, list):
+        html += "\n".join(
+            [f"""<script src="{url}"></script>""" for url in swagger_js_url]
+        )
+    else:
+        html += f"""<script src="{swagger_js_url}"></script>"""
+
+    html += f"""<!-- `SwaggerUIBundle` is now available on the page -->
     <script>
     const ui = SwaggerUIBundle({{
         url: '{openapi_url}',

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from fastapi.encoders import jsonable_encoder
 from starlette.responses import HTMLResponse
@@ -45,7 +45,7 @@ def get_swagger_ui_html(
         ),
     ],
     swagger_js_url: Annotated[
-        Union[str, list[str]],
+        Union[str, List[str]],
         Doc(
             """
             The URL to use to load the Swagger UI JavaScript.
@@ -55,7 +55,7 @@ def get_swagger_ui_html(
         ),
     ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.9.0/swagger-ui-bundle.js",
     swagger_css_url: Annotated[
-        Union[str, list[str]],
+        Union[str, List[str]],
         Doc(
             """
             The URL to use to load the Swagger UI CSS.

--- a/tests/test_local_docs.py
+++ b/tests/test_local_docs.py
@@ -32,6 +32,25 @@ def test_strings_in_custom_swagger():
     assert swagger_favicon_url in body_content
 
 
+def test_list_of_strings_in_css_and_js():
+    swagger_js_url = ["swagger_fake_file_1.js", "swagger_fake_file_2.js"]
+    swagger_css_url = ["swagger_fake_file_1.css", "swagger_fake_file_2.css"]
+    swagger_favicon_url = "swagger_fake_file.png"
+    html = get_swagger_ui_html(
+        openapi_url="/docs",
+        title="title",
+        swagger_js_url=swagger_js_url,
+        swagger_css_url=swagger_css_url,
+        swagger_favicon_url=swagger_favicon_url,
+    )
+    body_content = html.body.decode()
+    assert swagger_js_url[0] in body_content
+    assert swagger_js_url[1] in body_content
+    assert swagger_css_url[0] in body_content
+    assert swagger_css_url[1] in body_content
+    assert swagger_favicon_url in body_content
+
+
 def test_strings_in_generated_redoc():
     sig = inspect.signature(get_redoc_html)
     redoc_js_url = sig.parameters.get("redoc_js_url").default  # type: ignore


### PR DESCRIPTION
Raised this PR based on discussion [here](https://github.com/tiangolo/fastapi/discussions/10927#discussioncomment-8090100).

Basically, this PR allows users to add multiple swagger `css` and `js` urls in `get_swagger_ui_html` function.

This is specially useful if you want to override things on swagger UI. Check out my comment linked above for example.