### PR TITLE
🐛 Remove `Required` shadowing from fastapi using Pydantic v2

### DIFF
--- a/docs_src/query_params_str_validations/tutorial006d.py
+++ b/docs_src/query_params_str_validations/tutorial006d.py
@@ -1,11 +1,10 @@
 from fastapi import FastAPI, Query
-from pydantic import Required
 
 app = FastAPI()
 
 
 @app.get("/items/")
-async def read_items(q: str = Query(default=Required, min_length=3)):
+async def read_items(q: str = Query(default = ..., min_length=3)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
         results.update({"q": q})

--- a/docs_src/query_params_str_validations/tutorial006d.py
+++ b/docs_src/query_params_str_validations/tutorial006d.py
@@ -4,7 +4,7 @@ app = FastAPI()
 
 
 @app.get("/items/")
-async def read_items(q: str = Query(default = ..., min_length=3)):
+async def read_items(q: str = Query(default=..., min_length=3)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
         results.update({"q": q})

--- a/docs_src/query_params_str_validations/tutorial006d_an.py
+++ b/docs_src/query_params_str_validations/tutorial006d_an.py
@@ -1,12 +1,11 @@
 from fastapi import FastAPI, Query
-from pydantic import Required
 from typing_extensions import Annotated
 
 app = FastAPI()
 
 
 @app.get("/items/")
-async def read_items(q: Annotated[str, Query(min_length=3)] = Required):
+async def read_items(q: Annotated[str, Query(min_length=3)] = ...):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
         results.update({"q": q})

--- a/docs_src/query_params_str_validations/tutorial006d_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial006d_an_py39.py
@@ -1,13 +1,12 @@
 from typing import Annotated
 
 from fastapi import FastAPI, Query
-from pydantic import Required
 
 app = FastAPI()
 
 
 @app.get("/items/")
-async def read_items(q: Annotated[str, Query(min_length=3)] = Required):
+async def read_items(q: Annotated[str, Query(min_length=3)] = ...):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
         results.update({"q": q})

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -312,6 +312,7 @@ else:
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         ModelField as ModelField,  # noqa: F401
     )
+
     # from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
     #     Required as Required,  # noqa: F401
     # )

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -71,7 +71,8 @@ if PYDANTIC_V2:
             general_plain_validator_function as with_info_plain_validator_function,  # noqa: F401
         )
 
-    RequiredParam = Undefined = PydanticUndefined
+    RequiredParam = PydanticUndefined
+    Undefined = PydanticUndefined
     UndefinedType = PydanticUndefinedType
     evaluate_forwardref = eval_type_lenient
     Validator = Any

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -71,7 +71,7 @@ if PYDANTIC_V2:
             general_plain_validator_function as with_info_plain_validator_function,  # noqa: F401
         )
 
-    Undefined = PydanticUndefined
+    RequiredParam = Undefined = PydanticUndefined
     UndefinedType = PydanticUndefinedType
     evaluate_forwardref = eval_type_lenient
     Validator = Any
@@ -316,7 +316,7 @@ else:
     # from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
     #     Required as Required,  # noqa: F401
     # )
-    Required: Any = Ellipsis
+    RequiredParam: Any = Ellipsis
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         Undefined as Undefined,
     )

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -313,6 +313,7 @@ else:
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         ModelField as ModelField,  # noqa: F401
     )
+
     # Keeping old "Required" functionality from Pydantic V1, without
     # shadowing typing.Required.
     RequiredParam: Any = Ellipsis  # type: ignore[no-redef]

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -71,7 +71,6 @@ if PYDANTIC_V2:
             general_plain_validator_function as with_info_plain_validator_function,  # noqa: F401
         )
 
-    Required = PydanticUndefined
     Undefined = PydanticUndefined
     UndefinedType = PydanticUndefinedType
     evaluate_forwardref = eval_type_lenient
@@ -313,9 +312,10 @@ else:
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         ModelField as ModelField,  # noqa: F401
     )
-    from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
-        Required as Required,  # noqa: F401
-    )
+    # from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
+    #     Required as Required,  # noqa: F401
+    # )
+    Required = Ellipsis
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         Undefined as Undefined,
     )

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -314,9 +314,6 @@ else:
         ModelField as ModelField,  # noqa: F401
     )
 
-    # from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
-    #     Required as Required,  # noqa: F401
-    # )
     RequiredParam: Any = Ellipsis  # type: ignore[no-redef]
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         Undefined as Undefined,

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -316,7 +316,7 @@ else:
     # from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
     #     Required as Required,  # noqa: F401
     # )
-    Required = Ellipsis
+    Required: Any = Ellipsis
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         Undefined as Undefined,
     )

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -316,7 +316,7 @@ else:
     # from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
     #     Required as Required,  # noqa: F401
     # )
-    RequiredParam: Any = Ellipsis
+    RequiredParam: Any = Ellipsis  # type: ignore[no-redef]
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         Undefined as Undefined,
     )

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -313,7 +313,8 @@ else:
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         ModelField as ModelField,  # noqa: F401
     )
-
+    # Keeping old "Required" functionality from Pydantic V1, without
+    # shadowing typing.Required.
     RequiredParam: Any = Ellipsis  # type: ignore[no-redef]
     from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
         Undefined as Undefined,

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -375,7 +375,7 @@ def analyze_param(
                 assert not is_path_param, "Path parameters cannot have default values"
                 field_info.default = value
             else:
-                field_info.default = Ellipsis
+                field_info.default = Undefined
         # Get Annotated Depends
         elif isinstance(fastapi_annotation, params.Depends):
             depends = fastapi_annotation

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -368,7 +368,9 @@ def analyze_param(
             field_info = copy_field_info(
                 field_info=fastapi_annotation, annotation=use_annotation
             )
-            assert field_info.default is Undefined or field_info.default is RequiredParam, (
+            assert (
+                field_info.default is Undefined or field_info.default is RequiredParam
+            ), (
                 f"`{field_info.__class__.__name__}` default value cannot be set in"
                 f" `Annotated` for {param_name!r}. Set the default value with `=` instead."
             )

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -24,7 +24,6 @@ from fastapi._compat import (
     PYDANTIC_V2,
     ErrorWrapper,
     ModelField,
-    Required,
     Undefined,
     _regenerate_error_with_loc,
     copy_field_info,
@@ -368,7 +367,7 @@ def analyze_param(
             field_info = copy_field_info(
                 field_info=fastapi_annotation, annotation=use_annotation
             )
-            assert field_info.default is Undefined or field_info.default is Required, (
+            assert field_info.default is Undefined or field_info.default is Ellipsis, (
                 f"`{field_info.__class__.__name__}` default value cannot be set in"
                 f" `Annotated` for {param_name!r}. Set the default value with `=` instead."
             )
@@ -376,7 +375,7 @@ def analyze_param(
                 assert not is_path_param, "Path parameters cannot have default values"
                 field_info.default = value
             else:
-                field_info.default = Required
+                field_info.default = Ellipsis
         # Get Annotated Depends
         elif isinstance(fastapi_annotation, params.Depends):
             depends = fastapi_annotation
@@ -425,9 +424,9 @@ def analyze_param(
         ), f"Cannot specify FastAPI annotation for type {type_annotation!r}"
     # Handle default assignations, neither field_info nor depends was not found in Annotated nor default value
     elif field_info is None and depends is None:
-        default_value = value if value is not inspect.Signature.empty else Required
+        default_value = value if value is not inspect.Signature.empty else Ellipsis
         if is_path_param:
-            # We might check here that `default_value is Required`, but the fact is that the same
+            # We might check here that `default_value is Ellipsis`, but the fact is that the same
             # parameter might sometimes be a path parameter and sometimes not. See
             # `tests/test_infer_param_optionality.py` for an example.
             field_info = params.Path(annotation=use_annotation)
@@ -471,7 +470,7 @@ def analyze_param(
             type_=use_annotation_from_field_info,
             default=field_info.default,
             alias=alias,
-            required=field_info.default in (Required, Undefined),
+            required=field_info.default in (Ellipsis, Undefined),
             field_info=field_info,
         )
         if is_path_param:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -24,6 +24,7 @@ from fastapi._compat import (
     PYDANTIC_V2,
     ErrorWrapper,
     ModelField,
+    RequiredParam,
     Undefined,
     _regenerate_error_with_loc,
     copy_field_info,
@@ -367,7 +368,7 @@ def analyze_param(
             field_info = copy_field_info(
                 field_info=fastapi_annotation, annotation=use_annotation
             )
-            assert field_info.default is Undefined or field_info.default is Ellipsis, (
+            assert field_info.default is Undefined or field_info.default is RequiredParam, (
                 f"`{field_info.__class__.__name__}` default value cannot be set in"
                 f" `Annotated` for {param_name!r}. Set the default value with `=` instead."
             )
@@ -375,7 +376,7 @@ def analyze_param(
                 assert not is_path_param, "Path parameters cannot have default values"
                 field_info.default = value
             else:
-                field_info.default = Undefined
+                field_info.default = RequiredParam
         # Get Annotated Depends
         elif isinstance(fastapi_annotation, params.Depends):
             depends = fastapi_annotation
@@ -424,9 +425,9 @@ def analyze_param(
         ), f"Cannot specify FastAPI annotation for type {type_annotation!r}"
     # Handle default assignations, neither field_info nor depends was not found in Annotated nor default value
     elif field_info is None and depends is None:
-        default_value = value if value is not inspect.Signature.empty else Ellipsis
+        default_value = value if value is not inspect.Signature.empty else RequiredParam
         if is_path_param:
-            # We might check here that `default_value is Ellipsis`, but the fact is that the same
+            # We might check here that `default_value is RequiredParam`, but the fact is that the same
             # parameter might sometimes be a path parameter and sometimes not. See
             # `tests/test_infer_param_optionality.py` for an example.
             field_info = params.Path(annotation=use_annotation)
@@ -470,7 +471,7 @@ def analyze_param(
             type_=use_annotation_from_field_info,
             default=field_info.default,
             alias=alias,
-            required=field_info.default in (Ellipsis, Undefined),
+            required=field_info.default in (RequiredParam, Undefined),
             field_info=field_info,
         )
         if is_path_param:

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -19,7 +19,7 @@ def Path(  # noqa: N802
             The parameter is available only for compatibility.
             """
         ),
-    ] = Undefined,
+    ] = ...,
     *,
     default_factory: Annotated[
         Union[Callable[[], Any], None],

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -19,7 +19,7 @@ def Path(  # noqa: N802
             The parameter is available only for compatibility.
             """
         ),
-    ] = ...,
+    ] = Undefined,
     *,
     default_factory: Annotated[
         Union[Callable[[], Any], None],


### PR DESCRIPTION
Re:
* https://github.com/vllm-project/vllm/issues/8212
* https://github.com/vllm-project/vllm/issues/8450
* https://github.com/fastapi/fastapi/discussions/11952

(and potentially others)

I think I found the underlying cause. We're still supporting `pydantic.Required` in FastAPI, which has the possibility to shadow the new `Required` type. To me, this seems like a Pydantic + fastapi bug. Here's how 0.113.0 introduced it:

1. `fastapi` has the new `get_model_fields()` function, which deals with `TypeAdapter()`, and is called for every field
2. TypeAdapter gets a `globalns` from the `sys._getframe()`, meaning it gets the ns from `_compat`. This is important because pydantic bases their type evaluations from that `globalns`. Why they are doing this is a question for later.
3. Because `Required = PydanticUndefined` is in _compat.py, we are getting that value set in the `globalns`
4. Independently, `openai` uses `TypedDict` with the `Required` annotations in its fields.
4. `vllm` (and potentially other libs) uses `fastapi` + `pydantic` + `openai` TypedDict classes

The smoking gun was: `TypeError: 'pydantic_core._pydantic_core.PydanticUndefinedType' object is not subscriptable`

Focusing on https://github.com/vllm-project/vllm/issues/8450, the offending type annotation was `Required[Union[str, Iterable[X]]`. It needed to have been `Required` that was a `PydanticUndefinedType`, otherwise it would be complaining about `Union[str, Iterable[X]]`, or some other annotation. I ran the snippet [here](https://github.com/fastapi/fastapi/issues/12133#issuecomment-2342858880) using `fastapi 0.114.1, pydantic 2.9.0, vllm 0.6.1, python = 3.8.20`, and was able to reproduce the issue again. Using `pdb.pm()`, I was able to inspect the globalns and connect the dots.

# How to test

Run the code example in [this](https://github.com/fastapi/fastapi/issues/12133#issuecomment-2342858880) comment Python 3.8. It will fail without the changes, and pass with the changes. 

