### PR TITLE
✏️ Fix minor typo in `fastapi/applications.py`

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -297,7 +297,7 @@ class FastAPI(Starlette):
                 browser tabs open). Or if you want to leave fixed the possible URLs.
 
                 If the servers `list` is not provided, or is an empty `list`, the
-                default value would be a a `dict` with a `url` value of `/`.
+                default value would be a `dict` with a `url` value of `/`.
 
                 Each item in the `list` is a `dict` containing:
 


### PR DESCRIPTION
Fixes a minor typo duplicating an `a`.
