### PR TITLE
🌐 Update Chinese translation for `docs/zh/docs/how-to/index.md`

### DIFF
--- a/docs/zh/docs/how-to/index.md
+++ b/docs/zh/docs/how-to/index.md
@@ -6,7 +6,7 @@
 
 如果某些内容看起来对你的项目有用，请继续查阅，否则请直接跳过它们。
 
-/// tip
+/// tip | 小技巧
 
 如果你想以系统的方式**学习 FastAPI**（推荐），请阅读 [教程 - 用户指南](../tutorial/index.md){.internal-link target=_blank} 的每一章节。
 

--- a/docs/zh/docs/how-to/index.md
+++ b/docs/zh/docs/how-to/index.md
@@ -6,7 +6,7 @@
 
 如果某些内容看起来对你的项目有用，请继续查阅，否则请直接跳过它们。
 
-/// 小技巧
+/// tip
 
 如果你想以系统的方式**学习 FastAPI**（推荐），请阅读 [教程 - 用户指南](../tutorial/index.md){.internal-link target=_blank} 的每一章节。
 


### PR DESCRIPTION
The `小技巧` label in the admonition was causing rendering issues in MkDocs, so replacing it with the standard `tip` label fixes this problem.