### PR TITLE
🌐 Update Portuguese translation for `docs/pt/docs/advanced/settings.md`

### DIFF
--- a/docs/pt/docs/advanced/settings.md
+++ b/docs/pt/docs/advanced/settings.md
@@ -8,7 +8,7 @@ Por isso é comum prover essas configurações como variáveis de ambiente que s
 
 ## Variáveis de Ambiente
 
-/// dica
+/// tip | Dica
 
 Se você já sabe o que são variáveis de ambiente e como utilizá-las, sinta-se livre para avançar para o próximo tópico.
 
@@ -67,7 +67,7 @@ name = os.getenv("MY_NAME", "World")
 print(f"Hello {name} from Python")
 ```
 
-/// dica
+/// tip | Dica
 
 O segundo parâmetro em <a href="https://docs.python.org/3.8/library/os.html#os.getenv" class="external-link" target="_blank">`os.getenv()`</a> é o valor padrão para o retorno.
 
@@ -124,7 +124,7 @@ Hello World from Python
 
 </div>
 
-/// dica
+/// tip | Dica
 
 Você pode ler mais sobre isso em: <a href="https://12factor.net/pt_br/config" class="external-link" target="_blank">The Twelve-Factor App: Configurações</a>.
 
@@ -196,7 +196,7 @@ Na versão 1 do Pydantic você importaria `BaseSettings` diretamente do módulo 
 
 ////
 
-/// dica
+/// tip | Dica
 
 Se você quiser algo pronto para copiar e colar na sua aplicação, não use esse exemplo, mas sim o exemplo abaixo.
 
@@ -226,7 +226,7 @@ $ ADMIN_EMAIL="deadpool@example.com" APP_NAME="ChimichangApp" fastapi run main.p
 
 </div>
 
-/// dica
+/// tip | Dica
 
 Para definir múltiplas variáveis de ambiente para um único comando basta separá-las utilizando espaços, e incluir todas elas antes do comando.
 
@@ -250,7 +250,7 @@ E utilizar essa configuração em `main.py`:
 
 {* ../../docs_src/settings/app01/main.py hl[3,11:13] *}
 
-/// dica
+/// tip | Dica
 
 Você também precisa incluir um arquivo `__init__.py` como visto em [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md){.internal-link target=\_blank}.
 
@@ -276,7 +276,7 @@ Agora criamos a dependência que retorna um novo objeto `config.Settings()`.
 
 {* ../../docs_src/settings/app02_an_py39/main.py hl[6,12:13] *}
 
-/// dica
+/// tip | Dica
 
 Vamos discutir sobre `@lru_cache` logo mais.
 
@@ -304,7 +304,7 @@ Se você tiver muitas configurações que variem bastante, talvez em ambientes d
 
 Essa prática é tão comum que possui um nome, essas variáveis de ambiente normalmente são colocadas em um arquivo `.env`, e esse arquivo é chamado de "dotenv".
 
-/// dica
+/// tip | Dica
 
 Um arquivo iniciando com um ponto final (`.`) é um arquivo oculto em sistemas baseados em Unix, como Linux e MacOS.
 
@@ -314,7 +314,7 @@ Mas um arquivo dotenv não precisa ter esse nome exato.
 
 Pydantic suporta a leitura desses tipos de arquivos utilizando uma biblioteca externa. Você pode ler mais em <a href="https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support" class="external-link" target="_blank">Pydantic Settings: Dotenv (.env) support</a>.
 
-/// dica
+/// tip | Dica
 
 Para que isso funcione você precisa executar `pip install python-dotenv`.
 
@@ -337,7 +337,7 @@ E então adicionar o seguinte código em `config.py`:
 
 {* ../../docs_src/settings/app03_an/config.py hl[9] *}
 
-/// dica
+/// tip | Dica
 
 O atributo `model_config` é usado apenas para configuração do Pydantic. Você pode ler mais em <a href="https://docs.pydantic.dev/latest/usage/model_config/" class="external-link" target="_blank">Pydantic Model Config</a>.
 
@@ -349,7 +349,7 @@ O atributo `model_config` é usado apenas para configuração do Pydantic. Você
 
 {* ../../docs_src/settings/app03_an/config_pv1.py hl[9:10] *}
 
-/// dica
+/// tip | Dica
 
 A classe `Config` é usada apenas para configuração do Pydantic. Você pode ler mais em <a href="https://docs.pydantic.dev/1.10/usage/model_config/" class="external-link" target="_blank">Pydantic Model Config</a>.
 


### PR DESCRIPTION
The admonitions on this page were broken.

It was like:

/// dica

instead of:

/// tip | Dica