### PR TITLE
✏️ Fix typos in docstrings

### DIFF
--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -441,7 +441,7 @@ class OAuth2PasswordBearer(OAuth2):
             bool,
             Doc(
                 """
-                By default, if no HTTP Auhtorization header is provided, required for
+                By default, if no HTTP Authorization header is provided, required for
                 OAuth2 authentication, it will automatically cancel the request and
                 send the client an error.
 
@@ -543,7 +543,7 @@ class OAuth2AuthorizationCodeBearer(OAuth2):
             bool,
             Doc(
                 """
-                By default, if no HTTP Auhtorization header is provided, required for
+                By default, if no HTTP Authorization header is provided, required for
                 OAuth2 authentication, it will automatically cancel the request and
                 send the client an error.
 

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -49,7 +49,7 @@ class OpenIdConnect(SecurityBase):
             bool,
             Doc(
                 """
-                By default, if no HTTP Auhtorization header is provided, required for
+                By default, if no HTTP Authorization header is provided, required for
                 OpenID Connect authentication, it will automatically cancel the request
                 and send the client an error.
 


### PR DESCRIPTION
Simple typo fix: when looking at the [security reference in the docs](https://fastapi.tiangolo.com/reference/security/?h=auhtorization) I found and fixed the typo from `Auhtorization` to `Authorization`.