### PR TITLE
🔧 Expose examples at swagger

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -126,7 +126,10 @@ def get_openapi_operation_parameters(
                     parameter["examples"] = jsonable_encoder(field_info.examples)
                 else:
                     parameter["examples"] = jsonable_encoder(
-                        [{"value": item, "summary": item} for item in field_info.examples]
+                        [
+                            {"value": item, "summary": item}
+                            for item in field_info.examples
+                        ]
                     )
         if field_info.example != Undefined:
             parameter["example"] = jsonable_encoder(field_info.example)

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -120,7 +120,15 @@ def get_openapi_operation_parameters(
             parameter["description"] = field_info.description
         if field_info.openapi_examples:
             parameter["examples"] = jsonable_encoder(field_info.openapi_examples)
-        elif field_info.example != Undefined:
+        elif field_info.examples:
+            if isinstance(field_info.examples, list) and len(field_info.examples) > 0:
+                if isinstance(field_info.examples[0], dict):
+                    parameter["examples"] = jsonable_encoder(field_info.examples)
+                else:
+                    parameter["examples"] = jsonable_encoder(
+                        [{"value": item, "summary": item} for item in field_info.examples]
+                    )
+        if field_info.example != Undefined:
             parameter["example"] = jsonable_encoder(field_info.example)
         if field_info.deprecated:
             parameter["deprecated"] = field_info.deprecated

--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -479,9 +479,13 @@ def test_openapi_schema():
                                 "title": "Item Id",
                                 "type": "string",
                                 "examples": ["item_1", "item_2"],
-                            },
+                            },                            
                             "name": "item_id",
-                            "in": "path",
+                            "in": "path",                            
+                            "examples": [
+                                {"value": "item_1", "summary": "item_1"},
+                                {"value": "item_2", "summary": "item_2"},
+                            ],                            
                         }
                     ],
                     "responses": {
@@ -507,7 +511,7 @@ def test_openapi_schema():
                     "summary": "Path Example Examples",
                     "operationId": "path_example_examples_path_example_examples__item_id__get",
                     "parameters": [
-                        {
+                        {                        
                             "required": True,
                             "schema": {
                                 "title": "Item Id",
@@ -516,7 +520,11 @@ def test_openapi_schema():
                             },
                             "example": "item_overridden",
                             "name": "item_id",
-                            "in": "path",
+                            "in": "path",                                
+                            "examples": [
+                                {"value": "item_1", "summary": "item_1"},
+                                {"value": "item_2", "summary": "item_2"},
+                            ],                            
                         }
                     ],
                     "responses": {
@@ -601,6 +609,10 @@ def test_openapi_schema():
                             ),
                             "name": "data",
                             "in": "query",
+                            "examples": [
+                                {"value": "query1", "summary": "query1"},
+                                {"value": "query2", "summary": "query2"},
+                            ],                            
                         }
                     ],
                     "responses": {
@@ -646,6 +658,10 @@ def test_openapi_schema():
                             "example": "query_overridden",
                             "name": "data",
                             "in": "query",
+                            "examples": [
+                                {"value": "query1", "summary": "query1"},
+                                {"value": "query2", "summary": "query2"},
+                            ],                            
                         }
                     ],
                     "responses": {
@@ -730,6 +746,10 @@ def test_openapi_schema():
                             ),
                             "name": "data",
                             "in": "header",
+                            "examples": [
+                                {"value": "header1", "summary": "header1"},
+                                {"value": "header2", "summary": "header2"},
+                            ],                            
                         }
                     ],
                     "responses": {
@@ -775,6 +795,10 @@ def test_openapi_schema():
                             "example": "header_overridden",
                             "name": "data",
                             "in": "header",
+                            "examples": [
+                                {"value": "header1", "summary": "header1"},
+                                {"value": "header2", "summary": "header2"},
+                            ],                            
                         }
                     ],
                     "responses": {
@@ -859,6 +883,10 @@ def test_openapi_schema():
                             ),
                             "name": "data",
                             "in": "cookie",
+                            "examples": [
+                                {"value": "cookie1", "summary": "cookie1"},
+                                {"value": "cookie2", "summary": "cookie2"},
+                            ],                            
                         }
                     ],
                     "responses": {
@@ -904,6 +932,10 @@ def test_openapi_schema():
                             "example": "cookie_overridden",
                             "name": "data",
                             "in": "cookie",
+                            "examples": [
+                                {"value": "cookie1", "summary": "cookie1"},
+                                {"value": "cookie2", "summary": "cookie2"},
+                            ],                            
                         }
                     ],
                     "responses": {

--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -479,13 +479,13 @@ def test_openapi_schema():
                                 "title": "Item Id",
                                 "type": "string",
                                 "examples": ["item_1", "item_2"],
-                            },                            
+                            },
                             "name": "item_id",
-                            "in": "path",                            
+                            "in": "path",
                             "examples": [
                                 {"value": "item_1", "summary": "item_1"},
                                 {"value": "item_2", "summary": "item_2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {
@@ -511,7 +511,7 @@ def test_openapi_schema():
                     "summary": "Path Example Examples",
                     "operationId": "path_example_examples_path_example_examples__item_id__get",
                     "parameters": [
-                        {                        
+                        {
                             "required": True,
                             "schema": {
                                 "title": "Item Id",
@@ -520,11 +520,11 @@ def test_openapi_schema():
                             },
                             "example": "item_overridden",
                             "name": "item_id",
-                            "in": "path",                                
+                            "in": "path",
                             "examples": [
                                 {"value": "item_1", "summary": "item_1"},
                                 {"value": "item_2", "summary": "item_2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {
@@ -612,7 +612,7 @@ def test_openapi_schema():
                             "examples": [
                                 {"value": "query1", "summary": "query1"},
                                 {"value": "query2", "summary": "query2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {
@@ -661,7 +661,7 @@ def test_openapi_schema():
                             "examples": [
                                 {"value": "query1", "summary": "query1"},
                                 {"value": "query2", "summary": "query2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {
@@ -749,7 +749,7 @@ def test_openapi_schema():
                             "examples": [
                                 {"value": "header1", "summary": "header1"},
                                 {"value": "header2", "summary": "header2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {
@@ -798,7 +798,7 @@ def test_openapi_schema():
                             "examples": [
                                 {"value": "header1", "summary": "header1"},
                                 {"value": "header2", "summary": "header2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {
@@ -886,7 +886,7 @@ def test_openapi_schema():
                             "examples": [
                                 {"value": "cookie1", "summary": "cookie1"},
                                 {"value": "cookie2", "summary": "cookie2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {
@@ -935,7 +935,7 @@ def test_openapi_schema():
                             "examples": [
                                 {"value": "cookie1", "summary": "cookie1"},
                                 {"value": "cookie2", "summary": "cookie2"},
-                            ],                            
+                            ],
                         }
                     ],
                     "responses": {


### PR DESCRIPTION
Expose `examples` attributes at swagger docs.

If I use example at param, it warns `'example' has been deprecated, please use 'examples' instead`.
But `Query param's examples attributes` are couldn't see at swagger docs.

This PR exposes `Query param's examples attributes` at swagger docs.