### PR TITLE
✏️ Fix typo in `fastapi/params.py`

### DIFF
--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -556,7 +556,7 @@ class Body(FieldInfo):
             kwargs["examples"] = examples
         if regex is not None:
             warnings.warn(
-                "`regex` has been depreacated, please use `pattern` instead",
+                "`regex` has been deprecated, please use `pattern` instead",
                 category=DeprecationWarning,
                 stacklevel=4,
             )


### PR DESCRIPTION
#What
- There was a spelling mistake. `deprecated` was spelt wrong