### PR TITLE
Add support for csrf tokens in html form with jinja

### DIFF
--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -2,13 +2,15 @@ import functools
 import http.cookies
 import secrets
 from re import Pattern
-from typing import Dict, List, Optional, Set, Any
+from typing import Any, Dict, List, Optional, Set
+
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
 
 class CSRFMiddleware:
     def __init__(
@@ -151,8 +153,9 @@ class CSRFMiddleware:
         )
 
     def _receive_with_body(self, receive, body) -> dict:
-        async def inner() -> dict :
+        async def inner() -> dict:
             return {"type": "http.request", "body": body, "more_body": False}
+
         return inner
 
 
@@ -168,4 +171,5 @@ def csrf_token_processor(csrf_cookie_name: str, csrf_header_name: str):
             "csrf_input": csrf_input,
             "csrf_header": csrf_header,
         }
+
     return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -4,6 +4,7 @@ import secrets
 import typing
 from re import Pattern
 from typing import Dict, List, Optional, Set, cast
+
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
@@ -155,6 +156,7 @@ class CSRFMiddleware:
     def _receive_with_body(self, receive, body):
         async def inner():
             return {"type": "http.request", "body": body, "more_body": False}
+
         return inner
 
 
@@ -172,4 +174,5 @@ def csrf_token_processor(
             "csrf_input": csrf_input,
             "csrf_header": csrf_header,
         }
+
     return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -1,0 +1,170 @@
+import functools
+import http.cookies
+import secrets
+import typing
+from re import Pattern
+from typing import Dict, List, Optional, Set, cast
+from itsdangerous import BadSignature
+from itsdangerous.url_safe import URLSafeSerializer
+from starlette.datastructures import URL, MutableHeaders
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+class CSRFMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        secret: str,
+        *,
+        required_urls: Optional[List[Pattern]] = None,
+        exempt_urls: Optional[List[Pattern]] = None,
+        sensitive_cookies: Optional[Set[str]] = None,
+        safe_methods: Set[str] = {"GET", "HEAD", "OPTIONS", "TRACE"},
+        cookie_name: str = "csrftoken",
+        cookie_path: str = "/",
+        cookie_domain: Optional[str] = None,
+        cookie_secure: bool = False,
+        cookie_httponly: bool = False,
+        cookie_samesite: str = "lax",
+        header_name: str = "x-csrftoken",
+    ) -> None:
+        self.app = app
+        self.serializer = URLSafeSerializer(secret, "csrftoken")
+        self.secret = secret
+        self.required_urls = required_urls
+        self.exempt_urls = exempt_urls
+        self.sensitive_cookies = sensitive_cookies
+        self.safe_methods = safe_methods
+        self.cookie_name = cookie_name
+        self.cookie_path = cookie_path
+        self.cookie_domain = cookie_domain
+        self.cookie_secure = cookie_secure
+        self.cookie_httponly = cookie_httponly
+        self.cookie_samesite = cookie_samesite
+        self.header_name = header_name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):  # pragma: no cover            
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
+        body = await self._get_request_body(request)        
+        csrf_cookie = request.cookies.get(self.cookie_name)        
+
+        if self._url_is_required(request.url) or (
+            request.method not in self.safe_methods
+            and not self._url_is_exempt(request.url)
+            and self._has_sensitive_cookies(request.cookies)
+        ):
+            submitted_csrf_token = await self._get_submitted_csrf_token(request)
+                     
+            if (
+                not csrf_cookie
+                or not submitted_csrf_token
+                or not self._csrf_tokens_match(csrf_cookie, submitted_csrf_token)
+            ):
+                response = self._get_error_response(request)
+                await response(scope, receive, send)
+                return
+        
+        request._receive = self._receive_with_body(request._receive, body)
+        send = functools.partial(self.send, send=send, scope=scope)
+        await self.app(scope, request.receive, send)              
+
+    async def send(self, message: Message, send: Send, scope: Scope) -> None:
+        request = Request(scope)
+        csrf_cookie = request.cookies.get(self.cookie_name)
+
+        if csrf_cookie is None:
+            message.setdefault("headers", [])
+            headers = MutableHeaders(scope=message)
+
+            cookie: http.cookies.BaseCookie = http.cookies.SimpleCookie()
+            cookie_name = self.cookie_name
+            cookie[cookie_name] = self._generate_csrf_token()
+            cookie[cookie_name]["path"] = self.cookie_path
+            cookie[cookie_name]["secure"] = self.cookie_secure
+            cookie[cookie_name]["httponly"] = self.cookie_httponly
+            cookie[cookie_name]["samesite"] = self.cookie_samesite
+            if self.cookie_domain is not None:
+                cookie[cookie_name]["domain"] = self.cookie_domain  # pragma: no cover
+            headers.append("set-cookie", cookie.output(header="").strip())
+        
+        await send(message)
+        
+    def _has_sensitive_cookies(self, cookies: Dict[str, str]) -> bool:
+        if not self.sensitive_cookies:
+            return True
+        for sensitive_cookie in self.sensitive_cookies:
+            if sensitive_cookie in cookies:
+                return True
+        return False
+
+    def _url_is_required(self, url: URL) -> bool:
+        if not self.required_urls:
+            return False
+        for required_url in self.required_urls:
+            if required_url.match(url.path):
+                return True
+        return False
+
+    def _url_is_exempt(self, url: URL) -> bool:
+        if not self.exempt_urls:
+            return False
+        for exempt_url in self.exempt_urls:
+            if exempt_url.match(url.path):
+                return True
+        return False
+    
+    async def _get_request_body(self, request: Request):
+        if request.method in ("POST", "PUT", "PATCH", "DELETE"):
+            return await request.body()
+        return b""
+
+    async def _get_submitted_csrf_token(self, request: Request) -> Optional[str]:
+        csrf_token_header = request.headers.get(self.header_name)
+        if csrf_token_header:
+            return csrf_token_header        
+        
+        csrftoken_form = await self._get_csrf_token_form(request)
+        return csrftoken_form        
+
+    async def _get_csrf_token_form(self, request: Request) -> str: 
+        form = await request.form()        
+        csrf_token = form.get(self.cookie_name, "")        
+        return csrf_token
+
+    def _generate_csrf_token(self) -> str:
+        return cast(str, self.serializer.dumps(secrets.token_urlsafe(128)))
+
+    def _csrf_tokens_match(self, token1: str, token2: str) -> bool:
+        try:
+            decoded1: str = self.serializer.loads(token1)
+            decoded2: str = self.serializer.loads(token2)            
+            return secrets.compare_digest(decoded1, decoded2)
+        except BadSignature:
+            return False
+
+    def _get_error_response(self, request: Request) -> Response:
+        return PlainTextResponse(
+            content="CSRF token verification failed", status_code=403
+        )
+    
+    def _receive_with_body(self, receive, body):
+        async def inner():
+            return {"type": "http.request", "body": body, "more_body": False}
+        return inner
+
+def csrf_token_processor(csrf_cookie_name: str, csrf_header_name: str) -> typing.Callable[[Request], typing.Dict[str, typing.Any]]:
+    def processor(request: Request) -> typing.Dict[str, typing.Any]:
+        csrf_token = request.cookies.get(csrf_cookie_name)
+        csrf_input = f'<input type="hidden" name="{csrf_cookie_name}" value="{csrf_token}">'
+        csrf_header = {csrf_header_name: csrf_token}
+        return {
+            'csrf_token': csrf_token,
+            'csrf_input': csrf_input,
+            'csrf_header': csrf_header 
+        }
+    return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -20,7 +20,7 @@ class CSRFMiddleware:
         required_urls: Optional[List[Pattern]] = None,
         exempt_urls: Optional[List[Pattern]] = None,
         sensitive_cookies: Optional[Set[str]] = None,
-        safe_methods: Set[str] = {"GET", "HEAD", "OPTIONS", "TRACE"},
+        safe_methods: Optional[Set[str]] = None,
         cookie_name: str = "csrftoken",
         cookie_path: str = "/",
         cookie_domain: Optional[str] = None,
@@ -35,7 +35,8 @@ class CSRFMiddleware:
         self.required_urls = required_urls
         self.exempt_urls = exempt_urls
         self.sensitive_cookies = sensitive_cookies
-        self.safe_methods = safe_methods
+        if safe_methods is None:
+            safe_methods = {"GET", "HEAD", "OPTIONS", "TRACE"}
         self.cookie_name = cookie_name
         self.cookie_path = cookie_path
         self.cookie_domain = cookie_domain

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -2,12 +2,7 @@ import functools
 import http.cookies
 import secrets
 from re import Pattern
-<<<<<<< HEAD
 from typing import Dict, List, Optional, Set, Any
-=======
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Set, cast
-
->>>>>>> e3a49391d27f6589ecd72a2d5e5f019340669b7a
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
@@ -156,15 +151,9 @@ class CSRFMiddleware:
             content="CSRF token verification failed", status_code=403
         )
 
-<<<<<<< HEAD
     def _receive_with_body(self, receive, body) -> dict:
         async def inner() -> dict :
-=======
-    def _receive_with_body(self, receive, body) -> Coroutine[Any, Any, dict]:
-        async def inner() -> dict:
->>>>>>> e3a49391d27f6589ecd72a2d5e5f019340669b7a
             return {"type": "http.request", "body": body, "more_body": False}
-
         return inner
 
 
@@ -180,5 +169,4 @@ def csrf_token_processor(csrf_cookie_name: str, csrf_header_name: str):
             "csrf_input": csrf_input,
             "csrf_header": csrf_header,
         }
-
     return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -4,12 +4,14 @@ import secrets
 import typing
 from re import Pattern
 from typing import Dict, List, Optional, Set, cast
+
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
 
 class CSRFMiddleware:
     def __init__(
@@ -45,13 +47,13 @@ class CSRFMiddleware:
         self.header_name = header_name
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] not in ("http", "websocket"):  # pragma: no cover            
+        if scope["type"] not in ("http", "websocket"):  # pragma: no cover
             await self.app(scope, receive, send)
             return
 
         request = Request(scope, receive)
-        body = await self._get_request_body(request)        
-        csrf_cookie = request.cookies.get(self.cookie_name)        
+        body = await self._get_request_body(request)
+        csrf_cookie = request.cookies.get(self.cookie_name)
 
         if self._url_is_required(request.url) or (
             request.method not in self.safe_methods
@@ -59,7 +61,7 @@ class CSRFMiddleware:
             and self._has_sensitive_cookies(request.cookies)
         ):
             submitted_csrf_token = await self._get_submitted_csrf_token(request)
-                     
+
             if (
                 not csrf_cookie
                 or not submitted_csrf_token
@@ -68,10 +70,10 @@ class CSRFMiddleware:
                 response = self._get_error_response(request)
                 await response(scope, receive, send)
                 return
-        
+
         request._receive = self._receive_with_body(request._receive, body)
         send = functools.partial(self.send, send=send, scope=scope)
-        await self.app(scope, request.receive, send)              
+        await self.app(scope, request.receive, send)
 
     async def send(self, message: Message, send: Send, scope: Scope) -> None:
         request = Request(scope)
@@ -91,9 +93,9 @@ class CSRFMiddleware:
             if self.cookie_domain is not None:
                 cookie[cookie_name]["domain"] = self.cookie_domain  # pragma: no cover
             headers.append("set-cookie", cookie.output(header="").strip())
-        
+
         await send(message)
-        
+
     def _has_sensitive_cookies(self, cookies: Dict[str, str]) -> bool:
         if not self.sensitive_cookies:
             return True
@@ -117,7 +119,7 @@ class CSRFMiddleware:
             if exempt_url.match(url.path):
                 return True
         return False
-    
+
     async def _get_request_body(self, request: Request):
         if request.method in ("POST", "PUT", "PATCH", "DELETE"):
             return await request.body()
@@ -126,14 +128,14 @@ class CSRFMiddleware:
     async def _get_submitted_csrf_token(self, request: Request) -> Optional[str]:
         csrf_token_header = request.headers.get(self.header_name)
         if csrf_token_header:
-            return csrf_token_header        
-        
-        csrftoken_form = await self._get_csrf_token_form(request)
-        return csrftoken_form        
+            return csrf_token_header
 
-    async def _get_csrf_token_form(self, request: Request) -> str: 
-        form = await request.form()        
-        csrf_token = form.get(self.cookie_name, "")        
+        csrftoken_form = await self._get_csrf_token_form(request)
+        return csrftoken_form
+
+    async def _get_csrf_token_form(self, request: Request) -> str:
+        form = await request.form()
+        csrf_token = form.get(self.cookie_name, "")
         return csrf_token
 
     def _generate_csrf_token(self) -> str:
@@ -142,7 +144,7 @@ class CSRFMiddleware:
     def _csrf_tokens_match(self, token1: str, token2: str) -> bool:
         try:
             decoded1: str = self.serializer.loads(token1)
-            decoded2: str = self.serializer.loads(token2)            
+            decoded2: str = self.serializer.loads(token2)
             return secrets.compare_digest(decoded1, decoded2)
         except BadSignature:
             return False
@@ -151,20 +153,27 @@ class CSRFMiddleware:
         return PlainTextResponse(
             content="CSRF token verification failed", status_code=403
         )
-    
+
     def _receive_with_body(self, receive, body):
         async def inner():
             return {"type": "http.request", "body": body, "more_body": False}
+
         return inner
 
-def csrf_token_processor(csrf_cookie_name: str, csrf_header_name: str) -> typing.Callable[[Request], typing.Dict[str, typing.Any]]:
+
+def csrf_token_processor(
+    csrf_cookie_name: str, csrf_header_name: str
+) -> typing.Callable[[Request], typing.Dict[str, typing.Any]]:
     def processor(request: Request) -> typing.Dict[str, typing.Any]:
         csrf_token = request.cookies.get(csrf_cookie_name)
-        csrf_input = f'<input type="hidden" name="{csrf_cookie_name}" value="{csrf_token}">'
+        csrf_input = (
+            f'<input type="hidden" name="{csrf_cookie_name}" value="{csrf_token}">'
+        )
         csrf_header = {csrf_header_name: csrf_token}
         return {
-            'csrf_token': csrf_token,
-            'csrf_input': csrf_input,
-            'csrf_header': csrf_header 
+            "csrf_token": csrf_token,
+            "csrf_input": csrf_input,
+            "csrf_header": csrf_header,
         }
+
     return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -4,7 +4,6 @@ import secrets
 import typing
 from re import Pattern
 from typing import Dict, List, Optional, Set, cast
-
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
@@ -83,7 +82,6 @@ class CSRFMiddleware:
         if csrf_cookie is None:
             message.setdefault("headers", [])
             headers = MutableHeaders(scope=message)
-
             cookie: http.cookies.BaseCookie = http.cookies.SimpleCookie()
             cookie_name = self.cookie_name
             cookie[cookie_name] = self._generate_csrf_token()
@@ -130,7 +128,6 @@ class CSRFMiddleware:
         csrf_token_header = request.headers.get(self.header_name)
         if csrf_token_header:
             return csrf_token_header
-
         csrftoken_form = await self._get_csrf_token_form(request)
         return csrftoken_form
 
@@ -158,7 +155,6 @@ class CSRFMiddleware:
     def _receive_with_body(self, receive, body):
         async def inner():
             return {"type": "http.request", "body": body, "more_body": False}
-
         return inner
 
 
@@ -176,5 +172,4 @@ def csrf_token_processor(
             "csrf_input": csrf_input,
             "csrf_header": csrf_header,
         }
-
     return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -2,8 +2,7 @@ import functools
 import http.cookies
 import secrets
 from re import Pattern
-from typing import Any, Dict, List, Optional, Set
-
+from typing import Dict, List, Optional, Set, Any
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
@@ -153,9 +152,8 @@ class CSRFMiddleware:
         )
 
     def _receive_with_body(self, receive, body) -> dict:
-        async def inner() -> dict:
+        async def inner() -> dict :
             return {"type": "http.request", "body": body, "more_body": False}
-
         return inner
 
 
@@ -171,5 +169,4 @@ def csrf_token_processor(csrf_cookie_name: str, csrf_header_name: str):
             "csrf_input": csrf_input,
             "csrf_header": csrf_header,
         }
-
     return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -2,7 +2,8 @@ import functools
 import http.cookies
 import secrets
 from re import Pattern
-from typing import Dict, List, Optional, Set, Any
+from typing import Any, Dict, List, Optional, Set
+
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
@@ -152,8 +153,9 @@ class CSRFMiddleware:
         )
 
     def _receive_with_body(self, receive, body) -> dict:
-        async def inner() -> dict :
+        async def inner() -> dict:
             return {"type": "http.request", "body": body, "more_body": False}
+
         return inner
 
 
@@ -169,4 +171,5 @@ def csrf_token_processor(csrf_cookie_name: str, csrf_header_name: str):
             "csrf_input": csrf_input,
             "csrf_header": csrf_header,
         }
+
     return processor

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -10,7 +10,6 @@ from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-
 class CSRFMiddleware:
     def __init__(
         self,

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -2,7 +2,7 @@ import functools
 import http.cookies
 import secrets
 from re import Pattern
-from typing import Dict, List, Optional, Set, cast, Coroutine, Callable, Any
+from typing import Dict, List, Optional, Set, Any
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
@@ -136,7 +136,7 @@ class CSRFMiddleware:
         return csrf_token
 
     def _generate_csrf_token(self) -> str:
-        return cast(str, self.serializer.dumps(secrets.token_urlsafe(128)))
+        return self.serializer.dumps(secrets.token_urlsafe(128))
 
     def _csrf_tokens_match(self, token1: str, token2: str) -> bool:
         try:
@@ -151,15 +151,13 @@ class CSRFMiddleware:
             content="CSRF token verification failed", status_code=403
         )
 
-    def _receive_with_body(self, receive, body) -> Coroutine[Any, Any, dict]:
+    def _receive_with_body(self, receive, body) -> dict:
         async def inner() -> dict :
             return {"type": "http.request", "body": body, "more_body": False}
         return inner
 
 
-def csrf_token_processor(
-    csrf_cookie_name: str, csrf_header_name: str
-) -> Callable[[Request], Dict[str, Any]]:
+def csrf_token_processor(csrf_cookie_name: str, csrf_header_name: str):
     def processor(request: Request) -> Dict[str, Any]:
         csrf_token = request.cookies.get(csrf_cookie_name)
         csrf_input = (

--- a/fastapi/middleware/csrf.py
+++ b/fastapi/middleware/csrf.py
@@ -2,7 +2,8 @@ import functools
 import http.cookies
 import secrets
 from re import Pattern
-from typing import Dict, List, Optional, Set, cast, Coroutine, Callable, Any
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Set, cast
+
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
@@ -152,8 +153,9 @@ class CSRFMiddleware:
         )
 
     def _receive_with_body(self, receive, body) -> Coroutine[Any, Any, dict]:
-        async def inner() -> dict :
+        async def inner() -> dict:
             return {"type": "http.request", "body": body, "more_body": False}
+
         return inner
 
 
@@ -171,4 +173,5 @@ def csrf_token_processor(
             "csrf_input": csrf_input,
             "csrf_header": csrf_header,
         }
+
     return processor


### PR DESCRIPTION
Now FastAPI with support for csrf tokens in html forms with jinja

Added some improvements for using CSRF tokens in HTML forms without affecting the current functionality of the middleware **starlette-csrf**. The improvement simplifies the process of obtaining the CSRF token by unifying the search logic into a single function _get_submitted_csrf_token. Now, the function will first attempt to obtain the token from the headers, and if it does not find it there, it will search for it in the form. Additionally, this new functionality addresses the crash issue that occurs in Starlette due to body consumption.

This is particularly useful for integration with FastAPI and the development of secure websites utilizing forms.

Now, all that's needed is to add the starlette_csrf middleware and utilize the following template processor in your FastAPI code:

```py
from fastapi import FastAPI
from fastapi.middleware.csrf import CSRFMiddleware, csrf_token_processor

app = FastAPI()

your_cookie_name = "your_cookie_name"
your_header_name = "your_header_name"

app.add_middleware(
   CSRFMiddleware, 
   secret = "your_secret",
   cookie_name = your_cookie_name,
   header_name = your_header_name,
   )

templates = Jinja2Templates(
    directory="templates", 
    context_processors=[csrf_token_processor(your_cookie_name, your_header_name)]
    )

```
Now, the middleware integrates with a context processor, a function that returns a dictionary containing the CSRF token, CSRF input, and CSRF header for use with other tools such as HTMX.

Simply using {{ csrf_input | safe }} in each form is now sufficient to ensure a more secure web application. For example:

```html
<form method="post">
    {{ csrf_input | safe }}
    <!-- Other form fields here -->
    <button type="submit">Submit</button>
</form>
```

Furthermore, we can use {{ csrf_header }} in HTMX requests. For example:

```html
<form hx-patch="/route/edit" hx-headers='{{ csrf_header | tojson | safe }}'  hx-trigger="submit" hx-target="#yourtarget" hx-swap="outerHTML" >
    <!-- Other form fields here -->
    <button type="submit">Submit</button>
</form>
```

Feel free to let me know if you need further adjustments or improvements!