### PR TITLE
♻️ Fix `notify_translations.py` empty env var handling for PR label events vs workflow_dispatch

### DIFF
--- a/scripts/notify_translations.py
+++ b/scripts/notify_translations.py
@@ -176,6 +176,8 @@ class AllDiscussionsResponse(BaseModel):
 
 
 class Settings(BaseSettings):
+    model_config = {"env_ignore_empty": True}
+
     github_repository: str
     github_token: SecretStr
     github_event_path: Path


### PR DESCRIPTION
♻️ Fix `notify_translations.py` empty env var handling for PR label events vs workflow_dispatch