### PR TITLE
📝 Fix async test example not to trigger DeprecationWarning

### DIFF
--- a/docs/de/docs/advanced/async-tests.md
+++ b/docs/de/docs/advanced/async-tests.md
@@ -72,7 +72,7 @@ Beachten Sie, dass die Testfunktion jetzt `async def` ist und nicht nur `def` wi
 
 Dann können wir einen `AsyncClient` mit der App erstellen und mit `await` asynchrone Requests an ihn senden.
 
-```Python hl_lines="9-10"
+```Python hl_lines="9-12"
 {!../../../docs_src/async_tests/test_main.py!}
 ```
 

--- a/docs/em/docs/advanced/async-tests.md
+++ b/docs/em/docs/advanced/async-tests.md
@@ -72,7 +72,7 @@ $ pytest
 
 ⤴️ 👥 💪 ✍ `AsyncClient` ⏮️ 📱, &amp; 📨 🔁 📨 ⚫️, ⚙️ `await`.
 
-```Python hl_lines="9-10"
+```Python hl_lines="9-12"
 {!../../../docs_src/async_tests/test_main.py!}
 ```
 

--- a/docs/en/docs/advanced/async-tests.md
+++ b/docs/en/docs/advanced/async-tests.md
@@ -72,7 +72,7 @@ Note that the test function is now `async def` instead of just `def` as before w
 
 Then we can create an `AsyncClient` with the app, and send async requests to it, using `await`.
 
-```Python hl_lines="9-10"
+```Python hl_lines="9-12"
 {!../../../docs_src/async_tests/test_main.py!}
 ```
 

--- a/docs/pt/docs/advanced/async-tests.md
+++ b/docs/pt/docs/advanced/async-tests.md
@@ -72,7 +72,7 @@ Note que a função de teste é `async def` agora, no lugar de apenas `def` como
 
 Então podemos criar um `AsyncClient` com a aplicação, e enviar requisições assíncronas para ela utilizando `await`.
 
-```Python hl_lines="9-10"
+```Python hl_lines="9-12"
 {!../../../docs_src/async_tests/test_main.py!}
 ```
 

--- a/docs_src/async_tests/test_main.py
+++ b/docs_src/async_tests/test_main.py
@@ -1,12 +1,14 @@
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from .main import app
 
 
 @pytest.mark.anyio
 async def test_root():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
         response = await ac.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "Tomato"}


### PR DESCRIPTION
The code sample in `docs_src/async_tests/test_main.py` triggers the following deprecation warning with recent versions of `httpx`:

    DeprecationWarning: The 'app' shortcut is now deprecated.
    Use the explicit style 'transport=ASGITransport(app=...)' instead.

We fix it as suggested by the warning.

Note that due to https://github.com/encode/httpx/issues/3111 the new way of creating `AsyncClient` passes type checks only when using httpx version 0.27.2 or newer. This is not a problem for FastAPI itself though because it does not type check code samples.