### PR TITLE
💚 Set `include-hidden-files` to `True` when using the `upload-artifact` GH action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           name: docs-site-${{ matrix.lang }}
           path: ./site/**
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   docs-all-green:  # This job does nothing and is only used for the branch protection

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
           path: coverage
+          include-hidden-files: true
 
   coverage-combine:
     needs: [test]
@@ -123,6 +124,7 @@ jobs:
         with:
           name: coverage-html
           path: htmlcov
+          include-hidden-files: true
 
   # https://github.com/marketplace/actions/alls-green#why
   check:  # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
The CI was failing because hidden files are automatically excluded since `actions/upload-artifact` [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0).

This PR specifically sets the parameter to `True` so the `.coverage` files are found.

