### PR TITLE
Validation of pydantic models in query params

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -10,6 +10,7 @@ from typing import (
     FrozenSet,
     List,
     Mapping,
+    Optional,
     Sequence,
     Set,
     Tuple,
@@ -635,7 +636,7 @@ def is_uploadfile_sequence_annotation(annotation: Any) -> bool:
 
 
 def validate_model_with_config(
-    model_class: Type[BaseModel],
+    model_class: Optional[Callable[..., Any]],
     received_params: Union[Mapping[str, Any], QueryParams, Headers],
 ) -> List[Any]:
     errors = []

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -42,6 +42,7 @@ from fastapi._compat import (
     lenient_issubclass,
     sequence_types,
     serialize_sequence_value,
+    validate_model_with_config,
     value_is_sequence,
 )
 from fastapi.background import BackgroundTasks
@@ -602,6 +603,11 @@ async def solve_dependencies(
             values[sub_dependant.name] = solved
         if sub_dependant.cache_key not in dependency_cache:
             dependency_cache[sub_dependant.cache_key] = solved
+
+    params_model_errors = validate_model_with_config(
+        dependant.call, request.query_params
+    )
+
     path_values, path_errors = request_params_to_args(
         dependant.path_params, request.path_params
     )
@@ -618,7 +624,9 @@ async def solve_dependencies(
     values.update(query_values)
     values.update(header_values)
     values.update(cookie_values)
-    errors += path_errors + query_errors + header_errors + cookie_errors
+    errors += (
+        path_errors + query_errors + header_errors + cookie_errors + params_model_errors
+    )
     if dependant.body_params:
         (
             body_values,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from fastapi import Depends, FastAPI, UploadFile
+from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
     ModelField,
     Undefined,
@@ -91,40 +91,3 @@ def test_is_uploadfile_sequence_annotation():
     # and other types, but I'm not even sure it's a good idea to support it as a first
     # class "feature"
     assert is_uploadfile_sequence_annotation(Union[List[str], List[UploadFile]])
-
-
-@needs_pydanticv2
-def test_validate_extra_field_config_pydantic_v2():
-    app = FastAPI()
-
-    class NoExtraFields(BaseModel):
-        model_config = ConfigDict(extra="forbid")
-        a: int
-        b: int
-
-    @app.get("/")
-    def foo(foo: NoExtraFields = Depends()):
-        return foo
-
-    client = TestClient(app)
-
-    response = client.get("/", params={"a": 1, "b": 2, "c": 2})
-    assert response.status_code == 422, response.text
-
-
-@needs_pydanticv1
-def test_validate_extra_field_conf_pydantic_v1():
-    app = FastAPI()
-
-    class NoExtraFields(BaseModel, extra="forbid"):
-        a: int
-        b: int
-
-    @app.get("/")
-    def foo(foo: NoExtraFields = Depends()):
-        return foo
-
-    client = TestClient(app)
-
-    response = client.get("/", params={"a": 1, "b": 2, "c": 2})
-    assert response.status_code == 422, response.text

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -93,11 +93,30 @@ def test_is_uploadfile_sequence_annotation():
     assert is_uploadfile_sequence_annotation(Union[List[str], List[UploadFile]])
 
 
-def test_validate_extra_field_config():
+@needs_pydanticv2
+def test_validate_extra_field_config_pydantic_v2():
     app = FastAPI()
 
     class NoExtraFields(BaseModel):
         model_config = ConfigDict(extra="forbid")
+        a: int
+        b: int
+
+    @app.get("/")
+    def foo(foo: NoExtraFields = Depends()):
+        return foo
+
+    client = TestClient(app)
+
+    response = client.get("/", params={"a": 1, "b": 2, "c": 2})
+    assert response.status_code == 422, response.text
+
+
+@needs_pydanticv1
+def test_validate_extra_field_conf_pydantic_v1():
+    app = FastAPI()
+
+    class NoExtraFields(BaseModel, extra="forbid"):
         a: int
         b: int
 

--- a/tests/test_param_model_validation.py
+++ b/tests/test_param_model_validation.py
@@ -1,0 +1,59 @@
+from fastapi import Depends, FastAPI
+from pydantic import BaseModel, ConfigDict
+from starlette.testclient import TestClient
+
+from tests.utils import needs_pydanticv1, needs_pydanticv2
+
+app = FastAPI()
+
+
+@needs_pydanticv1
+class NoExtraFieldsV1(BaseModel, extra="forbid"):
+    a: int
+    b: int
+
+
+@needs_pydanticv2
+class NoExtraFieldsV2(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    a: int
+    b: int
+
+
+@app.get("/v1")
+def foov1(foo: NoExtraFieldsV1 = Depends()):
+    return foo
+
+
+@app.get("/v2")
+def foov2(foo: NoExtraFieldsV2 = Depends()):
+    return foo
+
+
+client = TestClient(app)
+
+
+@needs_pydanticv2
+def test_validate_extra_field_config_pydantic_v2_additional_field():
+    response = client.get("/v2", params={"a": 1, "b": 2, "c": 2})
+    assert response.status_code == 422, response.text
+
+
+@needs_pydanticv1
+def test_validate_extra_field_conf_pydantic_v1_additional_field():
+    response = client.get("/v1", params={"a": 1, "b": 2, "c": 2})
+    assert response.status_code == 422, response.text
+
+
+@needs_pydanticv2
+def test_validate_extra_field_config_pydantic_v2():
+    response = client.get("/v2", params={"a": 1, "b": 2})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"a": 1, "b": 2}
+
+
+@needs_pydanticv1
+def test_validate_extra_field_conf_pydantic_v1():
+    response = client.get("/v1", params={"a": 1, "b": 2})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"a": 1, "b": 2}


### PR DESCRIPTION
If a pydantic model is supplied as params and auto cast via fastapi.Depends() the models config is ignored:

Take a look at this example:

```python
app = FastAPI()

class NoExtraFields(BaseModel):
    model_config = ConfigDict(extra="forbid")
    a: int
    b: int

@app.get("/")
def foo(foo: NoExtraFields = Depends()):
    return foo

client = TestClient(app)

response = client.get("/", params={"a": 1, "b": 2, "c": 3})
assert response.status_code == 200, response.text
```
This assert will pass, since the config is ignored. This is a result of all the params field getting validated separately in `solve_dependencies` instead of together as is done with `body_params`. 

While there are workarounds as [discussed here](https://github.com/tiangolo/fastapi/issues/2859), this is not a satisfactory state considering the otherwise great compatibility with pydantic.

This PR addresses this by doing a validation for the model as a whole for query params as well.