### PR TITLE
Add doc for `compresslevel` of the GZipMiddleware and use compresslevel=5 in the example

### DIFF
--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -85,6 +85,7 @@ The middleware will handle both standard and streaming responses.
 The following arguments are supported:
 
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
+* `compresslevel` -  Used during GZip compression. It is an integer ranging from 1 to 9. Defaults to `9`. A lower value results in faster compression but larger file sizes, while a higher value results in slower compression but smaller file sizes.
 
 ## Other middlewares
 

--- a/docs_src/advanced_middleware/tutorial003.py
+++ b/docs_src/advanced_middleware/tutorial003.py
@@ -3,7 +3,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 
 app = FastAPI()
 
-app.add_middleware(GZipMiddleware, minimum_size=1000)
+app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
 
 
 @app.get("/")


### PR DESCRIPTION
`compresslevel` is defined there in starlette's GZipMiddleware:
https://github.com/encode/starlette/blob/4e453ce91940cc7c995e6c728e3fdf341c039056/starlette/middleware/gzip.py#L30

compresslevel=5 is typically a better CPU / compression level tradeoff than 9, e.g. see:
https://tukaani.org/lzma/benchmarks.html