### PR TITLE
Update README to Allow Install and Run Commands to Be Copied As Is

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ FastAPI stands on the shoulders of giants:
 
 ```console
 $ pip install fastapi
-
----> 100%
 ```
 
 </div>
@@ -201,7 +199,9 @@ Run the server with:
 
 ```console
 $ fastapi dev main.py
+```
 
+```console
  ╭────────── FastAPI CLI - Development mode ───────────╮
  │                                                     │
  │  Serving at: http://127.0.0.1:8000                  │

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ FastAPI stands on the shoulders of giants:
 <div class="termy">
 
 ```console
-$ pip install fastapi
+pip install fastapi
 ```
 
 </div>
@@ -198,7 +198,7 @@ Run the server with:
 <div class="termy">
 
 ```console
-$ fastapi dev main.py
+fastapi dev main.py
 ```
 
 ```console

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -135,8 +135,6 @@ FastAPI stands on the shoulders of giants:
 
 ```console
 $ pip install fastapi
-
----> 100%
 ```
 
 </div>
@@ -202,7 +200,9 @@ Run the server with:
 
 ```console
 $ fastapi dev main.py
+```
 
+```console
  ╭────────── FastAPI CLI - Development mode ───────────╮
  │                                                     │
  │  Serving at: http://127.0.0.1:8000                  │

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -134,7 +134,7 @@ FastAPI stands on the shoulders of giants:
 <div class="termy">
 
 ```console
-$ pip install fastapi
+pip install fastapi
 ```
 
 </div>
@@ -199,7 +199,7 @@ Run the server with:
 <div class="termy">
 
 ```console
-$ fastapi dev main.py
+fastapi dev main.py
 ```
 
 ```console


### PR DESCRIPTION
The current version of the README contains extra text that make commands fail.

Example:

![image](https://github.com/tiangolo/fastapi/assets/143892700/2c040bc8-6916-4b53-901b-af642359d738)

But if we use the command as is, we get an error:

![image](https://github.com/tiangolo/fastapi/assets/143892700/45d469c9-b72d-4f4b-8965-b4e7d1fa031a)

![image](https://github.com/tiangolo/fastapi/assets/143892700/640b09ba-4a4b-46af-8eff-08840b975013)

My humble proposal is to align the README with other parts of the README, which adopts a similar format (without the dollar sign and output as part of the command text).

Here is an example currently in the README, at the bottom:

![image](https://github.com/tiangolo/fastapi/assets/143892700/844d788c-25f0-4410-a77f-a71d4bc89f14)

Additionally, this format is good as it aligns with other documentation formats, such as that used by GitHub. Here is an example from the GitHub docs on generating new SSH keys:

![image](https://github.com/tiangolo/fastapi/assets/143892700/eb75488c-35c3-4491-83dc-48ceb1284ec5)