### PR TITLE
🔧 Add configs and setup for `fastapi-slim` including optional extras `fastapi-slim[standard]`, and `fastapi` including by default the same `standard` extras

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,6 @@ on:
   release:
     types:
       - created
-  # TODO: remove this
-  push:
-    branches:
-      - slim
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types:
       - created
+  # TODO: remove this
+  push:
+    branches:
+      - slim
 
 jobs:
   publish:
@@ -12,6 +16,7 @@ jobs:
       matrix:
         package:
           - fastapi
+          - fastapi-slim
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/test-redistribute.yml
+++ b/.github/workflows/test-redistribute.yml
@@ -12,6 +12,11 @@ on:
 jobs:
   test-redistribute:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          - fastapi
+          - fastapi-slim
     steps:
       - name: Dump GitHub context
         env:
@@ -22,12 +27,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          # Issue ref: https://github.com/actions/setup-python/issues/436
-          # cache: "pip"
-          # cache-dependency-path: pyproject.toml
       - name: Install build dependencies
         run: pip install build
       - name: Build source distribution
+        env:
+          TIANGOLO_BUILD_PACKAGE: ${{ matrix.package }}
         run: python -m build --sdist
       - name: Decompress source distribution
         run: |
@@ -35,16 +39,16 @@ jobs:
           tar xvf fastapi*.tar.gz
       - name: Install test dependencies
         run: |
-          cd dist/fastapi-*/
+          cd dist/fastapi*/
           pip install -r requirements-tests.txt
       - name: Run source distribution tests
         run: |
-          cd dist/fastapi-*/
+          cd dist/fastapi*/
           bash scripts/test.sh
       - name: Build wheel distribution
         run: |
           cd dist
-          pip wheel --no-deps fastapi-*.tar.gz
+          pip wheel --no-deps fastapi*.tar.gz
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,6 +1,6 @@
 """FastAPI framework, high performance, easy to learn, fast to code, ready for production"""
 
-__version__ = "0.110.3"
+__version__ = "0.111.0.dev1"
 
 from starlette import status as status
 

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -1,0 +1,39 @@
+import os
+from typing import Any, Dict, List
+
+from pdm.backend.hooks import Context
+
+TIANGOLO_BUILD_PACKAGE = os.getenv("TIANGOLO_BUILD_PACKAGE", "fastapi")
+
+
+def pdm_build_initialize(context: Context) -> None:
+    metadata = context.config.metadata
+    # Get custom config for the current package, from the env var
+    config: Dict[str, Any] = context.config.data["tool"]["tiangolo"][
+        "_internal-slim-build"
+    ]["packages"][TIANGOLO_BUILD_PACKAGE]
+    project_config: Dict[str, Any] = config["project"]
+    # Get main optional dependencies, extras
+    optional_dependencies: Dict[str, List[str]] = metadata.get(
+        "optional-dependencies", {}
+    )
+    # Get custom optional dependencies name to always include in this (non-slim) package
+    include_optional_dependencies: List[str] = config.get(
+        "include-optional-dependencies", []
+    )
+    # Override main [project] configs with custom configs for this package
+    for key, value in project_config.items():
+        metadata[key] = value
+    # Get custom build config for the current package
+    build_config: Dict[str, Any] = (
+        config.get("tool", {}).get("pdm", {}).get("build", {})
+    )
+    # Override PDM build config with custom build config for this package
+    for key, value in build_config.items():
+        context.config.build_config[key] = value
+    # Get main dependencies
+    dependencies: List[str] = metadata.get("dependencies", [])
+    # Add optional dependencies to the default dependencies for this (non-slim) package
+    for include_optional in include_optional_dependencies:
+        optional_dependencies_group = optional_dependencies.get(include_optional, [])
+        dependencies.extend(optional_dependencies_group)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,11 @@ standard = [
     "email_validator >=2.0.0",
     # Uvicorn with uvloop
     "uvicorn[standard] >=0.12.0",
-    # Settings management
-    "pydantic-settings >=2.0.0",
-    # Extra Pydantic data types
-    "pydantic-extra-types >=2.0.0",
+    # TODO: this should be part of some pydantic optional extra dependencies
+    # # Settings management
+    # "pydantic-settings >=2.0.0",
+    # # Extra Pydantic data types
+    # "pydantic-extra-types >=2.0.0",
 ]
 
 all = [
@@ -120,6 +121,28 @@ name = "fastapi-slim"
 include-optional-dependencies = ["standard"]
 
 [tool.tiangolo._internal-slim-build.packages.fastapi.project.optional-dependencies]
+# TODO: remove `standard` once pydantic has an optional extra including pydantic-settings and pydantic-extra-types
+standard = [
+    # For the test client
+    "httpx >=0.23.0",
+    # For templates
+    "jinja2 >=2.11.2",
+    # For forms and file uploads
+    "python-multipart >=0.0.7",
+    # For UJSONResponse
+    "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
+    # For ORJSONResponse
+    "orjson >=3.2.1",
+    # To validate email fields
+    "email_validator >=2.0.0",
+    # Uvicorn with uvloop
+    "uvicorn[standard] >=0.12.0",
+    # # Settings management
+    "pydantic-settings >=2.0.0",
+    # # Extra Pydantic data types
+    "pydantic-extra-types >=2.0.0",
+]
+
 all = [
     # # For the test client
     "httpx >=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,28 +121,6 @@ name = "fastapi-slim"
 include-optional-dependencies = ["standard"]
 
 [tool.tiangolo._internal-slim-build.packages.fastapi.project.optional-dependencies]
-# TODO: remove `standard` once pydantic has an optional extra including pydantic-settings and pydantic-extra-types
-standard = [
-    # For the test client
-    "httpx >=0.23.0",
-    # For templates
-    "jinja2 >=2.11.2",
-    # For forms and file uploads
-    "python-multipart >=0.0.7",
-    # For UJSONResponse
-    "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
-    # For ORJSONResponse
-    "orjson >=3.2.1",
-    # To validate email fields
-    "email_validator >=2.0.0",
-    # Uvicorn with uvloop
-    "uvicorn[standard] >=0.12.0",
-    # # Settings management
-    "pydantic-settings >=2.0.0",
-    # # Extra Pydantic data types
-    "pydantic-extra-types >=2.0.0",
-]
-
 all = [
     # # For the test client
     "httpx >=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,26 +53,26 @@ Repository = "https://github.com/tiangolo/fastapi"
 
 [project.optional-dependencies]
 
-# standard = [
-#     # For the test client
-#     "httpx >=0.23.0",
-#     # For templates
-#     "jinja2 >=2.11.2",
-#     # For forms and file uploads
-#     "python-multipart >=0.0.7",
-#     # For UJSONResponse
-#     "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
-#     # For ORJSONResponse
-#     "orjson >=3.2.1",
-#     # To validate email fields
-#     "email_validator >=2.0.0",
-#     # Uvicorn with uvloop
-#     "uvicorn[standard] >=0.12.0",
-#     # Settings management
-#     "pydantic-settings >=2.0.0",
-#     # Extra Pydantic data types
-#     "pydantic-extra-types >=2.0.0",
-# ]
+standard = [
+    # For the test client
+    "httpx >=0.23.0",
+    # For templates
+    "jinja2 >=2.11.2",
+    # For forms and file uploads
+    "python-multipart >=0.0.7",
+    # For UJSONResponse
+    "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
+    # For ORJSONResponse
+    "orjson >=3.2.1",
+    # To validate email fields
+    "email_validator >=2.0.0",
+    # Uvicorn with uvloop
+    "uvicorn[standard] >=0.12.0",
+    # Settings management
+    "pydantic-settings >=2.0.0",
+    # Extra Pydantic data types
+    "pydantic-extra-types >=2.0.0",
+]
 
 all = [
     # # For the test client
@@ -113,6 +113,37 @@ source-includes = [
     "docs/en/docs/img/favicon.png",
     ]
 
+[tool.tiangolo._internal-slim-build.packages.fastapi-slim.project]
+name = "fastapi-slim"
+
+[tool.tiangolo._internal-slim-build.packages.fastapi]
+include-optional-dependencies = ["standard"]
+
+[tool.tiangolo._internal-slim-build.packages.fastapi.project.optional-dependencies]
+all = [
+    # # For the test client
+    "httpx >=0.23.0",
+    # For templates
+    "jinja2 >=2.11.2",
+    # For forms and file uploads
+    "python-multipart >=0.0.7",
+    # For Starlette's SessionMiddleware, not commonly used with FastAPI
+    "itsdangerous >=1.1.0",
+    # For Starlette's schema generation, would not be used with FastAPI
+    "pyyaml >=5.3.1",
+    # For UJSONResponse
+    "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
+    # For ORJSONResponse
+    "orjson >=3.2.1",
+    # To validate email fields
+    "email_validator >=2.0.0",
+    # Uvicorn with uvloop
+    "uvicorn[standard] >=0.12.0",
+    # Settings management
+    "pydantic-settings >=2.0.0",
+    # Extra Pydantic data types
+    "pydantic-extra-types >=2.0.0",
+]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
🔧 Add configs and setup for `fastapi-slim` including optional extras `fastapi-slim[standard]`, and `fastapi` including by default the same `standard` extras

The `fastapi` package now includes the `standard` default recommended packages, and `fastapi-slim` comes without those recommended standard packages and with a group of optional dependencies `fastapi-slim[standard]`, equivalent to `fastapi`, for those that want to opt out of those default `standard` packages.