### PR TITLE
Replace depricated functions for pydantic 2.5+

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -442,12 +442,12 @@ else:
         return use_errors
 
     def _model_rebuild(model: Type[BaseModel]) -> None:
-        model.update_forward_refs()
+        model.model_rebuild()
 
     def _model_dump(
         model: BaseModel, mode: Literal["json", "python"] = "json", **kwargs: Any
     ) -> Any:
-        return model.dict(**kwargs)
+        return model.model_dump(**kwargs)
 
     def _get_model_config(model: BaseModel) -> Any:
         return model.__config__  # type: ignore[attr-defined]

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -128,8 +128,8 @@ def create_cloned_field(
         if use_type is None:
             use_type = create_model(original_type.__name__, __base__=original_type)
             cloned_types[original_type] = use_type
-            for f in original_type.__fields__.values():
-                use_type.__fields__[f.name] = create_cloned_field(
+            for f in original_type.model_fields.values():
+                use_type.model_fields[f.name] = create_cloned_field(
                     f, cloned_types=cloned_types
                 )
     new_field = create_model_field(name=field.name, type_=use_type)

--- a/tests/test_validate_response_recursive/app_pv1.py
+++ b/tests/test_validate_response_recursive/app_pv1.py
@@ -11,7 +11,7 @@ class RecursiveItem(BaseModel):
     name: str
 
 
-RecursiveItem.update_forward_refs()
+RecursiveItem.model_rebuild()
 
 
 class RecursiveSubitemInSubmodel(BaseModel):
@@ -24,7 +24,7 @@ class RecursiveItemViaSubmodel(BaseModel):
     name: str
 
 
-RecursiveSubitemInSubmodel.update_forward_refs()
+RecursiveSubitemInSubmodel.model_rebuild()
 
 
 @app.get("/items/recursive", response_model=RecursiveItem)


### PR DESCRIPTION
Hey, hope you are doing well. 

I have seen that in the requirements, we already use the pydantic version 2.5.3+, and as in these documentation I found that, for models, instead of model.dict(...) we should use model_dump, and instead of  attribute __fields__ we should use model_fields, and instead of update_forward_refs we should use model_rebuild function. So, I added these changes in source where I found them. 

Here is the links for details: 

https://docs.pydantic.dev/2.5/concepts/models/#rebuild-model-schema

https://docs.pydantic.dev/2.5/concepts/serialization/#modelmodel_dump


It's just minor changes, don't know if it matters to add or not, but I decided maybe it's better to change deprecated functions.


