### PR TITLE
✏️ Fix docstring typos in http security

### DIFF
--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -277,7 +277,7 @@ class HTTPBearer(HTTPBase):
             bool,
             Doc(
                 """
-                By default, if the HTTP Bearer token not provided (in an
+                By default, if the HTTP Bearer token is not provided (in an
                 `Authorization` header), `HTTPBearer` will automatically cancel the
                 request and send the client an error.
 
@@ -380,7 +380,7 @@ class HTTPDigest(HTTPBase):
             bool,
             Doc(
                 """
-                By default, if the HTTP Digest not provided, `HTTPDigest` will
+                By default, if the HTTP Digest is not provided, `HTTPDigest` will
                 automatically cancel the request and send the client an error.
 
                 If `auto_error` is set to `False`, when the HTTP Digest is not


### PR DESCRIPTION
Fix docstring typos in http security.