### PR TITLE
Fix ruff B039 warning: avoid using mutable default values for ContextVar

### DIFF
--- a/docs_src/sql_databases_peewee/sql_app/database.py
+++ b/docs_src/sql_databases_peewee/sql_app/database.py
@@ -4,7 +4,8 @@ import peewee
 
 DATABASE_NAME = "test.db"
 db_state_default = {"closed": None, "conn": None, "ctx": None, "transactions": None}
-db_state = ContextVar("db_state", default=db_state_default.copy())
+db_state = ContextVar("db_state", default=None)
+db_state.set(db_state_default.copy())
 
 
 class PeeweeConnectionState(peewee._ConnectionState):


### PR DESCRIPTION
Fix B039 warning: avoid using mutable default values for ContextVar.

This fix addresses the B039 warning in ruff version 0.8.4. It is necessary to allow upgrading the ruff version in the requirements to 0.8.4, which previously failed in the tests for pull request #13131.