### PR TITLE
✨ Add support for ReDoc parameters

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -444,6 +444,15 @@ class FastAPI(Starlette):
                 """
             ),
         ] = "/redoc",
+        redoc_ui_parameters: Annotated[
+            Optional[Dict[str, Any]],
+            Doc(
+                """
+                Parameters to configure ReDoc documentation (by default at `/redocs`).
+                Use kebab-case for [parameters](https://redocly.com/docs/redoc/config).
+                """
+            ),
+        ] = None,
         swagger_ui_oauth2_redirect_url: Annotated[
             Optional[str],
             Doc(
@@ -833,6 +842,7 @@ class FastAPI(Starlette):
         self.root_path_in_servers = root_path_in_servers
         self.docs_url = docs_url
         self.redoc_url = redoc_url
+        self.redoc_ui_parameters = redoc_ui_parameters
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
         self.swagger_ui_parameters = swagger_ui_parameters
@@ -1043,7 +1053,9 @@ class FastAPI(Starlette):
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 return get_redoc_html(
-                    openapi_url=openapi_url, title=f"{self.title} - ReDoc"
+                    openapi_url=openapi_url,
+                    title=f"{self.title} - ReDoc",
+                    redoc_ui_parameters=self.redoc_ui_parameters,
                 )
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -448,7 +448,7 @@ class FastAPI(Starlette):
             Optional[Dict[str, Any]],
             Doc(
                 """
-                Parameters to configure ReDoc documentation (by default at `/redocs`).
+                Parameters to configure ReDoc documentation (by default at `/redoc`).
                 Use kebab-case for [parameters](https://redocly.com/docs/redoc/config).
                 """
             ),

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -229,7 +229,7 @@ def get_redoc_html(
     config_string = ""
     if redoc_ui_parameters:
         for key, value in redoc_ui_parameters.items():
-            config_string += f" {key}=\"{value}\""
+            config_string += f' {key}="{value}"'
 
     html = f"""
     <!DOCTYPE html>

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -205,6 +205,16 @@ def get_redoc_html(
             """
         ),
     ] = True,
+    redoc_ui_parameters: Annotated[
+        Optional[Dict[str, Any]],
+        Doc(
+            """
+            Configuration parameters for ReDoc
+
+            It defaults to None.
+            """
+        ),
+    ] = None,
 ) -> HTMLResponse:
     """
     Generate and return the HTML response that loads ReDoc for the alternative
@@ -216,6 +226,11 @@ def get_redoc_html(
     Read more about it in the
     [FastAPI docs for Custom Docs UI Static Assets (Self-Hosting)](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
     """
+    config_string = ""
+    if redoc_ui_parameters:
+        for key, value in redoc_ui_parameters.items():
+            config_string += f" {key}=\"{value}\""
+
     html = f"""
     <!DOCTYPE html>
     <html>
@@ -245,7 +260,7 @@ def get_redoc_html(
     <noscript>
         ReDoc requires Javascript to function. Please enable it to browse the documentation.
     </noscript>
-    <redoc spec-url="{openapi_url}"></redoc>
+    <redoc spec-url="{openapi_url}"{config_string}></redoc>
     <script src="{redoc_js_url}"> </script>
     </body>
     </html>

--- a/tests/test_local_docs.py
+++ b/tests/test_local_docs.py
@@ -65,3 +65,17 @@ def test_google_fonts_in_generated_redoc():
         openapi_url="/docs", title="title", with_google_fonts=False
     ).body.decode()
     assert "fonts.googleapis.com" not in body_without_google_fonts
+
+
+def test_generated_redoc_with_parameters():
+    body_with_parameters = get_redoc_html(
+        openapi_url="/docs", title="title", with_google_fonts=False, redoc_ui_parameters={"disable-search": "true"}
+    ).body.decode()
+    assert "disable-search=\"true\"" in body_with_parameters
+
+
+def test_generated_redoc_without_parameters():
+    body_without_parameters = get_redoc_html(
+        openapi_url="/docs", title="title", with_google_fonts=False
+    ).body.decode()
+    assert "disable-search=\"true\"" not in body_without_parameters

--- a/tests/test_local_docs.py
+++ b/tests/test_local_docs.py
@@ -69,13 +69,16 @@ def test_google_fonts_in_generated_redoc():
 
 def test_generated_redoc_with_parameters():
     body_with_parameters = get_redoc_html(
-        openapi_url="/docs", title="title", with_google_fonts=False, redoc_ui_parameters={"disable-search": "true"}
+        openapi_url="/docs",
+        title="title",
+        with_google_fonts=False,
+        redoc_ui_parameters={"disable-search": "true"},
     ).body.decode()
-    assert "disable-search=\"true\"" in body_with_parameters
+    assert 'disable-search="true"' in body_with_parameters
 
 
 def test_generated_redoc_without_parameters():
     body_without_parameters = get_redoc_html(
         openapi_url="/docs", title="title", with_google_fonts=False
     ).body.decode()
-    assert "disable-search=\"true\"" not in body_without_parameters
+    assert 'disable-search="true"' not in body_without_parameters


### PR DESCRIPTION
This PR add simple support for ReDoc parameters - see here https://redocly.com/docs/redoc/config

Example config:
```python
{
   "disable-search": "true"
}
```

Will look like this:

```python
app = FastAPI(
    title="My API",
    docs_url=None,
    redoc_url="/docs",
    openapi_url="/docs/openapi.json",
    redoc_ui_parameters={
        "disable-search": "true"
    }
)
```

Will be added to the generated html:
```html
<redoc spec-url="/docs/openapi.json" disable-search="true"></redoc>
```

ReDoc will pickup the parameter and act accordingly.