### PR TITLE
✨ Add relative docs everywhere

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,5 +1,6 @@
 import pytest
 from dirty_equals import IsDict
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from .main import app
@@ -1281,3 +1282,20 @@ def test_openapi_schema():
             }
         },
     }
+
+
+def test_relative_docs():
+    _app = FastAPI(relative_docs=True)
+    _client = TestClient(_app)
+
+    response = _client.get("/docs")
+    assert response.status_code == 200, response.text
+    assert "./openapi.json" in response.text
+
+    response = _client.get("/redoc")
+    assert response.status_code == 200, response.text
+    assert "./openapi.json" in response.text
+
+    response = _client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert "../" in response.text

--- a/tests/test_local_docs.py
+++ b/tests/test_local_docs.py
@@ -1,6 +1,7 @@
 import inspect
 
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.openapi.utils import calculate_relative_url
 
 
 def test_strings_in_generated_swagger():
@@ -65,3 +66,25 @@ def test_google_fonts_in_generated_redoc():
         openapi_url="/docs", title="title", with_google_fonts=False
     ).body.decode()
     assert "fonts.googleapis.com" not in body_without_google_fonts
+
+
+def test_calculate_relative_url() -> None:
+    assert calculate_relative_url("/docs/", "/docs/a.json") == "./a.json"
+    assert calculate_relative_url("/docs", "/docs/a.json") == "./docs/a.json"
+    assert calculate_relative_url("/docs/", "/docs/subdir/a.json") == "./subdir/a.json"
+    assert (
+        calculate_relative_url("/docs", "/docs/subdir/a.json") == "./docs/subdir/a.json"
+    )
+    assert calculate_relative_url("/", "/a.json") == "./a.json"
+    assert calculate_relative_url("/b.json", "/a.json") == "./a.json"
+    assert calculate_relative_url("/docs/a.json", "/docs/a.json") == "./a.json"
+    assert calculate_relative_url("/", "/docs/a.json") == "./docs/a.json"
+    assert calculate_relative_url("/docs", "/") == "./"
+    assert calculate_relative_url("/docs/", "/") == "../"
+
+    assert calculate_relative_url(None, "/any/path") == "/any/path"
+    assert calculate_relative_url("http://example.com", "/any/path") == "/any/path"
+    assert (
+        calculate_relative_url("http://example.com", "http://a.com/any/path")
+        == "http://a.com/any/path"
+    )


### PR DESCRIPTION
In some situations, you might need to use a proxy server like Traefik or Nginx with a configuration that adds an extra path prefix that is not seen by your application.

The [Behind a Proxy](https://fastapi.tiangolo.com/advanced/behind-a-proxy/)  handle these specific cases.

However, the relative path I obtained could be a more optimal solution.