### PR TITLE
Performance improvements for jsonable_encoder

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -262,11 +262,6 @@ def jsonable_encoder(
         return obj
     if isinstance(obj, dict):
         encoded_dict = {}
-        allowed_keys = set(obj.keys())
-        if include is not None:
-            allowed_keys &= set(include)
-        if exclude is not None:
-            allowed_keys -= set(exclude)
         for key, value in obj.items():
             if (
                 (
@@ -275,7 +270,8 @@ def jsonable_encoder(
                     or (not key.startswith("_sa"))
                 )
                 and (value is not None or not exclude_none)
-                and key in allowed_keys
+                and (include is None or key in include)
+                and (exclude is None or key not in exclude)
             ):
                 encoded_key = jsonable_encoder(
                     key,

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -216,7 +216,7 @@ def jsonable_encoder(
         exclude = set(exclude)
     if isinstance(obj, BaseModel):
         # TODO: remove when deprecating Pydantic v1
-        encoders: Dict[Any, Any] = {}
+        encoders = None
         if not PYDANTIC_V2:
             encoders = getattr(obj.__config__, "json_encoders", {})  # type: ignore[attr-defined]
             if custom_encoder is not None:

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -57,14 +57,14 @@ def decimal_encoder(dec_value: Decimal) -> Union[int, float]:
 
 
 ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
-    bytes: methodcaller('decode'),
+    bytes: methodcaller("decode"),
     Color: str,
     datetime.date: isoformat,
     datetime.datetime: isoformat,
     datetime.time: isoformat,
-    datetime.timedelta: methodcaller('total_seconds'),
+    datetime.timedelta: methodcaller("total_seconds"),
     Decimal: decimal_encoder,
-    Enum: attrgetter('value'),
+    Enum: attrgetter("value"),
     frozenset: list,
     deque: list,
     GeneratorType: list,
@@ -76,7 +76,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     IPv6Network: str,
     NameEmail: str,
     Path: str,
-    Pattern: attrgetter('pattern'),
+    Pattern: attrgetter("pattern"),
     SecretBytes: str,
     SecretStr: str,
     set: list,

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -27,10 +27,7 @@ from typing_extensions import Annotated, Doc  # type: ignore [attr-defined]
 
 from ._compat import PYDANTIC_V2, Url, _model_dump
 
-
-# Taken from Pydantic v1 as is
-def isoformat(o: Union[datetime.date, datetime.time]) -> str:
-    return o.isoformat()
+isoformat: Callable[[Union[datetime.date, datetime.time]], str] = methodcaller("isoformat")
 
 
 # Taken from Pydantic v1 as is

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -201,14 +201,14 @@ def jsonable_encoder(
     Read more about it in the
     [FastAPI docs for JSON Compatible Encoder](https://fastapi.tiangolo.com/tutorial/encoder/).
     """
-    custom_encoder = custom_encoder or {}
-    if custom_encoder:
-        if type(obj) in custom_encoder:
-            return custom_encoder[type(obj)](obj)
-        else:
-            for encoder_type, encoder_instance in custom_encoder.items():
-                if isinstance(obj, encoder_type):
-                    return encoder_instance(obj)
+    custom_encoder = custom_encoder or None
+    if custom_encoder is not None:
+        encoder_instance = custom_encoder.get(type(obj))
+        if encoder_instance is not None:
+            return encoder_instance(obj)
+        for encoder_type, encoder_instance in custom_encoder.items():
+            if isinstance(obj, encoder_type):
+                return encoder_instance(obj)
     if include is not None and not isinstance(include, (set, dict)):
         include = set(include)
     if exclude is not None and not isinstance(exclude, (set, dict)):
@@ -218,7 +218,7 @@ def jsonable_encoder(
         encoders: Dict[Any, Any] = {}
         if not PYDANTIC_V2:
             encoders = getattr(obj.__config__, "json_encoders", {})  # type: ignore[attr-defined]
-            if custom_encoder:
+            if custom_encoder is not None:
                 encoders.update(custom_encoder)
         obj_dict = _model_dump(
             obj,

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -27,7 +27,9 @@ from typing_extensions import Annotated, Doc  # type: ignore [attr-defined]
 
 from ._compat import PYDANTIC_V2, Url, _model_dump
 
-isoformat: Callable[[Union[datetime.date, datetime.time]], str] = methodcaller("isoformat")
+isoformat: Callable[[Union[datetime.date, datetime.time]], str] = methodcaller(
+    "isoformat"
+)
 
 
 # Taken from Pydantic v1 as is

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -261,8 +261,23 @@ def jsonable_encoder(
     if isinstance(obj, (str, int, float, type(None))):
         return obj
     if isinstance(obj, dict):
-        encoded_dict = {}
-        for key, value in obj.items():
+        return {
+            jsonable_encoder(
+                key,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_none=exclude_none,
+                custom_encoder=custom_encoder,
+                sqlalchemy_safe=sqlalchemy_safe,
+            ): jsonable_encoder(
+                value,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_none=exclude_none,
+                custom_encoder=custom_encoder,
+                sqlalchemy_safe=sqlalchemy_safe,
+            )
+            for key, value in obj.items()
             if (
                 (
                     not sqlalchemy_safe
@@ -272,25 +287,8 @@ def jsonable_encoder(
                 and (value is not None or not exclude_none)
                 and (include is None or key in include)
                 and (exclude is None or key not in exclude)
-            ):
-                encoded_key = jsonable_encoder(
-                    key,
-                    by_alias=by_alias,
-                    exclude_unset=exclude_unset,
-                    exclude_none=exclude_none,
-                    custom_encoder=custom_encoder,
-                    sqlalchemy_safe=sqlalchemy_safe,
-                )
-                encoded_value = jsonable_encoder(
-                    value,
-                    by_alias=by_alias,
-                    exclude_unset=exclude_unset,
-                    exclude_none=exclude_none,
-                    custom_encoder=custom_encoder,
-                    sqlalchemy_safe=sqlalchemy_safe,
-                )
-                encoded_dict[encoded_key] = encoded_value
-        return encoded_dict
+            )
+        }
     if isinstance(obj, (list, set, frozenset, GeneratorType, tuple, deque)):
         return [
             jsonable_encoder(


### PR DESCRIPTION
Hello! This is my first contribution to FastAPI so don't hesitate to point out any issues so I can improve. Today I have focused on improving the performance of **jsonable_encoder** as it seems to be a hot path in many applications.

Given this [test file](https://openaedmap.org/api/v1/countries/PL.geojson), there seems to be about ~14% performance gain. Most of which come from dict/list comprehensions and reduced set operations.

**Before**
```sh
python -m timeit -n 15 -s 'from fastapi.encoders import jsonable_encoder' -s 'from pathlib import Path' -s 'import json' -s 'data = json.loads(Path("PL.geojson").read_bytes())' 'jsonable_encoder(data)'
```
> 15 loops, best of 5: 145 msec per loop

**After**
```sh
python -m timeit -n 15 -s 'from fastapi.encoders import jsonable_encoder' -s 'from pathlib import Path' -s 'import json' -s 'data = json.loads(Path("PL.geojson").read_bytes())' 'jsonable_encoder(data)'
```
> 15 loops, best of 5: 125 msec per loop

Obviously, your experience may vary depending on the environment and the data. Having said that, I believe those are safe and widely applicable optimizations.

Feel free to ask questions - I am very active on GitHub and I tend to respond quickly.