### PR TITLE
Empty string("") as a path parameter default value.

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1468,7 +1468,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -1841,7 +1841,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -2219,7 +2219,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -2597,7 +2597,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -2970,7 +2970,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -3343,7 +3343,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -3716,7 +3716,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -4094,7 +4094,7 @@ class FastAPI(Starlette):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1320,7 +1320,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -1697,7 +1697,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -2079,7 +2079,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -2461,7 +2461,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -2838,7 +2838,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -3215,7 +3215,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -3597,7 +3597,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,
@@ -3979,7 +3979,7 @@ class APIRouter(routing.Router):
                 For example, in `http://example.com/items`, the path is `/items`.
                 """
             ),
-        ],
+        ] = "",
         *,
         response_model: Annotated[
             Any,

--- a/tests/test_empty_router.py
+++ b/tests/test_empty_router.py
@@ -8,7 +8,7 @@ app = FastAPI()
 router = APIRouter()
 
 
-@router.get("")
+@router.get()
 def get_empty():
     return ["OK"]
 


### PR DESCRIPTION
Hello! 

This PR is about set empty string(`""`) as a default value of path.

I think `@app.get()` is more elegance than `@app.get("")`,
beacause of below reasones. 


- if `()`and `("")` do same works, may be "" is not important information. 

1. we don't have to do same job of typing "".
2. When using with other parameters, you can focus on other parameters.


**before**
```python
from http import HTTPStatus
from fastapi import FastAPI, APIRouter

app = FastAPI()
router = APIRouter(prefix="/users")

@router.get("")
def foo():
    pass

@router.post(
    "", # or path=""
    response_model=Bar,
    status_code=HTTPStatus.CREATED
)
def bar():
    return Bar()

app.include_router(router)
```

**after**
```python
from http import HTTPStatus
from fastapi import FastAPI, APIRouter

app = FastAPI()
router = APIRouter(prefix="/users")

@router.get()
def foo():
    pass

@router.post(
    response_model=Bar,
    status_code=HTTPStatus.OK
)
def bar():
    return Bar()

app.include_router(router)
```

And i think about problems after this change and how to prevent.

1. backward compatibility: It is just a **default**, so people who using with "" or "/" will not trap in any problem.
2. Not expected path by default:  show warning log or option about want to use default value.

So i made this changes : )

----
P. S
this is just my opinion and i also want to listen about other people thinking!