### PR TITLE
✏️ Fix typo for dependencies docs in script example tutorial006

### DIFF
--- a/docs_src/dependencies/tutorial006.py
+++ b/docs_src/dependencies/tutorial006.py
@@ -6,6 +6,7 @@ app = FastAPI()
 async def verify_token(x_token: str = Header()):
     if x_token != "fake-super-secret-token":
         raise HTTPException(status_code=400, detail="X-Token header invalid")
+    return x_token
 
 
 async def verify_key(x_key: str = Header()):

--- a/docs_src/dependencies/tutorial006_an.py
+++ b/docs_src/dependencies/tutorial006_an.py
@@ -7,6 +7,7 @@ app = FastAPI()
 async def verify_token(x_token: Annotated[str, Header()]):
     if x_token != "fake-super-secret-token":
         raise HTTPException(status_code=400, detail="X-Token header invalid")
+    return x_token
 
 
 async def verify_key(x_key: Annotated[str, Header()]):

--- a/docs_src/dependencies/tutorial006_an_py39.py
+++ b/docs_src/dependencies/tutorial006_an_py39.py
@@ -8,7 +8,7 @@ app = FastAPI()
 async def verify_token(x_token: Annotated[str, Header()]):
     if x_token != "fake-super-secret-token":
         raise HTTPException(status_code=400, detail="X-Token header invalid")
-
+    return x_token
 
 async def verify_key(x_key: Annotated[str, Header()]):
     if x_key != "fake-super-secret-key":

--- a/docs_src/dependencies/tutorial006_an_py39.py
+++ b/docs_src/dependencies/tutorial006_an_py39.py
@@ -10,6 +10,7 @@ async def verify_token(x_token: Annotated[str, Header()]):
         raise HTTPException(status_code=400, detail="X-Token header invalid")
     return x_token
 
+
 async def verify_key(x_key: Annotated[str, Header()]):
     if x_key != "fake-super-secret-key":
         raise HTTPException(status_code=400, detail="X-Key header invalid")


### PR DESCRIPTION
verify_token() function is missing the 'return x_token' value. The function is missing a return statement after the 'if' statement. Now, I've added the return statement and am proposing this change.