### PR TITLE
🔇 Ignore warning from attrs in Trio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,6 @@ filterwarnings = [
     "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
     # see https://trio.readthedocs.io/en/stable/history.html#trio-0-22-0-2022-09-28
     "ignore:You seem to already have a custom.*:RuntimeWarning:trio",
-    "ignore::trio.TrioDeprecationWarning",
     # TODO remove pytest-cov
     'ignore::pytest.PytestDeprecationWarning:pytest_cov',
     # TODO: remove after upgrading SQLAlchemy to a version that includes the following changes
@@ -169,6 +168,10 @@ filterwarnings = [
     #   - https://github.com/mpdavis/python-jose/issues/332
     #   - https://github.com/mpdavis/python-jose/issues/334
     'ignore:datetime\.datetime\.utcnow\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning:jose',
+    # Trio 24.1.0 raises a warning from attrs
+    # Ref: https://github.com/python-trio/trio/pull/3054
+    # Remove once there's a new version of Trio
+    'ignore::DeprecationWarning:trio',
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ filterwarnings = [
     # Trio 24.1.0 raises a warning from attrs
     # Ref: https://github.com/python-trio/trio/pull/3054
     # Remove once there's a new version of Trio
-    'ignore::DeprecationWarning:trio',
+    'ignore:The `hash` argument is deprecated*:DeprecationWarning:trio',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
🔇 Ignore warning from attrs in Trio

A recent release of a attrs marked a parameter `hash` as deprecated. It is used by Trio (fixed here: https://github.com/python-trio/trio/pull/3054, but still unreleased). Trio is used by AnyIO's pytest plugin.

This currently shows a deprecation warning that is breaking tests in FastAPI. This PR adds an ignore for that warning so tests here can keep running.