### PR TITLE
Fix errors "ImportError: cannot import name 'DictIntStrAny|SetIntStr'…

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -26,7 +26,6 @@ from typing_extensions import Annotated, Doc
 
 from ._compat import PYDANTIC_V2, UndefinedType, Url, _model_dump
 
-
 DictIntStrAny = Dict[Union[int, str], Any]
 SetIntStr = Set[Union[int, str]]
 

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -14,7 +14,7 @@ from ipaddress import (
 from pathlib import Path, PurePath
 from re import Pattern
 from types import GeneratorType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 from uuid import UUID
 
 from fastapi.types import IncEx
@@ -25,6 +25,10 @@ from pydantic.types import SecretBytes, SecretStr
 from typing_extensions import Annotated, Doc
 
 from ._compat import PYDANTIC_V2, UndefinedType, Url, _model_dump
+
+
+DictIntStrAny = Dict[Union[int, str], Any]
+SetIntStr = Set[Union[int, str]]
 
 
 # Taken from Pydantic v1 as is


### PR DESCRIPTION
Using SQLAlchemy and FastAPI, we got the following issue, and I'm requesting to fix it:
```python
  File "/home/user/project/main.py", line 12, in <module>
    from fastapi_amis_admin.admin.settings import Settings
  File "/home/user/project/venv/lib/python3.10/site-packages/fastapi_amis_admin/admin/__init__.py", line 1, in <module>
    from .admin import (
  File "/home/user/project/venv/lib/python3.10/site-packages/fastapi_amis_admin/admin/admin.py", line 38, in <module>
    from fastapi_amis_admin.admin.handlers import register_exception_handlers
  File "/home/user/project/venv/lib/python3.10/site-packages/fastapi_amis_admin/admin/handlers.py", line 17, in <module>
    from fastapi_amis_admin.crud import BaseApiOut
  File "/home/user/project/venv/lib/python3.10/site-packages/fastapi_amis_admin/crud/__init__.py", line 3, in <module>
    from ._sqlmodel import SQLModelCrud, SQLModelSelector
  File "/home/user/project/venv/lib/python3.10/site-packages/fastapi_amis_admin/crud/_sqlmodel.py", line 18, in <module>
    from fastapi.encoders import DictIntStrAny, SetIntStr
ImportError: cannot import name 'DictIntStrAny' from 'fastapi.encoders' (/home/user/project/venv/lib/python3.10/site-packages/fastapi/encoders.py)
```