### PR TITLE
🧪 Add test for segmentation fault when using `asyncio.eager_task_factory`

### DIFF
--- a/tests/test_asyncio_eager_task_factory.py
+++ b/tests/test_asyncio_eager_task_factory.py
@@ -1,0 +1,30 @@
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Dict
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):  # pragma: no cover
+    loop = asyncio.get_event_loop()
+    loop.set_task_factory(asyncio.eager_task_factory)
+    yield
+
+
+app = FastAPI(title="test", lifespan=lifespan, debug=True)
+
+
+@app.get("/tst")
+async def endpoint() -> Dict[str, str]:  # pragma: no cover
+    return {"message": "Hello World"}
+
+
+@pytest.mark.skip(
+    reason="Currently causes segfaults in the tests, needs further investigation",
+)
+def test_eager_task_factory():  # pragma: no cover
+    with TestClient(app=app) as client:
+        client.get("/tst")


### PR DESCRIPTION
This add tests for  https://github.com/fastapi/fastapi/discussions/11868. (disabled because they cause segfault)

TLDR: using eager_task_factory from asyncio causes segfault and crash
Cause: unknown

Here are witness runs verifiing this is real issue https://github.com/fastapi/fastapi/actions/runs/10573940061/job/29294417766?pr=12079
(3.8 error is me using too new syntax for 3.8)

I at least added test that are curently skiped
There is also known workaround so i could document that. 