### PR TITLE
♻️ Update pyproject.toml with separate optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,39 @@ all = [
     "pydantic-settings >=2.0.0",
     "pydantic-extra-types >=2.0.0",
 ]
+httpx = [
+    "httpx >=0.23.0",
+]
+jinja = [
+    "jinja2 >=2.11.2",
+]
+python-multipart = [
+    "python-multipart >=0.0.5",
+]
+itsdangerous = [
+    "itsdangerous >=1.1.0",
+]
+pyyaml = [
+    "pyyaml >=5.3.1",
+]
+ujson = [
+    "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
+]
+orjson = [
+    "orjson >=3.2.1",
+]
+email_validator = [
+    "email_validator >=2.0.0",
+]
+uvicorn = [
+    "uvicorn[standard] >=0.12.0",
+]
+pydantic-settings = [
+    "pydantic-settings >=2.0.0",
+]
+pydantic-extra-types = [
+    "pydantic-extra-types >=2.0.0",
+]
 
 [tool.hatch.version]
 path = "fastapi/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Repository = "https://github.com/tiangolo/fastapi"
 all = [
     "httpx >=0.23.0",
     "jinja2 >=2.11.2",
-    "python-multipart >=0.0.5",
+    "python-multipart >=0.0.7",
     "itsdangerous >=1.1.0",
     "pyyaml >=5.3.1",
     "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
@@ -73,7 +73,7 @@ jinja = [
     "jinja2 >=2.11.2",
 ]
 python-multipart = [
-    "python-multipart >=0.0.5",
+    "python-multipart >=0.0.7",
 ]
 itsdangerous = [
     "itsdangerous >=1.1.0",


### PR DESCRIPTION
I met an issue that `poetry add fastapi` and `poetry add 'fastapi[all]'` works correctly, but not `poetry add 'fastapi[uvicorn]'`. So I propose to fix it by adding following lines into the `[project.optional-dependencies]` section of `pyproject.toml` in order to let users add only needed dependencies in poetry:
```toml
httpx = [
    "httpx >=0.23.0",
]
jinja = [
    "jinja2 >=2.11.2",
]
python-multipart = [
    "python-multipart >=0.0.5",
]
# and so on for other extra dependencies, full code see in committed changes
```
