### PR TITLE
🐛 Fix unhandled growing memory for internal server errors, refactor dependencies with `yield` and `except` to require raising again as in regular Python

### DIFF
--- a/docs_src/dependencies/tutorial008c.py
+++ b/docs_src/dependencies/tutorial008c.py
@@ -1,0 +1,27 @@
+from fastapi import Depends, FastAPI, HTTPException
+
+app = FastAPI()
+
+
+class InternalError(Exception):
+    pass
+
+
+def get_username():
+    try:
+        yield "Rick"
+    except InternalError:
+        print("Oops, we didn't raise again, Britney 😱")
+
+
+@app.get("/items/{item_id}")
+def get_item(item_id: str, username: str = Depends(get_username)):
+    if item_id == "portal-gun":
+        raise InternalError(
+            f"The portal gun is too dangerous to be owned by {username}"
+        )
+    if item_id != "plumbus":
+        raise HTTPException(
+            status_code=404, detail="Item not found, there's only a plumbus here"
+        )
+    return item_id

--- a/docs_src/dependencies/tutorial008c_an.py
+++ b/docs_src/dependencies/tutorial008c_an.py
@@ -1,0 +1,28 @@
+from fastapi import Depends, FastAPI, HTTPException
+from typing_extensions import Annotated
+
+app = FastAPI()
+
+
+class InternalError(Exception):
+    pass
+
+
+def get_username():
+    try:
+        yield "Rick"
+    except InternalError:
+        print("Oops, we didn't raise again, Britney 😱")
+
+
+@app.get("/items/{item_id}")
+def get_item(item_id: str, username: Annotated[str, Depends(get_username)]):
+    if item_id == "portal-gun":
+        raise InternalError(
+            f"The portal gun is too dangerous to be owned by {username}"
+        )
+    if item_id != "plumbus":
+        raise HTTPException(
+            status_code=404, detail="Item not found, there's only a plumbus here"
+        )
+    return item_id

--- a/docs_src/dependencies/tutorial008c_an_py39.py
+++ b/docs_src/dependencies/tutorial008c_an_py39.py
@@ -1,0 +1,29 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, HTTPException
+
+app = FastAPI()
+
+
+class InternalError(Exception):
+    pass
+
+
+def get_username():
+    try:
+        yield "Rick"
+    except InternalError:
+        print("Oops, we didn't raise again, Britney 😱")
+
+
+@app.get("/items/{item_id}")
+def get_item(item_id: str, username: Annotated[str, Depends(get_username)]):
+    if item_id == "portal-gun":
+        raise InternalError(
+            f"The portal gun is too dangerous to be owned by {username}"
+        )
+    if item_id != "plumbus":
+        raise HTTPException(
+            status_code=404, detail="Item not found, there's only a plumbus here"
+        )
+    return item_id

--- a/docs_src/dependencies/tutorial008d.py
+++ b/docs_src/dependencies/tutorial008d.py
@@ -1,0 +1,28 @@
+from fastapi import Depends, FastAPI, HTTPException
+
+app = FastAPI()
+
+
+class InternalError(Exception):
+    pass
+
+
+def get_username():
+    try:
+        yield "Rick"
+    except InternalError:
+        print("We don't swallow the internal error here, we raise again 😎")
+        raise
+
+
+@app.get("/items/{item_id}")
+def get_item(item_id: str, username: str = Depends(get_username)):
+    if item_id == "portal-gun":
+        raise InternalError(
+            f"The portal gun is too dangerous to be owned by {username}"
+        )
+    if item_id != "plumbus":
+        raise HTTPException(
+            status_code=404, detail="Item not found, there's only a plumbus here"
+        )
+    return item_id

--- a/docs_src/dependencies/tutorial008d_an.py
+++ b/docs_src/dependencies/tutorial008d_an.py
@@ -1,0 +1,29 @@
+from fastapi import Depends, FastAPI, HTTPException
+from typing_extensions import Annotated
+
+app = FastAPI()
+
+
+class InternalError(Exception):
+    pass
+
+
+def get_username():
+    try:
+        yield "Rick"
+    except InternalError:
+        print("We don't swallow the internal error here, we raise again 😎")
+        raise
+
+
+@app.get("/items/{item_id}")
+def get_item(item_id: str, username: Annotated[str, Depends(get_username)]):
+    if item_id == "portal-gun":
+        raise InternalError(
+            f"The portal gun is too dangerous to be owned by {username}"
+        )
+    if item_id != "plumbus":
+        raise HTTPException(
+            status_code=404, detail="Item not found, there's only a plumbus here"
+        )
+    return item_id

--- a/docs_src/dependencies/tutorial008d_an_py39.py
+++ b/docs_src/dependencies/tutorial008d_an_py39.py
@@ -1,0 +1,30 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, HTTPException
+
+app = FastAPI()
+
+
+class InternalError(Exception):
+    pass
+
+
+def get_username():
+    try:
+        yield "Rick"
+    except InternalError:
+        print("We don't swallow the internal error here, we raise again 😎")
+        raise
+
+
+@app.get("/items/{item_id}")
+def get_item(item_id: str, username: Annotated[str, Depends(get_username)]):
+    if item_id == "portal-gun":
+        raise InternalError(
+            f"The portal gun is too dangerous to be owned by {username}"
+        )
+    if item_id != "plumbus":
+        raise HTTPException(
+            status_code=404, detail="Item not found, there's only a plumbus here"
+        )
+    return item_id

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -216,19 +216,14 @@ def get_request_handler(
         actual_response_class = response_class
 
     async def app(request: Request) -> Response:
-        exception_to_reraise: Optional[Exception] = None
         response: Union[Response, None] = None
-        async with AsyncExitStack() as async_exit_stack:
-            # TODO: remove this scope later, after a few releases
-            # This scope fastapi_astack is no longer used by FastAPI, kept for
-            # compatibility, just in case
-            request.scope["fastapi_astack"] = async_exit_stack
+        async with AsyncExitStack() as file_stack:
             try:
                 body: Any = None
                 if body_field:
                     if is_body_form:
                         body = await request.form()
-                        async_exit_stack.push_async_callback(body.close)
+                        file_stack.push_async_callback(body.close)
                     else:
                         body_bytes = await request.body()
                         if body_bytes:
@@ -260,18 +255,17 @@ def get_request_handler(
                     ],
                     body=e.doc,
                 )
-                exception_to_reraise = validation_error
                 raise validation_error from e
-            except HTTPException as e:
-                exception_to_reraise = e
+            except HTTPException:
+                # If a middleware raises an HTTPException, it should be raised again
                 raise
             except Exception as e:
                 http_error = HTTPException(
                     status_code=400, detail="There was an error parsing the body"
                 )
-                exception_to_reraise = http_error
                 raise http_error from e
-            try:
+            errors: List[Any] = []
+            async with AsyncExitStack() as async_exit_stack:
                 solved_result = await solve_dependencies(
                     request=request,
                     dependant=dependant,
@@ -280,59 +274,53 @@ def get_request_handler(
                     async_exit_stack=async_exit_stack,
                 )
                 values, errors, background_tasks, sub_response, _ = solved_result
-            except Exception as e:
-                exception_to_reraise = e
-                raise e
+                if not errors:
+                    raw_response = await run_endpoint_function(
+                        dependant=dependant, values=values, is_coroutine=is_coroutine
+                    )
+                    if isinstance(raw_response, Response):
+                        if raw_response.background is None:
+                            raw_response.background = background_tasks
+                        response = raw_response
+                    else:
+                        response_args: Dict[str, Any] = {"background": background_tasks}
+                        # If status_code was set, use it, otherwise use the default from the
+                        # response class, in the case of redirect it's 307
+                        current_status_code = (
+                            status_code if status_code else sub_response.status_code
+                        )
+                        if current_status_code is not None:
+                            response_args["status_code"] = current_status_code
+                        if sub_response.status_code:
+                            response_args["status_code"] = sub_response.status_code
+                        content = await serialize_response(
+                            field=response_field,
+                            response_content=raw_response,
+                            include=response_model_include,
+                            exclude=response_model_exclude,
+                            by_alias=response_model_by_alias,
+                            exclude_unset=response_model_exclude_unset,
+                            exclude_defaults=response_model_exclude_defaults,
+                            exclude_none=response_model_exclude_none,
+                            is_coroutine=is_coroutine,
+                        )
+                        response = actual_response_class(content, **response_args)
+                        if not is_body_allowed_for_status_code(response.status_code):
+                            response.body = b""
+                        response.headers.raw.extend(sub_response.headers.raw)
             if errors:
                 validation_error = RequestValidationError(
                     _normalize_errors(errors), body=body
                 )
-                exception_to_reraise = validation_error
                 raise validation_error
-            else:
-                try:
-                    raw_response = await run_endpoint_function(
-                        dependant=dependant, values=values, is_coroutine=is_coroutine
-                    )
-                except Exception as e:
-                    exception_to_reraise = e
-                    raise e
-                if isinstance(raw_response, Response):
-                    if raw_response.background is None:
-                        raw_response.background = background_tasks
-                    response = raw_response
-                else:
-                    response_args: Dict[str, Any] = {"background": background_tasks}
-                    # If status_code was set, use it, otherwise use the default from the
-                    # response class, in the case of redirect it's 307
-                    current_status_code = (
-                        status_code if status_code else sub_response.status_code
-                    )
-                    if current_status_code is not None:
-                        response_args["status_code"] = current_status_code
-                    if sub_response.status_code:
-                        response_args["status_code"] = sub_response.status_code
-                    content = await serialize_response(
-                        field=response_field,
-                        response_content=raw_response,
-                        include=response_model_include,
-                        exclude=response_model_exclude,
-                        by_alias=response_model_by_alias,
-                        exclude_unset=response_model_exclude_unset,
-                        exclude_defaults=response_model_exclude_defaults,
-                        exclude_none=response_model_exclude_none,
-                        is_coroutine=is_coroutine,
-                    )
-                    response = actual_response_class(content, **response_args)
-                    if not is_body_allowed_for_status_code(response.status_code):
-                        response.body = b""
-                    response.headers.raw.extend(sub_response.headers.raw)
-        # This exception was possibly handled by the dependency but it should
-        # still bubble up so that the ServerErrorMiddleware can return a 500
-        # or the ExceptionMiddleware can catch and handle any other exceptions
-        if exception_to_reraise:
-            raise exception_to_reraise
-        assert response is not None, "An error occurred while generating the request"
+        if response is None:
+            raise FastAPIError(
+                "No response object was returned. There's a high chance that the "
+                "application code is raising an exception and a dependency with yield "
+                "has a block with a bare except, or a block with except Exception, "
+                "and is not raising the exception again. Read more about it in the "
+                "docs: https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/#dependencies-with-yield-and-except"
+            )
         return response
 
     return app

--- a/tests/test_dependency_contextmanager.py
+++ b/tests/test_dependency_contextmanager.py
@@ -55,6 +55,7 @@ async def asyncgen_state_try(state: Dict[str, str] = Depends(get_state)):
         yield state["/async_raise"]
     except AsyncDependencyError:
         errors.append("/async_raise")
+        raise
     finally:
         state["/async_raise"] = "asyncgen raise finalized"
 
@@ -65,6 +66,7 @@ def generator_state_try(state: Dict[str, str] = Depends(get_state)):
         yield state["/sync_raise"]
     except SyncDependencyError:
         errors.append("/sync_raise")
+        raise
     finally:
         state["/sync_raise"] = "generator raise finalized"
 

--- a/tests/test_dependency_normal_exceptions.py
+++ b/tests/test_dependency_normal_exceptions.py
@@ -20,6 +20,7 @@ async def get_database():
         fake_database.update(temp_database)
     except HTTPException:
         state["except"] = True
+        raise
     finally:
         state["finally"] = True
 

--- a/tests/test_tutorial/test_dependencies/test_tutorial008b_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008b_an_py39.py
@@ -1,23 +1,33 @@
+import pytest
 from fastapi.testclient import TestClient
 
-from docs_src.dependencies.tutorial008b_an import app
-
-client = TestClient(app)
+from ...utils import needs_py39
 
 
-def test_get_no_item():
+@pytest.fixture(name="client")
+def get_client():
+    from docs_src.dependencies.tutorial008b_an_py39 import app
+
+    client = TestClient(app)
+    return client
+
+
+@needs_py39
+def test_get_no_item(client: TestClient):
     response = client.get("/items/foo")
     assert response.status_code == 404, response.text
     assert response.json() == {"detail": "Item not found"}
 
 
-def test_owner_error():
+@needs_py39
+def test_owner_error(client: TestClient):
     response = client.get("/items/plumbus")
     assert response.status_code == 400, response.text
     assert response.json() == {"detail": "Owner error: Rick"}
 
 
-def test_get_item():
+@needs_py39
+def test_get_item(client: TestClient):
     response = client.get("/items/portal-gun")
     assert response.status_code == 200, response.text
     assert response.json() == {"description": "Gun to create portals", "owner": "Rick"}

--- a/tests/test_tutorial/test_dependencies/test_tutorial008c.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008c.py
@@ -1,0 +1,38 @@
+import pytest
+from fastapi.exceptions import FastAPIError
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(name="client")
+def get_client():
+    from docs_src.dependencies.tutorial008c import app
+
+    client = TestClient(app)
+    return client
+
+
+def test_get_no_item(client: TestClient):
+    response = client.get("/items/foo")
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
+
+def test_get(client: TestClient):
+    response = client.get("/items/plumbus")
+    assert response.status_code == 200, response.text
+    assert response.json() == "plumbus"
+
+
+def test_fastapi_error(client: TestClient):
+    with pytest.raises(FastAPIError) as exc_info:
+        client.get("/items/portal-gun")
+    assert "No response object was returned" in exc_info.value.args[0]
+
+
+def test_internal_server_error():
+    from docs_src.dependencies.tutorial008c import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/items/portal-gun")
+    assert response.status_code == 500, response.text
+    assert response.text == "Internal Server Error"

--- a/tests/test_tutorial/test_dependencies/test_tutorial008c_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008c_an.py
@@ -1,0 +1,38 @@
+import pytest
+from fastapi.exceptions import FastAPIError
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(name="client")
+def get_client():
+    from docs_src.dependencies.tutorial008c_an import app
+
+    client = TestClient(app)
+    return client
+
+
+def test_get_no_item(client: TestClient):
+    response = client.get("/items/foo")
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
+
+def test_get(client: TestClient):
+    response = client.get("/items/plumbus")
+    assert response.status_code == 200, response.text
+    assert response.json() == "plumbus"
+
+
+def test_fastapi_error(client: TestClient):
+    with pytest.raises(FastAPIError) as exc_info:
+        client.get("/items/portal-gun")
+    assert "No response object was returned" in exc_info.value.args[0]
+
+
+def test_internal_server_error():
+    from docs_src.dependencies.tutorial008c_an import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/items/portal-gun")
+    assert response.status_code == 500, response.text
+    assert response.text == "Internal Server Error"

--- a/tests/test_tutorial/test_dependencies/test_tutorial008c_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008c_an_py39.py
@@ -12,11 +12,13 @@ def get_client():
     client = TestClient(app)
     return client
 
+
 @needs_py39
 def test_get_no_item(client: TestClient):
     response = client.get("/items/foo")
     assert response.status_code == 404, response.text
     assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
 
 @needs_py39
 def test_get(client: TestClient):
@@ -24,15 +26,18 @@ def test_get(client: TestClient):
     assert response.status_code == 200, response.text
     assert response.json() == "plumbus"
 
+
 @needs_py39
 def test_fastapi_error(client: TestClient):
     with pytest.raises(FastAPIError) as exc_info:
         client.get("/items/portal-gun")
     assert "No response object was returned" in exc_info.value.args[0]
 
+
 @needs_py39
 def test_internal_server_error():
     from docs_src.dependencies.tutorial008c_an_py39 import app
+
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/items/portal-gun")
     assert response.status_code == 500, response.text

--- a/tests/test_tutorial/test_dependencies/test_tutorial008c_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008c_an_py39.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi.exceptions import FastAPIError
+from fastapi.testclient import TestClient
+
+from ...utils import needs_py39
+
+
+@pytest.fixture(name="client")
+def get_client():
+    from docs_src.dependencies.tutorial008c_an_py39 import app
+
+    client = TestClient(app)
+    return client
+
+@needs_py39
+def test_get_no_item(client: TestClient):
+    response = client.get("/items/foo")
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
+@needs_py39
+def test_get(client: TestClient):
+    response = client.get("/items/plumbus")
+    assert response.status_code == 200, response.text
+    assert response.json() == "plumbus"
+
+@needs_py39
+def test_fastapi_error(client: TestClient):
+    with pytest.raises(FastAPIError) as exc_info:
+        client.get("/items/portal-gun")
+    assert "No response object was returned" in exc_info.value.args[0]
+
+@needs_py39
+def test_internal_server_error():
+    from docs_src.dependencies.tutorial008c_an_py39 import app
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/items/portal-gun")
+    assert response.status_code == 500, response.text
+    assert response.text == "Internal Server Error"

--- a/tests/test_tutorial/test_dependencies/test_tutorial008d.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008d.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(name="client")
+def get_client():
+    from docs_src.dependencies.tutorial008d import app
+
+    client = TestClient(app)
+    return client
+
+
+def test_get_no_item(client: TestClient):
+    response = client.get("/items/foo")
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
+
+def test_get(client: TestClient):
+    response = client.get("/items/plumbus")
+    assert response.status_code == 200, response.text
+    assert response.json() == "plumbus"
+
+
+def test_internal_error(client: TestClient):
+    from docs_src.dependencies.tutorial008d import InternalError
+
+    with pytest.raises(InternalError) as exc_info:
+        client.get("/items/portal-gun")
+    assert (
+        exc_info.value.args[0] == "The portal gun is too dangerous to be owned by Rick"
+    )
+
+
+def test_internal_server_error():
+    from docs_src.dependencies.tutorial008d import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/items/portal-gun")
+    assert response.status_code == 500, response.text
+    assert response.text == "Internal Server Error"

--- a/tests/test_tutorial/test_dependencies/test_tutorial008d_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008d_an.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(name="client")
+def get_client():
+    from docs_src.dependencies.tutorial008d_an import app
+
+    client = TestClient(app)
+    return client
+
+
+def test_get_no_item(client: TestClient):
+    response = client.get("/items/foo")
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
+
+def test_get(client: TestClient):
+    response = client.get("/items/plumbus")
+    assert response.status_code == 200, response.text
+    assert response.json() == "plumbus"
+
+
+def test_internal_error(client: TestClient):
+    from docs_src.dependencies.tutorial008d_an import InternalError
+
+    with pytest.raises(InternalError) as exc_info:
+        client.get("/items/portal-gun")
+    assert (
+        exc_info.value.args[0] == "The portal gun is too dangerous to be owned by Rick"
+    )
+
+
+def test_internal_server_error():
+    from docs_src.dependencies.tutorial008d_an import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/items/portal-gun")
+    assert response.status_code == 500, response.text
+    assert response.text == "Internal Server Error"

--- a/tests/test_tutorial/test_dependencies/test_tutorial008d_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008d_an_py39.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from ...utils import needs_py39
+
+
+@pytest.fixture(name="client")
+def get_client():
+    from docs_src.dependencies.tutorial008d_an_py39 import app
+
+    client = TestClient(app)
+    return client
+
+@needs_py39
+def test_get_no_item(client: TestClient):
+    response = client.get("/items/foo")
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
+@needs_py39
+def test_get(client: TestClient):
+    response = client.get("/items/plumbus")
+    assert response.status_code == 200, response.text
+    assert response.json() == "plumbus"
+
+@needs_py39
+def test_internal_error(client: TestClient):
+    from docs_src.dependencies.tutorial008d_an_py39 import InternalError
+    with pytest.raises(InternalError) as exc_info:
+        client.get("/items/portal-gun")
+    assert exc_info.value.args[0] == "The portal gun is too dangerous to be owned by Rick"
+
+@needs_py39
+def test_internal_server_error():
+    from docs_src.dependencies.tutorial008d_an_py39 import app
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/items/portal-gun")
+    assert response.status_code == 500, response.text
+    assert response.text == "Internal Server Error"

--- a/tests/test_tutorial/test_dependencies/test_tutorial008d_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008d_an_py39.py
@@ -11,11 +11,13 @@ def get_client():
     client = TestClient(app)
     return client
 
+
 @needs_py39
 def test_get_no_item(client: TestClient):
     response = client.get("/items/foo")
     assert response.status_code == 404, response.text
     assert response.json() == {"detail": "Item not found, there's only a plumbus here"}
+
 
 @needs_py39
 def test_get(client: TestClient):
@@ -23,16 +25,22 @@ def test_get(client: TestClient):
     assert response.status_code == 200, response.text
     assert response.json() == "plumbus"
 
+
 @needs_py39
 def test_internal_error(client: TestClient):
     from docs_src.dependencies.tutorial008d_an_py39 import InternalError
+
     with pytest.raises(InternalError) as exc_info:
         client.get("/items/portal-gun")
-    assert exc_info.value.args[0] == "The portal gun is too dangerous to be owned by Rick"
+    assert (
+        exc_info.value.args[0] == "The portal gun is too dangerous to be owned by Rick"
+    )
+
 
 @needs_py39
 def test_internal_server_error():
     from docs_src.dependencies.tutorial008d_an_py39 import app
+
     client = TestClient(app, raise_server_exceptions=False)
     response = client.get("/items/portal-gun")
     assert response.status_code == 500, response.text


### PR DESCRIPTION
🐛 Fix unhandled growing memory for internal server errors, refactor dependencies with `yield` and `except` to require raising again as in regular Python.

This fixes a bug of growing unhandled memory/memory leak reported internally by @rushilsrivastava. :nerd_face: 