### PR TITLE
✨ Add the 'path' attribute to the endpoint function for internal access

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -880,7 +880,7 @@ class APIRouter(routing.Router):
         current_generate_unique_id = get_value_or_default(
             generate_unique_id_function, self.generate_unique_id_function
         )
-        setattr(endpoint, 'path', path)
+        endpoint.path = path
         route = route_class(
             self.prefix + path,
             endpoint=endpoint,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -880,6 +880,7 @@ class APIRouter(routing.Router):
         current_generate_unique_id = get_value_or_default(
             generate_unique_id_function, self.generate_unique_id_function
         )
+        endpoint.path = path
         route = route_class(
             self.prefix + path,
             endpoint=endpoint,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -880,7 +880,7 @@ class APIRouter(routing.Router):
         current_generate_unique_id = get_value_or_default(
             generate_unique_id_function, self.generate_unique_id_function
         )
-        endpoint.path = path
+        setattr(endpoint, 'path', path)
         route = route_class(
             self.prefix + path,
             endpoint=endpoint,


### PR DESCRIPTION
This pull request makes a modification to the APIRouter framework by adding the path attribute to the endpoint function when creating routes. This attribute enables accessing the endpoint's path from within the function itself, simplifying the creation of complex endpoints that require access to the path.

This change is crucial in cases where accessing the request path inside the endpoint is necessary.

When creating complex endpoints that require calling other endpoints, using request.url to determine the path is not suitable because the request is unique within the scope of calling a complex endpoint. In such scenarios, simple endpoints called from within the complex one will have the same path as the complex endpoint.