### PR TITLE
README Update to Account for Keyboard Interrupt Error with Current Uvicorn Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ FastAPI stands on the shoulders of giants:
 
 ```console
 $ pip install fastapi
-
----> 100%
 ```
 
 </div>
@@ -200,7 +198,9 @@ Run the server with:
 
 ```console
 $ fastapi dev main.py
+```
 
+```console
  ╭────────── FastAPI CLI - Development mode ───────────╮
  │                                                     │
  │  Serving at: http://127.0.0.1:8000                  │

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ to help you work around this error being logged to the console, by rolling back 
 prior release.
 
 1. Uninstall Uvicorn by running the command: <code> pip uninstall uvicorn </code>
-2. Install Uvicorn version <code> 0.27.1 </code> by running the command: <code> pip install -Iv uvicorn ==0.27.1 </code>
+2. Install Uvicorn version <code> 0.27.1 </code> by running the command: <code> pip install -Iv uvicorn==0.27.1 </code>
 
 After rolling back to this version of Uvicorn, your save should not cause the extra error text to appear in the console.
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,19 @@ You can read more about it in the <a href="https://fastapi.tiangolo.com/fastapi-
 
 </details>
 
+<details markdown="1">
+<summary>A note about <code> Uvicorn </code>...</summary>
+
+As of this writing, the current Uvicorn version will cause a series of errors to output to the console
+whenever you save your app with 'dev' mode watching for file changes. Included here are quick instructions
+to help you work around this error being logged to the console, by rolling back the Uvicorn version to a
+prior release.
+
+1. Uninstall Uvicorn by running the command: <code> pip uninstall uvicorn </code>
+2. Install Uvicorn version <code> 0.27.1 </code> by running the command: <code> pip install -Iv uvicorn ==0.27.1 </code>
+
+After rolling back to this version of Uvicorn, your save should not cause the extra error text to appear in the console.
+
 ### Check it
 
 Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" class="external-link" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ prior release.
 
 After rolling back to this version of Uvicorn, your save should not cause the extra error text to appear in the console.
 
+</details>
+
 ### Check it
 
 Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" class="external-link" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.


### PR DESCRIPTION
When using the current version of Uvicorn shipping with FastAPI, a specific error will occur when running the server in dev mode. When you make a change to the 'main.py' file, the console throws a long error string, which ends up being related to a keyboard interrupt issue. Below are some screenshots:

![image](https://github.com/tiangolo/fastapi/assets/143892700/4c4d95c5-03ac-4568-a39e-86b964314ecd)

![image](https://github.com/tiangolo/fastapi/assets/143892700/29f59900-c947-4357-9294-d5758686a95e)

![image](https://github.com/tiangolo/fastapi/assets/143892700/76faa5d1-779b-4a41-89b3-297f4d1664be)

![image](https://github.com/tiangolo/fastapi/assets/143892700/15da4661-1112-4fc3-b121-187a652cea18)


In short, the workaround is simple: roll back to a prior version of Uvicorn. This README update simply lets FastAPI users know there is an issue with Uvicorn and that this small step can be taken to avoid a lot of confusion.

Command to roll back:

![image](https://github.com/tiangolo/fastapi/assets/143892700/2842c9b3-ce65-41ee-9d2b-5051699215cd)

Then after saving file changes, you get the nice clean output we all like to see:

![image](https://github.com/tiangolo/fastapi/assets/143892700/310a15d0-e623-4b3b-ad71-8ab11f932875)

I know this is technically an issue with an external library, but it is an external library referenced directly by the current version of the README and this change might save some people headaches.

Note: my images here are using PowerShell, but the change to the README is not picky.
