### PR TITLE
🧑‍💻 Define strict return value typing for `Depends` and `Security`

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union, cast
 
 from fastapi import params
 from fastapi._compat import Undefined
@@ -2217,9 +2217,12 @@ def File(  # noqa: N802
     )
 
 
+DependencyResult = TypeVar("DependencyResult")
+
+
 def Depends(  # noqa: N802
     dependency: Annotated[
-        Optional[Callable[..., Any]],
+        Optional[Callable[..., DependencyResult]],
         Doc(
             """
             A "dependable" callable (like a function).
@@ -2244,7 +2247,7 @@ def Depends(  # noqa: N802
             """
         ),
     ] = True,
-) -> Any:
+) -> DependencyResult:
     """
     Declare a FastAPI dependency.
 
@@ -2274,12 +2277,14 @@ def Depends(  # noqa: N802
         return commons
     ```
     """
-    return params.Depends(dependency=dependency, use_cache=use_cache)
+    return cast(
+        DependencyResult, params.Depends(dependency=dependency, use_cache=use_cache)
+    )
 
 
 def Security(  # noqa: N802
     dependency: Annotated[
-        Optional[Callable[..., Any]],
+        Optional[Callable[..., DependencyResult]],
         Doc(
             """
             A "dependable" callable (like a function).
@@ -2321,7 +2326,7 @@ def Security(  # noqa: N802
             """
         ),
     ] = True,
-) -> Any:
+) -> DependencyResult:
     """
     Declare a FastAPI Security dependency.
 
@@ -2357,4 +2362,7 @@ def Security(  # noqa: N802
         return [{"item_id": "Foo", "owner": current_user.username}]
     ```
     """
-    return params.Security(dependency=dependency, scopes=scopes, use_cache=use_cache)
+    return cast(
+        DependencyResult,
+        params.Security(dependency=dependency, scopes=scopes, use_cache=use_cache),
+    )


### PR DESCRIPTION
Depends can be used with a direct form, which although not recommended, is still supported. The following code is problematic wrt. type checking.

```
def dependency() -> str:
    return "dependency"

@router.get("/")
def endpoint(value: int = Depends(dependency)):
    pass
```

Currently, `Depends(dependency)` returns Any, which then happily gets assigned to the int. This patch changes it to return a type matching what the dependency returns, making the above code fail type checking with mypy  as it should.