### PR TITLE
📝 Add External Link: Tips on migrating from Flask to FastAPI and vice-versa

### DIFF
--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -302,6 +302,15 @@ Articles:
     author_link: https://qiita.com/mtitg
     link: https://qiita.com/mtitg/items/47770e9a562dd150631d
     title: FastAPI｜DB接続してCRUDするPython製APIサーバーを構築
+  - author: Jessica Temporal
+    author_link: https://jtemporal.com/socials
+    link: https://jtemporal.com/tips-on-migrating-from-flask-to-fastapi-and-vice-versa/
+    title: Tips on migrating from Flask to FastAPI and vice-versa
+  Portuguese:
+  - author: Jessica Temporal
+    author_link: https://jtemporal.com/socials
+    link: https://jtemporal.com/dicas-para-migrar-de-flask-para-fastapi-e-vice-versa/
+    title: Dicas para migrar uma aplicação de Flask para FastAPI e vice-versa
   Russian:
   - author: Troy Köhler
     author_link: https://www.linkedin.com/in/trkohler/

--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -1,5 +1,9 @@
 Articles:
   English:
+  - author: Jessica Temporal
+    author_link: https://jtemporal.com/socials
+    link: https://jtemporal.com/tips-on-migrating-from-flask-to-fastapi-and-vice-versa/
+    title: Tips on migrating from Flask to FastAPI and vice-versa
   - author: Ankit Anchlia
     author_link: https://linkedin.com/in/aanchlia21
     link: https://hackernoon.com/explore-how-to-effectively-use-jwt-with-fastapi
@@ -302,10 +306,6 @@ Articles:
     author_link: https://qiita.com/mtitg
     link: https://qiita.com/mtitg/items/47770e9a562dd150631d
     title: FastAPI｜DB接続してCRUDするPython製APIサーバーを構築
-  - author: Jessica Temporal
-    author_link: https://jtemporal.com/socials
-    link: https://jtemporal.com/tips-on-migrating-from-flask-to-fastapi-and-vice-versa/
-    title: Tips on migrating from Flask to FastAPI and vice-versa
   Portuguese:
   - author: Jessica Temporal
     author_link: https://jtemporal.com/socials


### PR DESCRIPTION
Adds blog post to the list of external links:

- Adds blog post in english
- Adds section named ‘Portuguese’
- Adds blog post to portuguese section

Link to blog posts:

- [English](https://jtemporal.com/tips-on-migrating-from-flask-to-fastapi-and-vice-versa/)
- [Portuguese](https://jtemporal.com/dicas-para-migrar-de-flask-para-fastapi-e-vice-versa/)