### PR TITLE
➖ Remove orjson and ujson from default dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,11 +468,14 @@ Used by Starlette:
 Used by FastAPI / Starlette:
 
 * <a href="https://www.uvicorn.org" target="_blank"><code>uvicorn</code></a> - for the server that loads and serves your application.
-* <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
-* <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Required if you want to use `UJSONResponse`.
 * `fastapi-cli` - to provide the `fastapi` command.
 
 When you install `fastapi` it comes these standard dependencies.
+
+Additional optional dependencies:
+
+* <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
+* <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Required if you want to use `UJSONResponse`.
 
 ## `fastapi-slim`
 

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -39,7 +39,7 @@ But if you are certain that the content that you are returning is **serializable
     And it will be documented as such in OpenAPI.
 
 !!! tip
-    The `ORJSONResponse` is currently only available in FastAPI, not in Starlette.
+    The `ORJSONResponse` is only available in FastAPI, not in Starlette.
 
 ## HTML Response
 
@@ -149,9 +149,15 @@ This is the default response used in **FastAPI**, as you read above.
 
 A fast alternative JSON response using <a href="https://github.com/ijl/orjson" class="external-link" target="_blank">`orjson`</a>, as you read above.
 
+!!! info
+    This requires installing `orjson` for example with `pip install orjson`.
+
 ### `UJSONResponse`
 
 An alternative JSON response using <a href="https://github.com/ultrajson/ultrajson" class="external-link" target="_blank">`ujson`</a>.
+
+!!! info
+    This requires installing `ujson` for example with `pip install ujson`.
 
 !!! warning
     `ujson` is less careful than Python's built-in implementation in how it handles some edge-cases.

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -466,11 +466,14 @@ Used by Starlette:
 Used by FastAPI / Starlette:
 
 * <a href="https://www.uvicorn.org" target="_blank"><code>uvicorn</code></a> - for the server that loads and serves your application.
-* <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
-* <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Required if you want to use `UJSONResponse`.
 * `fastapi-cli` - to provide the `fastapi` command.
 
 When you install `fastapi` it comes these standard dependencies.
+
+Additional optional dependencies:
+
+* <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
+* <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Required if you want to use `UJSONResponse`.
 
 ## `fastapi-slim`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,6 @@ standard = [
     "jinja2 >=2.11.2",
     # For forms and file uploads
     "python-multipart >=0.0.7",
-    # For UJSONResponse
-    "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
-    # For ORJSONResponse
-    "orjson >=3.2.1",
     # To validate email fields
     "email_validator >=2.0.0",
     # Uvicorn with uvloop


### PR DESCRIPTION
As discussed in https://github.com/tiangolo/fastapi/discussions/11659, and following from PR https://github.com/tiangolo/fastapi/pull/11720, installing ORJSON by default makes the default installation of FastAPI into work on PyPy.

I'm removing them from the default dependencies. They are still included in the extra optional dependencies `all`.

So, people that install:

```
pip install "fastapi[all]"
```

will have it installed.