### PR TITLE
📝 Update link to Swagger UI configuration docs

### DIFF
--- a/docs/de/docs/how-to/configure-swagger-ui.md
+++ b/docs/de/docs/how-to/configure-swagger-ui.md
@@ -1,6 +1,6 @@
 # Swagger-Oberfläche konfigurieren
 
-Sie können einige zusätzliche <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">Parameter der Swagger-Oberfläche</a> konfigurieren.
+Sie können einige zusätzliche <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">Parameter der Swagger-Oberfläche</a> konfigurieren.
 
 Um diese zu konfigurieren, übergeben Sie das Argument `swagger_ui_parameters` beim Erstellen des `FastAPI()`-App-Objekts oder an die Funktion `get_swagger_ui_html()`.
 
@@ -58,7 +58,7 @@ Um beispielsweise `deepLinking` zu deaktivieren, könnten Sie folgende Einstellu
 
 ## Andere Parameter der Swagger-Oberfläche
 
-Um alle anderen möglichen Konfigurationen zu sehen, die Sie verwenden können, lesen Sie die offizielle <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">Dokumentation für die Parameter der Swagger-Oberfläche</a>.
+Um alle anderen möglichen Konfigurationen zu sehen, die Sie verwenden können, lesen Sie die offizielle <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">Dokumentation für die Parameter der Swagger-Oberfläche</a>.
 
 ## JavaScript-basierte Einstellungen
 

--- a/docs/en/docs/how-to/configure-swagger-ui.md
+++ b/docs/en/docs/how-to/configure-swagger-ui.md
@@ -1,6 +1,6 @@
 # Configure Swagger UI
 
-You can configure some extra <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">Swagger UI parameters</a>.
+You can configure some extra <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">Swagger UI parameters</a>.
 
 To configure them, pass the `swagger_ui_parameters` argument when creating the `FastAPI()` app object or to the `get_swagger_ui_html()` function.
 
@@ -58,7 +58,7 @@ For example, to disable `deepLinking` you could pass these settings to `swagger_
 
 ## Other Swagger UI Parameters
 
-To see all the other possible configurations you can use, read the official <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">docs for Swagger UI parameters</a>.
+To see all the other possible configurations you can use, read the official <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration//" class="external-link" target="_blank">docs for Swagger UI parameters</a>.
 
 ## JavaScript-only settings
 

--- a/docs/en/docs/how-to/configure-swagger-ui.md
+++ b/docs/en/docs/how-to/configure-swagger-ui.md
@@ -58,7 +58,7 @@ For example, to disable `deepLinking` you could pass these settings to `swagger_
 
 ## Other Swagger UI Parameters
 
-To see all the other possible configurations you can use, read the official <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration//" class="external-link" target="_blank">docs for Swagger UI parameters</a>.
+To see all the other possible configurations you can use, read the official <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">docs for Swagger UI parameters</a>.
 
 ## JavaScript-only settings
 

--- a/docs/en/docs/how-to/configure-swagger-ui.md
+++ b/docs/en/docs/how-to/configure-swagger-ui.md
@@ -58,7 +58,7 @@ For example, to disable `deepLinking` you could pass these settings to `swagger_
 
 ## Other Swagger UI Parameters
 
-To see all the other possible configurations you can use, read the official <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">docs for Swagger UI parameters</a>.
+To see all the other possible configurations you can use, read the official <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">docs for Swagger UI parameters</a>.
 
 ## JavaScript-only settings
 

--- a/docs/pt/docs/how-to/configure-swagger-ui.md
+++ b/docs/pt/docs/how-to/configure-swagger-ui.md
@@ -1,6 +1,6 @@
 # Configurar Swagger UI
 
-Você pode configurar alguns <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">parâmetros extras da UI do Swagger</a>.
+Você pode configurar alguns <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">parâmetros extras da UI do Swagger</a>.
 
 Para configurá-los, passe o argumento `swagger_ui_parameters` ao criar o objeto de aplicativo `FastAPI()` ou para a função `get_swagger_ui_html()`.
 
@@ -58,7 +58,7 @@ Por exemplo, para desabilitar `deepLinking` você pode passar essas configuraç�
 
 ## Outros parâmetros da UI do Swagger
 
-Para ver todas as outras configurações possíveis que você pode usar, leia a <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">documentação oficial dos parâmetros da UI do Swagger</a>.
+Para ver todas as outras configurações possíveis que você pode usar, leia a <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">documentação oficial dos parâmetros da UI do Swagger</a>.
 
 ## Configurações somente JavaScript
 

--- a/docs/zh/docs/how-to/configure-swagger-ui.md
+++ b/docs/zh/docs/how-to/configure-swagger-ui.md
@@ -1,6 +1,6 @@
 # 配置 Swagger UI
 
-你可以配置一些额外的 <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">Swagger UI 参数</a>.
+你可以配置一些额外的 <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">Swagger UI 参数</a>.
 
 如果需要配置它们，可以在创建 `FastAPI()` 应用对象时或调用 `get_swagger_ui_html()` 函数时传递 `swagger_ui_parameters` 参数。
 
@@ -58,7 +58,7 @@ FastAPI 包含了一些默认配置参数，适用于大多数用例。
 
 ## 其他 Swagger UI 参数
 
-查看其他 Swagger UI 参数，请阅读 <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration" class="external-link" target="_blank">docs for Swagger UI parameters</a>。
+查看其他 Swagger UI 参数，请阅读 <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">docs for Swagger UI parameters</a>。
 
 ## JavaScript-only 配置
 


### PR DESCRIPTION
I've noticed that the [old link](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration) now leads to the "404 Not found" page on swagger.io, found the new link and updated it wherever possible (there appear to be only 4 languages that even have `configure-swagger-ui.md` page).

Even though it appears to be a problem that should be resolved on swagger.io side, I think that updating the link may be better.

P.S. I've created a [bug report](https://github.com/swagger-api/swagger.io-docs/issues/362) in the swagger.io-docs repo.
P.S.S. I still believe it's best to have the trailing slashes at the end of the link, because without them, users are getting 308 Permanent Redirect to other webpage, so adding a / will make life easier for both parties.