### PR TITLE
✏️ Update Strawberry integration docs

### DIFF
--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -35,7 +35,7 @@ Depending on your use case, you might prefer to use a different library, but if 
 
 Here's a small preview of how you could integrate Strawberry with FastAPI:
 
-{* ../../docs_src/graphql/tutorial001.py hl[3,22,25:26] *}
+{* ../../docs_src/graphql/tutorial001.py hl[3,22,25] *}
 
 You can learn more about Strawberry in the <a href="https://strawberry.rocks/" class="external-link" target="_blank">Strawberry documentation</a>.
 

--- a/docs_src/graphql/tutorial001.py
+++ b/docs_src/graphql/tutorial001.py
@@ -1,6 +1,6 @@
 import strawberry
 from fastapi import FastAPI
-from strawberry.asgi import GraphQL
+from strawberry.fastapi import GraphQLRouter
 
 
 @strawberry.type
@@ -19,8 +19,7 @@ class Query:
 schema = strawberry.Schema(query=Query)
 
 
-graphql_app = GraphQL(schema)
+graphql_app = GraphQLRouter(schema)
 
 app = FastAPI()
-app.add_route("/graphql", graphql_app)
-app.add_websocket_route("/graphql", graphql_app)
+app.include_router(graphql_app, prefix="/graphql")


### PR DESCRIPTION
Docs regarding `Strawberry` integration are updated with the currently proper way. I also propose to remove the websocket reference because it is not needed as part of a minimum working example.