### PR TITLE
fixed Upcoming Pydantic 2.10 is going to break version comparison che…

### DIFF
--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -105,7 +105,7 @@ class Param(FieldInfo):
                 stacklevel=4,
             )
         current_json_schema_extra = json_schema_extra or extra
-        if PYDANTIC_VERSION < "2.7.0":
+        if tuple(map(int, PYDANTIC_VERSION.split('.'))) < (2, 7, 0):
             self.deprecated = deprecated
         else:
             kwargs["deprecated"] = deprecated

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -105,7 +105,7 @@ class Param(FieldInfo):
                 stacklevel=4,
             )
         current_json_schema_extra = json_schema_extra or extra
-        if tuple(map(int, PYDANTIC_VERSION.split('.'))) < (2, 7, 0):
+        if tuple(map(int, PYDANTIC_VERSION.split("."))) < (2, 7, 0):
             self.deprecated = deprecated
         else:
             kwargs["deprecated"] = deprecated


### PR DESCRIPTION
Fixes #12901

# Idea

```python
>>> '2.7.0' > '2.10.0'
True
>>> (2, 7, 0) > (2, 10, 0)
False
```