### PR TITLE
Adjust a test for error URL added in Pydantic 2.7.0

### DIFF
--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -38,7 +38,7 @@ def test_get_enums_invalid():
                     "input": "foo",
                     "ctx": {"expected": "'alexnet', 'resnet' or 'lenet'"},
                     # e.g. https://errors.pydantic.dev/2.7/v/enum
-                    "url": IsStr(regex=r"https://errors.pydantic.dev/.*/enum")
+                    "url": IsStr(regex=r"https://errors.pydantic.dev/.*/enum"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -1,4 +1,4 @@
-from dirty_equals import IsDict
+from dirty_equals import IsDict, IsStr
 from fastapi.testclient import TestClient
 
 from docs_src.path_params.tutorial005 import app
@@ -28,6 +28,22 @@ def test_get_enums_invalid():
     response = client.get("/models/foo")
     assert response.status_code == 422
     assert response.json() == IsDict(
+        # Pydantic 2.7
+        {
+            "detail": [
+                {
+                    "type": "enum",
+                    "loc": ["path", "model_name"],
+                    "msg": "Input should be 'alexnet', 'resnet' or 'lenet'",
+                    "input": "foo",
+                    "ctx": {"expected": "'alexnet', 'resnet' or 'lenet'"},
+                    # e.g. https://errors.pydantic.dev/2.7/v/enum
+                    "url": IsStr(regex=r"https://errors.pydantic.dev/.*/enum")
+                }
+            ]
+        }
+    ) | IsDict(
+        # Pydantic 2.0-2.6
         {
             "detail": [
                 {


### PR DESCRIPTION
One test, `tests/test_tutorial/test_path_params/test_tutorial005.py::test_get_enums_invalid`, has started failing with Pydantic 2.7.0

The failure is easily reproduced by checking out the current master, 3425c834cc113060d00b8a295d3456eb306a109d, and running the tests as described in https://fastapi.tiangolo.com/contributing/#tests.

This PR adapts that test for the new error URL included in the response to the validation failure.