### PR TITLE
✨ Allow superimposing an additional response's media type in openapi schema

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -347,7 +347,9 @@ def get_openapi_path(
                         response_schema = {}
 
                 route_responses = {str(k): v for k, v in route.responses.items()}
-                if status_code not in route_responses or not route_responses.get(status_code, {}).get('superimpose'):
+                if status_code not in route_responses or not route_responses.get(
+                    status_code, {}
+                ).get("superimpose"):
                     operation.setdefault("responses", {}).setdefault(
                         status_code, {}
                     ).setdefault("content", {}).setdefault(

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -347,12 +347,14 @@ def get_openapi_path(
                         response_schema = {}
 
                 route_responses = dict((str(k), v) for k, v in route.responses.items())
-                if status_code not in route_responses or not route_responses.get(status_code).get('superimpose'):
+                if status_code not in route_responses or not route_responses.get(
+                    status_code
+                ).get("superimpose"):
                     operation.setdefault("responses", {}).setdefault(
                         status_code, {}
-                    ).setdefault("content", {}).setdefault(route_response_media_type, {})[
-                        "schema"
-                    ] = response_schema
+                    ).setdefault("content", {}).setdefault(
+                        route_response_media_type, {}
+                    )["schema"] = response_schema
 
             if route.responses:
                 operation_responses = operation.setdefault("responses", {})

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -345,11 +345,15 @@ def get_openapi_path(
                         )
                     else:
                         response_schema = {}
-                operation.setdefault("responses", {}).setdefault(
-                    status_code, {}
-                ).setdefault("content", {}).setdefault(route_response_media_type, {})[
-                    "schema"
-                ] = response_schema
+
+                route_responses = dict((str(k), v) for k, v in route.responses.items())
+                if status_code not in route_responses or not route_responses.get(status_code).get('superimpose'):
+                    operation.setdefault("responses", {}).setdefault(
+                        status_code, {}
+                    ).setdefault("content", {}).setdefault(route_response_media_type, {})[
+                        "schema"
+                    ] = response_schema
+
             if route.responses:
                 operation_responses = operation.setdefault("responses", {})
                 for (
@@ -358,6 +362,7 @@ def get_openapi_path(
                 ) in route.responses.items():
                     process_response = additional_response.copy()
                     process_response.pop("model", None)
+                    process_response.pop("superimpose", None)
                     status_code_key = str(additional_status_code).upper()
                     if status_code_key == "DEFAULT":
                         status_code_key = "default"

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -346,10 +346,8 @@ def get_openapi_path(
                     else:
                         response_schema = {}
 
-                route_responses = dict((str(k), v) for k, v in route.responses.items())
-                if status_code not in route_responses or not route_responses.get(
-                    status_code
-                ).get("superimpose"):
+                route_responses = {str(k): v for k, v in route.responses.items()}
+                if status_code not in route_responses or not route_responses.get(status_code, {}).get('superimpose'):
                     operation.setdefault("responses", {}).setdefault(
                         status_code, {}
                     ).setdefault("content", {}).setdefault(

--- a/tests/test_additional_responses_default_media_type.py
+++ b/tests/test_additional_responses_default_media_type.py
@@ -1,6 +1,6 @@
 """
-    This test is about the possibility of superimposing an additional response's media_type
-    over the default route's response class's media_type.
+This test is about the possibility of superimposing an additional response's media_type
+over the default route's response class's media_type.
 """
 
 from fastapi import FastAPI

--- a/tests/test_additional_responses_default_media_type.py
+++ b/tests/test_additional_responses_default_media_type.py
@@ -3,11 +3,10 @@
     over the default route's response class's media_type.
 """
 
-from pydantic import BaseModel
-from starlette.status import HTTP_200_OK, HTTP_500_INTERNAL_SERVER_ERROR
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from starlette.status import HTTP_200_OK, HTTP_500_INTERNAL_SERVER_ERROR
 
 app = FastAPI()
 client = TestClient(app)
@@ -22,7 +21,7 @@ class Error(BaseModel):
     "/a",
     responses={
         HTTP_200_OK: {"superimpose": True, "content": {"text/event-stream": {}}},
-        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}
+        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error},
     },
 )
 def a():
@@ -33,14 +32,19 @@ def a():
     "/b",
     responses={
         str(HTTP_200_OK): {"content": {"text/event-stream": {}}},
-        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}
-    }
+        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error},
+    },
 )
 def b():
     pass  # pragma: no cover
 
 
-@app.get("/c", responses={HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}})
+@app.get(
+    "/c",
+    responses={
+        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}
+    },
+)
 def c():
     pass  # pragma: no cover
 
@@ -56,10 +60,7 @@ def test_openapi_schema():
     assert response.status_code == 200, response.text
     assert response.json() == {
         "openapi": "3.1.0",
-        "info": {
-            "title": "FastAPI",
-            "version": "0.1.0"
-        },
+        "info": {"title": "FastAPI", "version": "0.1.0"},
         "paths": {
             "/a": {
                 "get": {
@@ -68,23 +69,17 @@ def test_openapi_schema():
                     "responses": {
                         "200": {
                             "description": "Successful Response",
-                            "content": {
-                                "text/event-stream": {
-
-                                }
-                            }
+                            "content": {"text/event-stream": {}},
                         },
                         "500": {
                             "description": "Error",
                             "content": {
                                 "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/Error"
-                                    }
+                                    "schema": {"$ref": "#/components/schemas/Error"}
                                 }
-                            }
-                        }
-                    }
+                            },
+                        },
+                    },
                 }
             },
             "/b": {
@@ -95,27 +90,19 @@ def test_openapi_schema():
                         "200": {
                             "description": "Successful Response",
                             "content": {
-                                "application/json": {
-                                    "schema": {
-
-                                    }
-                                },
-                                "text/event-stream": {
-
-                                }
-                            }
+                                "application/json": {"schema": {}},
+                                "text/event-stream": {},
+                            },
                         },
                         "500": {
                             "description": "Error",
                             "content": {
                                 "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/Error"
-                                    }
+                                    "schema": {"$ref": "#/components/schemas/Error"}
                                 }
-                            }
-                        }
-                    }
+                            },
+                        },
+                    },
                 }
             },
             "/c": {
@@ -125,25 +112,17 @@ def test_openapi_schema():
                     "responses": {
                         "200": {
                             "description": "Successful Response",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-
-                                    }
-                                }
-                            }
+                            "content": {"application/json": {"schema": {}}},
                         },
                         "500": {
                             "description": "Error",
                             "content": {
                                 "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/Error"
-                                    }
+                                    "schema": {"$ref": "#/components/schemas/Error"}
                                 }
-                            }
-                        }
-                    }
+                            },
+                        },
+                    },
                 }
             },
             "/d": {
@@ -153,38 +132,23 @@ def test_openapi_schema():
                     "responses": {
                         "200": {
                             "description": "Successful Response",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-
-                                    }
-                                }
-                            }
+                            "content": {"application/json": {"schema": {}}},
                         }
-                    }
+                    },
                 }
-            }
+            },
         },
         "components": {
             "schemas": {
                 "Error": {
                     "properties": {
-                        "status": {
-                            "type": "string",
-                            "title": "Status"
-                        },
-                        "title": {
-                            "type": "string",
-                            "title": "Title"
-                        }
+                        "status": {"type": "string", "title": "Status"},
+                        "title": {"type": "string", "title": "Title"},
                     },
                     "type": "object",
-                    "required": [
-                        "status",
-                        "title"
-                    ],
-                    "title": "Error"
+                    "required": ["status", "title"],
+                    "title": "Error",
                 }
             }
-        }
+        },
     }

--- a/tests/test_additional_responses_default_media_type.py
+++ b/tests/test_additional_responses_default_media_type.py
@@ -1,0 +1,190 @@
+"""
+    This test is about the possibility of superimposing an additional response's media_type
+    over the default route's response class's media_type.
+"""
+
+from pydantic import BaseModel
+from starlette.status import HTTP_200_OK, HTTP_500_INTERNAL_SERVER_ERROR
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+client = TestClient(app)
+
+
+class Error(BaseModel):
+    status: str
+    title: str
+
+
+@app.get(
+    "/a",
+    responses={
+        HTTP_200_OK: {"superimpose": True, "content": {"text/event-stream": {}}},
+        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}
+    },
+)
+def a():
+    pass  # pragma: no cover
+
+
+@app.get(
+    "/b",
+    responses={
+        str(HTTP_200_OK): {"content": {"text/event-stream": {}}},
+        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}
+    }
+)
+def b():
+    pass  # pragma: no cover
+
+
+@app.get("/c", responses={HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}})
+def c():
+    pass  # pragma: no cover
+
+
+@app.get("/d")
+def d():
+    pass  # pragma: no cover
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "FastAPI",
+            "version": "0.1.0"
+        },
+        "paths": {
+            "/a": {
+                "get": {
+                    "summary": "A",
+                    "operationId": "a_a_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "text/event-stream": {
+
+                                }
+                            }
+                        },
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Error"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/b": {
+                "get": {
+                    "summary": "B",
+                    "operationId": "b_b_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+
+                                    }
+                                },
+                                "text/event-stream": {
+
+                                }
+                            }
+                        },
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Error"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/c": {
+                "get": {
+                    "summary": "C",
+                    "operationId": "c_c_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+
+                                    }
+                                }
+                            }
+                        },
+                        "500": {
+                            "description": "Error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/Error"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/d": {
+                "get": {
+                    "summary": "D",
+                    "operationId": "d_d_get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Error": {
+                    "properties": {
+                        "status": {
+                            "type": "string",
+                            "title": "Status"
+                        },
+                        "title": {
+                            "type": "string",
+                            "title": "Title"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "status",
+                        "title"
+                    ],
+                    "title": "Error"
+                }
+            }
+        }
+    }


### PR DESCRIPTION
I've seen the following discussion: https://github.com/tiangolo/fastapi/discussions/11217 ; and I thought that it would be handy to superimpose an additional response's media type over the default route's response class's media type that is displayed in _/docs_.

Example:
```python
@app.get(
    "/a",
    responses={
        HTTP_200_OK: {"superimpose": True, "content": {"text/event-stream": {}}},
        HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Error", "model": Error}
    },
)
def a():
    pass
```
with the key _superimpose_, _fastapi's openAPI_ generator will ignore the default media type object set by the route's response class (in this case _JSONResponse_), so in _/docs_ is displayed in the _responses section 200 status code_ only one media type (_text/event-stream_) in the media type dropdown