### PR TITLE
🐛 Fix issue with Swagger theme change example in the official tutorial

### DIFF
--- a/docs_src/configure_swagger_ui/tutorial002.py
+++ b/docs_src/configure_swagger_ui/tutorial002.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-app = FastAPI(swagger_ui_parameters={"syntaxHighlight.theme": "obsidian"})
+app = FastAPI(swagger_ui_parameters={"syntaxHighlight": {"theme": "obsidian"}})
 
 
 @app.get("/users/{username}")

--- a/tests/test_tutorial/test_configure_swagger_ui/test_tutorial002.py
+++ b/tests/test_tutorial/test_configure_swagger_ui/test_tutorial002.py
@@ -12,7 +12,7 @@ def test_swagger_ui():
         '"syntaxHighlight": false' not in response.text
     ), "not used parameters should not be included"
     assert (
-        '"syntaxHighlight.theme": "obsidian"' in response.text
+        '"syntaxHighlight": {"theme": "obsidian"}' in response.text
     ), "parameters with middle dots should be included in a JSON compatible way"
     assert (
         '"dom_id": "#swagger-ui"' in response.text


### PR DESCRIPTION
I discovered that a part of the code in the [tutorial on changing the Swagger theme](https://fastapi.tiangolo.com/how-to/configure-swagger-ui/#change-the-theme) doesn't work properly, possibly due to a missing update in the latest version of Swagger.

Below are images comparing the code before and after the modification in the tutorial.

<table border="1">
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/8b134482-5eb3-4b2b-aeb3-5ea0765af77f" alt="Before" width="3360" /></td>
      <td><img src="https://github.com/user-attachments/assets/f780f13d-cd3e-417b-9ea3-607c69728039" alt="After" width="3360" /></td>
    </tr>
  </tbody>
</table>
