### PR TITLE
🌐 Add Turkish translation for `docs/tr/docs/tutorial/path-params.md`

### DIFF
--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -245,7 +245,7 @@ Böylece şunun gibi bir kullanım yapabilirsiniz:
 **FastAPI** ile kısa, sezgisel ve standart Python tip tanımlamaları kullanarak şunları elde edersiniz:
 
 * Editör desteği: hata denetimi, otomatik tamamlama, vb.
-* Veri "<abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">ayrıştırma</abbr>"
+* Veri "<abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">dönüştürme</abbr>"
 * Veri doğrulama
 * API tanımlamaları ve otomatik dokümantasyon
 

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -25,7 +25,7 @@ Standart Python tip belirteçlerini kullanarak yol parametresinin tipini fonksiy
 Bu durumda, `item_id` bir `int` olarak tanımlanacaktır.
 
 !!! check "Ek bilgi"
-    Bu sayede fonksiyonun içerisinde hata denetimi, kod tamamlama gibi konularda editör desteğine kavuşacaksınız.
+    Bu sayede, fonksiyon içerisinde hata denetimi, kod tamamlama gibi konularda editör desteğine kavuşacaksınız.
 
 ## Veri <abbr title="Dönüşüm: serialization, parsing ve marshalling olarak da biliniyor">Dönüşümü</abbr>
 
@@ -173,7 +173,7 @@ Parametreyi, yarattığınız enum olan `ModelName` içerisindeki *enumeration �
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-#### *Enumeration Değerini* Alalım
+#### *Enumeration Değerini* Edinelim
 
 `model_name.value` veya genel olarak `your_enum_member.value` tanımlarını kullanarak (bu durumda bir `str` olan) gerçek değere ulaşabilirsiniz:
 

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -107,7 +107,7 @@ Bunlardan birkaçı, bu eğitimin ileriki bölümlerinde irdelenmiştir.
 
 Farz edelim ki `/users/me` yolu geçerli kullanıcı hakkında bilgi almak için kullanılıyor olsun.
 
-Benzer şekilde `/users/{user_id}` gibi tanımlanmış ve belirli bir kullanıcı hakkında veri almak için kullanıcı ID numarası kullanılan bir yolunuz da mevcut olabilir.  
+Benzer şekilde `/users/{user_id}` gibi tanımlanmış ve belirli bir kullanıcı hakkında veri almak için kullanıcı ID numarası kullanılan bir yolunuz da mevcut olabilir.
 
 *Yol operasyonları* sıralı bir şekilde gözden geçirildiğinden dolayı `/users/me` yolunun `/users/{user_id}` yolundan önce tanımlanmış olmasından emin olmanız gerekmektedir:
 
@@ -133,7 +133,7 @@ Eğer *yol parametresi* alan bir *yol operasyonun* varsa ve olağan ve geçerli 
 
 `Enum` sınıfını içeri aktarıp `str` ile `Enum` sınıflarını miras alan bir alt sınıf yaratalım.
 
-`str` sınıfı miras alındığından dolayı, API dokümanı, değerlerin `string` tipinden olması gerektiğini anlayabilecek ve doğru bir şekilde işlenecektir. 
+`str` sınıfı miras alındığından dolayı, API dokümanı, değerlerin `string` tipinden olması gerektiğini anlayabilecek ve doğru bir şekilde işlenecektir.
 
 Sonrasında, sınıf içerisinde, mevcut ve geçerli değerler olacak olan sabit değerli öznitelikleri oluşturalım:
 
@@ -221,7 +221,7 @@ Parametrenin bir yol içermesi gerektiğini belirten herhangi bir doküman eklem
 
 ### Yol dönüştürücü
 
-Direkt olarak Starlette kütüphanesinden gelen bir opsiyonu ve aşağıdaki gibi bir URL'yi kullanarak *yol* içeren bir *yol parametresi* tanımlayabilirsin: 
+Direkt olarak Starlette kütüphanesinden gelen bir opsiyonu ve aşağıdaki gibi bir URL'yi kullanarak *yol* içeren bir *yol parametresi* tanımlayabilirsin:
 
 ```
 /files/{file_path:path}

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -16,7 +16,7 @@ Eğer bu örneği çalıştırıp <a href="http://127.0.0.1:8000/items/foo" clas
 
 ## Tip İçeren Yol Parametreleri
 
-Standart Python tip belirteçlerini kullanarak yol parametresinin tipini fonksiyonda tanımlayabilirsiniz.
+Standart Python tip belirteçlerini kullanarak yol parametresinin tipini fonksiyonun içerisinde tanımlayabilirsiniz.
 
 ```Python hl_lines="7"
 {!../../../docs_src/path_params/tutorial002.py!}

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -1,0 +1,254 @@
+# Yol Parametreleri
+
+Yol "parametrelerini" veya "değişkenlerini" Python string biçimlemede kullanılan aynı söz dizimi ile tanımlayabilirsin.
+
+```Python hl_lines="6-7"
+{!../../../docs_src/path_params/tutorial001.py!}
+```
+
+Yol parametresi olan `item_id`'nin değeri, fonksiyonuna `item_id` argümanı olarak geçirilecektir.
+
+Demek oluyor ki, eğer bu örneği çalıştırırsan ve <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> sayfasına gidersen, şöyle bir yanıt ile karşılaşacaksın:
+
+```JSON
+{"item_id":"foo"}
+```
+
+## Tip içeren yol parametreleri
+
+Standart Python tip anotasyonları kullanarak yol parametresinin tipini fonksiyonda tanımlayabilirsin.
+
+```Python hl_lines="7"
+{!../../../docs_src/path_params/tutorial002.py!}
+```
+
+Bu durumda, `item_id` bir `int` olarak tanımlanacaktır.
+
+!!! check
+    Bu özellik, fonksiyonunun içinde sana hata denetimi, kod tamamlama ve benzeri gibi özelliklerle birlikte editör desteği kazandıracaktır.
+
+## Veri <abbr title="ayrıca şöyle bilinir: serileştirme, ayrıştırma, hizalama">dönüşümü</abbr>
+
+Eğer bu örneği çalıştırırsan ve tarayıcında <a href="http://127.0.0.1:8000/items/3" class="external-link" target="_blank">http://127.0.0.1:8000/items/3</a> linkini açarsan, şöyle bir yanıt ile karşılaşacaksın:
+
+```JSON
+{"item_id":3}
+```
+
+!!! check
+    Dikkatini çekerim ki, fonksiyonunun aldığı (ve döndürdüğü) değer olan `3` bir string `"3"` değil aksine bir Python `int`'idir.
+
+    Böylece, bu tanımlamayla birlikte, **FastAPI** sana otomatik istek <abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">"ayrıştırma"</abbr> özelliği sağlar.
+
+## Veri doğrulama
+
+Fakat, eğer tarayıcında <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> adresine gidersen, şuna benzer güzel bir HTTP hatası ile karşılaşacaksın:
+
+```JSON
+{
+  "detail": [
+    {
+      "type": "int_parsing",
+      "loc": [
+        "path",
+        "item_id"
+      ],
+      "msg": "Input should be a valid integer, unable to parse string as an integer",
+      "input": "foo",
+      "url": "https://errors.pydantic.dev/2.1/v/int_parsing"
+    }
+  ]
+}
+```
+
+çünkü yol parametresi olan `item_id` değişkeni, veri tipi `int` olmayan `"foo"` gibi bir değere sahipti.
+
+Aynı hata `int` yerine `float` bir değer verseydik de ortaya çıkardı, şuradaki gibi: <a href="http://127.0.0.1:8000/items/4.2" class="external-link" target="_blank">http://127.0.0.1:8000/items/4.2</a>
+
+!!! check
+    Böylece, aynı Python tip tanımlaması ile birlikte, **FastAPI** sana veri doğrulaması özelliği sağlar.
+
+    Dikkatini çekerim ki, karşılaştığın hata, doğrulamanın geçersiz olduğu mutlak noktayı da açık bir şekilde belirtiyor.
+
+    Bu özellik, API'ınla iletişime geçen kodu geliştirirken ve ayıklarken inanılmaz derecede yararlı olacaktır.
+
+## Dokümantasyon
+
+Ayrıca, tarayıcını <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a> adresinde açarsan, aşağıdaki gibi otomatik ve interaktif bir API dökümantasyonu ile karşılaşacaksın:
+
+<img src="/img/tutorial/path-params/image01.png">
+
+!!! check
+    Üstelik, sadece aynı Python tip tanımlaması ile, **FastAPI** sana otomatik ve interaktif (Swagger UI ile entegre) bir dokümantasyon sağlar.
+
+    Dikkatini çekerim ki, yol parametresi integer olarak tanımlanmıştır.
+
+## Standartlara dayalı avantajlar, alternatif dokümantasyon
+
+Ve türetilmiş olan şema <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> standartına uygun olduğu için birçok uyumlu araç bulunmaktadır.
+
+Bu sayede, **FastAPI**'ın kendisi <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a> linkinden erişebileceğiniz alternatif (Redoc kullanan) bir API dokümantasyonu sağlar:
+
+<img src="/img/tutorial/path-params/image02.png">
+
+Aynı şekilde, farklı diller için kod türetme araçları içeren çok sayıda uyumlu araç bulunur.
+
+## Pydantic
+
+Tüm veri doğrulamaları <a href="https://pydantic-docs.helpmanual.io/" class="external-link" target="_blank">Pydantic</a> tarafından arka planda gerçekleştirilir, bu sayede tüm avantajlardan faydalanabilirsin. Böylece, emin ellerde olduğunu hissedebilirsin.
+
+Aynı tip tanımlamalarını `str`, `float`, `bool` ile ve diğer kompleks veri tipleri ile de kullanabilirsin.
+
+Bunlardan birkaçı, bu eğitimin ileriki bölümlerinde irdelenmiştir.
+
+## Sıralama önem arz eder
+
+*Yol operasyonları* tasarlarken sabit yol barındıran durumlar ile karşılaşabilirsin.
+
+Farz edelim ki `/users/me` yolu geçerli kullanıcı hakkında bilgi almak için kullanılıyor olsun.
+
+Benzer şekilde `/users/{user_id}` gibi tanımlanmış ve belirli bir kullanıcı hakkında veri almak için kullanıcı ID numarası kullanılan bir yolunuz da mevcut olabilir.  
+
+*Yol operasyonları* sıralı bir şekilde gözden geçirildiğinden dolayı `/users/me` yolunun `/users/{user_id}` yolundan önce tanımlanmış olmasından emin olmanız gerekmektedir:
+
+```Python hl_lines="6  11"
+{!../../../docs_src/path_params/tutorial003.py!}
+```
+
+Aksi halde, `/users/{user_id}` yolu `"me"` değerini alan `user_id` adlı bir parametresi olduğunu "düşünerek" `/users/me` isimli yol ile eşleşir.
+
+Benzer şekilde, bir yol operasyonunu yeniden tanımlamanız mümkün değildir:
+
+```Python hl_lines="6  11"
+{!../../../docs_src/path_params/tutorial003b.py!}
+```
+
+Yol ilk kısım ile eşleştiğinden dolayı her koşulda ilk yol operasyonu kullanılacaktır.
+
+## Ön tanımlı değerler
+
+Eğer *yol parametresi* alan bir *yol operasyonun* varsa ve olağan ve geçerli *yol parametresi* değerlerinin ön tanımlı olmasını istiyorsan, standart Python <abbr title="Enumeration">`Enum`</abbr> kullanabilirsin.
+
+### Bir `Enum` sınıfı yarat
+
+`Enum` sınıfını içeri aktarıp `str` ile `Enum` sınıflarını miras alan bir alt sınıf yaratalım.
+
+`str` sınıfı miras alındığından dolayı, API dokümanı, değerlerin `string` tipinden olması gerektiğini anlayabilecek ve doğru bir şekilde işlenecektir. 
+
+Sonrasında, sınıf içerisinde, mevcut ve geçerli değerler olacak olan sabit değerli öznitelikleri oluşturalım:
+
+```Python hl_lines="1  6-9"
+{!../../../docs_src/path_params/tutorial005.py!}
+```
+
+!!! info
+    3.4 sürümünden beri <a href="https://docs.python.org/3/library/enum.html" class="external-link" target="_blank">enumerationlar (ya da enumlar) Python'da mevcuttur</a>.
+
+!!! tip
+    Merak ediyorsanız söyleyeyim, "AlexNet", "ResNet" ve "LeNet" isimleri Makine Öğrenmesi <abbr title="Teknik olarak, Derin Öğrenme model mimarileri">modellerini</abbr> temsil eder.
+
+### Bir *yol parametresi* tanımla
+
+Sonrasında, yarattığımız (`ModelName`) isimli enum sınıfını kullanarak tip anotasyonu aracılığıyla bir *yol parametresi* oluşturalım:
+
+```Python hl_lines="16"
+{!../../../docs_src/path_params/tutorial005.py!}
+```
+
+### Dokümana göz at
+
+*Yol parametresi* için mevcut değerler ön tanımlı olduğundan dolayı, interaktif döküman onları güzel bir şekilde gösterebilir:
+
+<img src="/img/tutorial/path-params/image03.png">
+
+### Python *enumerationları* ile çalışmak
+
+*Yol parametresinin* değeri bir *enumeration üyesi* olacaktır.
+
+#### *Enumeration üyelerini* karşılaştır
+
+Parametreyi, yarattığın enum olan `ModelName` içerisindeki *enumeration üyesi* ile karşılaştırabilirsin:
+
+```Python hl_lines="17"
+{!../../../docs_src/path_params/tutorial005.py!}
+```
+
+#### *Enumeration değerini* elde et
+
+`model_name.value` veya genel olarak `your_enum_member.value` tanımlarını kullanarak (bu durumda bir `str` olan) gerçek değere ulaşabilirsin:
+
+```Python hl_lines="20"
+{!../../../docs_src/path_params/tutorial005.py!}
+```
+
+!!! tip
+    `"lenet"` değerine `ModelName.lenet.value` tanımı ile de ulaşabilirsin.
+
+#### *Enumeration üyelerini* döndür
+
+JSON gövdesine (örneğin bir `dict`) gömülü olsalar bile *yol operasyonundaki* *enum üyelerini* döndürebilirsin.
+
+Bu üyeler istemciye iletilmeden önce kendilerine karşılık gelen değerlerine (bu durumda string) dönüştürüleceklerdir:
+
+```Python hl_lines="18  21  23"
+{!../../../docs_src/path_params/tutorial005.py!}
+```
+
+İstemci tarafında şuna benzer bir JSON yanıtı göreceksin:
+
+```JSON
+{
+  "model_name": "alexnet",
+  "message": "Deep Learning FTW!"
+}
+```
+
+## Yol içeren yol parametreleri
+
+Farz edelim ki elinde `/files/{file_path}` isminde bir *path operasyonu* var.
+
+Fakat `file_path` değerinin `home/johndoe/myfile.txt` gibi bir *yol* barındırmasını istiyorsun.
+
+Sonuç olarak, oluşturmak istediğin URL `/files/home/johndoe/myfile.txt` gibi bir şey olacaktır.
+
+### OpenAPI desteği
+
+Test etmesi ve tanımlaması zor senaryolara sebebiyet vereceğinden dolayı OpenAPI, *yol* barındıran *yol parametrelerini* tanımlayacak bir çözüm sunmuyor.
+
+Buna rağmen, bu durumu, Starlette kütüphanesinin dahili araçlarından birini kullanan **FastAPI**'da gerçekleştirebilirsin.
+
+Parametrenin bir yol içermesi gerektiğini belirten herhangi bir doküman eklemememize rağmen dokümanlar yine de çalışacaktır.
+
+### Yol dönüştürücü
+
+Direkt olarak Starlette kütüphanesinden gelen bir opsiyonu ve aşağıdaki gibi bir URL'yi kullanarak *yol* içeren bir *yol parametresi* tanımlayabilirsin: 
+
+```
+/files/{file_path:path}
+```
+
+Bu durumda, parametrenin adı `file_path` olacaktır ve son kısım olan `:path` kısmı, parametrenin herhangi bir *yol* ile eşleşmesi gerektiğini belirtecektir.
+
+Böylece şunun gibi bir kullanım yapabilirsin:
+
+```Python hl_lines="6"
+{!../../../docs_src/path_params/tutorial004.py!}
+```
+
+!!! tip
+    Parametrenin `/home/johndoe/myfile.txt` yolunu, baştaki (`/`) işareti ile birlikte kullanman gerektiği durumlar olabilir.
+
+    Bu durumda, URL `files` ile `home` arasında iki eğik çizgiye (`//`) sahip olup `/files//home/johndoe/myfile.txt` gibi gözükecektir.
+
+## Özet
+
+**FastAPI** ile kısa, sezgisel ve standart Python tip tanımlamaları kullanarak şunları elde edersin:
+
+* Editör desteği: hata denetimi, otomatik tamamlama, vb.
+* Veri "<abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">ayrıştırma</abbr>"
+* Veri doğrulama
+* API anotasyonları ve otomatik dokümantasyon
+
+Ve sadece, bunları bir kez tanımlaman yeterli.
+
+Diğer frameworkler ile karşılaştırıldığında (ham performans dışında), üstte anlatılan durum muhtemelen **FastAPI**'ın göze çarpan başlıca avantajıdır.

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -165,7 +165,7 @@ Sonrasında, yarattığımız (`ModelName`) isimli enum sınıfını kullanarak 
 
 *Yol parametresinin* değeri bir *enumeration üyesi* olacaktır.
 
-#### *Enumeration Üyelerini* Karşılaştır
+#### *Enumeration Üyelerini* Karşılaştıralım
 
 Parametreyi, yarattığınız enum olan `ModelName` içerisindeki *enumeration üyesi* ile karşılaştırabilirsiniz:
 

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -115,7 +115,7 @@ Benzer şekilde `/users/{user_id}` gibi tanımlanmış ve belirli bir kullanıc�
 {!../../../docs_src/path_params/tutorial003.py!}
 ```
 
-Aksi halde, `/users/{user_id}` yolu `"me"` değerini alan `user_id` adlı bir parametresi olduğunu "düşünerek" `/users/me` isimli yol ile de eşleşir.
+Aksi halde, `/users/{user_id}` yolu `"me"` değerinin `user_id` parametresi için gönderildiğini "düşünerek" `/users/me` ile de eşleşir.
 
 Benzer şekilde, bir yol operasyonunu yeniden tanımlamanız mümkün değildir:
 
@@ -127,15 +127,15 @@ Yol, ilk kısım ile eşleştiğinden dolayı her koşulda ilk yol operasyonu ku
 
 ## Ön Tanımlı Değerler
 
-Eğer *yol parametresi* alan bir *yol operasyonunuz* varsa ve olağan ve geçerli *yol parametresi* değerlerinin ön tanımlı olmasını istiyorsanız, standart Python <abbr title="Enumeration">`Enum`</abbr> kullanabilirsiniz.
+Eğer *yol parametresi* alan bir *yol operasyonunuz* varsa ve alabileceği *yol parametresi* değerlerinin ön tanımlı olmasını istiyorsanız, standart Python <abbr title="Enumeration">`Enum`</abbr> tipini kullanabilirsiniz.
 
 ### Bir `Enum` Sınıfı Oluşturalım
 
-`Enum` sınıfını içeri aktarıp `str` ile `Enum` sınıflarını miras alan bir alt sınıf yaratalım.
+`Enum` sınıfını projemize dahil edip `str` ile `Enum` sınıflarını miras alan bir alt sınıf yaratalım.
 
-`str` sınıfı miras alındığından dolayı, API dokümanı, değerlerin `string` tipinden olması gerektiğini anlayabilecek ve doğru bir şekilde işlenecektir.
+`str` sınıfı miras alındığından dolayı, API dokümanı, değerlerin `string` tipinde olması gerektiğini anlayabilecek ve doğru bir şekilde işlenecektir.
 
-Sonrasında, sınıf içerisinde, mevcut ve geçerli değerler olacak olan sabit değerli öznitelikleri oluşturalım:
+Sonrasında, sınıf içerisinde, mevcut ve geçerli değerler olacak olan sabit değerli özelliklerini oluşturalım:
 
 ```Python hl_lines="1  6-9"
 {!../../../docs_src/path_params/tutorial005.py!}
@@ -149,7 +149,7 @@ Sonrasında, sınıf içerisinde, mevcut ve geçerli değerler olacak olan sabit
 
 ### Bir *Yol Parametresi* Tanımlayalım
 
-Sonrasında, yarattığımız (`ModelName`) isimli enum sınıfını kullanarak tip belirteci aracılığıyla bir *yol parametresi* oluşturalım:
+Sonrasında, yarattığımız enum sınıfını (`ModelName`) kullanarak tip belirteci aracılığıyla bir *yol parametresi* oluşturalım:
 
 ```Python hl_lines="16"
 {!../../../docs_src/path_params/tutorial005.py!}
@@ -173,7 +173,7 @@ Parametreyi, yarattığınız enum olan `ModelName` içerisindeki *enumeration �
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-#### *Enumeration Değerini* Elde Edelim
+#### *Enumeration Değerini* Alalım
 
 `model_name.value` veya genel olarak `your_enum_member.value` tanımlarını kullanarak (bu durumda bir `str` olan) gerçek değere ulaşabilirsiniz:
 
@@ -205,7 +205,7 @@ Bu üyeler istemciye iletilmeden önce kendilerine karşılık gelen değerlerin
 
 ## Yol İçeren Yol Parametreleri
 
-Farz edelim ki elinizde `/files/{file_path}` isminde bir *path operasyonu* var.
+Farz edelim ki elinizde `/files/{file_path}` isminde bir *yol operasyonu* var.
 
 Fakat `file_path` değerinin `home/johndoe/myfile.txt` gibi bir *yol* barındırmasını istiyorsunuz.
 
@@ -215,13 +215,13 @@ Sonuç olarak, oluşturmak istediğin URL `/files/home/johndoe/myfile.txt` gibi 
 
 Test etmesi ve tanımlaması zor senaryolara sebebiyet vereceğinden dolayı OpenAPI, *yol* barındıran *yol parametrelerini* tanımlayacak bir çözüm sunmuyor.
 
-Buna rağmen, bu durumu, Starlette kütüphanesinin dahili araçlarından birini kullanan **FastAPI**'da gerçekleştirebilirsiniz.
+Ancak bunu, Starlette kütüphanesinin dahili araçlarından birini kullanarak **FastAPI**'da gerçekleştirebilirsiniz.
 
 Parametrenin bir yol içermesi gerektiğini belirten herhangi bir doküman eklemememize rağmen dokümanlar yine de çalışacaktır.
 
 ### Yol Dönüştürücü
 
-Direkt olarak Starlette kütüphanesinden gelen bir opsiyonu ve aşağıdaki gibi bir URL'yi kullanarak *yol* içeren bir *yol parametresi* tanımlayabilirsiniz:
+Direkt olarak Starlette kütüphanesinden gelen bir opsiyon sayesinde aşağıdaki gibi *yol* içeren bir *yol parametresi* bağlantısı tanımlayabilirsiniz:
 
 ```
 /files/{file_path:path}
@@ -236,7 +236,7 @@ Böylece şunun gibi bir kullanım yapabilirsiniz:
 ```
 
 !!! tip "İpucu"
-    Parametrenin `/home/johndoe/myfile.txt` yolunu, baştaki (`/`) işareti ile birlikte kullanmanız gerektiği durumlar olabilir.
+    Parametrenin başında `/home/johndoe/myfile.txt` yolunda olduğu gibi (`/`) işareti ile birlikte kullanmanız gerektiği durumlar olabilir.
 
     Bu durumda, URL, `files` ile `home` arasında iki eğik çizgiye (`//`) sahip olup `/files//home/johndoe/myfile.txt` gibi gözükecektir.
 
@@ -247,7 +247,7 @@ Böylece şunun gibi bir kullanım yapabilirsiniz:
 * Editör desteği: hata denetimi, otomatik tamamlama, vb.
 * Veri "<abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">ayrıştırma</abbr>"
 * Veri doğrulama
-* API anotasyonları ve otomatik dokümantasyon
+* API tanımlamaları ve otomatik dokümantasyon
 
 Ve sadece, bunları bir kez tanımlamanız yeterli.
 

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -29,7 +29,7 @@ Bu durumda, `item_id` bir `int` olarak tanımlanacaktır.
 
 ## Veri <abbr title="Dönüşüm: serialization, parsing ve marshalling olarak da biliniyor">Dönüşümü</abbr>
 
-Eğer bu örneği çalıştırıp ve tarayıcınızda <a href="http://127.0.0.1:8000/items/3" class="external-link" target="_blank">http://127.0.0.1:8000/items/3</a> sayfasını açarsanız, şöyle bir yanıt ile karşılaşırsınız:
+Eğer bu örneği çalıştırıp tarayıcınızda <a href="http://127.0.0.1:8000/items/3" class="external-link" target="_blank">http://127.0.0.1:8000/items/3</a> sayfasını açarsanız, şöyle bir yanıt ile karşılaşırsınız:
 
 ```JSON
 {"item_id":3}
@@ -38,11 +38,11 @@ Eğer bu örneği çalıştırıp ve tarayıcınızda <a href="http://127.0.0.1:
 !!! check "Ek bilgi"
     Dikkatinizi çekerim ki, fonksiyonunuzun aldığı (ve döndürdüğü) değer olan `3` bir string `"3"` değil aksine bir Python `int`'idir.
 
-    Böylece, bu tanımlamayla birlikte, **FastAPI** size otomatik istek <abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">"ayrıştırma"</abbr> özelliği sağlar.
+    Bu tanımlamayla birlikte, **FastAPI** size otomatik istek <abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">"ayrıştırma"</abbr> özelliği sağlar.
 
 ## Veri Doğrulama
 
-Fakat, eğer tarayıcınızda <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> adresine giderseniz, şuna benzer güzel bir HTTP hatası ile karşılaşırsınız:
+Eğer tarayıcınızda <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> sayfasını açarsanız, şuna benzer güzel bir HTTP hatası ile karşılaşırsınız:
 
 ```JSON
 {
@@ -61,12 +61,12 @@ Fakat, eğer tarayıcınızda <a href="http://127.0.0.1:8000/items/foo" class="e
 }
 ```
 
-çünkü yol parametresi olan `item_id` değişkeni, veri tipi `int` olmayan `"foo"` gibi bir değere sahipti.
+Çünkü burada `item_id` yol parametresi `int` tipinde bir değer beklerken `"foo"` yani `string` tipinde bir değer almıştı.
 
-Aynı hata `int` yerine `float` bir değer verseydik de ortaya çıkardı, şuradaki gibi: <a href="http://127.0.0.1:8000/items/4.2" class="external-link" target="_blank">http://127.0.0.1:8000/items/4.2</a>
+Aynı hata <a href="http://127.0.0.1:8000/items/4.2" class="external-link" target="_blank">http://127.0.0.1:8000/items/4.2</a> sayfasında olduğu gibi `int` yerine `float` bir değer verseydik de ortaya çıkardı.
 
 !!! check "Ek bilgi"
-    Böylece, aynı Python tip tanımlaması ile birlikte, **FastAPI** size veri doğrulaması özelliği sağlar.
+    Böylece, aynı Python tip tanımlaması ile birlikte, **FastAPI** veri doğrulama özelliği sağlar.
 
     Dikkatinizi çekerim ki, karşılaştığınız hata, doğrulamanın geçersiz olduğu mutlak noktayı da açık bir şekilde belirtiyor.
 
@@ -85,19 +85,19 @@ Ayrıca, tarayıcınızı <a href="http://127.0.0.1:8000/docs" class="external-l
 
 ## Standartlara Dayalı Avantajlar, Alternatif Dokümantasyon
 
-Ve türetilmiş olan şema <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> standartına uygun olduğu için birçok uyumlu araç bulunmaktadır.
+Oluşturulan şema <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> standardına uygun olduğu için birçok uyumlu araç mevcuttur.
 
-Bu sayede, **FastAPI**'ın bizzat kendisi <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a> linkinden erişebileceğiniz alternatif (Redoc kullanan) bir API dokümantasyonu sağlar:
+Bu sayede, **FastAPI**'ın bizzat kendisi <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a> sayfasından erişebileceğiniz alternatif (ReDoc kullanan) bir API dokümantasyonu sağlar:
 
 <img src="/img/tutorial/path-params/image02.png">
 
-Aynı şekilde, farklı diller için kod türetme araçları içeren çok sayıda uyumlu araç bulunur.
+Aynı şekilde, farklı diller için kod türetme araçları da dahil olmak üzere çok sayıda uyumlu araç bulunur.
 
 ## Pydantic
 
 Tüm veri doğrulamaları <a href="https://pydantic-docs.helpmanual.io/" class="external-link" target="_blank">Pydantic</a> tarafından arka planda gerçekleştirilir, bu sayede tüm avantajlardan faydalanabilirsiniz. Böylece, emin ellerde olduğunuzu hissedebilirsiniz.
 
-Aynı tip tanımlamalarını `str`, `float`, `bool` ile ve diğer kompleks veri tipleri ile de kullanma imkanınız vardır.
+Aynı tip tanımlamalarını `str`, `float`, `bool` ve diğer karmaşık veri tipleri ile kullanma imkanınız vardır.
 
 Bunlardan birkaçı, bu eğitimin ileriki bölümlerinde irdelenmiştir.
 
@@ -107,7 +107,7 @@ Bunlardan birkaçı, bu eğitimin ileriki bölümlerinde irdelenmiştir.
 
 Farz edelim ki `/users/me` yolu geçerli kullanıcı hakkında bilgi almak için kullanılıyor olsun.
 
-Benzer şekilde `/users/{user_id}` gibi tanımlanmış ve belirli bir kullanıcı hakkında veri almak için kullanıcı ID numarası kullanılan bir yolunuz da mevcut olabilir.
+Benzer şekilde `/users/{user_id}` gibi tanımlanmış ve belirli bir kullanıcı hakkında veri almak için kullanıcının ID bilgisini kullanan bir yolunuz da mevcut olabilir.
 
 *Yol operasyonları* sıralı bir şekilde gözden geçirildiğinden dolayı `/users/me` yolunun `/users/{user_id}` yolundan önce tanımlanmış olmasından emin olmanız gerekmektedir:
 
@@ -115,7 +115,7 @@ Benzer şekilde `/users/{user_id}` gibi tanımlanmış ve belirli bir kullanıc�
 {!../../../docs_src/path_params/tutorial003.py!}
 ```
 
-Aksi halde, `/users/{user_id}` yolu `"me"` değerini alan `user_id` adlı bir parametresi olduğunu "düşünerek" `/users/me` isimli yol ile eşleşir.
+Aksi halde, `/users/{user_id}` yolu `"me"` değerini alan `user_id` adlı bir parametresi olduğunu "düşünerek" `/users/me` isimli yol ile de eşleşir.
 
 Benzer şekilde, bir yol operasyonunu yeniden tanımlamanız mümkün değildir:
 
@@ -123,13 +123,13 @@ Benzer şekilde, bir yol operasyonunu yeniden tanımlamanız mümkün değildir:
 {!../../../docs_src/path_params/tutorial003b.py!}
 ```
 
-Yol ilk kısım ile eşleştiğinden dolayı her koşulda ilk yol operasyonu kullanılacaktır.
+Yol, ilk kısım ile eşleştiğinden dolayı her koşulda ilk yol operasyonu kullanılacaktır.
 
 ## Ön Tanımlı Değerler
 
 Eğer *yol parametresi* alan bir *yol operasyonunuz* varsa ve olağan ve geçerli *yol parametresi* değerlerinin ön tanımlı olmasını istiyorsanız, standart Python <abbr title="Enumeration">`Enum`</abbr> kullanabilirsiniz.
 
-### Bir `Enum` Sınıfı Yarat
+### Bir `Enum` Sınıfı Oluşturalım
 
 `Enum` sınıfını içeri aktarıp `str` ile `Enum` sınıflarını miras alan bir alt sınıf yaratalım.
 
@@ -147,7 +147,7 @@ Sonrasında, sınıf içerisinde, mevcut ve geçerli değerler olacak olan sabit
 !!! tip "İpucu"
     Merak ediyorsanız söyleyeyim, "AlexNet", "ResNet" ve "LeNet" isimleri Makine Öğrenmesi <abbr title="Teknik olarak, Derin Öğrenme model mimarileri">modellerini</abbr> temsil eder.
 
-### Bir *Yol Parametresi* Tanımla
+### Bir *Yol Parametresi* Tanımlayalım
 
 Sonrasında, yarattığımız (`ModelName`) isimli enum sınıfını kullanarak tip belirteci aracılığıyla bir *yol parametresi* oluşturalım:
 
@@ -155,7 +155,7 @@ Sonrasında, yarattığımız (`ModelName`) isimli enum sınıfını kullanarak 
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-### Dokümana Göz At
+### Dokümana Göz Atalım
 
 *Yol parametresi* için mevcut değerler ön tanımlı olduğundan dolayı, interaktif döküman onları güzel bir şekilde gösterebilir:
 
@@ -173,7 +173,7 @@ Parametreyi, yarattığınız enum olan `ModelName` içerisindeki *enumeration �
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-#### *Enumeration Değerini* Elde Et
+#### *Enumeration Değerini* Elde Edelim
 
 `model_name.value` veya genel olarak `your_enum_member.value` tanımlarını kullanarak (bu durumda bir `str` olan) gerçek değere ulaşabilirsiniz:
 
@@ -184,7 +184,7 @@ Parametreyi, yarattığınız enum olan `ModelName` içerisindeki *enumeration �
 !!! tip "İpucu"
     `"lenet"` değerine `ModelName.lenet.value` tanımı ile de ulaşabilirsiniz.
 
-#### *Enumeration Üyelerini* Döndür
+#### *Enumeration Üyelerini* Döndürelim
 
 JSON gövdesine (örneğin bir `dict`) gömülü olsalar bile *yol operasyonundaki* *enum üyelerini* döndürebilirsiniz.
 

--- a/docs/tr/docs/tutorial/path-params.md
+++ b/docs/tr/docs/tutorial/path-params.md
@@ -1,22 +1,22 @@
 # Yol Parametreleri
 
-Yol "parametrelerini" veya "değişkenlerini" Python string biçimlemede kullanılan aynı söz dizimi ile tanımlayabilirsin.
+Yol "parametrelerini" veya "değişkenlerini" Python <abbr title="String Biçimleme: Format String">string biçimlemede</abbr> kullanılan sözdizimi ile tanımlayabilirsiniz.
 
 ```Python hl_lines="6-7"
 {!../../../docs_src/path_params/tutorial001.py!}
 ```
 
-Yol parametresi olan `item_id`'nin değeri, fonksiyonuna `item_id` argümanı olarak geçirilecektir.
+Yol parametresi olan `item_id`'nin değeri, fonksiyonunuza `item_id` argümanı olarak aktarılacaktır.
 
-Demek oluyor ki, eğer bu örneği çalıştırırsan ve <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> sayfasına gidersen, şöyle bir yanıt ile karşılaşacaksın:
+Eğer bu örneği çalıştırıp <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> sayfasına giderseniz, şöyle bir çıktı ile karşılaşırsınız:
 
 ```JSON
 {"item_id":"foo"}
 ```
 
-## Tip içeren yol parametreleri
+## Tip İçeren Yol Parametreleri
 
-Standart Python tip anotasyonları kullanarak yol parametresinin tipini fonksiyonda tanımlayabilirsin.
+Standart Python tip belirteçlerini kullanarak yol parametresinin tipini fonksiyonda tanımlayabilirsiniz.
 
 ```Python hl_lines="7"
 {!../../../docs_src/path_params/tutorial002.py!}
@@ -24,25 +24,25 @@ Standart Python tip anotasyonları kullanarak yol parametresinin tipini fonksiyo
 
 Bu durumda, `item_id` bir `int` olarak tanımlanacaktır.
 
-!!! check
-    Bu özellik, fonksiyonunun içinde sana hata denetimi, kod tamamlama ve benzeri gibi özelliklerle birlikte editör desteği kazandıracaktır.
+!!! check "Ek bilgi"
+    Bu sayede fonksiyonun içerisinde hata denetimi, kod tamamlama gibi konularda editör desteğine kavuşacaksınız.
 
-## Veri <abbr title="ayrıca şöyle bilinir: serileştirme, ayrıştırma, hizalama">dönüşümü</abbr>
+## Veri <abbr title="Dönüşüm: serialization, parsing ve marshalling olarak da biliniyor">Dönüşümü</abbr>
 
-Eğer bu örneği çalıştırırsan ve tarayıcında <a href="http://127.0.0.1:8000/items/3" class="external-link" target="_blank">http://127.0.0.1:8000/items/3</a> linkini açarsan, şöyle bir yanıt ile karşılaşacaksın:
+Eğer bu örneği çalıştırıp ve tarayıcınızda <a href="http://127.0.0.1:8000/items/3" class="external-link" target="_blank">http://127.0.0.1:8000/items/3</a> sayfasını açarsanız, şöyle bir yanıt ile karşılaşırsınız:
 
 ```JSON
 {"item_id":3}
 ```
 
-!!! check
-    Dikkatini çekerim ki, fonksiyonunun aldığı (ve döndürdüğü) değer olan `3` bir string `"3"` değil aksine bir Python `int`'idir.
+!!! check "Ek bilgi"
+    Dikkatinizi çekerim ki, fonksiyonunuzun aldığı (ve döndürdüğü) değer olan `3` bir string `"3"` değil aksine bir Python `int`'idir.
 
-    Böylece, bu tanımlamayla birlikte, **FastAPI** sana otomatik istek <abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">"ayrıştırma"</abbr> özelliği sağlar.
+    Böylece, bu tanımlamayla birlikte, **FastAPI** size otomatik istek <abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">"ayrıştırma"</abbr> özelliği sağlar.
 
-## Veri doğrulama
+## Veri Doğrulama
 
-Fakat, eğer tarayıcında <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> adresine gidersen, şuna benzer güzel bir HTTP hatası ile karşılaşacaksın:
+Fakat, eğer tarayıcınızda <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a> adresine giderseniz, şuna benzer güzel bir HTTP hatası ile karşılaşırsınız:
 
 ```JSON
 {
@@ -65,29 +65,29 @@ Fakat, eğer tarayıcında <a href="http://127.0.0.1:8000/items/foo" class="exte
 
 Aynı hata `int` yerine `float` bir değer verseydik de ortaya çıkardı, şuradaki gibi: <a href="http://127.0.0.1:8000/items/4.2" class="external-link" target="_blank">http://127.0.0.1:8000/items/4.2</a>
 
-!!! check
-    Böylece, aynı Python tip tanımlaması ile birlikte, **FastAPI** sana veri doğrulaması özelliği sağlar.
+!!! check "Ek bilgi"
+    Böylece, aynı Python tip tanımlaması ile birlikte, **FastAPI** size veri doğrulaması özelliği sağlar.
 
-    Dikkatini çekerim ki, karşılaştığın hata, doğrulamanın geçersiz olduğu mutlak noktayı da açık bir şekilde belirtiyor.
+    Dikkatinizi çekerim ki, karşılaştığınız hata, doğrulamanın geçersiz olduğu mutlak noktayı da açık bir şekilde belirtiyor.
 
-    Bu özellik, API'ınla iletişime geçen kodu geliştirirken ve ayıklarken inanılmaz derecede yararlı olacaktır.
+    Bu özellik, API'ınızla iletişime geçen kodu geliştirirken ve ayıklarken inanılmaz derecede yararlı olacaktır.
 
 ## Dokümantasyon
 
-Ayrıca, tarayıcını <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a> adresinde açarsan, aşağıdaki gibi otomatik ve interaktif bir API dökümantasyonu ile karşılaşacaksın:
+Ayrıca, tarayıcınızı <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a> adresinde açarsanız, aşağıdaki gibi otomatik ve interaktif bir API dökümantasyonu ile karşılaşırsınız:
 
 <img src="/img/tutorial/path-params/image01.png">
 
-!!! check
-    Üstelik, sadece aynı Python tip tanımlaması ile, **FastAPI** sana otomatik ve interaktif (Swagger UI ile entegre) bir dokümantasyon sağlar.
+!!! check "Ek bilgi"
+    Üstelik, sadece aynı Python tip tanımlaması ile, **FastAPI** size otomatik ve interaktif (Swagger UI ile entegre) bir dokümantasyon sağlar.
 
-    Dikkatini çekerim ki, yol parametresi integer olarak tanımlanmıştır.
+    Dikkatinizi çekerim ki, yol parametresi integer olarak tanımlanmıştır.
 
-## Standartlara dayalı avantajlar, alternatif dokümantasyon
+## Standartlara Dayalı Avantajlar, Alternatif Dokümantasyon
 
 Ve türetilmiş olan şema <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> standartına uygun olduğu için birçok uyumlu araç bulunmaktadır.
 
-Bu sayede, **FastAPI**'ın kendisi <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a> linkinden erişebileceğiniz alternatif (Redoc kullanan) bir API dokümantasyonu sağlar:
+Bu sayede, **FastAPI**'ın bizzat kendisi <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a> linkinden erişebileceğiniz alternatif (Redoc kullanan) bir API dokümantasyonu sağlar:
 
 <img src="/img/tutorial/path-params/image02.png">
 
@@ -95,15 +95,15 @@ Aynı şekilde, farklı diller için kod türetme araçları içeren çok sayıd
 
 ## Pydantic
 
-Tüm veri doğrulamaları <a href="https://pydantic-docs.helpmanual.io/" class="external-link" target="_blank">Pydantic</a> tarafından arka planda gerçekleştirilir, bu sayede tüm avantajlardan faydalanabilirsin. Böylece, emin ellerde olduğunu hissedebilirsin.
+Tüm veri doğrulamaları <a href="https://pydantic-docs.helpmanual.io/" class="external-link" target="_blank">Pydantic</a> tarafından arka planda gerçekleştirilir, bu sayede tüm avantajlardan faydalanabilirsiniz. Böylece, emin ellerde olduğunuzu hissedebilirsiniz.
 
-Aynı tip tanımlamalarını `str`, `float`, `bool` ile ve diğer kompleks veri tipleri ile de kullanabilirsin.
+Aynı tip tanımlamalarını `str`, `float`, `bool` ile ve diğer kompleks veri tipleri ile de kullanma imkanınız vardır.
 
 Bunlardan birkaçı, bu eğitimin ileriki bölümlerinde irdelenmiştir.
 
-## Sıralama önem arz eder
+## Sıralama Önem Arz Eder
 
-*Yol operasyonları* tasarlarken sabit yol barındıran durumlar ile karşılaşabilirsin.
+*Yol operasyonları* tasarlarken sabit yol barındıran durumlar ile karşılaşabilirsiniz.
 
 Farz edelim ki `/users/me` yolu geçerli kullanıcı hakkında bilgi almak için kullanılıyor olsun.
 
@@ -125,11 +125,11 @@ Benzer şekilde, bir yol operasyonunu yeniden tanımlamanız mümkün değildir:
 
 Yol ilk kısım ile eşleştiğinden dolayı her koşulda ilk yol operasyonu kullanılacaktır.
 
-## Ön tanımlı değerler
+## Ön Tanımlı Değerler
 
-Eğer *yol parametresi* alan bir *yol operasyonun* varsa ve olağan ve geçerli *yol parametresi* değerlerinin ön tanımlı olmasını istiyorsan, standart Python <abbr title="Enumeration">`Enum`</abbr> kullanabilirsin.
+Eğer *yol parametresi* alan bir *yol operasyonunuz* varsa ve olağan ve geçerli *yol parametresi* değerlerinin ön tanımlı olmasını istiyorsanız, standart Python <abbr title="Enumeration">`Enum`</abbr> kullanabilirsiniz.
 
-### Bir `Enum` sınıfı yarat
+### Bir `Enum` Sınıfı Yarat
 
 `Enum` sınıfını içeri aktarıp `str` ile `Enum` sınıflarını miras alan bir alt sınıf yaratalım.
 
@@ -141,52 +141,52 @@ Sonrasında, sınıf içerisinde, mevcut ve geçerli değerler olacak olan sabit
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-!!! info
+!!! info "Bilgi"
     3.4 sürümünden beri <a href="https://docs.python.org/3/library/enum.html" class="external-link" target="_blank">enumerationlar (ya da enumlar) Python'da mevcuttur</a>.
 
-!!! tip
+!!! tip "İpucu"
     Merak ediyorsanız söyleyeyim, "AlexNet", "ResNet" ve "LeNet" isimleri Makine Öğrenmesi <abbr title="Teknik olarak, Derin Öğrenme model mimarileri">modellerini</abbr> temsil eder.
 
-### Bir *yol parametresi* tanımla
+### Bir *Yol Parametresi* Tanımla
 
-Sonrasında, yarattığımız (`ModelName`) isimli enum sınıfını kullanarak tip anotasyonu aracılığıyla bir *yol parametresi* oluşturalım:
+Sonrasında, yarattığımız (`ModelName`) isimli enum sınıfını kullanarak tip belirteci aracılığıyla bir *yol parametresi* oluşturalım:
 
 ```Python hl_lines="16"
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-### Dokümana göz at
+### Dokümana Göz At
 
 *Yol parametresi* için mevcut değerler ön tanımlı olduğundan dolayı, interaktif döküman onları güzel bir şekilde gösterebilir:
 
 <img src="/img/tutorial/path-params/image03.png">
 
-### Python *enumerationları* ile çalışmak
+### Python *Enumerationları* ile Çalışmak
 
 *Yol parametresinin* değeri bir *enumeration üyesi* olacaktır.
 
-#### *Enumeration üyelerini* karşılaştır
+#### *Enumeration Üyelerini* Karşılaştır
 
-Parametreyi, yarattığın enum olan `ModelName` içerisindeki *enumeration üyesi* ile karşılaştırabilirsin:
+Parametreyi, yarattığınız enum olan `ModelName` içerisindeki *enumeration üyesi* ile karşılaştırabilirsiniz:
 
 ```Python hl_lines="17"
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-#### *Enumeration değerini* elde et
+#### *Enumeration Değerini* Elde Et
 
-`model_name.value` veya genel olarak `your_enum_member.value` tanımlarını kullanarak (bu durumda bir `str` olan) gerçek değere ulaşabilirsin:
+`model_name.value` veya genel olarak `your_enum_member.value` tanımlarını kullanarak (bu durumda bir `str` olan) gerçek değere ulaşabilirsiniz:
 
 ```Python hl_lines="20"
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-!!! tip
-    `"lenet"` değerine `ModelName.lenet.value` tanımı ile de ulaşabilirsin.
+!!! tip "İpucu"
+    `"lenet"` değerine `ModelName.lenet.value` tanımı ile de ulaşabilirsiniz.
 
-#### *Enumeration üyelerini* döndür
+#### *Enumeration Üyelerini* Döndür
 
-JSON gövdesine (örneğin bir `dict`) gömülü olsalar bile *yol operasyonundaki* *enum üyelerini* döndürebilirsin.
+JSON gövdesine (örneğin bir `dict`) gömülü olsalar bile *yol operasyonundaki* *enum üyelerini* döndürebilirsiniz.
 
 Bu üyeler istemciye iletilmeden önce kendilerine karşılık gelen değerlerine (bu durumda string) dönüştürüleceklerdir:
 
@@ -194,7 +194,7 @@ Bu üyeler istemciye iletilmeden önce kendilerine karşılık gelen değerlerin
 {!../../../docs_src/path_params/tutorial005.py!}
 ```
 
-İstemci tarafında şuna benzer bir JSON yanıtı göreceksin:
+İstemci tarafında şuna benzer bir JSON yanıtı ile karşılaşırsınız:
 
 ```JSON
 {
@@ -203,25 +203,25 @@ Bu üyeler istemciye iletilmeden önce kendilerine karşılık gelen değerlerin
 }
 ```
 
-## Yol içeren yol parametreleri
+## Yol İçeren Yol Parametreleri
 
-Farz edelim ki elinde `/files/{file_path}` isminde bir *path operasyonu* var.
+Farz edelim ki elinizde `/files/{file_path}` isminde bir *path operasyonu* var.
 
-Fakat `file_path` değerinin `home/johndoe/myfile.txt` gibi bir *yol* barındırmasını istiyorsun.
+Fakat `file_path` değerinin `home/johndoe/myfile.txt` gibi bir *yol* barındırmasını istiyorsunuz.
 
 Sonuç olarak, oluşturmak istediğin URL `/files/home/johndoe/myfile.txt` gibi bir şey olacaktır.
 
-### OpenAPI desteği
+### OpenAPI Desteği
 
 Test etmesi ve tanımlaması zor senaryolara sebebiyet vereceğinden dolayı OpenAPI, *yol* barındıran *yol parametrelerini* tanımlayacak bir çözüm sunmuyor.
 
-Buna rağmen, bu durumu, Starlette kütüphanesinin dahili araçlarından birini kullanan **FastAPI**'da gerçekleştirebilirsin.
+Buna rağmen, bu durumu, Starlette kütüphanesinin dahili araçlarından birini kullanan **FastAPI**'da gerçekleştirebilirsiniz.
 
 Parametrenin bir yol içermesi gerektiğini belirten herhangi bir doküman eklemememize rağmen dokümanlar yine de çalışacaktır.
 
-### Yol dönüştürücü
+### Yol Dönüştürücü
 
-Direkt olarak Starlette kütüphanesinden gelen bir opsiyonu ve aşağıdaki gibi bir URL'yi kullanarak *yol* içeren bir *yol parametresi* tanımlayabilirsin:
+Direkt olarak Starlette kütüphanesinden gelen bir opsiyonu ve aşağıdaki gibi bir URL'yi kullanarak *yol* içeren bir *yol parametresi* tanımlayabilirsiniz:
 
 ```
 /files/{file_path:path}
@@ -229,26 +229,26 @@ Direkt olarak Starlette kütüphanesinden gelen bir opsiyonu ve aşağıdaki gib
 
 Bu durumda, parametrenin adı `file_path` olacaktır ve son kısım olan `:path` kısmı, parametrenin herhangi bir *yol* ile eşleşmesi gerektiğini belirtecektir.
 
-Böylece şunun gibi bir kullanım yapabilirsin:
+Böylece şunun gibi bir kullanım yapabilirsiniz:
 
 ```Python hl_lines="6"
 {!../../../docs_src/path_params/tutorial004.py!}
 ```
 
-!!! tip
-    Parametrenin `/home/johndoe/myfile.txt` yolunu, baştaki (`/`) işareti ile birlikte kullanman gerektiği durumlar olabilir.
+!!! tip "İpucu"
+    Parametrenin `/home/johndoe/myfile.txt` yolunu, baştaki (`/`) işareti ile birlikte kullanmanız gerektiği durumlar olabilir.
 
-    Bu durumda, URL `files` ile `home` arasında iki eğik çizgiye (`//`) sahip olup `/files//home/johndoe/myfile.txt` gibi gözükecektir.
+    Bu durumda, URL, `files` ile `home` arasında iki eğik çizgiye (`//`) sahip olup `/files//home/johndoe/myfile.txt` gibi gözükecektir.
 
 ## Özet
 
-**FastAPI** ile kısa, sezgisel ve standart Python tip tanımlamaları kullanarak şunları elde edersin:
+**FastAPI** ile kısa, sezgisel ve standart Python tip tanımlamaları kullanarak şunları elde edersiniz:
 
 * Editör desteği: hata denetimi, otomatik tamamlama, vb.
 * Veri "<abbr title="HTTP isteği ile birlikte gelen string'i Python verisine dönüştürme">ayrıştırma</abbr>"
 * Veri doğrulama
 * API anotasyonları ve otomatik dokümantasyon
 
-Ve sadece, bunları bir kez tanımlaman yeterli.
+Ve sadece, bunları bir kez tanımlamanız yeterli.
 
 Diğer frameworkler ile karşılaştırıldığında (ham performans dışında), üstte anlatılan durum muhtemelen **FastAPI**'ın göze çarpan başlıca avantajıdır.


### PR DESCRIPTION
🌐 Add Turkish translation for `docs/tr/docs/tutorial/path-params.md`

[Original File](https://github.com/tiangolo/fastapi/blob/master/docs/en/docs/tutorial/path-params.md)

Discussion: #9193 