### PR TITLE
🐛 Replace underscores in parameter fields to ensure they get recognized correctly

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -713,7 +713,9 @@ def _validate_value_with_model_field(
         return v_, []
 
 
-def _get_value(field: ModelField, values: Mapping[str, Any], alias: Union[str, None] = None) -> Any:
+def _get_value(
+    field: ModelField, values: Mapping[str, Any], alias: Union[str, None] = None
+) -> Any:
     if is_sequence_field(field) and isinstance(values, (ImmutableMultiDict, Headers)):
         value = values.getlist(alias)
     else:
@@ -722,7 +724,7 @@ def _get_value(field: ModelField, values: Mapping[str, Any], alias: Union[str, N
 
 
 def _get_multidict_value(
-        field: ModelField, values: Mapping[str, Any], alias: Union[str, None] = None
+    field: ModelField, values: Mapping[str, Any], alias: Union[str, None] = None
 ) -> Any:
     alias = alias or field.alias
     value = _get_value(field, values, alias)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -713,14 +713,21 @@ def _validate_value_with_model_field(
         return v_, []
 
 
-def _get_multidict_value(
-    field: ModelField, values: Mapping[str, Any], alias: Union[str, None] = None
-) -> Any:
-    alias = alias or field.alias
+def _get_value(field: ModelField, values: Mapping[str, Any], alias: Union[str, None] = None) -> Any:
     if is_sequence_field(field) and isinstance(values, (ImmutableMultiDict, Headers)):
         value = values.getlist(alias)
     else:
         value = values.get(alias, None)
+    return value
+
+
+def _get_multidict_value(
+        field: ModelField, values: Mapping[str, Any], alias: Union[str, None] = None
+) -> Any:
+    alias = alias or field.alias
+    value = _get_value(field, values, alias)
+    if value is None and alias is not None:
+        value = _get_value(field, values, field.alias)
     if (
         value is None
         or (

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -126,8 +126,11 @@ def _get_openapi_operation_parameters(
                 field_mapping=field_mapping,
                 separate_input_output_schemas=separate_input_output_schemas,
             )
+            param_name = param.alias
+            if param_type == ParamTypes.header and param_name:
+                param_name = param.alias.replace("_", "-")
             parameter = {
-                "name": param.alias,
+                "name": param_name,
                 "in": param_type.value,
                 "required": param.required,
                 "schema": param_schema,


### PR DESCRIPTION
**When using the header parameter model, the parameter fields displayed in the swagger-ui interface documentation are incorrect, which leads to the inability to use the swagger-ui documentation for interface testing.**
使用header参数模型时，swagger-ui接口文档展示的参数字段错误，从而导致无法使用swagger-ui文档进行接口测试。

```py
class CommonHeaderSchema(BaseModel):
    main_account_id: int
    shop_id: int
    merchant_id: Optional[int] = None

async def common_header_parameters(headers: Annotated[CommonHeaderSchema, Header()]):
    return headers

router = APIRouter(dependencies=[Depends(common_header_parameters)])

@router.post("/create_auto_operation_config")
def create_auto_operation_config(region_item_config_id: int):
    return ResponseInfo.success(data=auto_config_service.create_auto_operation_config(region_item_config_id))
```
**If there is a CommonHeaderSchema, the swagger-ui interface documentation is displayed as shown in the figure.**
如存在一个CommonHeaderSchema，swagger-ui接口文档展示的如图所示：
<img width="1086" alt="image" src="https://github.com/user-attachments/assets/b29f6018-040e-4a51-ba65-d8f2c0673fdb" />
**The reasons are as follows: Since the swagger-ui documentation does not perform conversion on fields with underscores (converting underscores to dashes), fields with underscores cannot be recognized.**
原因如下：由于swagger-ui文档未对带有下划线的字段做转换（下划线转换为破折号），导致无法识别带下划线的字段。

after bug fix
代码修复后：
<img width="760" alt="image" src="https://github.com/user-attachments/assets/abfc60f1-63ba-44a7-85b7-8adbbc16ef3d" />
