### PR TITLE
♻️ Update logic to import and check `python-multipart` for compatibility with newer version

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -74,9 +74,17 @@ from starlette.websockets import WebSocket
 from typing_extensions import Annotated, get_args, get_origin
 
 multipart_not_installed_error = (
-    'Form data requires a recent version of "python-multipart" to be installed. \n'
+    'Form data requires "python-multipart" to be installed. \n'
     'You can install "python-multipart" with: \n\n'
-    "pip install --upgrade python-multipart\n"
+    "pip install python-multipart\n"
+)
+multipart_incorrect_install_error = (
+    'Form data requires "python-multipart" to be installed. '
+    'It seems you installed "multipart" instead. \n'
+    'You can remove "multipart" with: \n\n'
+    "pip uninstall multipart\n\n"
+    'And then install "python-multipart" with: \n\n'
+    "pip install python-multipart\n"
 )
 
 
@@ -85,10 +93,24 @@ def ensure_multipart_is_installed() -> None:
         from python_multipart import __version__
 
         # Import an attribute that can be mocked/deleted in testing
-        assert __version__
-    except ImportError:
-        logger.error(multipart_not_installed_error)
-        raise RuntimeError(multipart_not_installed_error) from None
+        assert __version__ > "0.0.12"
+    except (ImportError, AssertionError):
+        try:
+            # __version__ is available in both multiparts, and can be mocked
+            from multipart import __version__
+
+            assert __version__
+            try:
+                # parse_options_header is only available in the right multipart
+                from multipart.multipart import parse_options_header
+
+                assert parse_options_header  # type: ignore[truthy-function]
+            except ImportError:
+                logger.error(multipart_incorrect_install_error)
+                raise RuntimeError(multipart_incorrect_install_error) from None
+        except ImportError:
+            logger.error(multipart_not_installed_error)
+            raise RuntimeError(multipart_not_installed_error) from None
 
 
 def get_param_sub_dependant(

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -97,14 +97,16 @@ def ensure_multipart_is_installed() -> None:
     except (ImportError, AssertionError):
         try:
             # __version__ is available in both multiparts, and can be mocked
-            from multipart import __version__
+            from multipart import __version__  # type: ignore[no-redef,import-untyped]
 
             assert __version__
             try:
                 # parse_options_header is only available in the right multipart
-                from multipart.multipart import parse_options_header
+                from multipart.multipart import (  # type: ignore[import-untyped]
+                    parse_options_header,
+                )
 
-                assert parse_options_header  # type: ignore[truthy-function]
+                assert parse_options_header
             except ImportError:
                 logger.error(multipart_incorrect_install_error)
                 raise RuntimeError(multipart_incorrect_install_error) from None

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -74,34 +74,18 @@ from starlette.websockets import WebSocket
 from typing_extensions import Annotated, get_args, get_origin
 
 multipart_not_installed_error = (
-    'Form data requires "python-multipart" to be installed. \n'
+    'Form data requires a recent version of "python-multipart" to be installed. \n'
     'You can install "python-multipart" with: \n\n'
-    "pip install python-multipart\n"
-)
-multipart_incorrect_install_error = (
-    'Form data requires "python-multipart" to be installed. '
-    'It seems you installed "multipart" instead. \n'
-    'You can remove "multipart" with: \n\n'
-    "pip uninstall multipart\n\n"
-    'And then install "python-multipart" with: \n\n'
-    "pip install python-multipart\n"
+    "pip install --upgrade python-multipart\n"
 )
 
 
 def ensure_multipart_is_installed() -> None:
     try:
-        # __version__ is available in both multiparts, and can be mocked
-        from multipart import __version__
+        from python_multipart import __version__
 
+        # Import an attribute that can be mocked/deleted in testing
         assert __version__
-        try:
-            # parse_options_header is only available in the right multipart
-            from multipart.multipart import parse_options_header
-
-            assert parse_options_header  # type: ignore[truthy-function]
-        except ImportError:
-            logger.error(multipart_incorrect_install_error)
-            raise RuntimeError(multipart_incorrect_install_error) from None
     except ImportError:
         logger.error(multipart_not_installed_error)
         raise RuntimeError(multipart_not_installed_error) from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ standard = [
     # For templates
     "jinja2 >=2.11.2",
     # For forms and file uploads
-    "python-multipart >=0.0.7",
+    "python-multipart >=0.0.16",
     # To validate email fields
     "email-validator >=2.0.0",
     # Uvicorn with uvloop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ all = [
     # For templates
     "jinja2 >=2.11.2",
     # For forms and file uploads
-    "python-multipart >=0.0.7",
+    "python-multipart >=0.0.16",
     # For Starlette's SessionMiddleware, not commonly used with FastAPI
     "itsdangerous >=1.1.0",
     # For Starlette's schema generation, would not be used with FastAPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ standard = [
     # For templates
     "jinja2 >=2.11.2",
     # For forms and file uploads
-    "python-multipart >=0.0.16",
+    "python-multipart >=0.0.7",
     # To validate email fields
     "email-validator >=2.0.0",
     # Uvicorn with uvloop
@@ -81,7 +81,7 @@ all = [
     # For templates
     "jinja2 >=2.11.2",
     # For forms and file uploads
-    "python-multipart >=0.0.16",
+    "python-multipart >=0.0.7",
     # For Starlette's SessionMiddleware, not commonly used with FastAPI
     "itsdangerous >=1.1.0",
     # For Starlette's schema generation, would not be used with FastAPI

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -1,63 +1,12 @@
 import pytest
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.dependencies.utils import (
-    multipart_incorrect_install_error,
     multipart_not_installed_error,
 )
 
 
-def test_incorrect_multipart_installed_form(monkeypatch):
-    monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
-        app = FastAPI()
-
-        @app.post("/")
-        async def root(username: str = Form()):
-            return username  # pragma: nocover
-
-
-def test_incorrect_multipart_installed_file_upload(monkeypatch):
-    monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
-        app = FastAPI()
-
-        @app.post("/")
-        async def root(f: UploadFile = File()):
-            return f  # pragma: nocover
-
-
-def test_incorrect_multipart_installed_file_bytes(monkeypatch):
-    monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
-        app = FastAPI()
-
-        @app.post("/")
-        async def root(f: bytes = File()):
-            return f  # pragma: nocover
-
-
-def test_incorrect_multipart_installed_multi_form(monkeypatch):
-    monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
-        app = FastAPI()
-
-        @app.post("/")
-        async def root(username: str = Form(), password: str = Form()):
-            return username  # pragma: nocover
-
-
-def test_incorrect_multipart_installed_form_file(monkeypatch):
-    monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
-        app = FastAPI()
-
-        @app.post("/")
-        async def root(username: str = Form(), f: UploadFile = File()):
-            return username  # pragma: nocover
-
-
 def test_no_multipart_installed(monkeypatch):
-    monkeypatch.delattr("multipart.__version__", raising=False)
+    monkeypatch.delattr("python_multipart.__version__", raising=False)
     with pytest.raises(RuntimeError, match=multipart_not_installed_error):
         app = FastAPI()
 
@@ -67,7 +16,7 @@ def test_no_multipart_installed(monkeypatch):
 
 
 def test_no_multipart_installed_file(monkeypatch):
-    monkeypatch.delattr("multipart.__version__", raising=False)
+    monkeypatch.delattr("python_multipart.__version__", raising=False)
     with pytest.raises(RuntimeError, match=multipart_not_installed_error):
         app = FastAPI()
 
@@ -77,7 +26,7 @@ def test_no_multipart_installed_file(monkeypatch):
 
 
 def test_no_multipart_installed_file_bytes(monkeypatch):
-    monkeypatch.delattr("multipart.__version__", raising=False)
+    monkeypatch.delattr("python_multipart.__version__", raising=False)
     with pytest.raises(RuntimeError, match=multipart_not_installed_error):
         app = FastAPI()
 
@@ -87,7 +36,7 @@ def test_no_multipart_installed_file_bytes(monkeypatch):
 
 
 def test_no_multipart_installed_multi_form(monkeypatch):
-    monkeypatch.delattr("multipart.__version__", raising=False)
+    monkeypatch.delattr("python_multipart.__version__", raising=False)
     with pytest.raises(RuntimeError, match=multipart_not_installed_error):
         app = FastAPI()
 
@@ -97,7 +46,7 @@ def test_no_multipart_installed_multi_form(monkeypatch):
 
 
 def test_no_multipart_installed_form_file(monkeypatch):
-    monkeypatch.delattr("multipart.__version__", raising=False)
+    monkeypatch.delattr("python_multipart.__version__", raising=False)
     with pytest.raises(RuntimeError, match=multipart_not_installed_error):
         app = FastAPI()
 

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -1,13 +1,19 @@
+import warnings
+
 import pytest
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.dependencies.utils import (
+    multipart_incorrect_install_error,
     multipart_not_installed_error,
 )
 
 
-def test_no_multipart_installed(monkeypatch):
-    monkeypatch.delattr("python_multipart.__version__", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+def test_incorrect_multipart_installed_form(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
+    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
         app = FastAPI()
 
         @app.post("/")
@@ -15,9 +21,12 @@ def test_no_multipart_installed(monkeypatch):
             return username  # pragma: nocover
 
 
-def test_no_multipart_installed_file(monkeypatch):
-    monkeypatch.delattr("python_multipart.__version__", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+def test_incorrect_multipart_installed_file_upload(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
+    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
         app = FastAPI()
 
         @app.post("/")
@@ -25,9 +34,12 @@ def test_no_multipart_installed_file(monkeypatch):
             return f  # pragma: nocover
 
 
-def test_no_multipart_installed_file_bytes(monkeypatch):
-    monkeypatch.delattr("python_multipart.__version__", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+def test_incorrect_multipart_installed_file_bytes(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
+    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
         app = FastAPI()
 
         @app.post("/")
@@ -35,9 +47,12 @@ def test_no_multipart_installed_file_bytes(monkeypatch):
             return f  # pragma: nocover
 
 
-def test_no_multipart_installed_multi_form(monkeypatch):
-    monkeypatch.delattr("python_multipart.__version__", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+def test_incorrect_multipart_installed_multi_form(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
+    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
         app = FastAPI()
 
         @app.post("/")
@@ -45,11 +60,79 @@ def test_no_multipart_installed_multi_form(monkeypatch):
             return username  # pragma: nocover
 
 
-def test_no_multipart_installed_form_file(monkeypatch):
-    monkeypatch.delattr("python_multipart.__version__", raising=False)
-    with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+def test_incorrect_multipart_installed_form_file(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.multipart.parse_options_header", raising=False)
+    with pytest.raises(RuntimeError, match=multipart_incorrect_install_error):
         app = FastAPI()
 
         @app.post("/")
         async def root(username: str = Form(), f: UploadFile = File()):
             return username  # pragma: nocover
+
+
+def test_no_multipart_installed(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.__version__", raising=False)
+        with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+            app = FastAPI()
+
+            @app.post("/")
+            async def root(username: str = Form()):
+                return username  # pragma: nocover
+
+
+def test_no_multipart_installed_file(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.__version__", raising=False)
+        with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+            app = FastAPI()
+
+            @app.post("/")
+            async def root(f: UploadFile = File()):
+                return f  # pragma: nocover
+
+
+def test_no_multipart_installed_file_bytes(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.__version__", raising=False)
+        with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+            app = FastAPI()
+
+            @app.post("/")
+            async def root(f: bytes = File()):
+                return f  # pragma: nocover
+
+
+def test_no_multipart_installed_multi_form(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.__version__", raising=False)
+        with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+            app = FastAPI()
+
+            @app.post("/")
+            async def root(username: str = Form(), password: str = Form()):
+                return username  # pragma: nocover
+
+
+def test_no_multipart_installed_form_file(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.__version__", raising=False)
+        with pytest.raises(RuntimeError, match=multipart_not_installed_error):
+            app = FastAPI()
+
+            @app.post("/")
+            async def root(username: str = Form(), f: UploadFile = File()):
+                return username  # pragma: nocover

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -136,3 +136,14 @@ def test_no_multipart_installed_form_file(monkeypatch):
             @app.post("/")
             async def root(username: str = Form(), f: UploadFile = File()):
                 return username  # pragma: nocover
+
+
+def test_old_multipart_installed(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.12")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        app = FastAPI()
+
+        @app.post("/")
+        async def root(username: str = Form()):
+            return username  # pragma: nocover


### PR DESCRIPTION
⬆️ Upgrade python-multipart to `>=0.0.16` as the minimum version