### PR TITLE
✏️ Fix typo in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ FastAPI depends on Pydantic and Starlette.
 
 ### `standard` Dependencies
 
-When you install FastAPI with `pip install "fastapi[standard]"` it comes the `standard` group of optional dependencies:
+When you install FastAPI with `pip install "fastapi[standard]"` it comes with the `standard` group of optional dependencies:
 
 Used by Pydantic:
 

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -456,7 +456,7 @@ FastAPI depends on Pydantic and Starlette.
 
 ### `standard` Dependencies
 
-When you install FastAPI with `pip install "fastapi[standard]"` it comes the `standard` group of optional dependencies:
+When you install FastAPI with `pip install "fastapi[standard]"` it comes with the `standard` group of optional dependencies:
 
 Used by Pydantic:
 


### PR DESCRIPTION
Fixed a missing word in the installation instructions:

Before: "it comes the standard group"
After: "it comes with the standard group"