### PR TITLE
⬆️ Upgrade configuration for Ruff v0.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.2
+    rev: v0.2.0
     hooks:
     -   id: ruff
         args:

--- a/docs_src/dependencies/tutorial005_an.py
+++ b/docs_src/dependencies/tutorial005_an.py
@@ -21,6 +21,6 @@ def query_or_cookie_extractor(
 
 @app.get("/items/")
 async def read_query(
-    query_or_default: Annotated[str, Depends(query_or_cookie_extractor)]
+    query_or_default: Annotated[str, Depends(query_or_cookie_extractor)],
 ):
     return {"q_or_cookie": query_or_default}

--- a/docs_src/dependencies/tutorial005_an_py310.py
+++ b/docs_src/dependencies/tutorial005_an_py310.py
@@ -20,6 +20,6 @@ def query_or_cookie_extractor(
 
 @app.get("/items/")
 async def read_query(
-    query_or_default: Annotated[str, Depends(query_or_cookie_extractor)]
+    query_or_default: Annotated[str, Depends(query_or_cookie_extractor)],
 ):
     return {"q_or_cookie": query_or_default}

--- a/docs_src/dependencies/tutorial005_an_py39.py
+++ b/docs_src/dependencies/tutorial005_an_py39.py
@@ -20,6 +20,6 @@ def query_or_cookie_extractor(
 
 @app.get("/items/")
 async def read_query(
-    query_or_default: Annotated[str, Depends(query_or_cookie_extractor)]
+    query_or_default: Annotated[str, Depends(query_or_cookie_extractor)],
 ):
     return {"q_or_cookie": query_or_default}

--- a/docs_src/header_params/tutorial002.py
+++ b/docs_src/header_params/tutorial002.py
@@ -7,6 +7,6 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    strange_header: Union[str, None] = Header(default=None, convert_underscores=False)
+    strange_header: Union[str, None] = Header(default=None, convert_underscores=False),
 ):
     return {"strange_header": strange_header}

--- a/docs_src/header_params/tutorial002_an_py310.py
+++ b/docs_src/header_params/tutorial002_an_py310.py
@@ -7,6 +7,6 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    strange_header: Annotated[str | None, Header(convert_underscores=False)] = None
+    strange_header: Annotated[str | None, Header(convert_underscores=False)] = None,
 ):
     return {"strange_header": strange_header}

--- a/docs_src/header_params/tutorial002_py310.py
+++ b/docs_src/header_params/tutorial002_py310.py
@@ -5,6 +5,6 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    strange_header: str | None = Header(default=None, convert_underscores=False)
+    strange_header: str | None = Header(default=None, convert_underscores=False),
 ):
     return {"strange_header": strange_header}

--- a/docs_src/query_params_str_validations/tutorial003.py
+++ b/docs_src/query_params_str_validations/tutorial003.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Union[str, None] = Query(default=None, min_length=3, max_length=50)
+    q: Union[str, None] = Query(default=None, min_length=3, max_length=50),
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial003_an.py
+++ b/docs_src/query_params_str_validations/tutorial003_an.py
@@ -8,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Annotated[Union[str, None], Query(min_length=3, max_length=50)] = None
+    q: Annotated[Union[str, None], Query(min_length=3, max_length=50)] = None,
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial003_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial003_an_py310.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Annotated[str | None, Query(min_length=3, max_length=50)] = None
+    q: Annotated[str | None, Query(min_length=3, max_length=50)] = None,
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial003_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial003_an_py39.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Annotated[Union[str, None], Query(min_length=3, max_length=50)] = None
+    q: Annotated[Union[str, None], Query(min_length=3, max_length=50)] = None,
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial007.py
+++ b/docs_src/query_params_str_validations/tutorial007.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Union[str, None] = Query(default=None, title="Query string", min_length=3)
+    q: Union[str, None] = Query(default=None, title="Query string", min_length=3),
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial007_an.py
+++ b/docs_src/query_params_str_validations/tutorial007_an.py
@@ -8,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Annotated[Union[str, None], Query(title="Query string", min_length=3)] = None
+    q: Annotated[Union[str, None], Query(title="Query string", min_length=3)] = None,
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial007_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial007_an_py310.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Annotated[str | None, Query(title="Query string", min_length=3)] = None
+    q: Annotated[str | None, Query(title="Query string", min_length=3)] = None,
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial007_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial007_an_py39.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: Annotated[Union[str, None], Query(title="Query string", min_length=3)] = None
+    q: Annotated[Union[str, None], Query(title="Query string", min_length=3)] = None,
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial007_py310.py
+++ b/docs_src/query_params_str_validations/tutorial007_py310.py
@@ -5,7 +5,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    q: str | None = Query(default=None, title="Query string", min_length=3)
+    q: str | None = Query(default=None, title="Query string", min_length=3),
 ):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:

--- a/docs_src/query_params_str_validations/tutorial014.py
+++ b/docs_src/query_params_str_validations/tutorial014.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    hidden_query: Union[str, None] = Query(default=None, include_in_schema=False)
+    hidden_query: Union[str, None] = Query(default=None, include_in_schema=False),
 ):
     if hidden_query:
         return {"hidden_query": hidden_query}

--- a/docs_src/query_params_str_validations/tutorial014_an.py
+++ b/docs_src/query_params_str_validations/tutorial014_an.py
@@ -8,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    hidden_query: Annotated[Union[str, None], Query(include_in_schema=False)] = None
+    hidden_query: Annotated[Union[str, None], Query(include_in_schema=False)] = None,
 ):
     if hidden_query:
         return {"hidden_query": hidden_query}

--- a/docs_src/query_params_str_validations/tutorial014_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial014_an_py310.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    hidden_query: Annotated[str | None, Query(include_in_schema=False)] = None
+    hidden_query: Annotated[str | None, Query(include_in_schema=False)] = None,
 ):
     if hidden_query:
         return {"hidden_query": hidden_query}

--- a/docs_src/query_params_str_validations/tutorial014_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial014_an_py39.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    hidden_query: Annotated[Union[str, None], Query(include_in_schema=False)] = None
+    hidden_query: Annotated[Union[str, None], Query(include_in_schema=False)] = None,
 ):
     if hidden_query:
         return {"hidden_query": hidden_query}

--- a/docs_src/query_params_str_validations/tutorial014_py310.py
+++ b/docs_src/query_params_str_validations/tutorial014_py310.py
@@ -5,7 +5,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(
-    hidden_query: str | None = Query(default=None, include_in_schema=False)
+    hidden_query: str | None = Query(default=None, include_in_schema=False),
 ):
     if hidden_query:
         return {"hidden_query": hidden_query}

--- a/docs_src/security/tutorial003_an.py
+++ b/docs_src/security/tutorial003_an.py
@@ -68,7 +68,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Depends(get_current_user)]
+    current_user: Annotated[User, Depends(get_current_user)],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -90,6 +90,6 @@ async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
 
 @app.get("/users/me")
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user

--- a/docs_src/security/tutorial003_an_py310.py
+++ b/docs_src/security/tutorial003_an_py310.py
@@ -67,7 +67,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Depends(get_current_user)]
+    current_user: Annotated[User, Depends(get_current_user)],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -89,6 +89,6 @@ async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
 
 @app.get("/users/me")
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user

--- a/docs_src/security/tutorial003_an_py39.py
+++ b/docs_src/security/tutorial003_an_py39.py
@@ -67,7 +67,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Depends(get_current_user)]
+    current_user: Annotated[User, Depends(get_current_user)],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -89,6 +89,6 @@ async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
 
 @app.get("/users/me")
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user

--- a/docs_src/security/tutorial004.py
+++ b/docs_src/security/tutorial004.py
@@ -114,7 +114,7 @@ async def get_current_active_user(current_user: User = Depends(get_current_user)
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends()
+    form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:

--- a/docs_src/security/tutorial004_an.py
+++ b/docs_src/security/tutorial004_an.py
@@ -108,7 +108,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Depends(get_current_user)]
+    current_user: Annotated[User, Depends(get_current_user)],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -117,7 +117,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -135,13 +135,13 @@ async def login_for_access_token(
 
 @app.get("/users/me/", response_model=User)
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user
 
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]

--- a/docs_src/security/tutorial004_an_py310.py
+++ b/docs_src/security/tutorial004_an_py310.py
@@ -107,7 +107,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Depends(get_current_user)]
+    current_user: Annotated[User, Depends(get_current_user)],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -116,7 +116,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -134,13 +134,13 @@ async def login_for_access_token(
 
 @app.get("/users/me/", response_model=User)
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user
 
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]

--- a/docs_src/security/tutorial004_an_py39.py
+++ b/docs_src/security/tutorial004_an_py39.py
@@ -107,7 +107,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Depends(get_current_user)]
+    current_user: Annotated[User, Depends(get_current_user)],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -116,7 +116,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -134,13 +134,13 @@ async def login_for_access_token(
 
 @app.get("/users/me/", response_model=User)
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user
 
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]

--- a/docs_src/security/tutorial004_py310.py
+++ b/docs_src/security/tutorial004_py310.py
@@ -113,7 +113,7 @@ async def get_current_active_user(current_user: User = Depends(get_current_user)
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends()
+    form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:

--- a/docs_src/security/tutorial005.py
+++ b/docs_src/security/tutorial005.py
@@ -136,7 +136,7 @@ async def get_current_user(
 
 
 async def get_current_active_user(
-    current_user: User = Security(get_current_user, scopes=["me"])
+    current_user: User = Security(get_current_user, scopes=["me"]),
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -145,7 +145,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends()
+    form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -165,7 +165,7 @@ async def read_users_me(current_user: User = Depends(get_current_active_user)):
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: User = Security(get_current_active_user, scopes=["items"])
+    current_user: User = Security(get_current_active_user, scopes=["items"]),
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]
 

--- a/docs_src/security/tutorial005_an.py
+++ b/docs_src/security/tutorial005_an.py
@@ -137,7 +137,7 @@ async def get_current_user(
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Security(get_current_user, scopes=["me"])]
+    current_user: Annotated[User, Security(get_current_user, scopes=["me"])],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -146,7 +146,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -161,14 +161,14 @@ async def login_for_access_token(
 
 @app.get("/users/me/", response_model=User)
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user
 
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: Annotated[User, Security(get_current_active_user, scopes=["items"])]
+    current_user: Annotated[User, Security(get_current_active_user, scopes=["items"])],
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]
 

--- a/docs_src/security/tutorial005_an_py310.py
+++ b/docs_src/security/tutorial005_an_py310.py
@@ -136,7 +136,7 @@ async def get_current_user(
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Security(get_current_user, scopes=["me"])]
+    current_user: Annotated[User, Security(get_current_user, scopes=["me"])],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -145,7 +145,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -160,14 +160,14 @@ async def login_for_access_token(
 
 @app.get("/users/me/", response_model=User)
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user
 
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: Annotated[User, Security(get_current_active_user, scopes=["items"])]
+    current_user: Annotated[User, Security(get_current_active_user, scopes=["items"])],
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]
 

--- a/docs_src/security/tutorial005_an_py39.py
+++ b/docs_src/security/tutorial005_an_py39.py
@@ -136,7 +136,7 @@ async def get_current_user(
 
 
 async def get_current_active_user(
-    current_user: Annotated[User, Security(get_current_user, scopes=["me"])]
+    current_user: Annotated[User, Security(get_current_user, scopes=["me"])],
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -145,7 +145,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -160,14 +160,14 @@ async def login_for_access_token(
 
 @app.get("/users/me/", response_model=User)
 async def read_users_me(
-    current_user: Annotated[User, Depends(get_current_active_user)]
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ):
     return current_user
 
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: Annotated[User, Security(get_current_active_user, scopes=["items"])]
+    current_user: Annotated[User, Security(get_current_active_user, scopes=["items"])],
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]
 

--- a/docs_src/security/tutorial005_py310.py
+++ b/docs_src/security/tutorial005_py310.py
@@ -135,7 +135,7 @@ async def get_current_user(
 
 
 async def get_current_active_user(
-    current_user: User = Security(get_current_user, scopes=["me"])
+    current_user: User = Security(get_current_user, scopes=["me"]),
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -144,7 +144,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends()
+    form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -164,7 +164,7 @@ async def read_users_me(current_user: User = Depends(get_current_active_user)):
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: User = Security(get_current_active_user, scopes=["items"])
+    current_user: User = Security(get_current_active_user, scopes=["items"]),
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]
 

--- a/docs_src/security/tutorial005_py39.py
+++ b/docs_src/security/tutorial005_py39.py
@@ -136,7 +136,7 @@ async def get_current_user(
 
 
 async def get_current_active_user(
-    current_user: User = Security(get_current_user, scopes=["me"])
+    current_user: User = Security(get_current_user, scopes=["me"]),
 ):
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
@@ -145,7 +145,7 @@ async def get_current_active_user(
 
 @app.post("/token")
 async def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends()
+    form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Token:
     user = authenticate_user(fake_users_db, form_data.username, form_data.password)
     if not user:
@@ -165,7 +165,7 @@ async def read_users_me(current_user: User = Depends(get_current_active_user)):
 
 @app.get("/users/me/items/")
 async def read_own_items(
-    current_user: User = Security(get_current_active_user, scopes=["items"])
+    current_user: User = Security(get_current_active_user, scopes=["items"]),
 ):
     return [{"item_id": "Foo", "owner": current_user.username}]
 

--- a/docs_src/security/tutorial007_an.py
+++ b/docs_src/security/tutorial007_an.py
@@ -10,7 +10,7 @@ security = HTTPBasic()
 
 
 def get_current_username(
-    credentials: Annotated[HTTPBasicCredentials, Depends(security)]
+    credentials: Annotated[HTTPBasicCredentials, Depends(security)],
 ):
     current_username_bytes = credentials.username.encode("utf8")
     correct_username_bytes = b"stanleyjobson"

--- a/docs_src/security/tutorial007_an_py39.py
+++ b/docs_src/security/tutorial007_an_py39.py
@@ -10,7 +10,7 @@ security = HTTPBasic()
 
 
 def get_current_username(
-    credentials: Annotated[HTTPBasicCredentials, Depends(security)]
+    credentials: Annotated[HTTPBasicCredentials, Depends(security)],
 ):
     current_username_bytes = credentials.username.encode("utf8")
     correct_username_bytes = b"stanleyjobson"

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -743,7 +743,7 @@ async def request_body_to_args(
                 results: List[Union[bytes, str]] = []
 
                 async def process_fn(
-                    fn: Callable[[], Coroutine[Any, Any, Any]]
+                    fn: Callable[[], Coroutine[Any, Any, Any]],
                 ) -> None:
                     result = await fn()
                     results.append(result)  # noqa: B023

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -86,7 +86,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
 
 
 def generate_encoders_by_class_tuples(
-    type_encoder_map: Dict[Any, Callable[[Any], Any]]
+    type_encoder_map: Dict[Any, Callable[[Any], Any]],
 ) -> Dict[Callable[[Any], Any], Tuple[Any, ...]]:
     encoders_by_class_tuples: Dict[Callable[[Any], Any], Tuple[Any, ...]] = defaultdict(
         tuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ omit = [
     "docs_src/response_model/tutorial003_04_py310.py",
 ]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -155,7 +155,7 @@ ignore = [
     "W191",  # indentation contains tabs
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "docs_src/dependencies/tutorial007.py" = ["F821"]
 "docs_src/dependencies/tutorial008.py" = ["F821"]
@@ -188,9 +188,9 @@ ignore = [
 "docs_src/dependencies/tutorial008b_an_py39.py" = ["B904"]
 
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-third-party = ["fastapi", "pydantic", "starlette"]
 
-[tool.ruff.pyupgrade]
+[tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@ pydantic-settings >=2.0.0
 pytest >=7.1.3,<8.0.0
 coverage[toml] >= 6.5.0,< 8.0
 mypy ==1.4.1
-ruff ==0.1.2
+ruff ==0.2.0
 email_validator >=1.1.1,<3.0.0
 dirty-equals ==0.6.0
 # TODO: once removing databases from tutorial, upgrade SQLAlchemy

--- a/tests/test_param_include_in_schema.py
+++ b/tests/test_param_include_in_schema.py
@@ -9,14 +9,14 @@ app = FastAPI()
 
 @app.get("/hidden_cookie")
 async def hidden_cookie(
-    hidden_cookie: Optional[str] = Cookie(default=None, include_in_schema=False)
+    hidden_cookie: Optional[str] = Cookie(default=None, include_in_schema=False),
 ):
     return {"hidden_cookie": hidden_cookie}
 
 
 @app.get("/hidden_header")
 async def hidden_header(
-    hidden_header: Optional[str] = Header(default=None, include_in_schema=False)
+    hidden_header: Optional[str] = Header(default=None, include_in_schema=False),
 ):
     return {"hidden_header": hidden_header}
 
@@ -28,7 +28,7 @@ async def hidden_path(hidden_path: str = Path(include_in_schema=False)):
 
 @app.get("/hidden_query")
 async def hidden_query(
-    hidden_query: Optional[str] = Query(default=None, include_in_schema=False)
+    hidden_query: Optional[str] = Query(default=None, include_in_schema=False),
 ):
     return {"hidden_query": hidden_query}
 

--- a/tests/test_regex_deprecated_body.py
+++ b/tests/test_regex_deprecated_body.py
@@ -14,7 +14,7 @@ def get_client():
 
         @app.post("/items/")
         async def read_items(
-            q: Annotated[str | None, Form(regex="^fixedquery$")] = None
+            q: Annotated[str | None, Form(regex="^fixedquery$")] = None,
         ):
             if q:
                 return f"Hello {q}"

--- a/tests/test_regex_deprecated_params.py
+++ b/tests/test_regex_deprecated_params.py
@@ -14,7 +14,7 @@ def get_client():
 
         @app.get("/items/")
         async def read_items(
-            q: Annotated[str | None, Query(regex="^fixedquery$")] = None
+            q: Annotated[str | None, Query(regex="^fixedquery$")] = None,
         ):
             if q:
                 return f"Hello {q}"


### PR DESCRIPTION
In Ruff v0.2.0 (upcoming), we start to warn about adding these settings under `[tool.ruff]` instead of `[tool.ruff.lint]`. This PR just adjusts FastAPI's configuration to fix those warnings. (This works today, with the version of FastAPI uses now, and will also work with v0.2.0.)