### PR TITLE
🐛 Fix wrong OpenApi scheme generation for custom models with computed fields in additional responses

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -530,7 +530,9 @@ class APIRoute(routing.Route):
                     additional_status_code
                 ), f"Status code {additional_status_code} must not have a response body"
                 response_name = f"Response_{additional_status_code}_{self.unique_id}"
-                response_field = create_model_field(name=response_name, type_=model, mode="serialization")
+                response_field = create_model_field(
+                    name=response_name, type_=model, mode="serialization"
+                )
                 response_fields[additional_status_code] = response_field
         if response_fields:
             self.response_fields: Dict[Union[int, str], ModelField] = response_fields

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -530,7 +530,7 @@ class APIRoute(routing.Route):
                     additional_status_code
                 ), f"Status code {additional_status_code} must not have a response body"
                 response_name = f"Response_{additional_status_code}_{self.unique_id}"
-                response_field = create_model_field(name=response_name, type_=model)
+                response_field = create_model_field(name=response_name, type_=model, mode="serialization")
                 response_fields[additional_status_code] = response_field
         if response_fields:
             self.response_fields: Dict[Union[int, str], ModelField] = response_fields

--- a/tests/test_additional_responses_custom_model_with_computed_fields.py
+++ b/tests/test_additional_responses_custom_model_with_computed_fields.py
@@ -1,0 +1,75 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from pydantic.fields import computed_field
+
+
+class Rectangle(BaseModel):
+    width: int
+    height: int
+
+    @computed_field
+    def area(self) -> int:
+        return self.width * self.height
+
+
+app = FastAPI()
+
+
+@app.get(
+    "/rectangle/",
+    responses={
+        200: {
+            "model": Rectangle,
+        },
+    },
+)
+async def rectangle() -> Rectangle:
+    return Rectangle(
+        width=10,
+        height=5,
+    )
+
+
+client = TestClient(app)
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {"title": "FastAPI", "version": "0.1.0"},
+        "paths": {
+            "/rectangle/": {
+                "get": {
+                    "summary": "Rectangle",
+                    "operationId": "rectangle_rectangle__get",
+                    "responses": {
+                        "200": {
+                            "description": "Successful Response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Rectangle"}
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Rectangle": {
+                    "properties": {
+                        "width": {"type": "integer", "title": "Width"},
+                        "height": {"type": "integer", "title": "Height"},
+                        "area": {"type": "integer", "title": "Area", "readOnly": True},
+                    },
+                    "type": "object",
+                    "required": ["width", "height", "area"],
+                    "title": "Rectangle",
+                }
+            }
+        },
+    }


### PR DESCRIPTION
Previously discussed here: **@computed_field not showing in OpenAPI Json** https://github.com/fastapi/fastapi/discussions/9856

### 📕 Description
- When using computed fields in a custom Pydantic model, FastAPI incorrectly uses `mode="validation"` for the additional responses model schema.

- This causes an issue where the response model is interpreted as an `-Input` model, thus excluding read-only computed fields from the documentation (note: the fields are correctly returned in the answer even if they are not shown in the documentation).

#### 👀 Example code
```python
from fastapi import FastAPI
from pydantic import BaseModel
from pydantic.fields import computed_field

app = FastAPI()

class Rectangle(BaseModel):
    width: int
    height: int

    @computed_field
    def area(self) -> int:
        return self.width * self.height

@app.get(
    "/rectangle/",
    responses={200: {"model": Rectangle}},
)
async def rectangle() -> Rectangle:
    return Rectangle(width=10, height=5)
```

#### ❌ Wrong (current) schema
<details>
<summary>Click to expand</summary>

![image](https://github.com/user-attachments/assets/1f67f5d1-7f9a-41b0-ae25-2377b909d32a)


```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "FastAPI",
    "version": "0.1.0"
  },
  "paths": {
    "/rectangle/": {
      "get": {
        "summary": "Rectangle",
        "operationId": "rectangle_rectangle__get",
        "responses": {
          "200": {
            "description": "Successful Response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Rectangle-Input"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "Rectangle-Input": {
        "properties": {
          "width": {
            "type": "integer",
            "title": "Width"
          },
          "height": {
            "type": "integer",
            "title": "Height"
          }
        },
        "type": "object",
        "required": [
          "width",
          "height"
        ],
        "title": "Rectangle"
      },
      "Rectangle-Output": {
        "properties": {
          "width": {
            "type": "integer",
            "title": "Width"
          },
          "height": {
            "type": "integer",
            "title": "Height"
          },
          "area": {
            "type": "integer",
            "title": "Area",
            "readOnly": true
          }
        },
        "type": "object",
        "required": [
          "width",
          "height",
          "area"
        ],
        "title": "Rectangle"
      }
    }
  }
}
```
</details>

#### ✅ Correct (fixed) schema:
<details>
<summary>Click to expand</summary>

![image](https://github.com/user-attachments/assets/9b95d47a-950c-4e53-8698-a9ecafc1a883)

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "FastAPI",
    "version": "0.1.0"
  },
  "paths": {
    "/rectangle/": {
      "get": {
        "summary": "Rectangle",
        "operationId": "rectangle_rectangle__get",
        "responses": {
          "200": {
            "description": "Successful Response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Rectangle"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "Rectangle": {
        "properties": {
          "width": {
            "type": "integer",
            "title": "Width"
          },
          "height": {
            "type": "integer",
            "title": "Height"
          },
          "area": {
            "type": "integer",
            "title": "Area",
            "readOnly": true
          }
        },
        "type": "object",
        "required": [
          "width",
          "height",
          "area"
        ],
        "title": "Rectangle"
      }
    }
  }
}
```
</details>

#### OpenApi schema diff (wrong ➡️ correct)
```diff
18c18
<                   "$ref": "#/components/schemas/Rectangle-Input"
---
>                   "$ref": "#/components/schemas/Rectangle"
29,47c29
<       "Rectangle-Input": {
<         "properties": {
<           "width": {
<             "type": "integer",
<             "title": "Width"
<           },
<           "height": {
<             "type": "integer",
<             "title": "Height"
<           }
<         },
<         "type": "object",
<         "required": [
<           "width",
<           "height"
<         ],
<         "title": "Rectangle"
<       },
<       "Rectangle-Output": {
---
>       "Rectangle": {
```

### 💊 Fix
Use `mode="serialization"` for `create_model_field` for additional responses model.

### 🧪 Added tests!
- All tests pass and the code has been formatted
- `tests/test_additional_responses_custom_model_with_computed_fields.py`

