### PR TITLE
⬆️ Allow Starlette 0.42.x, update the pin to >=0.40.0,<0.43.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.40.0,<0.42.0",
+    "starlette>=0.40.0,<0.43.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
 ]


### PR DESCRIPTION
I ran the tests (on Python 3.12, with Starlette 0.42.0) and did not observe any regressions.

https://github.com/encode/starlette/releases/tag/0.42.0