### PR TITLE
👷 Update GitHub actions to download and upload artifacts to v4, for docs and coverage

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -108,7 +108,7 @@ jobs:
           path: docs/${{ matrix.lang }}/.cache
       - name: Build Docs
         run: python ./scripts/docs.py build-lang ${{ matrix.lang }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: ./site/**

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -110,7 +110,7 @@ jobs:
         run: python ./scripts/docs.py build-lang ${{ matrix.lang }}
       - uses: actions/upload-artifact@v4
         with:
-          name: docs-site
+          name: docs-site-${{ matrix.lang }}
           path: ./site/**
 
   # https://github.com/marketplace/actions/alls-green#why

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,19 +19,17 @@ jobs:
         run: |
           rm -rf ./site
           mkdir ./site
-      - name: Download Artifact Docs
+      - uses: actions/download-artifact@v4
         id: download
-        uses: dawidd6/action-download-artifact@v3.1.4
         with:
-          if_no_artifact_found: ignore
-          github_token: ${{ secrets.FASTAPI_PREVIEW_DOCS_DOWNLOAD_ARTIFACTS }}
-          workflow: build-docs.yml
-          run_id: ${{ github.event.workflow_run.id }}
-          name: docs-site-.*
-          name_is_regexp: true
           path: ./site/
+          pattern: docs-site-*
+          merge-multiple: true
+          github-token: ${{ secrets.FASTAPI_PREVIEW_DOCS_DOWNLOAD_ARTIFACTS }}
+          run-id: ${{ github.event.workflow_run.id }}
       - name: Deploy to Cloudflare Pages
-        if: steps.download.outputs.found_artifact == 'true'
+        # hashFiles returns an empty string if there are no files
+        if: hashFiles('./site/*')
         id: deploy
         uses: cloudflare/pages-action@v1
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,8 @@ jobs:
           github_token: ${{ secrets.FASTAPI_PREVIEW_DOCS_DOWNLOAD_ARTIFACTS }}
           workflow: build-docs.yml
           run_id: ${{ github.event.workflow_run.id }}
-          name: docs-site
+          name: docs-site-.*
+          name_is_regexp: true
           path: ./site/
       - name: Deploy to Cloudflare Pages
         if: steps.download.outputs.found_artifact == 'true'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,6 @@ jobs:
           rm -rf ./site
           mkdir ./site
       - uses: actions/download-artifact@v4
-        id: download
         with:
           path: ./site/
           pattern: docs-site-*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           # cache: "pip"
           # cache-dependency-path: pyproject.toml
       - name: Get coverage files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
           path: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
           CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}
       - name: Store coverage files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage
@@ -118,7 +118,7 @@ jobs:
       - run: coverage report
       - run: coverage html --show-contexts --title "Coverage for ${{ github.sha }}"
       - name: Store coverage HTML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: htmlcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Store coverage files
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
           path: coverage
 
   coverage-combine:
@@ -110,8 +110,9 @@ jobs:
       - name: Get coverage files
         uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-*
           path: coverage
+          merge-multiple: true
       - run: pip install coverage[toml]
       - run: ls -la coverage
       - run: coverage combine coverage


### PR DESCRIPTION
See
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.
