### PR TITLE
📝  Update docs with Ariadne reference from Starlette to FastAPI

### DIFF
--- a/docs/de/docs/how-to/graphql.md
+++ b/docs/de/docs/how-to/graphql.md
@@ -18,7 +18,7 @@ Hier sind einige der **GraphQL**-Bibliotheken, welche **ASGI** unterstützen. Di
 * <a href="https://strawberry.rocks/" class="external-link" target="_blank">Strawberry</a> 🍓
     * Mit <a href="https://strawberry.rocks/docs/integrations/fastapi" class="external-link" target="_blank">Dokumentation für FastAPI</a>
 * <a href="https://ariadnegraphql.org/" class="external-link" target="_blank">Ariadne</a>
-    * Mit <a href="https://ariadnegraphql.org/docs/starlette-integration" class="external-link" target="_blank">Dokumentation für Starlette</a> (welche auch für FastAPI gilt)
+    * Mit <a href="https://ariadnegraphql.org/docs/fastapi-integration" class="external-link" target="_blank">Dokumentation für FastAPI</a>
 * <a href="https://tartiflette.io/" class="external-link" target="_blank">Tartiflette</a>
     * Mit <a href="https://tartiflette.github.io/tartiflette-asgi/" class="external-link" target="_blank">Tartiflette ASGI</a>, für ASGI-Integration
 * <a href="https://graphene-python.org/" class="external-link" target="_blank">Graphene</a>

--- a/docs/em/docs/how-to/graphql.md
+++ b/docs/em/docs/how-to/graphql.md
@@ -18,7 +18,7 @@
 * <a href="https://strawberry.rocks/" class="external-link" target="_blank">🍓</a> 👶
     * ⏮️ <a href="https://strawberry.rocks/docs/integrations/fastapi" class="external-link" target="_blank">🩺 FastAPI</a>
 * <a href="https://ariadnegraphql.org/" class="external-link" target="_blank">👸</a>
-    * ⏮️ <a href="https://ariadnegraphql.org/docs/starlette-integration" class="external-link" target="_blank">🩺 💃</a> (👈 ✔ FastAPI)
+    * ⏮️ <a href="https://ariadnegraphql.org/docs/fastapi-integration" class="external-link" target="_blank">🩺 FastAPI</a>
 * <a href="https://tartiflette.io/" class="external-link" target="_blank">🍟</a>
     * ⏮️ <a href="https://tartiflette.github.io/tartiflette-asgi/" class="external-link" target="_blank">🍟 🔫</a> 🚚 🔫 🛠️
 * <a href="https://graphene-python.org/" class="external-link" target="_blank">⚗</a>

--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -18,7 +18,7 @@ Here are some of the **GraphQL** libraries that have **ASGI** support. You could
 * <a href="https://strawberry.rocks/" class="external-link" target="_blank">Strawberry</a> 🍓
     * With <a href="https://strawberry.rocks/docs/integrations/fastapi" class="external-link" target="_blank">docs for FastAPI</a>
 * <a href="https://ariadnegraphql.org/" class="external-link" target="_blank">Ariadne</a>
-    * With <a href="https://ariadnegraphql.org/docs/starlette-integration" class="external-link" target="_blank">docs for Starlette</a> (that also apply to FastAPI)
+    * With <a href="https://ariadnegraphql.org/docs/fastapi-integration" class="external-link" target="_blank">docs for FastAPI</a>
 * <a href="https://tartiflette.io/" class="external-link" target="_blank">Tartiflette</a>
     * With <a href="https://tartiflette.github.io/tartiflette-asgi/" class="external-link" target="_blank">Tartiflette ASGI</a> to provide ASGI integration
 * <a href="https://graphene-python.org/" class="external-link" target="_blank">Graphene</a>


### PR DESCRIPTION
Hi,

In Ariadne, we have had a FastAPI section for a long time. It would be perfect if we could update the FastAPI documentation to redirect people from the Starlette section to the FastAPI section.

Thanks!