### PR TITLE
🦺 Update implementation and docs for `RequestValidationError` in Pydantic v2

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -70,7 +70,7 @@ if PYDANTIC_V2:
         )
     except ImportError:  # pragma: no cover
         from pydantic_core.core_schema import (
-            general_plain_validator_function as with_info_plain_validator_function,  # noqa: F401
+            general_plain_validator_function as with_info_plain_validator_function,
         )
 
     RequiredParam = PydanticUndefined
@@ -296,14 +296,14 @@ else:
     from fastapi.openapi.constants import REF_PREFIX as REF_PREFIX
     from pydantic import AnyUrl as Url  # noqa: F401
     from pydantic import (  # type: ignore[assignment]
-        BaseConfig as BaseConfig,  # noqa: F401
+        BaseConfig as BaseConfig,
     )
-    from pydantic import ValidationError as ValidationError  # noqa: F401
+    from pydantic import ValidationError as ValidationError
     from pydantic.class_validators import (  # type: ignore[no-redef]
-        Validator as Validator,  # noqa: F401
+        Validator as Validator,
     )
     from pydantic.error_wrappers import (  # type: ignore[no-redef]
-        ErrorWrapper as ErrorWrapper,  # noqa: F401
+        ErrorWrapper as ErrorWrapper,
     )
     from pydantic.errors import MissingError
     from pydantic.fields import (  # type: ignore[attr-defined]
@@ -317,7 +317,7 @@ else:
     )
     from pydantic.fields import FieldInfo as FieldInfo
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
-        ModelField as ModelField,  # noqa: F401
+        ModelField as ModelField,
     )
 
     # Keeping old "Required" functionality from Pydantic V1, without
@@ -327,7 +327,7 @@ else:
         Undefined as Undefined,
     )
     from pydantic.fields import (  # type: ignore[no-redef, attr-defined]
-        UndefinedType as UndefinedType,  # noqa: F401
+        UndefinedType as UndefinedType,
     )
     from pydantic.schema import (
         field_schema,
@@ -335,14 +335,14 @@ else:
         get_model_name_map,
         model_process_schema,
     )
-    from pydantic.schema import (  # type: ignore[no-redef]  # noqa: F401
+    from pydantic.schema import (  # type: ignore[no-redef]
         get_annotation_from_field_info as get_annotation_from_field_info,
     )
     from pydantic.typing import (  # type: ignore[no-redef]
-        evaluate_forwardref as evaluate_forwardref,  # noqa: F401
+        evaluate_forwardref as evaluate_forwardref,
     )
     from pydantic.utils import (  # type: ignore[no-redef]
-        lenient_issubclass as lenient_issubclass,  # noqa: F401
+        lenient_issubclass as lenient_issubclass,
     )
 
     GetJsonSchemaHandler = Any  # type: ignore[assignment,misc]

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -1,5 +1,7 @@
-from typing import Any, Dict, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Type, Union
 
+if TYPE_CHECKING:  # pragma: nocover
+    from fastapi._compat import ErrorDetails
 from pydantic import BaseModel, create_model
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.exceptions import WebSocketException as StarletteWebSocketException
@@ -147,15 +149,15 @@ class FastAPIError(RuntimeError):
 
 
 class ValidationException(Exception):
-    def __init__(self, errors: Sequence[Any]) -> None:
+    def __init__(self, errors: Sequence["ErrorDetails"]) -> None:
         self._errors = errors
 
-    def errors(self) -> Sequence[Any]:
+    def errors(self) -> Sequence["ErrorDetails"]:
         return self._errors
 
 
 class RequestValidationError(ValidationException):
-    def __init__(self, errors: Sequence[Any], *, body: Any = None) -> None:
+    def __init__(self, errors: Sequence["ErrorDetails"], *, body: Any = None) -> None:
         super().__init__(errors)
         self.body = body
 
@@ -165,7 +167,7 @@ class WebSocketRequestValidationError(ValidationException):
 
 
 class ResponseValidationError(ValidationException):
-    def __init__(self, errors: Sequence[Any], *, body: Any = None) -> None:
+    def __init__(self, errors: Sequence["ErrorDetails"], *, body: Any = None) -> None:
         super().__init__(errors)
         self.body = body
 

--- a/tests/test_filter_pydantic_sub_model/app_pv1.py
+++ b/tests/test_filter_pydantic_sub_model/app_pv1.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from fastapi import Depends, FastAPI
 from pydantic import BaseModel, validator
@@ -20,7 +20,7 @@ class ModelA(BaseModel):
     model_b: ModelB
 
     @validator("name")
-    def lower_username(cls, name: str, values):
+    def lower_username(cls, name: str, values: Dict[str, Any]) -> str:
         if not name.endswith("A"):
             raise ValueError("name must end in A")
         return name
@@ -31,5 +31,7 @@ async def get_model_c() -> ModelC:
 
 
 @app.get("/model/{name}", response_model=ModelA)
-async def get_model_a(name: str, model_c=Depends(get_model_c)):
+async def get_model_a(
+    name: str, model_c: ModelC = Depends(get_model_c)
+) -> Dict[str, Any]:
     return {"name": name, "description": "model-a-desc", "model_b": model_c}

--- a/tests/test_filter_pydantic_sub_model/test_filter_pydantic_sub_model_pv1.py
+++ b/tests/test_filter_pydantic_sub_model/test_filter_pydantic_sub_model_pv1.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING, Sequence
+
 import pytest
+
+if TYPE_CHECKING:  # pragma: nocover
+    from fastapi._compat import ErrorDetails
 from fastapi.exceptions import ResponseValidationError
 from fastapi.testclient import TestClient
 
@@ -28,7 +33,8 @@ def test_filter_sub_model(client: TestClient) -> None:
 def test_validator_is_cloned(client: TestClient) -> None:
     with pytest.raises(ResponseValidationError) as err:
         client.get("/model/modelX")
-    assert err.value.errors() == [
+    errors: Sequence[ErrorDetails] = err.value.errors()
+    assert errors == [
         {
             "loc": ("response", "name"),
             "msg": "name must end in A",

--- a/tests/test_filter_pydantic_sub_model/test_filter_pydantic_sub_model_pv1.py
+++ b/tests/test_filter_pydantic_sub_model/test_filter_pydantic_sub_model_pv1.py
@@ -6,7 +6,7 @@ from ..utils import needs_pydanticv1
 
 
 @pytest.fixture(name="client")
-def get_client():
+def get_client() -> TestClient:
     from .app_pv1 import app
 
     client = TestClient(app)
@@ -14,7 +14,7 @@ def get_client():
 
 
 @needs_pydanticv1
-def test_filter_sub_model(client: TestClient):
+def test_filter_sub_model(client: TestClient) -> None:
     response = client.get("/model/modelA")
     assert response.status_code == 200, response.text
     assert response.json() == {
@@ -25,7 +25,7 @@ def test_filter_sub_model(client: TestClient):
 
 
 @needs_pydanticv1
-def test_validator_is_cloned(client: TestClient):
+def test_validator_is_cloned(client: TestClient) -> None:
     with pytest.raises(ResponseValidationError) as err:
         client.get("/model/modelX")
     assert err.value.errors() == [
@@ -38,7 +38,7 @@ def test_validator_is_cloned(client: TestClient):
 
 
 @needs_pydanticv1
-def test_openapi_schema(client: TestClient):
+def test_openapi_schema(client: TestClient) -> None:
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
     assert response.json() == {

--- a/tests/test_filter_pydantic_sub_model_pv2.py
+++ b/tests/test_filter_pydantic_sub_model_pv2.py
@@ -1,8 +1,11 @@
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence
 
 import pytest
-from dirty_equals import HasRepr, IsDict
+from dirty_equals import HasRepr
 from fastapi import Depends, FastAPI
+
+if TYPE_CHECKING:  # pragma: nocover
+    from fastapi._compat import ErrorDetails
 from fastapi.exceptions import ResponseValidationError
 from fastapi.testclient import TestClient
 
@@ -60,16 +63,15 @@ def test_filter_sub_model(client: TestClient) -> None:
 def test_validator_is_cloned(client: TestClient) -> None:
     with pytest.raises(ResponseValidationError) as err:
         client.get("/model/modelX")
-    assert err.value.errors() == [
-        IsDict(
-            {
-                "type": "value_error",
-                "loc": ("response", "name"),
-                "msg": "Value error, name must end in A",
-                "input": "modelX",
-                "ctx": {"error": HasRepr("ValueError('name must end in A')")},
-            }
-        )
+    errors: Sequence[ErrorDetails] = err.value.errors()
+    assert errors == [
+        {
+            "type": "value_error",
+            "loc": ("response", "name"),
+            "msg": "Value error, name must end in A",
+            "input": "modelX",
+            "ctx": {"error": HasRepr("ValueError('name must end in A')")},
+        }
     ]
 
 

--- a/tests/test_filter_pydantic_sub_model_pv2.py
+++ b/tests/test_filter_pydantic_sub_model_pv2.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from dirty_equals import HasRepr, IsDict, IsOneOf
+from dirty_equals import HasRepr, IsDict
 from fastapi import Depends, FastAPI
 from fastapi.exceptions import ResponseValidationError
 from fastapi.testclient import TestClient
@@ -68,14 +68,6 @@ def test_validator_is_cloned(client: TestClient):
                 "ctx": {"error": HasRepr("ValueError('name must end in A')")},
             }
         )
-        | IsDict(
-            # TODO remove when deprecating Pydantic v1
-            {
-                "loc": ("response", "name"),
-                "msg": "name must end in A",
-                "type": "value_error",
-            }
-        )
     ]
 
 
@@ -137,23 +129,14 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ModelA": {
                     "title": "ModelA",
-                    "required": IsOneOf(
-                        ["name", "description", "foo"],
-                        # TODO remove when deprecating Pydantic v1
-                        ["name", "foo"],
-                    ),
+                    "required": ["name", "foo"],
                     "type": "object",
                     "properties": {
                         "name": {"title": "Name", "type": "string"},
-                        "description": IsDict(
-                            {
-                                "title": "Description",
-                                "anyOf": [{"type": "string"}, {"type": "null"}],
-                            }
-                        )
-                        |
-                        # TODO remove when deprecating Pydantic v1
-                        IsDict({"title": "Description", "type": "string"}),
+                        "description": {
+                            "title": "Description",
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                        },
                         "foo": {"$ref": "#/components/schemas/ModelB"},
                     },
                 },


### PR DESCRIPTION
Change the signature of `ValidationException.errors` to return
`Sequence[pydantic_core.ErrorDetails]` in Pydantic V2.

Update the documentation to explain that `RequestValidationError` isn't
literally a subclass since Pydantic V2.

Closes (**UPD YuriiMotov:** actually not) #10424.
Closes #11176.
