### PR TITLE
📝 Added Python 3.10+ syntax for small part

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -385,13 +385,25 @@ q: Union[str, None] = None
 
 But we are now declaring it with `Query`, for example like:
 
-=== "Annotated"
+=== "Python 3.10+ Annotated"
+
+    ```Python
+    q: Annotated[str | None, Query(min_length=3)] = None
+    ```
+    
+=== "Python 3.9+ Annotated"
 
     ```Python
     q: Annotated[Union[str, None], Query(min_length=3)] = None
     ```
 
-=== "non-Annotated"
+=== "Python 3.10+ non-Annotated"
+
+    ```Python
+    q: str | None = Query(default=None, min_length=3)
+    ```
+    
+=== "Python 3.9+ non-Annotated"
 
     ```Python
     q: Union[str, None] = Query(default=None, min_length=3)

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -390,7 +390,7 @@ But we are now declaring it with `Query`, for example like:
     ```Python
     q: Annotated[str | None, Query(min_length=3)] = None
     ```
-    
+
 === "Python 3.9+ Annotated"
 
     ```Python
@@ -402,7 +402,7 @@ But we are now declaring it with `Query`, for example like:
     ```Python
     q: str | None = Query(default=None, min_length=3)
     ```
-    
+
 === "Python 3.9+ non-Annotated"
 
     ```Python

--- a/docs_src/body_fields/tutorial001.py
+++ b/docs_src/body_fields/tutorial001.py
@@ -9,7 +9,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     description: Union[str, None] = Field(
-        default=None, title="The description of the item", max_length=300
+        default=None, title="The title of the item", max_length=300
     )
     price: float = Field(gt=0, description="The price must be greater than zero")
     tax: Union[float, None] = None

--- a/docs_src/body_fields/tutorial001_an.py
+++ b/docs_src/body_fields/tutorial001_an.py
@@ -10,7 +10,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     description: Union[str, None] = Field(
-        default=None, title="The description of the item", max_length=300
+        default=None, title="The title of the item", max_length=300
     )
     price: float = Field(gt=0, description="The price must be greater than zero")
     tax: Union[float, None] = None

--- a/docs_src/body_fields/tutorial001_an_py310.py
+++ b/docs_src/body_fields/tutorial001_an_py310.py
@@ -9,7 +9,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     description: str | None = Field(
-        default=None, title="The description of the item", max_length=300
+        default=None, title="The title of the item", max_length=300
     )
     price: float = Field(gt=0, description="The price must be greater than zero")
     tax: float | None = None

--- a/docs_src/body_fields/tutorial001_an_py39.py
+++ b/docs_src/body_fields/tutorial001_an_py39.py
@@ -9,7 +9,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     description: Union[str, None] = Field(
-        default=None, title="The description of the item", max_length=300
+        default=None, title="The title of the item", max_length=300
     )
     price: float = Field(gt=0, description="The price must be greater than zero")
     tax: Union[float, None] = None

--- a/docs_src/body_fields/tutorial001_py310.py
+++ b/docs_src/body_fields/tutorial001_py310.py
@@ -7,7 +7,7 @@ app = FastAPI()
 class Item(BaseModel):
     name: str
     description: str | None = Field(
-        default=None, title="The description of the item", max_length=300
+        default=None, title="The title of the item", max_length=300
     )
     price: float = Field(gt=0, description="The price must be greater than zero")
     tax: float | None = None


### PR DESCRIPTION
Update this small part at: https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#make-it-required

where it was still written with `Union` (Python 3.9) syntax, and added tabs for `Python 3.10+ Annotated`