### PR TITLE
Example: native api client (without generating code) - DO NOT MERGE

### DIFF
--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -20,7 +20,7 @@ from .param_functions import Query as Query
 from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
-from .routing import APIRouter as APIRouter
 from .routing import APIClient as FastAPIClient
+from .routing import APIRouter as APIRouter
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -21,5 +21,6 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .routing import APIClient as FastAPIClient
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,9 +1,9 @@
-from abc import abstractmethod
 import asyncio
 import dataclasses
 import email.message
 import inspect
 import json
+from abc import abstractmethod
 from contextlib import AsyncExitStack
 from enum import Enum, IntEnum
 from typing import (
@@ -973,6 +973,7 @@ class APIRouter(routing.Router):
             )
 
             if inspect.isawaitable(func):
+
                 async def async_client_wrapper(*args, **kwargs):
                     client: "APIClient" = APIClient.get_active_client()
                     if client:
@@ -982,6 +983,7 @@ class APIRouter(routing.Router):
 
                 return async_client_wrapper
             else:
+
                 def client_wrapper(*args, **kwargs):
                     client: "APIClient" = APIClient.get_active_client()
                     if client:
@@ -991,6 +993,7 @@ class APIRouter(routing.Router):
                         return func(*args, **kwargs)
 
                 return client_wrapper
+
         return decorator
 
     def add_api_websocket_route(
@@ -4405,6 +4408,7 @@ class APIRouter(routing.Router):
 
         return decorator
 
+
 class APIClient:
     """Abstract class for holding configuration for the api
     client
@@ -4421,7 +4425,7 @@ class APIClient:
         return cls.__active_client_stack[-1]
 
     @abstractmethod
-    def send(route: APIRoute, args:list, kwargs: dict):
+    def send(route: APIRoute, args: list, kwargs: dict):
         """Async send an api client method to the specified route.
 
         Args:
@@ -4435,7 +4439,7 @@ class APIClient:
         pass
 
     @abstractmethod
-    async def send_async(route: APIRoute, args:list, kwargs: dict):
+    async def send_async(route: APIRoute, args: list, kwargs: dict):
         """Async send an api client method to the specified route.
 
         Args:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -973,6 +973,7 @@ class APIRouter(routing.Router):
             )
 
             if asyncio.iscoroutinefunction(func):
+
                 async def async_client_wrapper(*args, **kwargs):
                     client: "APIClient" = APIClient.get_active_client()
                     if client:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -972,7 +972,7 @@ class APIRouter(routing.Router):
                 generate_unique_id_function=generate_unique_id_function,
             )
 
-            if inspect.isawaitable(func):
+            if asyncio.iscoroutinefunction(func):
                 async def async_client_wrapper(*args, **kwargs):
                     client: "APIClient" = APIClient.get_active_client()
                     if client:


### PR DESCRIPTION
The following PR is an example for the issue: https://github.com/tiangolo/fastapi/discussions/8242 and  https://github.com/tiangolo/fastapi/discussions/11343

In short, an FastApiClient object was added that allows the auto capture of calls to the decorated method
in which the call is either directed to the function itself or is redirected to the an api client, depending on the context.

E.g. we can create an api client in the following manner:
```python
from fastapi import FastAPI, FastAPIClient
from fastapi.routing import APIRoute


class MyApiClient(FastAPIClient):
    # Client paramters to be added here.
    # But this dose nothing, We could implement a default api client.
    def __init__(self, host: str = "localhost:8080") -> None:
        super().__init__()

    def send(self, route: APIRoute, args: list, kwargs: dict):
        # Send the request given the route.
        # Dummy just returns the route and input values
        return route, args, kwargs

    async def send_async(self, route: APIRoute, args: list, kwargs: dict):
        # Send the aysnc request given the route.
        # Dummy just returns the route and input values
        return route, args, kwargs


api = FastAPI()


@api.get("/my_func")
def my_func(a, b):
    return a + b


client = MyApiClient()
# a call will be made to my_func.
print(my_func(2, 3))
with client:
    # A call will be made to the server, returning
    # the proper response.
    print(my_func(2, 3))
# a call will be made to my_func.
print(my_func(2, 3))
```