### PR TITLE
📝 Improve documentation on using dataclasses in FastAPI

### DIFF
--- a/docs/en/docs/advanced/dataclasses.md
+++ b/docs/en/docs/advanced/dataclasses.md
@@ -1,6 +1,6 @@
 # Using Dataclasses
 
-FastAPI is built on top of **Pydantic**, and allows the use of Pydantic models to declare requests and responses. 
+FastAPI is built on top of **Pydantic**, and allows the use of Pydantic models to declare requests and responses.
 Additionally, FastAPI supports <a href="https://docs.python.org/3/library/dataclasses.html" class="external-link" target="_blank">`dataclasses`</a> in a similar manner:
 
 

--- a/docs/en/docs/advanced/dataclasses.md
+++ b/docs/en/docs/advanced/dataclasses.md
@@ -1,6 +1,6 @@
 # Using Dataclasses
 
-FastAPI is built on top of **Pydantic**, and it allows the use of Pydantic models to declare requests and responses. 
+FastAPI is built on top of **Pydantic**, and allows the use of Pydantic models to declare requests and responses. 
 Additionally, FastAPI supports <a href="https://docs.python.org/3/library/dataclasses.html" class="external-link" target="_blank">`dataclasses`</a> in a similar manner:
 
 

--- a/docs/en/docs/advanced/dataclasses.md
+++ b/docs/en/docs/advanced/dataclasses.md
@@ -1,8 +1,8 @@
 # Using Dataclasses
 
-FastAPI is built on top of **Pydantic**, and I have been showing you how to use Pydantic models to declare requests and responses.
+FastAPI is built on top of **Pydantic**, and it allows the use of Pydantic models to declare requests and responses. 
+Additionally, FastAPI supports <a href="https://docs.python.org/3/library/dataclasses.html" class="external-link" target="_blank">`dataclasses`</a> in a similar manner:
 
-But FastAPI also supports using <a href="https://docs.python.org/3/library/dataclasses.html" class="external-link" target="_blank">`dataclasses`</a> the same way:
 
 ```Python hl_lines="1  7-12  19-20"
 {!../../../docs_src/dataclasses/tutorial001.py!}


### PR DESCRIPTION
I was reading the FastAPI documentation this morning and came across the following sentence: 'FastAPI is built on top of Pydantic, and I have been showing you how to use Pydantic models to declare requests and responses. But FastAPI also supports using [dataclasses](https://docs.python.org/3/library/dataclasses.html) the same way.' While I don't disagree with the content, it is widely known that FastAPI was initially maintained by a single person. Therefore, I decided to rephrase the sentence to remove the personal tone.

Revised the documentation to provide a clearer explanation of how FastAPI integrates with Pydantic and supports dataclasses. The previous language was instructional and personal, which may not be appropriate for all readers. The updated text maintains a neutral tone and emphasizes the functionality of FastAPI in handling dataclasses similarly to Pydantic models.
