### PR TITLE
📝 Update includes for `docs/es/docs/tutorial/query-params.md`

### DIFF
--- a/docs/es/docs/tutorial/query-params.md
+++ b/docs/es/docs/tutorial/query-params.md
@@ -2,9 +2,7 @@
 
 Cuando declaras otros parámetros de la función que no hacen parte de los parámetros de path estos se interpretan automáticamente como parámetros de "query".
 
-```Python hl_lines="9"
-{!../../docs_src/query_params/tutorial001.py!}
-```
+{* ../../docs_src/query_params/tutorial001.py hl[9] *}
 
 El query es el conjunto de pares de key-value que van después del `?` en la URL, separados por caracteres `&`.
 
@@ -63,9 +61,7 @@ Los valores de los parámetros en tu función serán:
 
 Del mismo modo puedes declarar parámetros de query opcionales definiendo el valor por defecto como `None`:
 
-```Python hl_lines="9"
-{!../../docs_src/query_params/tutorial002.py!}
-```
+{* ../../docs_src/query_params/tutorial002.py hl[9] *}
 
 En este caso el parámetro de la función `q` será opcional y será `None` por defecto.
 
@@ -87,9 +83,7 @@ El `Union` en `Union[str, None]` no es usado por FastAPI (FastAPI solo usará la
 
 También puedes declarar tipos `bool` y serán convertidos:
 
-```Python hl_lines="9"
-{!../../docs_src/query_params/tutorial003.py!}
-```
+{* ../../docs_src/query_params/tutorial003.py hl[9] *}
 
 En este caso, si vas a:
 
@@ -131,9 +125,7 @@ No los tienes que declarar en un orden específico.
 
 Serán detectados por nombre:
 
-```Python hl_lines="8  10"
-{!../../docs_src/query_params/tutorial004.py!}
-```
+{* ../../docs_src/query_params/tutorial004.py hl[8,10] *}
 
 ## Parámetros de query requeridos
 
@@ -143,9 +135,7 @@ Si no quieres añadir un valor específico sino solo hacerlo opcional, pon el va
 
 Pero cuando quieres hacer que un parámetro de query sea requerido, puedes simplemente no declararle un valor por defecto:
 
-```Python hl_lines="6-7"
-{!../../docs_src/query_params/tutorial005.py!}
-```
+{* ../../docs_src/query_params/tutorial005.py hl[6:7] *}
 
 Aquí el parámetro de query `needy` es un parámetro de query requerido, del tipo `str`.
 
@@ -189,9 +179,7 @@ http://127.0.0.1:8000/items/foo-item?needy=sooooneedy
 
 Por supuesto que también puedes definir algunos parámetros como requeridos, con un valor por defecto y otros completamente opcionales:
 
-```Python hl_lines="10"
-{!../../docs_src/query_params/tutorial006.py!}
-```
+{* ../../docs_src/query_params/tutorial006.py hl[10] *}
 
 En este caso hay 3 parámetros de query:
 


### PR DESCRIPTION
Part of #12554

This PR updates the code inclusion syntax in `docs/es/docs/tutorial/query-params.md` as per issue #12554.

- Replaced old inclusion syntax `{!...!}` with the new syntax `{*...*}`.
- Updated line highlights from `hl_lines="..."` to `hl[...]`.
- Removed unnecessary triple backticks and language specifiers.

Let me know if any changes are needed. Thank you!
