### PR TITLE
cleared up misinformation

### DIFF
--- a/docs/en/docs/virtual-environments.md
+++ b/docs/en/docs/virtual-environments.md
@@ -162,14 +162,6 @@ $ source .venv/Scripts/activate
 
 ////
 
-/// tip
-
-Every time you install a **new package** in that environment, **activate** the environment again.
-
-This makes sure that if you use a **terminal (<abbr title="command line interface">CLI</abbr>) program** installed by that package, you use the one from your virtual environment and not any other that could be installed globally, probably with a different version than what you need.
-
-///
-
 ## Check the Virtual Environment is Active
 
 Check that the virtual environment is active (the previous command worked).


### PR DESCRIPTION
While translating the documentation about virtual environments into Russian, I came across information that I couldn't believe. I double-checked the information and found no justification for the following statement.

> Every time you install a new package in that environment, activate the environment again.
> 
> This makes sure that if you use a terminal (CLI) program installed by that package, you use the one from your virtual environment and not any other that could be installed globally, probably with a different version than what you need.

 _I do not deny that I may have erred in my judgment, and if this is indeed the case please provide me with more information about this process to support the statement._ 