### PR TITLE
📝 Add missing `compresslevel` parameter on docs for `GZipMiddleware`

### DIFF
--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -85,6 +85,7 @@ The middleware will handle both standard and streaming responses.
 The following arguments are supported:
 
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
+* `compresslevel` - Used during GZip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
 
 ## Other middlewares
 

--- a/docs_src/advanced_middleware/tutorial003.py
+++ b/docs_src/advanced_middleware/tutorial003.py
@@ -3,7 +3,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 
 app = FastAPI()
 
-app.add_middleware(GZipMiddleware, minimum_size=1000)
+app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=9)
 
 
 @app.get("/")

--- a/docs_src/advanced_middleware/tutorial003.py
+++ b/docs_src/advanced_middleware/tutorial003.py
@@ -3,7 +3,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 
 app = FastAPI()
 
-app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=9)
+app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
 
 
 @app.get("/")


### PR DESCRIPTION
The compresslevel parameter was added in encode/starlette#1128 encode/starlette#2553.
But, it was not added to the document, so I added an explanation on docs.