### PR TITLE
📝 Move the Features docs to the top level to improve the main page menu

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -102,9 +102,8 @@ plugins:
           show_symbol_type_toc: true
 
 nav:
-- FastAPI:
-  - index.md
-  - features.md
+- FastAPI: index.md
+- features.md
 - Learn:
   - learn/index.md
   - python-types.md


### PR DESCRIPTION
📝 Move the Features docs to the top level to improve the main page menu

Before this PR, the main page has a side menu with only two items, "FastAPI" and "Features". It's particularly counterintuitive in mobile where the menu only has those two items, and going to the other sections (e.g. the tutorial) requires clicking on the "back" arrow button at the top.

After this, opening the menu shows the other sections.