### PR TITLE
Add easy "debug-on-exception" debugger middleware functionality (and remote debugging)

### DIFF
--- a/fastapi/middleware/debugger.py
+++ b/fastapi/middleware/debugger.py
@@ -1,0 +1,104 @@
+import typing
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+async def catch_exceptions_middleware(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
+    import pdb
+    import sys
+
+    try:
+        return await call_next(request)
+    except Exception as e:
+        sys.last_traceback = e.__traceback__
+        pdb.pm()
+        raise
+
+
+async def webpdb_catch_exceptions_middleware(
+    request: Request, call_next: RequestResponseEndpoint
+) -> Response:
+    """
+    Requires web-pdb package.
+
+    ```bash
+    pip install web-pdb
+    ```
+    """
+    import web_pdb  # type: ignore
+
+    with web_pdb.catch_post_mortem():
+        return await call_next(request)
+
+
+class DebuggerMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to intercept exceptions and start a debugger in that stack frame.
+
+    The default configured debugger is PDB since it comes packaged with Python.
+
+    Additionally web UI can be added by add web-pdb a dep., or a custom callable
+    be passed through the `start_debugger_func` middleware parameter to run
+    a debugger of choice.
+
+    Example:
+
+    ```python
+    # Add default (PDB) debugger
+    impost os
+
+    from fastapi import FastAPI
+    from fastapi.middleware.debugger import DebuggerMiddleware
+
+    app = FastAPI()
+
+    if os.getenv("ENV") == "LOCAL": # Or something along those lines to check and only run in locally
+        app.add_middleware(DebuggerMiddleware)
+    ```
+
+    ```python
+    # Add web_PDB debugger
+    impost os
+
+    from fastapi import FastAPI
+    from fastapi.middleware.debugger import DebuggerMiddleware, webpdb_catch_exceptions_middleware
+
+    app = FastAPI()
+
+    if os.getenv("ENV") == "LOCAL": # Or something along those lines to check and only run in locally
+        app.add_middleware(DebuggerMiddleware, start_debugger_func=webpdb_catch_exceptions_middleware)
+    ```
+
+    Additional notes:
+    A good practice would be to add rules to your linter or use a tool like Pre-commit to remove/ check
+    for forgotten breakpoints left in prod. code.
+
+    Also set `PYTHONBREAKPOINT=0` environment in your prod configs to prevent a python debugger running in
+    prod.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        start_debugger_func: typing.Optional[
+            typing.Callable[
+                [Request, RequestResponseEndpoint],
+                typing.Coroutine[typing.Any, typing.Any, Response],
+            ]
+        ] = None,
+    ) -> None:
+        if start_debugger_func:
+            self.start_debug = start_debugger_func
+        else:
+            self.start_debug = catch_exceptions_middleware
+        super().__init__(app, dispatch=None)
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        return await self.start_debug(request, call_next)

--- a/tests/test_middleware_debugger_class.py
+++ b/tests/test_middleware_debugger_class.py
@@ -8,8 +8,6 @@ from fastapi.middleware.debugger import (
 )
 from fastapi.testclient import TestClient
 
-MAGIC_VALUE_THAT_NEVER_RETURNS = 42
-
 
 def get_client_for_new_app(middlware_params=None):
     app = FastAPI()
@@ -18,7 +16,6 @@ def get_client_for_new_app(middlware_params=None):
     @app.get("/call-debugger-on-raise")
     async def raise_exception():
         raise ValueError("Test")
-        return MAGIC_VALUE_THAT_NEVER_RETURNS
 
     return TestClient(app)
 
@@ -39,8 +36,7 @@ def test_pdb(pdb_test_client):
     pdb_mock = MagicMock()
     with patch.dict("sys.modules", {"pdb": pdb_mock}):
         with pytest.raises(ValueError):
-            result = pdb_test_client.get("/call-debugger-on-raise")
-            assert result != MAGIC_VALUE_THAT_NEVER_RETURNS
+            _ = pdb_test_client.get("/call-debugger-on-raise")
 
     assert pdb_mock.pm.called
 
@@ -49,7 +45,6 @@ def test_webpdb(webpdb_test_client):
     webpdb_mock = MagicMock()
     with patch.dict("sys.modules", {"web_pdb": webpdb_mock}):
         with pytest.raises(ValueError):
-            result = webpdb_test_client.get("/call-debugger-on-raise")
-            assert result != MAGIC_VALUE_THAT_NEVER_RETURNS
+            _ = webpdb_test_client.get("/call-debugger-on-raise")
 
     assert webpdb_mock.catch_post_mortem.called

--- a/tests/test_middleware_debugger_class.py
+++ b/tests/test_middleware_debugger_class.py
@@ -39,7 +39,8 @@ def test_pdb(pdb_test_client):
     pdb_mock = MagicMock()
     with patch.dict("sys.modules", {"pdb": pdb_mock}):
         with pytest.raises(ValueError):
-            _ = pdb_test_client.get("/call-debugger-on-raise")
+            result = pdb_test_client.get("/call-debugger-on-raise")
+            assert result != MAGIC_VALUE_THAT_NEVER_RETURNS
 
     assert pdb_mock.pm.called
 
@@ -48,6 +49,7 @@ def test_webpdb(webpdb_test_client):
     webpdb_mock = MagicMock()
     with patch.dict("sys.modules", {"web_pdb": webpdb_mock}):
         with pytest.raises(ValueError):
-            _ = webpdb_test_client.get("/call-debugger-on-raise")
+            result = webpdb_test_client.get("/call-debugger-on-raise")
+            assert result != MAGIC_VALUE_THAT_NEVER_RETURNS
 
     assert webpdb_mock.catch_post_mortem.called

--- a/tests/test_middleware_debugger_class.py
+++ b/tests/test_middleware_debugger_class.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.debugger import (
+    DebuggerMiddleware,
+    webpdb_catch_exceptions_middleware,
+)
+from fastapi.testclient import TestClient
+
+MAGIC_VALUE_THAT_NEVER_RETURNS = 42
+
+
+def get_client_for_new_app(middlware_params=None):
+    app = FastAPI()
+    app.add_middleware(DebuggerMiddleware, **(middlware_params or {}))
+
+    @app.get("/call-debugger-on-raise")
+    async def raise_exception():
+        raise ValueError("Test")
+        return MAGIC_VALUE_THAT_NEVER_RETURNS
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def pdb_test_client():
+    return get_client_for_new_app()
+
+
+@pytest.fixture
+def webpdb_test_client():
+    return get_client_for_new_app(
+        {"start_debugger_func": webpdb_catch_exceptions_middleware}
+    )
+
+
+def test_pdb(pdb_test_client):
+    pdb_mock = MagicMock()
+    with patch.dict("sys.modules", {"pdb": pdb_mock}):
+        with pytest.raises(ValueError):
+            _ = pdb_test_client.get("/call-debugger-on-raise")
+
+    assert pdb_mock.pm.called
+
+
+def test_webpdb(webpdb_test_client):
+    webpdb_mock = MagicMock()
+    with patch.dict("sys.modules", {"web_pdb": webpdb_mock}):
+        with pytest.raises(ValueError):
+            _ = webpdb_test_client.get("/call-debugger-on-raise")
+
+    assert webpdb_mock.catch_post_mortem.called


### PR DESCRIPTION
### Intent:

- Quicker to replicate issues, less cycles to fix
  - Often webdev workflow involve dealing with mistakes that require some set of step to replicate, having the a debugger start up when the issue occurs initially can really mitigate the number of iterations on figuring out and fixing issues.

- Easy remote/ docker-ized debugging
  - Having easy access to a remote debugger such as webdev also makes debugging docker-ized (and/ or dev. envs. running on a remote machine) straightforward.

- Additionally having a debugger right in the browser can make the "ergonomics" of this cycle less cumbersome.

This PR attempts to achieve the above by providing an easy way to add debug-on-exception feature to Fastapi along side with some sensible default debugger options.
 
### Overview:
- Adds middleware class to allow intercepting exceptions in endpoints and starting a debugger in those stack frames

- Debugger is customizable by passing in a custom callable that can run debugger of choice

- Default debugger if not customized is PDB

- Adds support to use web-PDB by including pre made callable that can be passed in as a middleware arg