### PR TITLE
⬆ Upgrade Starlette dependency to `>= 0.37.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.36.3,<0.37.0",
+    "starlette>=0.37.1,<0.38.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
 ]


### PR DESCRIPTION
v0.36.0 to v0.37.0 had a regression failing on missing .env file.

Fixed in v0.37.1: encode/starlette#2485