### PR TITLE
♻️ Change methods not using its bound instance to staticmethods

### DIFF
--- a/docs_src/websockets/tutorial003.py
+++ b/docs_src/websockets/tutorial003.py
@@ -54,7 +54,8 @@ class ConnectionManager:
     def disconnect(self, websocket: WebSocket):
         self.active_connections.remove(websocket)
 
-    async def send_personal_message(self, message: str, websocket: WebSocket):
+    @staticmethod
+    async def send_personal_message(message: str, websocket: WebSocket):
         await websocket.send_text(message)
 
     async def broadcast(self, message: str):

--- a/docs_src/websockets/tutorial003_py39.py
+++ b/docs_src/websockets/tutorial003_py39.py
@@ -52,7 +52,8 @@ class ConnectionManager:
     def disconnect(self, websocket: WebSocket):
         self.active_connections.remove(websocket)
 
-    async def send_personal_message(self, message: str, websocket: WebSocket):
+    @staticmethod
+    async def send_personal_message(message: str, websocket: WebSocket):
         await websocket.send_text(message)
 
     async def broadcast(self, message: str):

--- a/tests/test_dependency_class.py
+++ b/tests/test_dependency_class.py
@@ -28,16 +28,20 @@ class AsyncCallableGenDependency:
 
 
 class MethodsDependency:
-    def synchronous(self, value: str) -> str:
+    @staticmethod
+    def synchronous(value: str) -> str:
         return value
 
-    async def asynchronous(self, value: str) -> str:
+    @staticmethod
+    async def asynchronous(value: str) -> str:
         return value
 
-    def synchronous_gen(self, value: str) -> Generator[str, None, None]:
+    @staticmethod
+    def synchronous_gen(value: str) -> Generator[str, None, None]:
         yield value
 
-    async def asynchronous_gen(self, value: str) -> AsyncGenerator[str, None]:
+    @staticmethod
+    async def asynchronous_gen(value: str) -> AsyncGenerator[str, None]:
         yield value
 
 


### PR DESCRIPTION
The method doesn't use its bound instance. Decorate this method with `@staticmethod` decorator, so that Python does not have to instantiate a bound method for every instance of this class thereby saving memory and computation. Read more about staticmethods [here](https://docs.python.org/3/library/functions.html#staticmethod).