### PR TITLE
✏️ Fix error in `docs/en/docs/contributing.md`

### DIFF
--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -107,7 +107,7 @@ $ cd docs/en/
 Then run `mkdocs` in that directory:
 
 ```console
-$ mkdocs serve --dev-addr localhost:8008
+$ mkdocs serve --dev-addr 127.0.0.1:8008
 ```
 
 ///
@@ -245,7 +245,7 @@ $ cd docs/es/
 Then run `mkdocs` in that directory:
 
 ```console
-$ mkdocs serve --dev-addr localhost:8008
+$ mkdocs serve --dev-addr 127.0.0.1:8008
 ```
 
 ///

--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -107,7 +107,7 @@ $ cd docs/en/
 Then run `mkdocs` in that directory:
 
 ```console
-$ mkdocs serve --dev-addr 8008
+$ mkdocs serve --dev-addr localhost:8008
 ```
 
 ///
@@ -245,7 +245,7 @@ $ cd docs/es/
 Then run `mkdocs` in that directory:
 
 ```console
-$ mkdocs serve --dev-addr 8008
+$ mkdocs serve --dev-addr localhost:8008
 ```
 
 ///


### PR DESCRIPTION
Fix the --dev-addr option format to use required HOST:PORT syntax
- Before: `mkdocs serve --dev-addr 8008`
- After: `mkdocs serve --dev-addr localhost:8008`