### PR TITLE
🔥 Remove Jina AI QA Bot from the docs

### DIFF
--- a/docs/en/overrides/main.html
+++ b/docs/en/overrides/main.html
@@ -73,35 +73,3 @@
   </div>
 </div>
 {% endblock %}
-{%- block scripts %}
-{{ super() }}
-<!-- DocsQA integration start -->
-<script src="https://cdn.jsdelivr.net/npm/qabot@0.4"></script>
-<script>
-  // This prevents the global search from interfering with qa-bot's internal text input.
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('qa-bot').forEach((x) => {
-      x.addEventListener('keydown', (event) => {
-        event.stopPropagation();
-      });
-    });
-  });
-</script>
-<qa-bot
-  server="https://tiangolo-fastapi.docsqa.jina.ai"
-  theme="infer"
-  title="FastAPI Bot"
-  description="FastAPI framework, high performance, easy to learn, fast to code, ready for production"
-  style="font-size: 0.8rem"
->
-  <template>
-      <dl>
-          <dt>You can ask questions about FastAPI. Try:</dt>
-          <dd>How do you deploy FastAPI?</dd>
-          <dd>What are type hints?</dd>
-          <dd>What is OpenAPI?</dd>
-      </dl>
-  </template>
-</qa-bot>
-<!-- DocsQA integration end -->
-{%- endblock %}


### PR DESCRIPTION
hey, Fastapi team. I am afraid we decided to not to maintain the DocsQA service.