### PR TITLE
📝 Update includes for `docs/es/docs/tutorial/path-params.md`

### DIFF
--- a/docs/es/docs/tutorial/path-params.md
+++ b/docs/es/docs/tutorial/path-params.md
@@ -2,9 +2,7 @@
 
 Puedes declarar los "parámetros" o "variables" con la misma sintaxis que usan los format strings de Python:
 
-```Python hl_lines="6-7"
-{!../../docs_src/path_params/tutorial001.py!}
-```
+{* ../../docs_src/path_params/tutorial001.py hl[6:7] *}
 
 El valor del parámetro de path `item_id` será pasado a tu función como el argumento `item_id`.
 
@@ -18,9 +16,7 @@ Entonces, si corres este ejemplo y vas a <a href="http://127.0.0.1:8000/items/fo
 
 Puedes declarar el tipo de un parámetro de path en la función usando las anotaciones de tipos estándar de Python:
 
-```Python hl_lines="7"
-{!../../docs_src/path_params/tutorial002.py!}
-```
+{* ../../docs_src/path_params/tutorial002.py hl[7] *}
 
 En este caso, `item_id` es declarado como un `int`.
 
@@ -121,9 +117,7 @@ Digamos algo como `/users/me` que sea para obtener datos del usuario actual.
 
 Porque las *operaciones de path* son evaluadas en orden, tienes que asegurarte de que el path para `/users/me` sea declarado antes que el path para `/users/{user_id}`:
 
-```Python hl_lines="6  11"
-{!../../docs_src/path_params/tutorial003.py!}
-```
+{* ../../docs_src/path_params/tutorial003.py hl[6,11] *}
 
 De otra manera el path para `/users/{user_id}` coincidiría también con `/users/me` "pensando" que está recibiendo el parámetro `user_id` con el valor `"me"`.
 
@@ -139,9 +133,7 @@ Al heredar desde `str` la documentación de la API podrá saber que los valores 
 
 Luego crea atributos de clase con valores fijos, que serán los valores disponibles válidos:
 
-```Python hl_lines="1  6-9"
-{!../../docs_src/path_params/tutorial005.py!}
-```
+{* ../../docs_src/path_params/tutorial005.py hl[1,6:9] *}
 
 /// info | Información
 
@@ -159,9 +151,7 @@ Si lo estás dudando, "AlexNet", "ResNet", y "LeNet" son solo nombres de <abbr t
 
 Luego, crea un *parámetro de path* con anotaciones de tipos usando la clase enum que creaste (`ModelName`):
 
-```Python hl_lines="16"
-{!../../docs_src/path_params/tutorial005.py!}
-```
+{* ../../docs_src/path_params/tutorial005.py hl[16] *}
 
 ### Revisa la documentación
 
@@ -177,17 +167,13 @@ El valor del *parámetro de path* será un *enumeration member*.
 
 Puedes compararlo con el *enumeration member* en el enum (`ModelName`) que creaste:
 
-```Python hl_lines="17"
-{!../../docs_src/path_params/tutorial005.py!}
-```
+{* ../../docs_src/path_params/tutorial005.py hl[17] *}
 
 #### Obtén el *enumeration value*
 
 Puedes obtener el valor exacto (un `str` en este caso) usando `model_name.value`, o en general, `your_enum_member.value`:
 
-```Python hl_lines="20"
-{!../../docs_src/path_params/tutorial005.py!}
-```
+{* ../../docs_src/path_params/tutorial005.py hl[20] *}
 
 /// tip | Consejo
 
@@ -201,9 +187,7 @@ Puedes devolver *enum members* desde tu *operación de path* inclusive en un bod
 
 Ellos serán convertidos a sus valores correspondientes (strings en este caso) antes de devolverlos al cliente:
 
-```Python hl_lines="18  21  23"
-{!../../docs_src/path_params/tutorial005.py!}
-```
+{* ../../docs_src/path_params/tutorial005.py hl[18,21,23] *}
 
 En tu cliente obtendrás una respuesta en JSON como:
 
@@ -242,9 +226,7 @@ En este caso el nombre del parámetro es `file_path` y la última parte, `:path`
 
 Entonces lo puedes usar con:
 
-```Python hl_lines="6"
-{!../../docs_src/path_params/tutorial004.py!}
-```
+{* ../../docs_src/path_params/tutorial004.py hl[6] *}
 
 /// tip | Consejo
 


### PR DESCRIPTION
Part of #12554

This PR updates the code inclusion syntax in `docs/es/docs/tutorial/path-params.md` as per issue #12554.

- Replaced old inclusion syntax `{!...!}` with the new syntax `{*...*}`.
- Updated line highlights from `hl_lines="..."` to `hl[...]`.
- Removed unnecessary triple backticks and language specifiers.

Let me know if any changes are needed. Thank you!
