### PR TITLE
✨ Add support for Pydantic's 2.7 new deprecated Field parameter, remove URL from validation errors response

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-pydantic-v2-${{ hashFiles('pyproject.toml', 'requirements-tests.txt', 'requirements-docs-tests.txt') }}-test-v07
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-pydantic-v2-${{ hashFiles('pyproject.toml', 'requirements-tests.txt', 'requirements-docs-tests.txt') }}-test-v08
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements-tests.txt
@@ -70,7 +70,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt', 'requirements-docs-tests.txt') }}-test-v07
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt', 'requirements-docs-tests.txt') }}-test-v08
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements-tests.txt

--- a/docs_src/path_operation_advanced_configuration/tutorial007.py
+++ b/docs_src/path_operation_advanced_configuration/tutorial007.py
@@ -30,5 +30,5 @@ async def create_item(request: Request):
     try:
         item = Item.model_validate(data)
     except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors())
+        raise HTTPException(status_code=422, detail=e.errors(include_url=False))
     return item

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -129,7 +129,7 @@ if PYDANTIC_V2:
                 )
             except ValidationError as exc:
                 return None, _regenerate_error_with_loc(
-                    errors=exc.errors(), loc_prefix=loc
+                    errors=exc.errors(include_url=False), loc_prefix=loc
                 )
 
         def serialize(
@@ -268,7 +268,7 @@ if PYDANTIC_V2:
     def get_missing_field_error(loc: Tuple[str, ...]) -> Dict[str, Any]:
         error = ValidationError.from_exception_data(
             "Field required", [{"type": "missing", "loc": loc, "input": {}}]
-        ).errors()[0]
+        ).errors(include_url=False)[0]
         error["input"] = None
         return error  # type: ignore[return-value]
 

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -20,10 +20,12 @@ from typing import (
 from fastapi.exceptions import RequestErrorModel
 from fastapi.types import IncEx, ModelNameMap, UnionType
 from pydantic import BaseModel, create_model
-from pydantic.version import VERSION as PYDANTIC_VERSION
+from pydantic.version import VERSION as P_VERSION
 from starlette.datastructures import UploadFile
 from typing_extensions import Annotated, Literal, get_args, get_origin
 
+# Reassign variable to make it reexported for mypy
+PYDANTIC_VERSION = P_VERSION
 PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
 
 

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -123,7 +123,7 @@ def get_openapi_operation_parameters(
         elif field_info.example != Undefined:
             parameter["example"] = jsonable_encoder(field_info.example)
         if field_info.deprecated:
-            parameter["deprecated"] = field_info.deprecated
+            parameter["deprecated"] = True
         parameters.append(parameter)
     return parameters
 

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -240,7 +240,7 @@ def Path(  # noqa: N802
         ),
     ] = None,
     deprecated: Annotated[
-        Optional[bool],
+        Union[deprecated, str, bool, None],
         Doc(
             """
             Mark this parameter field as deprecated.
@@ -565,7 +565,7 @@ def Query(  # noqa: N802
         ),
     ] = None,
     deprecated: Annotated[
-        Optional[bool],
+        Union[deprecated, str, bool, None],
         Doc(
             """
             Mark this parameter field as deprecated.
@@ -880,7 +880,7 @@ def Header(  # noqa: N802
         ),
     ] = None,
     deprecated: Annotated[
-        Optional[bool],
+        Union[deprecated, str, bool, None],
         Doc(
             """
             Mark this parameter field as deprecated.
@@ -1185,7 +1185,7 @@ def Cookie(  # noqa: N802
         ),
     ] = None,
     deprecated: Annotated[
-        Optional[bool],
+        Union[deprecated, str, bool, None],
         Doc(
             """
             Mark this parameter field as deprecated.
@@ -1512,7 +1512,7 @@ def Body(  # noqa: N802
         ),
     ] = None,
     deprecated: Annotated[
-        Optional[bool],
+        Union[deprecated, str, bool, None],
         Doc(
             """
             Mark this parameter field as deprecated.
@@ -1827,7 +1827,7 @@ def Form(  # noqa: N802
         ),
     ] = None,
     deprecated: Annotated[
-        Optional[bool],
+        Union[deprecated, str, bool, None],
         Doc(
             """
             Mark this parameter field as deprecated.
@@ -2141,7 +2141,7 @@ def File(  # noqa: N802
         ),
     ] = None,
     deprecated: Annotated[
-        Optional[bool],
+        Union[deprecated, str, bool, None],
         Doc(
             """
             Mark this parameter field as deprecated.

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -6,7 +6,7 @@ from fastapi.openapi.models import Example
 from pydantic.fields import FieldInfo
 from typing_extensions import Annotated, deprecated
 
-from ._compat import PYDANTIC_V2, Undefined
+from ._compat import PYDANTIC_V2, PYDANTIC_VERSION, Undefined
 
 _Unset: Any = Undefined
 
@@ -63,12 +63,11 @@ class Param(FieldInfo):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
-        self.deprecated = deprecated
         if example is not _Unset:
             warnings.warn(
                 "`example` has been deprecated, please use `examples` instead",
@@ -106,6 +105,10 @@ class Param(FieldInfo):
                 stacklevel=4,
             )
         current_json_schema_extra = json_schema_extra or extra
+        if PYDANTIC_VERSION < "2.7.0":
+            self.deprecated = deprecated
+        else:
+            kwargs["deprecated"] = deprecated
         if PYDANTIC_V2:
             kwargs.update(
                 {
@@ -174,7 +177,7 @@ class Path(Param):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
@@ -260,7 +263,7 @@ class Query(Param):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
@@ -345,7 +348,7 @@ class Header(Param):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
@@ -430,7 +433,7 @@ class Cookie(Param):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
@@ -514,14 +517,13 @@ class Body(FieldInfo):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
     ):
         self.embed = embed
         self.media_type = media_type
-        self.deprecated = deprecated
         if example is not _Unset:
             warnings.warn(
                 "`example` has been deprecated, please use `examples` instead",
@@ -559,6 +561,10 @@ class Body(FieldInfo):
                 stacklevel=4,
             )
         current_json_schema_extra = json_schema_extra or extra
+        if PYDANTIC_VERSION < "2.7.0":
+            self.deprecated = deprecated
+        else:
+            kwargs["deprecated"] = deprecated
         if PYDANTIC_V2:
             kwargs.update(
                 {
@@ -627,7 +633,7 @@ class Form(Body):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,
@@ -712,7 +718,7 @@ class File(Form):
             ),
         ] = _Unset,
         openapi_examples: Optional[Dict[str, Example]] = None,
-        deprecated: Optional[bool] = None,
+        deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
         **extra: Any,

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -221,9 +221,3 @@ def get_value_or_default(
         if not isinstance(item, DefaultPlaceholder):
             return item
     return first_item
-
-
-def match_pydantic_error_url(error_type: str) -> Any:
-    from dirty_equals import IsStr
-
-    return IsStr(regex=rf"^https://errors\.pydantic\.dev/.*/v/{error_type}")

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import APIRouter, FastAPI, Query
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from typing_extensions import Annotated
 
 app = FastAPI()
@@ -38,7 +37,6 @@ foo_is_missing = {
                 "msg": "Field required",
                 "type": "missing",
                 "input": None,
-                "url": match_pydantic_error_url("missing"),
             }
         )
         # TODO: remove when deprecating Pydantic v1
@@ -60,7 +58,6 @@ foo_is_short = {
                 "msg": "String should have at least 1 character",
                 "type": "string_too_short",
                 "input": "",
-                "url": match_pydantic_error_url("string_too_short"),
             }
         )
         # TODO: remove when deprecating Pydantic v1

--- a/tests/test_dependency_duplicates.py
+++ b/tests/test_dependency_duplicates.py
@@ -3,7 +3,6 @@ from typing import List
 from dirty_equals import IsDict
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -57,7 +56,6 @@ def test_no_duplicates_invalid():
                     "loc": ["body", "item2"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_dependency_overrides.py
+++ b/tests/test_dependency_overrides.py
@@ -4,7 +4,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 app = FastAPI()
 
@@ -63,7 +62,6 @@ def test_main_depends():
                     "loc": ["query", "q"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -110,7 +108,6 @@ def test_decorator_depends():
                     "loc": ["query", "q"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -151,7 +148,6 @@ def test_router_depends():
                     "loc": ["query", "q"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -198,7 +194,6 @@ def test_router_decorator_depends():
                     "loc": ["query", "q"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -285,7 +280,6 @@ def test_override_with_sub_main_depends():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -316,7 +310,6 @@ def test_override_with_sub__main_depends_q_foo():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -355,7 +348,6 @@ def test_override_with_sub_decorator_depends():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -386,7 +378,6 @@ def test_override_with_sub_decorator_depends_q_foo():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -425,7 +416,6 @@ def test_override_with_sub_router_depends():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -456,7 +446,6 @@ def test_override_with_sub_router_depends_q_foo():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -495,7 +484,6 @@ def test_override_with_sub_router_decorator_depends():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -526,7 +514,6 @@ def test_override_with_sub_router_decorator_depends_q_foo():
                     "loc": ["query", "k"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_filter_pydantic_sub_model_pv2.py
+++ b/tests/test_filter_pydantic_sub_model_pv2.py
@@ -5,7 +5,6 @@ from dirty_equals import HasRepr, IsDict, IsOneOf
 from fastapi import Depends, FastAPI
 from fastapi.exceptions import ResponseValidationError
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from .utils import needs_pydanticv2
 
@@ -67,7 +66,6 @@ def test_validator_is_cloned(client: TestClient):
                 "msg": "Value error, name must end in A",
                 "input": "modelX",
                 "ctx": {"error": HasRepr("ValueError('name must end in A')")},
-                "url": match_pydantic_error_url("value_error"),
             }
         )
         | IsDict(

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -4,7 +4,6 @@ from typing import List
 from dirty_equals import IsDict, IsOneOf
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from pydantic import BaseModel, condecimal
 
 app = FastAPI()
@@ -52,7 +51,6 @@ def test_jsonable_encoder_requiring_error():
                     "msg": "Input should be greater than 0",
                     "input": -1.0,
                     "ctx": {"gt": 0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }
@@ -82,28 +80,24 @@ def test_put_incorrect_body_multiple():
                     "loc": ["body", 0, "name"],
                     "msg": "Field required",
                     "input": {"age": "five"},
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "decimal_parsing",
                     "loc": ["body", 0, "age"],
                     "msg": "Input should be a valid decimal",
                     "input": "five",
-                    "url": match_pydantic_error_url("decimal_parsing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", 1, "name"],
                     "msg": "Field required",
                     "input": {"age": "six"},
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "decimal_parsing",
                     "loc": ["body", 1, "age"],
                     "msg": "Input should be a valid decimal",
                     "input": "six",
-                    "url": match_pydantic_error_url("decimal_parsing"),
                 },
             ]
         }

--- a/tests/test_multi_query_errors.py
+++ b/tests/test_multi_query_errors.py
@@ -3,7 +3,6 @@ from typing import List
 from dirty_equals import IsDict
 from fastapi import FastAPI, Query
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 app = FastAPI()
 
@@ -33,14 +32,12 @@ def test_multi_query_incorrect():
                     "loc": ["query", "q", 0],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "five",
-                    "url": match_pydantic_error_url("int_parsing"),
                 },
                 {
                     "type": "int_parsing",
                     "loc": ["query", "q", 1],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "six",
-                    "url": match_pydantic_error_url("int_parsing"),
                 },
             ]
         }

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from .main import app
 
@@ -54,7 +53,6 @@ def test_path_int_foobar():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foobar",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -83,7 +81,6 @@ def test_path_int_True():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "True",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -118,7 +115,6 @@ def test_path_int_42_5():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "42.5",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -147,7 +143,6 @@ def test_path_float_foobar():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid number, unable to parse string as a number",
                     "input": "foobar",
-                    "url": match_pydantic_error_url("float_parsing"),
                 }
             ]
         }
@@ -176,7 +171,6 @@ def test_path_float_True():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid number, unable to parse string as a number",
                     "input": "True",
-                    "url": match_pydantic_error_url("float_parsing"),
                 }
             ]
         }
@@ -217,7 +211,6 @@ def test_path_bool_foobar():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid boolean, unable to interpret input",
                     "input": "foobar",
-                    "url": match_pydantic_error_url("bool_parsing"),
                 }
             ]
         }
@@ -252,7 +245,6 @@ def test_path_bool_42():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid boolean, unable to interpret input",
                     "input": "42",
-                    "url": match_pydantic_error_url("bool_parsing"),
                 }
             ]
         }
@@ -281,7 +273,6 @@ def test_path_bool_42_5():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid boolean, unable to interpret input",
                     "input": "42.5",
-                    "url": match_pydantic_error_url("bool_parsing"),
                 }
             ]
         }
@@ -353,7 +344,6 @@ def test_path_param_minlength_fo():
                     "msg": "String should have at least 3 characters",
                     "input": "fo",
                     "ctx": {"min_length": 3},
-                    "url": match_pydantic_error_url("string_too_short"),
                 }
             ]
         }
@@ -390,7 +380,6 @@ def test_path_param_maxlength_foobar():
                     "msg": "String should have at most 3 characters",
                     "input": "foobar",
                     "ctx": {"max_length": 3},
-                    "url": match_pydantic_error_url("string_too_long"),
                 }
             ]
         }
@@ -427,7 +416,6 @@ def test_path_param_min_maxlength_foobar():
                     "msg": "String should have at most 3 characters",
                     "input": "foobar",
                     "ctx": {"max_length": 3},
-                    "url": match_pydantic_error_url("string_too_long"),
                 }
             ]
         }
@@ -458,7 +446,6 @@ def test_path_param_min_maxlength_f():
                     "msg": "String should have at least 2 characters",
                     "input": "f",
                     "ctx": {"min_length": 2},
-                    "url": match_pydantic_error_url("string_too_short"),
                 }
             ]
         }
@@ -494,7 +481,6 @@ def test_path_param_gt_2():
                     "msg": "Input should be greater than 3",
                     "input": "2",
                     "ctx": {"gt": 3.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }
@@ -531,7 +517,6 @@ def test_path_param_gt0_0():
                     "msg": "Input should be greater than 0",
                     "input": "0",
                     "ctx": {"gt": 0.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }
@@ -574,7 +559,6 @@ def test_path_param_ge_2():
                     "msg": "Input should be greater than or equal to 3",
                     "input": "2",
                     "ctx": {"ge": 3.0},
-                    "url": match_pydantic_error_url("greater_than_equal"),
                 }
             ]
         }
@@ -605,7 +589,6 @@ def test_path_param_lt_42():
                     "msg": "Input should be less than 3",
                     "input": "42",
                     "ctx": {"lt": 3.0},
-                    "url": match_pydantic_error_url("less_than"),
                 }
             ]
         }
@@ -648,7 +631,6 @@ def test_path_param_lt0_0():
                     "msg": "Input should be less than 0",
                     "input": "0",
                     "ctx": {"lt": 0.0},
-                    "url": match_pydantic_error_url("less_than"),
                 }
             ]
         }
@@ -679,7 +661,6 @@ def test_path_param_le_42():
                     "msg": "Input should be less than or equal to 3",
                     "input": "42",
                     "ctx": {"le": 3.0},
-                    "url": match_pydantic_error_url("less_than_equal"),
                 }
             ]
         }
@@ -728,7 +709,6 @@ def test_path_param_lt_gt_4():
                     "msg": "Input should be less than 3",
                     "input": "4",
                     "ctx": {"lt": 3.0},
-                    "url": match_pydantic_error_url("less_than"),
                 }
             ]
         }
@@ -759,7 +739,6 @@ def test_path_param_lt_gt_0():
                     "msg": "Input should be greater than 1",
                     "input": "0",
                     "ctx": {"gt": 1.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }
@@ -807,7 +786,6 @@ def test_path_param_le_ge_4():
                     "msg": "Input should be less than or equal to 3",
                     "input": "4",
                     "ctx": {"le": 3.0},
-                    "url": match_pydantic_error_url("less_than_equal"),
                 }
             ]
         }
@@ -844,7 +822,6 @@ def test_path_param_lt_int_42():
                     "msg": "Input should be less than 3",
                     "input": "42",
                     "ctx": {"lt": 3},
-                    "url": match_pydantic_error_url("less_than"),
                 }
             ]
         }
@@ -874,7 +851,6 @@ def test_path_param_lt_int_2_7():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "2.7",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -910,7 +886,6 @@ def test_path_param_gt_int_2():
                     "msg": "Input should be greater than 3",
                     "input": "2",
                     "ctx": {"gt": 3},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }
@@ -940,7 +915,6 @@ def test_path_param_gt_int_2_7():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "2.7",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -970,7 +944,6 @@ def test_path_param_le_int_42():
                     "msg": "Input should be less than or equal to 3",
                     "input": "42",
                     "ctx": {"le": 3},
-                    "url": match_pydantic_error_url("less_than_equal"),
                 }
             ]
         }
@@ -1012,7 +985,6 @@ def test_path_param_le_int_2_7():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "2.7",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -1054,7 +1026,6 @@ def test_path_param_ge_int_2():
                     "msg": "Input should be greater than or equal to 3",
                     "input": "2",
                     "ctx": {"ge": 3},
-                    "url": match_pydantic_error_url("greater_than_equal"),
                 }
             ]
         }
@@ -1084,7 +1055,6 @@ def test_path_param_ge_int_2_7():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "2.7",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -1120,7 +1090,6 @@ def test_path_param_lt_gt_int_4():
                     "msg": "Input should be less than 3",
                     "input": "4",
                     "ctx": {"lt": 3},
-                    "url": match_pydantic_error_url("less_than"),
                 }
             ]
         }
@@ -1151,7 +1120,6 @@ def test_path_param_lt_gt_int_0():
                     "msg": "Input should be greater than 1",
                     "input": "0",
                     "ctx": {"gt": 1},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }
@@ -1181,7 +1149,6 @@ def test_path_param_lt_gt_int_2_7():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "2.7",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -1229,7 +1196,6 @@ def test_path_param_le_ge_int_4():
                     "msg": "Input should be less than or equal to 3",
                     "input": "4",
                     "ctx": {"le": 3},
-                    "url": match_pydantic_error_url("less_than_equal"),
                 }
             ]
         }
@@ -1259,7 +1225,6 @@ def test_path_param_le_ge_int_2_7():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "2.7",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from .main import app
 
@@ -18,7 +17,6 @@ def test_query():
                     "loc": ["query", "query"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -53,7 +51,6 @@ def test_query_not_declared_baz():
                     "loc": ["query", "query"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -100,7 +97,6 @@ def test_query_int():
                     "loc": ["query", "query"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -135,7 +131,6 @@ def test_query_int_query_42_5():
                     "loc": ["query", "query"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "42.5",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -164,7 +159,6 @@ def test_query_int_query_baz():
                     "loc": ["query", "query"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "baz",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -193,7 +187,6 @@ def test_query_int_not_declared_baz():
                     "loc": ["query", "query"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -234,7 +227,6 @@ def test_query_int_optional_query_foo():
                     "loc": ["query", "query"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -275,7 +267,6 @@ def test_query_int_default_query_foo():
                     "loc": ["query", "query"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }
@@ -316,7 +307,6 @@ def test_query_param_required():
                     "loc": ["query", "query"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -351,7 +341,6 @@ def test_query_param_required_int():
                     "loc": ["query", "query"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -386,7 +375,6 @@ def test_query_param_required_int_query_foo():
                     "loc": ["query", "query"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_regex_deprecated_body.py
+++ b/tests/test_regex_deprecated_body.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI, Form
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from typing_extensions import Annotated
 
 from .utils import needs_py310
@@ -55,7 +54,6 @@ def test_query_nonregexquery():
                     "msg": "String should match pattern '^fixedquery$'",
                     "input": "nonregexquery",
                     "ctx": {"pattern": "^fixedquery$"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_regex_deprecated_params.py
+++ b/tests/test_regex_deprecated_params.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI, Query
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from typing_extensions import Annotated
 
 from .utils import needs_py310
@@ -55,7 +54,6 @@ def test_query_params_str_validations_item_query_nonregexquery():
                     "msg": "String should match pattern '^fixedquery$'",
                     "input": "nonregexquery",
                     "ctx": {"pattern": "^fixedquery$"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -2,7 +2,6 @@ from dirty_equals import IsDict
 from fastapi import Depends, FastAPI, Security
 from fastapi.security import OAuth2, OAuth2PasswordRequestFormStrict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -71,21 +70,18 @@ def test_strict_login_no_data():
                     "loc": ["body", "grant_type"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -124,7 +120,6 @@ def test_strict_login_no_grant_type():
                     "loc": ["body", "grant_type"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -157,7 +152,6 @@ def test_strict_login_incorrect_grant_type():
                     "msg": "String should match pattern 'password'",
                     "input": "incorrect",
                     "ctx": {"pattern": "password"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -4,7 +4,6 @@ from dirty_equals import IsDict
 from fastapi import Depends, FastAPI, Security
 from fastapi.security import OAuth2, OAuth2PasswordRequestFormStrict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -75,21 +74,18 @@ def test_strict_login_no_data():
                     "loc": ["body", "grant_type"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -128,7 +124,6 @@ def test_strict_login_no_grant_type():
                     "loc": ["body", "grant_type"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -161,7 +156,6 @@ def test_strict_login_incorrect_grant_type():
                     "msg": "String should match pattern 'password'",
                     "input": "incorrect",
                     "ctx": {"pattern": "password"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_security_oauth2_optional_description.py
+++ b/tests/test_security_oauth2_optional_description.py
@@ -4,7 +4,6 @@ from dirty_equals import IsDict
 from fastapi import Depends, FastAPI, Security
 from fastapi.security import OAuth2, OAuth2PasswordRequestFormStrict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -76,21 +75,18 @@ def test_strict_login_None():
                     "loc": ["body", "grant_type"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -129,7 +125,6 @@ def test_strict_login_no_grant_type():
                     "loc": ["body", "grant_type"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -162,7 +157,6 @@ def test_strict_login_incorrect_grant_type():
                     "msg": "String should match pattern 'password'",
                     "input": "incorrect",
                     "ctx": {"pattern": "password"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -14,7 +14,6 @@ def get_app():
 
 # TODO: pv2 add version with Pydantic v2
 @needs_pydanticv1
-@pytest.mark.xfail(reason="A change in SQLAlchemy conflicts with databases")
 def test_create_read(app: FastAPI):
     with TestClient(app) as client:
         note = {"text": "Foo bar", "completed": False}
@@ -24,10 +23,9 @@ def test_create_read(app: FastAPI):
         assert data["text"] == note["text"]
         assert data["completed"] == note["completed"]
         assert "id" in data
-        client.get("/notes/")
-        # This will fail until the databases issue is handled
-        # assert response.status_code == 200, response.text
-        # assert data in response.json()
+        response = client.get("/notes/")
+        assert response.status_code == 200, response.text
+        assert data in response.json()
 
 
 def test_openapi_schema(app: FastAPI):

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -14,7 +14,7 @@ def get_app():
 
 # TODO: pv2 add version with Pydantic v2
 @needs_pydanticv1
-@pytest.mark.skip(reason="A change in SQLAlchemy conflicts with databases")
+@pytest.mark.xfail(reason="A change in SQLAlchemy conflicts with databases")
 def test_create_read(app: FastAPI):
     with TestClient(app) as client:
         note = {"text": "Foo bar", "completed": False}
@@ -24,9 +24,10 @@ def test_create_read(app: FastAPI):
         assert data["text"] == note["text"]
         assert data["completed"] == note["completed"]
         assert "id" in data
-        response = client.get("/notes/")
-        assert response.status_code == 200, response.text
-        assert data in response.json()
+        client.get("/notes/")
+        # This will fail until the databases issue is handled
+        # assert response.status_code == 200, response.text
+        # assert data in response.json()
 
 
 def test_openapi_schema(app: FastAPI):

--- a/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_async_sql_databases/test_tutorial001.py
@@ -14,6 +14,7 @@ def get_app():
 
 # TODO: pv2 add version with Pydantic v2
 @needs_pydanticv1
+@pytest.mark.skip(reason="A change in SQLAlchemy conflicts with databases")
 def test_create_read(app: FastAPI):
     with TestClient(app) as client:
         note = {"text": "Foo bar", "completed": False}

--- a/tests/test_tutorial/test_bigger_applications/test_main.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -29,7 +28,6 @@ def test_users_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -64,7 +62,6 @@ def test_users_foo_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -99,7 +96,6 @@ def test_users_me_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -145,7 +141,6 @@ def test_items_with_no_token_jessica(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -192,7 +187,6 @@ def test_items_plumbus_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -233,7 +227,6 @@ def test_items_with_missing_x_token_header(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -262,7 +255,6 @@ def test_items_plumbus_with_missing_x_token_header(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -297,7 +289,6 @@ def test_root_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -326,14 +317,12 @@ def test_put_no_header(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_bigger_applications/test_main_an.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main_an.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -29,7 +28,6 @@ def test_users_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -64,7 +62,6 @@ def test_users_foo_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -99,7 +96,6 @@ def test_users_me_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -145,7 +141,6 @@ def test_items_with_no_token_jessica(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -192,7 +187,6 @@ def test_items_plumbus_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -233,7 +227,6 @@ def test_items_with_missing_x_token_header(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -262,7 +255,6 @@ def test_items_plumbus_with_missing_x_token_header(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -297,7 +289,6 @@ def test_root_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -326,14 +317,12 @@ def test_put_no_header(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_bigger_applications/test_main_an_py39.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -33,7 +32,6 @@ def test_users_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -70,7 +68,6 @@ def test_users_foo_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -107,7 +104,6 @@ def test_users_me_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -156,7 +152,6 @@ def test_items_with_no_token_jessica(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -206,7 +201,6 @@ def test_items_plumbus_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -250,7 +244,6 @@ def test_items_with_missing_x_token_header(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -280,7 +273,6 @@ def test_items_plumbus_with_missing_x_token_header(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -317,7 +309,6 @@ def test_root_with_no_token(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -347,14 +338,12 @@ def test_put_no_header(client: TestClient):
                     "loc": ["query", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture
@@ -74,7 +73,6 @@ def test_post_with_only_name(client: TestClient):
                     "loc": ["body", "price"],
                     "msg": "Field required",
                     "input": {"name": "Foo"},
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -103,7 +101,6 @@ def test_post_with_only_name_price(client: TestClient):
                     "loc": ["body", "price"],
                     "msg": "Input should be a valid number, unable to parse string as a number",
                     "input": "twenty",
-                    "url": match_pydantic_error_url("float_parsing"),
                 }
             ]
         }
@@ -132,14 +129,12 @@ def test_post_with_no_data(client: TestClient):
                     "loc": ["body", "name"],
                     "msg": "Field required",
                     "input": {},
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "price"],
                     "msg": "Field required",
                     "input": {},
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -173,7 +168,6 @@ def test_post_with_none(client: TestClient):
                     "loc": ["body"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -244,7 +238,6 @@ def test_post_form_for_json(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": "name=Foo&price=50.5",
-                    "url": match_pydantic_error_url("model_attributes_type"),
                 }
             ]
         }
@@ -308,9 +301,6 @@ def test_wrong_headers(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": '{"name": "Foo", "price": 50.5}',
-                    "url": match_pydantic_error_url(
-                        "model_attributes_type"
-                    ),  # "https://errors.pydantic.dev/0.38.0/v/dict_attributes_type",
                 }
             ]
         }
@@ -339,7 +329,6 @@ def test_wrong_headers(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": '{"name": "Foo", "price": 50.5}',
-                    "url": match_pydantic_error_url("model_attributes_type"),
                 }
             ]
         }
@@ -367,7 +356,6 @@ def test_wrong_headers(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": '{"name": "Foo", "price": 50.5}',
-                    "url": match_pydantic_error_url("model_attributes_type"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body/test_tutorial001_py310.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -81,7 +80,6 @@ def test_post_with_only_name(client: TestClient):
                     "loc": ["body", "price"],
                     "msg": "Field required",
                     "input": {"name": "Foo"},
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -111,7 +109,6 @@ def test_post_with_only_name_price(client: TestClient):
                     "loc": ["body", "price"],
                     "msg": "Input should be a valid number, unable to parse string as a number",
                     "input": "twenty",
-                    "url": match_pydantic_error_url("float_parsing"),
                 }
             ]
         }
@@ -141,14 +138,12 @@ def test_post_with_no_data(client: TestClient):
                     "loc": ["body", "name"],
                     "msg": "Field required",
                     "input": {},
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "price"],
                     "msg": "Field required",
                     "input": {},
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -183,7 +178,6 @@ def test_post_with_none(client: TestClient):
                     "loc": ["body"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -256,7 +250,6 @@ def test_post_form_for_json(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": "name=Foo&price=50.5",
-                    "url": match_pydantic_error_url("model_attributes_type"),
                 }
             ]
         }
@@ -324,7 +317,6 @@ def test_wrong_headers(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": '{"name": "Foo", "price": 50.5}',
-                    "url": match_pydantic_error_url("model_attributes_type"),
                 }
             ]
         }
@@ -353,7 +345,6 @@ def test_wrong_headers(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": '{"name": "Foo", "price": 50.5}',
-                    "url": match_pydantic_error_url("model_attributes_type"),
                 }
             ]
         }
@@ -381,7 +372,6 @@ def test_wrong_headers(client: TestClient):
                     "loc": ["body"],
                     "msg": "Input should be a valid dictionary or object to extract fields from",
                     "input": '{"name": "Foo", "price": 50.5}',
-                    "url": match_pydantic_error_url("model_attributes_type"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -57,7 +56,6 @@ def test_invalid_price(client: TestClient):
                     "msg": "Input should be greater than 0",
                     "input": -3.0,
                     "ctx": {"gt": 0.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_an.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -57,7 +56,6 @@ def test_invalid_price(client: TestClient):
                     "msg": "Input should be greater than 0",
                     "input": -3.0,
                     "ctx": {"gt": 0.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_an_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -62,7 +61,6 @@ def test_invalid_price(client: TestClient):
                     "msg": "Input should be greater than 0",
                     "input": -3.0,
                     "ctx": {"gt": 0.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -62,7 +61,6 @@ def test_invalid_price(client: TestClient):
                     "msg": "Input should be greater than 0",
                     "input": -3.0,
                     "ctx": {"gt": 0.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_fields/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -62,7 +61,6 @@ def test_invalid_price(client: TestClient):
                     "msg": "Input should be greater than 0",
                     "input": -3.0,
                     "ctx": {"gt": 0.0},
-                    "url": match_pydantic_error_url("greater_than"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -50,7 +49,6 @@ def test_post_id_foo(client: TestClient):
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -50,7 +49,6 @@ def test_post_id_foo(client: TestClient):
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -56,7 +55,6 @@ def test_post_id_foo(client: TestClient):
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -56,7 +55,6 @@ def test_post_id_foo(client: TestClient):
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -56,7 +55,6 @@ def test_post_id_foo(client: TestClient):
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -46,21 +45,18 @@ def test_post_body_no_data(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -99,21 +95,18 @@ def test_post_body_empty_list(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -46,21 +45,18 @@ def test_post_body_no_data(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -99,21 +95,18 @@ def test_post_body_empty_list(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -50,21 +49,18 @@ def test_post_body_no_data(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -104,21 +100,18 @@ def test_post_body_empty_list(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py39.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -50,21 +49,18 @@ def test_post_body_no_data(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -104,21 +100,18 @@ def test_post_body_empty_list(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003_py310.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -50,21 +49,18 @@ def test_post_body_no_data(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -104,21 +100,18 @@ def test_post_body_empty_list(client: TestClient):
                     "loc": ["body", "item"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "user"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "importance"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -31,7 +30,6 @@ def test_post_invalid_body(client: TestClient):
                     "loc": ["body", "foo", "[key]"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009_py39.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -35,7 +34,6 @@ def test_post_invalid_body(client: TestClient):
                     "loc": ["body", "foo", "[key]"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.custom_request_and_route.tutorial002 import app
 
@@ -23,7 +22,6 @@ def test_exception_handler_body_access():
                         "loc": ["body"],
                         "msg": "Input should be a valid list",
                         "input": {"numbers": [1, 2, 3]},
-                        "url": match_pydantic_error_url("list_type"),
                     }
                 ],
                 "body": '{"numbers": [1, 2, 3]}',

--- a/tests/test_tutorial/test_dataclasses/test_tutorial001.py
+++ b/tests/test_tutorial/test_dataclasses/test_tutorial001.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.dataclasses.tutorial001 import app
 
@@ -29,7 +28,6 @@ def test_post_invalid_item():
                     "loc": ["body", "price"],
                     "msg": "Input should be a valid number, unable to parse string as a number",
                     "input": "invalid price",
-                    "url": match_pydantic_error_url("float_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_dependencies/test_tutorial006.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.dependencies.tutorial006 import app
 
@@ -18,14 +17,12 @@ def test_get_no_headers():
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_dependencies/test_tutorial006_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006_an.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.dependencies.tutorial006_an import app
 
@@ -18,14 +17,12 @@ def test_get_no_headers():
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_dependencies/test_tutorial006_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -26,14 +25,12 @@ def test_get_no_headers(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_dependencies/test_tutorial012.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.dependencies.tutorial012 import app
 
@@ -18,14 +17,12 @@ def test_get_no_headers_items():
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -59,14 +56,12 @@ def test_get_no_headers_users():
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_dependencies/test_tutorial012_an.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012_an.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.dependencies.tutorial012_an import app
 
@@ -18,14 +17,12 @@ def test_get_no_headers_items():
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -59,14 +56,12 @@ def test_get_no_headers_users():
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_dependencies/test_tutorial012_an_py39.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -26,14 +25,12 @@ def test_get_no_headers_items(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -68,14 +65,12 @@ def test_get_no_headers_users(client: TestClient):
                     "loc": ["header", "x-token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["header", "x-key"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial005.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial005.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.handling_errors.tutorial005 import app
 
@@ -18,7 +17,6 @@ def test_post_validation_error():
                     "loc": ["body", "size"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "XL",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ],
             "body": {"title": "towel", "size": "XL"},

--- a/tests/test_tutorial/test_handling_errors/test_tutorial006.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial006.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.handling_errors.tutorial006 import app
 
@@ -18,7 +17,6 @@ def test_get_validation_error():
                     "loc": ["path", "item_id"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "foo",
-                    "url": match_pydantic_error_url("int_parsing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial007.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial007.py
@@ -1,6 +1,5 @@
 import pytest
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_pydanticv2
 
@@ -64,7 +63,6 @@ def test_post_invalid(client: TestClient):
                 "loc": ["tags", 3],
                 "msg": "Input should be a valid string",
                 "input": {"sneaky": "object"},
-                "url": match_pydantic_error_url("string_type"),
             }
         ]
     }

--- a/tests/test_tutorial/test_query_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial005.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.query_params.tutorial005 import app
 
@@ -24,7 +23,6 @@ def test_foo_no_needy():
                     "loc": ["query", "needy"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_query_params/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -34,21 +33,18 @@ def test_foo_no_needy(client: TestClient):
                     "loc": ["query", "needy"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "int_parsing",
                     "loc": ["query", "skip"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "a",
-                    "url": match_pydantic_error_url("int_parsing"),
                 },
                 {
                     "type": "int_parsing",
                     "loc": ["query", "limit"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "b",
-                    "url": match_pydantic_error_url("int_parsing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_query_params/test_tutorial006_py310.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -38,21 +37,18 @@ def test_foo_no_needy(client: TestClient):
                     "loc": ["query", "needy"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "int_parsing",
                     "loc": ["query", "skip"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "a",
-                    "url": match_pydantic_error_url("int_parsing"),
                 },
                 {
                     "type": "int_parsing",
                     "loc": ["query", "limit"],
                     "msg": "Input should be a valid integer, unable to parse string as an integer",
                     "input": "b",
-                    "url": match_pydantic_error_url("int_parsing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -45,7 +44,6 @@ def test_query_params_str_validations_item_query_nonregexquery(client: TestClien
                     "msg": "String should match pattern '^fixedquery$'",
                     "input": "nonregexquery",
                     "ctx": {"pattern": "^fixedquery$"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -45,7 +44,6 @@ def test_query_params_str_validations_item_query_nonregexquery(client: TestClien
                     "msg": "String should match pattern '^fixedquery$'",
                     "input": "nonregexquery",
                     "ctx": {"pattern": "^fixedquery$"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -51,7 +50,6 @@ def test_query_params_str_validations_item_query_nonregexquery(client: TestClien
                     "msg": "String should match pattern '^fixedquery$'",
                     "input": "nonregexquery",
                     "ctx": {"pattern": "^fixedquery$"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py39.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -51,7 +50,6 @@ def test_query_params_str_validations_item_query_nonregexquery(client: TestClien
                     "msg": "String should match pattern '^fixedquery$'",
                     "input": "nonregexquery",
                     "ctx": {"pattern": "^fixedquery$"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_py310.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010_py310.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py310
 
@@ -51,7 +50,6 @@ def test_query_params_str_validations_item_query_nonregexquery(client: TestClien
                     "msg": "String should match pattern '^fixedquery$'",
                     "input": "nonregexquery",
                     "ctx": {"pattern": "^fixedquery$"},
-                    "url": match_pydantic_error_url("string_pattern_mismatch"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.request_files.tutorial001 import app
 
@@ -29,7 +28,6 @@ def test_post_form_no_body():
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -58,7 +56,6 @@ def test_post_body_json():
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_an.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.request_files.tutorial001_an import app
 
@@ -18,7 +17,6 @@ def test_post_form_no_body():
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -47,7 +45,6 @@ def test_post_body_json():
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -26,7 +25,6 @@ def test_post_form_no_body(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -56,7 +54,6 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_files/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.request_files.tutorial002 import app
 
@@ -18,7 +17,6 @@ def test_post_form_no_body():
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -47,7 +45,6 @@ def test_post_body_json():
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_files/test_tutorial002_an.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002_an.py
@@ -1,6 +1,5 @@
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from docs_src.request_files.tutorial002_an import app
 
@@ -18,7 +17,6 @@ def test_post_form_no_body():
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -47,7 +45,6 @@ def test_post_body_json():
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_files/test_tutorial002_an_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002_an_py39.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -32,7 +31,6 @@ def test_post_form_no_body(client: TestClient):
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -62,7 +60,6 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_files/test_tutorial002_py39.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002_py39.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -43,7 +42,6 @@ def test_post_form_no_body(client: TestClient):
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -73,7 +71,6 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "files"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -29,7 +28,6 @@ def test_post_body_form_no_password(client: TestClient):
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -58,7 +56,6 @@ def test_post_body_form_no_username(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -87,14 +84,12 @@ def test_post_body_form_no_data(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -128,14 +123,12 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_request_forms/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001_an.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="client")
@@ -29,7 +28,6 @@ def test_post_body_form_no_password(client: TestClient):
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -58,7 +56,6 @@ def test_post_body_form_no_username(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -87,14 +84,12 @@ def test_post_body_form_no_data(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -128,14 +123,12 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_request_forms/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001_an_py39.py
@@ -1,7 +1,6 @@
 import pytest
 from dirty_equals import IsDict
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -33,7 +32,6 @@ def test_post_body_form_no_password(client: TestClient):
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -63,7 +61,6 @@ def test_post_body_form_no_username(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 }
             ]
         }
@@ -93,14 +90,12 @@ def test_post_body_form_no_data(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -135,14 +130,12 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "username"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "password"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="app")
@@ -29,21 +28,18 @@ def test_post_form_no_body(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -82,14 +78,12 @@ def test_post_form_no_file(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -123,21 +117,18 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -181,14 +172,12 @@ def test_post_file_no_token(tmp_path, app: FastAPI):
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 
 @pytest.fixture(name="app")
@@ -29,21 +28,18 @@ def test_post_form_no_body(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -82,14 +78,12 @@ def test_post_form_no_file(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -123,21 +117,18 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -181,14 +172,12 @@ def test_post_file_no_token(tmp_path, app: FastAPI):
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an_py39.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001_an_py39.py
@@ -2,7 +2,6 @@ import pytest
 from dirty_equals import IsDict
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from fastapi.utils import match_pydantic_error_url
 
 from ...utils import needs_py39
 
@@ -32,21 +31,18 @@ def test_post_form_no_body(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -86,14 +82,12 @@ def test_post_form_no_file(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -128,21 +122,18 @@ def test_post_body_json(client: TestClient):
                     "loc": ["body", "file"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }
@@ -187,14 +178,12 @@ def test_post_file_no_token(tmp_path, app: FastAPI):
                     "loc": ["body", "fileb"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
                 {
                     "type": "missing",
                     "loc": ["body", "token"],
                     "msg": "Field required",
                     "input": None,
-                    "url": match_pydantic_error_url("missing"),
                 },
             ]
         }


### PR DESCRIPTION
✨ Add support for Pydantic's 2.7 new deprecated Field parameter, remove URL from validation errors response

This also removes the no longer used internal util `match_pydantic_error_url`