### PR TITLE
✏️ Fix typos for Spanish documentation

### DIFF
--- a/docs/es/docs/advanced/additional-status-codes.md
+++ b/docs/es/docs/advanced/additional-status-codes.md
@@ -23,7 +23,7 @@ Para conseguir esto importa `JSONResponse` y devuelve ahí directamente tu conte
 
     No será serializado con el modelo, etc.
 
-    Asegurate de que la respuesta tenga los datos que quieras, y que los valores sean JSON válidos (si estás usando `JSONResponse`).
+    Asegúrate de que la respuesta tenga los datos que quieras, y que los valores sean JSON válidos (si estás usando `JSONResponse`).
 
 !!! note "Detalles Técnicos"
     También podrías utilizar `from starlette.responses import JSONResponse`.

--- a/docs/es/docs/advanced/response-directly.md
+++ b/docs/es/docs/advanced/response-directly.md
@@ -21,7 +21,7 @@ Y cuando devuelves una `Response`, **FastAPI** la pasará directamente.
 
 No hará ninguna conversión de datos con modelos Pydantic, no convertirá el contenido a ningún tipo, etc.
 
-Esto te da mucha flexibilidad. Puedes devolver cualquier tipo de dato, sobrescribir cualquer declaración de datos o validación, etc.
+Esto te da mucha flexibilidad. Puedes devolver cualquier tipo de dato, sobrescribir cualquier declaración de datos o validación, etc.
 
 ## Usando el `jsonable_encoder` en una `Response`
 

--- a/docs/es/docs/features.md
+++ b/docs/es/docs/features.md
@@ -13,7 +13,7 @@
 
 ### Documentación automática
 
-Documentación interactiva de la API e interfaces web de exploración. Hay múltiples opciones, dos incluídas por defecto, porque el framework está basado en OpenAPI.
+Documentación interactiva de la API e interfaces web de exploración. Hay múltiples opciones, dos incluidas por defecto, porque el framework está basado en OpenAPI.
 
 * <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank"><strong>Swagger UI</strong></a>, con exploración interactiva, llama y prueba tu API directamente desde tu navegador.
 
@@ -25,7 +25,7 @@ Documentación interactiva de la API e interfaces web de exploración. Hay múlt
 
 ### Simplemente Python moderno
 
-Todo está basado en las declaraciones de tipo de **Python 3.8** estándar (gracias a Pydantic). No necesitas aprender una sintáxis nueva, solo Python moderno.
+Todo está basado en las declaraciones de tipo de **Python 3.8** estándar (gracias a Pydantic). No necesitas aprender una sintaxis nueva, solo Python moderno.
 
 Si necesitas un repaso de 2 minutos de cómo usar los tipos de Python (así no uses FastAPI) prueba el tutorial corto: [Python Types](python-types.md){.internal-link target=_blank}.
 
@@ -72,9 +72,9 @@ my_second_user: User = User(**second_user_data)
 
 El framework fue diseñado en su totalidad para ser fácil e intuitivo de usar. Todas las decisiones fueron probadas en múltiples editores antes de comenzar el desarrollo para asegurar la mejor experiencia de desarrollo.
 
-En la última encuesta a desarrolladores de Python fue claro que <a href="https://www.jetbrains.com/research/python-developers-survey-2017/#tools-and-features" class="external-link" target="_blank">la característica más usada es el "autocompletado"</a>.
+En la última encuesta a desarrolladores de Python fue claro que <a href="https://www.jetbrains.com/research/python-developers-survey-2017/#tools-and-features" class="external-link" target="_blank">la característica más usada es el "auto-completado"</a>.
 
-El framework **FastAPI** está creado para satisfacer eso. El autocompletado funciona en todas partes.
+El framework **FastAPI** está creado para satisfacer eso. El auto-completado funciona en todas partes.
 
 No vas a tener que volver a la documentación seguido.
 
@@ -140,13 +140,13 @@ FastAPI incluye un sistema de <abbr title='En español: Inyección de Dependenci
 * Todas las dependencias pueden requerir datos de los requests y aumentar las restricciones del *path operation* y la documentación automática.
 * **Validación automática** inclusive para parámetros del *path operation* definidos en las dependencias.
 * Soporte para sistemas complejos de autenticación de usuarios, **conexiones con bases de datos**, etc.
-* **Sin comprometerse** con bases de datos, frontends, etc. Pero permitiendo integración fácil con todos ellos.
+* **Sin comprometerse** con bases de datos, frontend, etc. Pero permitiendo integración fácil con todos ellos.
 
 ### "Plug-ins" ilimitados
 
 O dicho de otra manera, no hay necesidad para "plug-ins". Importa y usa el código que necesites.
 
-Cualquier integración está diseñada para que sea tan sencilla de usar (con dependencias) que puedas crear un "plug-in" para tu aplicación en dos líneas de código usando la misma estructura y sintáxis que usaste para tus *path operations*.
+Cualquier integración está diseñada para que sea tan sencilla de usar (con dependencias) que puedas crear un "plug-in" para tu aplicación en dos líneas de código usando la misma estructura y sintaxis que usaste para tus *path operations*.
 
 ### Probado
 
@@ -181,7 +181,7 @@ Esto incluye a librerías externas basadas en Pydantic como <abbr title="Object-
 
 Esto también significa que en muchos casos puedes pasar el mismo objeto que obtuviste de un request **directamente a la base de datos**, dado que todo es validado automáticamente.
 
-Lo mismo aplica para el sentido contrario. En muchos casos puedes pasarle el objeto que obtienes de la base de datos **directamente al cliente**.
+Lo mismo aplica para el sentido contrario. En muchos casos puedes pasar el objeto que obtienes de la base de datos **directamente al cliente**.
 
 Con **FastAPI** obtienes todas las características de **Pydantic** (dado que FastAPI está basado en Pydantic para todo el manejo de datos):
 

--- a/docs/es/docs/index.md
+++ b/docs/es/docs/index.md
@@ -37,7 +37,7 @@ Sus características principales son:
 * **Robusto**: Crea código listo para producción con documentación automática interactiva.
 * **Basado en estándares**: Basado y totalmente compatible con los estándares abiertos para APIs: <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> (conocido previamente como Swagger) y <a href="https://json-schema.org/" class="external-link" target="_blank">JSON Schema</a>.
 
-<small>* Esta estimación está basada en pruebas con un equipo de desarrollo interno contruyendo aplicaciones listas para producción.</small>
+<small>* Esta estimación está basada en pruebas con un equipo de desarrollo interno construyendo aplicaciones listas para producción.</small>
 
 ## Sponsors
 
@@ -295,11 +295,11 @@ Ahora ve a <a href="http://127.0.0.1:8000/docs" class="external-link" target="_b
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-03-swagger-02.png)
 
-* Haz clíck en el botón de "Try it out" que te permite llenar los parámetros e interactuar directamente con la API:
+* Haz click en el botón de "Try it out" que te permite llenar los parámetros e interactuar directamente con la API:
 
 ![Swagger UI interaction](https://fastapi.tiangolo.com/img/index/index-04-swagger-03.png)
 
-* Luego haz clíck en el botón de "Execute". La interfaz de usuario se comunicará con tu API, enviará los parámetros y recibirá los resultados para mostrarlos en pantalla:
+* Luego haz click en el botón de "Execute". La interfaz de usuario se comunicará con tu API, enviará los parámetros y recibirá los resultados para mostrarlos en pantalla:
 
 ![Swagger UI interaction](https://fastapi.tiangolo.com/img/index/index-05-swagger-04.png)
 
@@ -317,7 +317,7 @@ En resumen, declaras los tipos de parámetros, body, etc. **una vez** como pará
 
 Lo haces con tipos modernos estándar de Python.
 
-No tienes que aprender una sintáxis nueva, los métodos o clases de una library específica, etc.
+No tienes que aprender una sintaxis nueva, los métodos o clases de una library específica, etc.
 
 Solo **Python 3.8+** estándar.
 

--- a/docs/es/docs/python-types.md
+++ b/docs/es/docs/python-types.md
@@ -2,7 +2,7 @@
 
 **Python 3.6+** tiene soporte para <abbr title="en español, anotaciones de tipo. En inglés también se conocen como: type annotations">"type hints"</abbr> opcionales.
 
-Estos **type hints** son una nueva sintáxis, desde Python 3.6+, que permite declarar el <abbr title="por ejemplo: str, int, float, bool">tipo</abbr> de una variable.
+Estos **type hints** son una nueva sintaxis, desde Python 3.6+, que permite declarar el <abbr title="por ejemplo: str, int, float, bool">tipo</abbr> de una variable.
 
 Usando las declaraciones de tipos para tus variables, los editores y otras herramientas pueden proveerte un soporte mejor.
 
@@ -33,7 +33,7 @@ La función hace lo siguiente:
 
 * Toma un `first_name` y un `last_name`.
 * Convierte la primera letra de cada uno en una letra mayúscula con `title()`.
-* Las <abbr title="las junta como si fuesen una. Con el contenido de una después de la otra. En inlgés: concatenate.">concatena</abbr> con un espacio en la mitad.
+* Las <abbr title="las junta como si fuesen una. Con el contenido de una después de la otra. En inglés: concatenate.">concatena</abbr> con un espacio en la mitad.
 
 ```Python hl_lines="2"
 {!../../../docs_src/python_types/tutorial001.py!}
@@ -51,9 +51,9 @@ Pero, luego tienes que llamar "ese método que convierte la primera letra en una
 
 Era `upper`? O era `uppercase`? `first_uppercase`? `capitalize`?
 
-Luego lo intentas con el viejo amigo de los programadores, el autocompletado del editor.
+Luego lo intentas con el viejo amigo de los programadores, el auto-completado del editor.
 
-Escribes el primer parámetro de la función `first_name`, luego un punto (`.`) y luego presionas `Ctrl+Space` para iniciar el autocompletado.
+Escribes el primer parámetro de la función `first_name`, luego un punto (`.`) y luego presionas `Ctrl+Space` para iniciar el auto-completado.
 
 Tristemente, no obtienes nada útil:
 
@@ -97,7 +97,7 @@ Añadir los type hints normalmente no cambia lo que sucedería si ellos no estuv
 
 Pero ahora imagina que nuevamente estás creando la función, pero con los type hints.
 
-En el mismo punto intentas iniciar el autocompletado con `Ctrl+Space` y ves:
+En el mismo punto intentas iniciar el auto-completado con `Ctrl+Space` y ves:
 
 <img src="https://fastapi.tiangolo.com/img/python-types/image02.png">
 
@@ -113,7 +113,7 @@ Mira esta función que ya tiene type hints:
 {!../../../docs_src/python_types/tutorial003.py!}
 ```
 
-Como el editor conoce el tipo de las variables no solo obtienes autocompletado, si no que también obtienes chequeo de errores:
+Como el editor conoce el tipo de las variables no solo obtienes auto-completado, si no que también obtienes chequeo de errores:
 
 <img src="https://fastapi.tiangolo.com/img/python-types/image04.png">
 
@@ -162,7 +162,7 @@ De `typing`, importa `List` (con una `L` mayúscula):
 {!../../../docs_src/python_types/tutorial006.py!}
 ```
 
-Declara la variable con la misma sintáxis de los dos puntos (`:`).
+Declara la variable con la misma sintaxis de los dos puntos (`:`).
 
 Pon `List` como el tipo.
 
@@ -176,7 +176,7 @@ Esto significa: la variable `items` es una `list` y cada uno de los ítems en es
 
 Con esta declaración tu editor puede proveerte soporte inclusive mientras está procesando ítems de la lista.
 
-Sin tipos el autocompletado en este tipo de estructura es casi imposible de lograr:
+Sin tipos el auto-completado en este tipo de estructura es casi imposible de lograr:
 
 <img src="https://fastapi.tiangolo.com/img/python-types/image05.png">
 

--- a/docs/es/docs/tutorial/first-steps.md
+++ b/docs/es/docs/tutorial/first-steps.md
@@ -303,7 +303,7 @@ En este caso es una función `async`.
 
 ---
 
-También podrías definirla como una función normal, en vez de `async def`:
+También podrías definirla como una función estándar en lugar de `async def`:
 
 ```Python hl_lines="7"
 {!../../../docs_src/first_steps/tutorial003.py!}

--- a/docs/es/docs/tutorial/index.md
+++ b/docs/es/docs/tutorial/index.md
@@ -28,7 +28,7 @@ $ uvicorn main:app --reload
 
 Se **RECOMIENDA** que escribas o copies el código, lo edites y lo ejecutes localmente.
 
-Usarlo en tu editor de código es lo que realmente te muestra los beneficios de FastAPI, al ver la poca cantidad de código que tienes que escribir, todas las verificaciones de tipo, autocompletado, etc.
+Usarlo en tu editor de código es lo que realmente te muestra los beneficios de FastAPI, al ver la poca cantidad de código que tienes que escribir, todas las verificaciones de tipo, auto-completado, etc.
 
 ---
 

--- a/docs/es/docs/tutorial/path-params.md
+++ b/docs/es/docs/tutorial/path-params.md
@@ -25,7 +25,7 @@ Puedes declarar el tipo de un parámetro de path en la función usando las anota
 En este caso, `item_id` es declarado como un `int`.
 
 !!! check "Revisa"
-    Esto te dará soporte en el editor dentro de tu función, con chequeos de errores, autocompletado, etc.
+    Esto te dará soporte en el editor dentro de tu función, con chequeo de errores, auto-completado, etc.
 
 ## <abbr title="también conocido en inglés como: serialization, parsing, marshalling">Conversión</abbr> de datos
 
@@ -135,7 +135,7 @@ Luego crea atributos de clase con valores fijos, que serán los valores disponib
     Las <a href="https://docs.python.org/3/library/enum.html" class="external-link" target="_blank">Enumerations (o enums) están disponibles en Python</a> desde la versión 3.4.
 
 !!! tip "Consejo"
-    Si lo estás dudando, "AlexNet", "ResNet", y "LeNet" son solo nombres de <abbr title="Tecnicamente, arquitecturas de modelos de Deep Learning">modelos</abbr> de Machine Learning.
+    Si lo estás dudando, "AlexNet", "ResNet", y "LeNet" son solo nombres de <abbr title="Técnicamente, arquitecturas de modelos de Deep Learning">modelos</abbr> de Machine Learning.
 
 ### Declara un *parámetro de path*
 
@@ -234,7 +234,7 @@ Entonces lo puedes usar con:
 
 Con **FastAPI**, usando declaraciones de tipo de Python intuitivas y estándares, obtienes:
 
-* Soporte en el editor: chequeos de errores, auto-completado, etc.
+* Soporte en el editor: chequeo de errores, auto-completado, etc.
 * "<abbr title="convertir el string que viene de un HTTP request a datos de Python">Parsing</abbr>" de datos
 * Validación de datos
 * Anotación de la API y documentación automática


### PR DESCRIPTION
- Fix some small typos on Spanish Docs, like removing some "acentos" on documentation.