### PR TITLE
⬆ Update httpx requirement to >=0.23.0,<0.29.0

### DIFF
--- a/requirements-docs-tests.txt
+++ b/requirements-docs-tests.txt
@@ -1,4 +1,4 @@
 # For mkdocstrings and tests
-httpx >=0.23.0,<0.28.0
+httpx >=0.23.0,<0.29.0
 # For linting and generating docs versions
 ruff ==0.11.2

--- a/requirements-github-actions.txt
+++ b/requirements-github-actions.txt
@@ -1,6 +1,6 @@
 PyGithub>=2.3.0,<3.0.0
 pydantic>=2.5.3,<3.0.0
 pydantic-settings>=2.1.0,<3.0.0
-httpx>=0.27.0,<0.28.0
+httpx>=0.27.0,<0.29.0
 pyyaml >=5.3.1,<7.0.0
 smokeshow

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
@@ -1,4 +1,4 @@
-from dirty_equals import IsDict
+from dirty_equals import IsDict, IsOneOf
 from fastapi.testclient import TestClient
 
 from docs_src.custom_request_and_route.tutorial002 import app
@@ -24,14 +24,16 @@ def test_exception_handler_body_access():
                         "input": {"numbers": [1, 2, 3]},
                     }
                 ],
-                "body": '{"numbers": [1, 2, 3]}',
+                # httpx 0.28.0 switches to compact JSON https://github.com/encode/httpx/issues/3363
+                "body": IsOneOf('{"numbers": [1, 2, 3]}', '{"numbers":[1,2,3]}')
             }
         }
     ) | IsDict(
         # TODO: remove when deprecating Pydantic v1
         {
             "detail": {
-                "body": '{"numbers": [1, 2, 3]}',
+                # httpx 0.28.0 switches to compact JSON https://github.com/encode/httpx/issues/3363
+                "body": IsOneOf('{"numbers": [1, 2, 3]}', '{"numbers":[1,2,3]}'),
                 "errors": [
                     {
                         "loc": ["body"],

--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
@@ -25,7 +25,7 @@ def test_exception_handler_body_access():
                     }
                 ],
                 # httpx 0.28.0 switches to compact JSON https://github.com/encode/httpx/issues/3363
-                "body": IsOneOf('{"numbers": [1, 2, 3]}', '{"numbers":[1,2,3]}')
+                "body": IsOneOf('{"numbers": [1, 2, 3]}', '{"numbers":[1,2,3]}'),
             }
         }
     ) | IsDict(


### PR DESCRIPTION
This is similar to a later pull request https://github.com/fastapi/fastapi/pull/13130, while this PR also updates tests for newer httpx.