### PR TITLE
📝 Update `docs/en/docs/tutorial/first-steps.md`

### DIFF
--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -227,9 +227,9 @@ When building APIs, you normally use these specific HTTP methods to perform a sp
 
 Normally you use:
 
-* `POST`: to create data.
+* `POST`: to create, append, or update data in a data record.
 * `GET`: to read data.
-* `PUT`: to update data.
+* `PUT`: to create or replace a data record.
 * `DELETE`: to delete data.
 
 So, in OpenAPI, each of the HTTP methods is called an "operation".


### PR DESCRIPTION
According to [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-post), the current HTTP specification says:

"The POST method requests that the [target resource](https://datatracker.ietf.org/doc/html/rfc9110#target.resource) process the representation enclosed in the request according to the resource's own specific semantics."

... and:

"The PUT method requests that the state of the [target resource](https://datatracker.ietf.org/doc/html/rfc9110#target.resource) be created or replaced with the state defined by the representation enclosed in the request message content."

So, the tutorial is patently incorrect about PUT (updating has never been it's function, as far as I remember), and, I think, it unnecessarily over-simplifies POST.

This patch increases the accuracy of the doc, while only trivially increasing the complexity. 

If this patch is controversial, I suggest simply removing PUT from this tutorial, since the new definition of POST makes PUT unnecessary for very many web applications. (Which have been using POST and ignoring PUT for many years before the new standard anyway...)
