### PR TITLE
fix: resolve bold markup rendering issue in zh-hant document

### DIFF
--- a/docs/zh-hant/mkdocs.yml
+++ b/docs/zh-hant/mkdocs.yml
@@ -1,1 +1,5 @@
 INHERIT: ../en/mkdocs.yml
+
+markdown_extensions:
+  pymdownx.betterem:
+    smart_enable: underscore # This is will override the `en/mkdocs.yml` pymdownx.betterem plugin


### PR DESCRIPTION
# Issue Description
I've discovered a rendering issue with bold markup (**) in the FastAPI Traditional Chinese (zh-hant) documentation when using the pymdownx.betterem plugin with MkDocs. This issue appears to have started around early August 2024.

# Problem Details
When using `**` to mark bold text, the rendering result is incorrect.
This issue only occurs in the Traditional Chinese documentation; other language versions are unaffected.
The problem may be related to the smart_enable setting of the pymdownx.betterem plugin.

# Temporary Solution
I've implemented the following temporary solution:
override the `smart_enable` setting of `pymdownx.betterem` to `underscore`(default value) in `docs/zh-hant/mkdocs.yml`

# Discussion Objectives
Confirm if this is a known issue with MkDocs or the pymdownx.betterem plugin.
Explore better long-term solutions.
Decide if we need to submit an issue to MkDocs or the pymdownx.betterem plugin.

# Reference PR and document
#12424 
[pymdown-extensions betterem plugin document](https://facelessuser.github.io/pymdown-extensions/extensions/betterem/)