### PR TITLE
♻️ Rename internal `create_response_field()` to `create_model_field()` as it's used for more than response models

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -55,7 +55,7 @@ from fastapi.logger import logger
 from fastapi.security.base import SecurityBase
 from fastapi.security.oauth2 import OAuth2, SecurityScopes
 from fastapi.security.open_id_connect_url import OpenIdConnect
-from fastapi.utils import create_response_field, get_path_param_names
+from fastapi.utils import create_model_field, get_path_param_names
 from pydantic.fields import FieldInfo
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
 from starlette.concurrency import run_in_threadpool
@@ -449,7 +449,7 @@ def analyze_param(
         else:
             alias = field_info.alias or param_name
         field_info.alias = alias
-        field = create_response_field(
+        field = create_model_field(
             name=param_name,
             type_=use_annotation_from_field_info,
             default=field_info.default,
@@ -818,7 +818,7 @@ def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
         ]
         if len(set(body_param_media_types)) == 1:
             BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
-    final_field = create_response_field(
+    final_field = create_model_field(
         name="body",
         type_=BodyModel,
         required=required,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -49,7 +49,7 @@ from fastapi.exceptions import (
 from fastapi.types import DecoratedCallable, IncEx
 from fastapi.utils import (
     create_cloned_field,
-    create_response_field,
+    create_model_field,
     generate_unique_id,
     get_value_or_default,
     is_body_allowed_for_status_code,
@@ -497,7 +497,7 @@ class APIRoute(routing.Route):
                 status_code
             ), f"Status code {status_code} must not have a response body"
             response_name = "Response_" + self.unique_id
-            self.response_field = create_response_field(
+            self.response_field = create_model_field(
                 name=response_name,
                 type_=self.response_model,
                 mode="serialization",
@@ -530,7 +530,7 @@ class APIRoute(routing.Route):
                     additional_status_code
                 ), f"Status code {additional_status_code} must not have a response body"
                 response_name = f"Response_{additional_status_code}_{self.unique_id}"
-                response_field = create_response_field(name=response_name, type_=model)
+                response_field = create_model_field(name=response_name, type_=model)
                 response_fields[additional_status_code] = response_field
         if response_fields:
             self.response_fields: Dict[Union[int, str], ModelField] = response_fields

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -60,9 +60,9 @@ def get_path_param_names(path: str) -> Set[str]:
     return set(re.findall("{(.*?)}", path))
 
 
-def create_response_field(
+def create_model_field(
     name: str,
-    type_: Type[Any],
+    type_: Any,
     class_validators: Optional[Dict[str, Validator]] = None,
     default: Optional[Any] = Undefined,
     required: Union[bool, UndefinedType] = Undefined,
@@ -71,9 +71,6 @@ def create_response_field(
     alias: Optional[str] = None,
     mode: Literal["validation", "serialization"] = "validation",
 ) -> ModelField:
-    """
-    Create a new response field. Raises if type_ is invalid.
-    """
     class_validators = class_validators or {}
     if PYDANTIC_V2:
         field_info = field_info or FieldInfo(
@@ -135,7 +132,7 @@ def create_cloned_field(
                 use_type.__fields__[f.name] = create_cloned_field(
                     f, cloned_types=cloned_types
                 )
-    new_field = create_response_field(name=field.name, type_=use_type)
+    new_field = create_model_field(name=field.name, type_=use_type)
     new_field.has_alias = field.has_alias  # type: ignore[attr-defined]
     new_field.alias = field.alias  # type: ignore[misc]
     new_field.class_validators = field.class_validators  # type: ignore[attr-defined]


### PR DESCRIPTION
♻️ Rename internal `create_response_field()` to `create_model_field()` as it's used for more than response models