### PR TITLE
add ruff_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ archive.zip
 
 # macOS
 .DS_Store
+
+# Ruff Cache
+.ruff_cache/


### PR DESCRIPTION
I propose to add `.ruff_cache/` to the officially recommended `.gitignore` file of FastAPI. Ruff, being a widely used linting tool has been endorsed by the founder of FastAPI himself, so I believe implementing this small change would make it more intuitive for developers to use them together. By ignoring `.ruff_cache/`, we can prevent unnecessary cache files from cluttering the version control system.