### PR TITLE
Resolve the mismatch of 'item' type.

### DIFF
--- a/docs_src/app_testing/app_b/main.py
+++ b/docs_src/app_testing/app_b/main.py
@@ -34,5 +34,5 @@ async def create_item(item: Item, x_token: str = Header()):
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:
         raise HTTPException(status_code=409, detail="Item already exists")
-    fake_db[item.id] = item
+    fake_db[item.id] = item.model_dump()
     return item

--- a/docs_src/app_testing/app_b_an/main.py
+++ b/docs_src/app_testing/app_b_an/main.py
@@ -35,5 +35,5 @@ async def create_item(item: Item, x_token: Annotated[str, Header()]):
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:
         raise HTTPException(status_code=400, detail="Item already exists")
-    fake_db[item.id] = item
+    fake_db[item.id] = item.model_dump()
     return item

--- a/docs_src/app_testing/app_b_an_py310/main.py
+++ b/docs_src/app_testing/app_b_an_py310/main.py
@@ -34,5 +34,5 @@ async def create_item(item: Item, x_token: Annotated[str, Header()]):
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:
         raise HTTPException(status_code=400, detail="Item already exists")
-    fake_db[item.id] = item
+    fake_db[item.id] = item.model_dump()
     return item

--- a/docs_src/app_testing/app_b_an_py39/main.py
+++ b/docs_src/app_testing/app_b_an_py39/main.py
@@ -34,5 +34,5 @@ async def create_item(item: Item, x_token: Annotated[str, Header()]):
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:
         raise HTTPException(status_code=400, detail="Item already exists")
-    fake_db[item.id] = item
+    fake_db[item.id] = item.model_dump()
     return item

--- a/docs_src/app_testing/app_b_py310/main.py
+++ b/docs_src/app_testing/app_b_py310/main.py
@@ -32,5 +32,5 @@ async def create_item(item: Item, x_token: str = Header()):
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:
         raise HTTPException(status_code=409, detail="Item already exists")
-    fake_db[item.id] = item
+    fake_db[item.id] = item.model_dump()
     return item


### PR DESCRIPTION
```
The error message indicates that an object of type "Item" cannot be assigned to a parameter named "_value" which expects a dictionary with string keys and string values in the function "setitem". The message specifies that "Item" is incompatible with "dict[str, str]".
```
The line fake_db[item.id] = item in your code is trying to assign an Item type object to an element of fake_db. However, fake_db is a dictionary, and its values should be of dictionary type, not Item type. When you try to add the item object (which is of Item type) to fake_db, a type mismatch problem occurs.