### PR TITLE
🐛 Fix: Excessive requests cause page blocking

### DIFF
--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -1,23 +1,35 @@
 const div = document.querySelector('.github-topic-projects')
 
 async function getDataBatch(page) {
-    const response = await fetch(`https://api.github.com/search/repositories?q=topic:fastapi&per_page=100&page=${page}`, { headers: { Accept: 'application/vnd.github.mercy-preview+json' } })
-    const data = await response.json()
-    return data
+  const response = await fetch(
+    `https://api.github.com/search/repositories?q=topic:fastapi&per_page=100&page=${page}`,
+    { headers: { Accept: "application/vnd.github.mercy-preview+json" } }
+  );
+  if (!response.ok) {
+    throw Error(`Request failed with status ${response.status}`);
+  }
+  const data = await response.json();
+  return data;
 }
 
 async function getData() {
-    let page = 1
-    let data = []
-    let dataBatch = await getDataBatch(page)
-    data = data.concat(dataBatch.items)
-    const totalCount = dataBatch.total_count
-    while (data.length < totalCount) {
-        page += 1
-        dataBatch = await getDataBatch(page)
-        data = data.concat(dataBatch.items)
+  let page = 1;
+  const pageThreshold = 4;
+  let data = [];
+  let dataBatch = await getDataBatch(page);
+  data = data.concat(dataBatch.items);
+  const totalCount = dataBatch.total_count;
+  while (data.length < totalCount && page < pageThreshold) {
+    page += 1;
+    try {
+      dataBatch = await getDataBatch(page);
+      data = data.concat(dataBatch.items);
+    } catch (error) {
+      console.error("An error occurred:", error.message);
+      break;
     }
-    return data
+  }
+  return data;
 }
 
 function setupTermynal() {


### PR DESCRIPTION
Fastapi now have **14,329** topics, and in the `getData` function, so `14329 / 100 ` requests will be made. It far exceeds github's limits, and constantly failing requests can cause the page to block.

![console_cap](https://github.com/user-attachments/assets/65ceb48c-ef85-4d7d-9408-2c1243f48e00)

So I set an upper limit (400 rows)  for the data displayed on the page, and the request will stop in time when the request fails.

This upper limit can be changed as you wish~

