### PR TITLE
🌐 Update Traditional Chinese translation for `docs/zh-hant/docs/deployment/cloud.md`

### DIFF
--- a/docs/zh-hant/docs/deployment/cloud.md
+++ b/docs/zh-hant/docs/deployment/cloud.md
@@ -1,14 +1,14 @@
 # 在雲端部署 FastAPI
 
-你幾乎可以使用 **任何雲端供應商** 來部署你的 FastAPI 應用程式。
+你幾乎可以使用**任何雲端供應商**來部署你的 FastAPI 應用程式。
 
 在大多數情況下，主要的雲端供應商都有部署 FastAPI 的指南。
 
 ## 雲端供應商 - 贊助商
 
-一些雲端供應商 ✨ [**贊助 FastAPI**](../help-fastapi.md#sponsor-the-author){.internal-link target=_blank} ✨，這確保了 FastAPI 及其 **生態系統** 持續健康地 **發展**。
+一些雲端供應商 ✨ [**贊助 FastAPI**](../help-fastapi.md#sponsor-the-author){.internal-link target=_blank} ✨，這確保了 FastAPI 及其**生態系統**持續健康地**發展**。
 
-這也展現了他們對 FastAPI 和其 **社群**（包括你）的真正承諾，他們不僅希望為你提供 **優質的服務**，還希望確保你擁有一個 **良好且健康的框架**：FastAPI。🙇
+這也展現了他們對 FastAPI 和其**社群**（包括你）的真正承諾，他們不僅希望為你提供**優質的服務**，還希望確保你擁有一個**良好且健康的框架**：FastAPI。🙇
 
 你可能會想嘗試他們的服務，以下有他們的指南：
 


### PR DESCRIPTION
### The reason for this update
The rendering issue was fixed in #12509 , so I deleted the space before and after the asterisks around Traditional Chinese.