### PR TITLE
🔧 Add Pydantic 2 trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Framework :: FastAPI",
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 1",
+    "Framework :: Pydantic :: 2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
FastAPI also supports Pydantic 2, so add the appropriate trove classifier.

https://github.com/fastapi/fastapi/blob/09a0295bf3bd604eb0acd7eb1f9d9cd4852f3805/pyproject.toml#L45