### PR TITLE
fix: all route params now in docs

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -258,6 +258,7 @@ def get_dependant(
     *,
     path: str,
     call: Callable[..., Any],
+    param_convertors: Optional[Dict[str, Any]] = {},
     name: Optional[str] = None,
     security_scopes: Optional[List[str]] = None,
     use_cache: bool = True,
@@ -272,6 +273,15 @@ def get_dependant(
         security_scopes=security_scopes,
         use_cache=use_cache,
     )
+    assert param_convertors is not None
+    for param_name, param_convertor in param_convertors.items():
+        assert "return" in param_convertor.convert.__annotations__
+        annotation = param_convertor.convert.__annotations__["return"]
+        param_details = analyze_param(
+            param_name=param_name, annotation=annotation, is_path_param=True, value=None
+        )
+        assert param_details is not None
+        add_param_to_fields(field=param_details.field, dependant=dependant)
     for param_name, param in signature_params.items():
         is_path_param = param_name in path_param_names
         param_details = analyze_param(

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -549,7 +549,11 @@ class APIRoute(routing.Route):
             self.response_fields = {}
 
         assert callable(endpoint), "An endpoint must be a callable"
-        self.dependant = get_dependant(path=self.path_format, call=self.endpoint, param_convertors=self.param_convertors)
+        self.dependant = get_dependant(
+            path=self.path_format,
+            call=self.endpoint,
+            param_convertors=self.param_convertors,
+        )
         for depends in self.dependencies[::-1]:
             self.dependant.dependencies.insert(
                 0,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -549,7 +549,7 @@ class APIRoute(routing.Route):
             self.response_fields = {}
 
         assert callable(endpoint), "An endpoint must be a callable"
-        self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+        self.dependant = get_dependant(path=self.path_format, call=self.endpoint, param_convertors=self.param_convertors)
         for depends in self.dependencies[::-1]:
             self.dependant.dependencies.insert(
                 0,


### PR DESCRIPTION
This is a reimplementation of a path originally provided within https://github.com/fastapi/fastapi/discussions/9987

All credit should go to the original author there (@OnyxMsi) 

## Example Code

```python
from fastapi import FastAPI, Request
from fastapi.testclient import TestClient

app = FastAPI()


@app.get("/{first:int}/{second}")
def route(request: Request):
    # This works
    return request.path_params["second"]

client = TestClient(app)
response = client.get("/openapi.json")
data = response.json()
assert "parameters" in data["paths"]["/{first}/{second}"]["get"]
```

## Description

This error concerns only the OpenAPI schema generation, the web part works fine.

It happen when using https://www.starlette.io/routing/#path-parameters request.path_params in order to access path attributes instead of declaring them as function attribute.
When parsing the routes to generate the OpenAPI stuff, fastapi is missing
them.

This PR addresses this by editing the get_dependant function in fastapi.dependencies.utils.