### PR TITLE
Remove Extra Line Item from Install Command and Separate Run Command from Output for Easier Copying of These Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ FastAPI stands on the shoulders of giants:
 
 ```console
 $ pip install fastapi
-
----> 100%
 ```
 
 </div>
@@ -200,7 +198,9 @@ Run the server with:
 
 ```console
 $ fastapi dev main.py
+```
 
+```console
  ╭────────── FastAPI CLI - Development mode ───────────╮
  │                                                     │
  │  Serving at: http://127.0.0.1:8000                  │


### PR DESCRIPTION
The README contains extra text in some of the commands users can copy, but this text is not part of a valid command.

Example:

This....

![image](https://github.com/tiangolo/fastapi/assets/143892700/960b8271-9732-4f1f-af6a-acd95272a227)

becomes this....

![image](https://github.com/tiangolo/fastapi/assets/143892700/35d4c0da-6cac-4a68-87ef-db025a51be4d)

The bottom line in the current version will cause the command to fail, like so:

![image](https://github.com/tiangolo/fastapi/assets/143892700/722e9a59-4eba-4f8c-a6de-341a46e34891)

The other change is similar in nature, but directed towards the command to run the example app. The output text displayed in the command line is not part of the command and shouldn't be copied by the user to run their app:

This....
![image](https://github.com/tiangolo/fastapi/assets/143892700/cec03437-5989-47a1-bcca-bdfd7a640269)

becomes this...

![image](https://github.com/tiangolo/fastapi/assets/143892700/cea6a4a5-40d0-4d03-bd73-d774db5293ca)

The command portion has been separated so that a user can copy it without the extra output text (which is still present but in its own section).

P.S. Could an argument may be made to omit the '$' in these commands and simply have the command itself? Then a user could straight up just copy and paste the command. Not sure if this is desired formatting wise though. Let me know! :)