### PR TITLE
✏️ Fix link in `fastapi-cli.md`

### DIFF
--- a/docs/en/docs/fastapi-cli.md
+++ b/docs/en/docs/fastapi-cli.md
@@ -81,4 +81,4 @@ It will listen on the IP address `0.0.0.0`, which means all the available IP add
 In most cases you would (and should) have a "termination proxy" handling HTTPS for you on top, this will depend on how you deploy your application, your provider might do this for you, or you might need to set it up yourself.
 
 !!! tip
-    You can learn more about it in the [deployment documentation](../deployment/index.md){.internal-link target=_blank}.
+    You can learn more about it in the [deployment documentation](../deployment/){.internal-link target=_blank}.

--- a/docs/en/docs/fastapi-cli.md
+++ b/docs/en/docs/fastapi-cli.md
@@ -81,4 +81,4 @@ It will listen on the IP address `0.0.0.0`, which means all the available IP add
 In most cases you would (and should) have a "termination proxy" handling HTTPS for you on top, this will depend on how you deploy your application, your provider might do this for you, or you might need to set it up yourself.
 
 !!! tip
-    You can learn more about it in the [deployment documentation](../deployment/){.internal-link target=_blank}.
+    You can learn more about it in the [deployment documentation](deployment/index.md){.internal-link target=_blank}.


### PR DESCRIPTION
As reported on [Twitter](https://twitter.com/lucabaggi_/status/1786271218758242771): the link gave a 404 as the `index.md` page doesn't exist. 