### PR TITLE
🐛 Fix incorrect HTTP status code in OpenIdConnect authentication

### DIFF
--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -4,7 +4,7 @@ from fastapi.openapi.models import OpenIdConnect as OpenIdConnectModel
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_403_FORBIDDEN
+from starlette.status import HTTP_401_UNAUTHORIZED
 from typing_extensions import Annotated, Doc
 
 
@@ -77,7 +77,7 @@ class OpenIdConnect(SecurityBase):
         if not authorization:
             if self.auto_error:
                 raise HTTPException(
-                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                    status_code=HTTP_401_UNAUTHORIZED, detail="Not authenticated"
                 )
             else:
                 return None


### PR DESCRIPTION
### **Fix incorrect HTTP status code for OpenID Connect missing Authentication header**

#### **Issue**
The `OpenIdConnect` authentication class currently raises an **HTTP 403 Forbidden (`HTTP_403_FORBIDDEN`)** error when a `Authorization` header is missing.

However, **HTTP 403 is incorrect** in this case because:
- **403 Forbidden** should be used when the user is successfully authenticated but lacks permission to access the resource or perform the requested operation.
- **401 Unauthorized** should be used when authentication fails (i.e., when credentials are missing or invalid).

#### **Fix**
This PR updates the status code to **HTTP 401 Unauthorized (`HTTP_401_UNAUTHORIZED`)**, which is the correct response for missing authentication details.

#### **Changes**
- Replaces:
  ```python
  raise HTTPException(
      status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
  )
  ```
  with:
  ```python
  from starlette.status import HTTP_401_UNAUTHORIZED

  raise HTTPException(
      status_code=HTTP_401_UNAUTHORIZED, detail="Not authenticated"
  )
  ```

#### **Why this is important**
- Ensures **correct adherence to RESTful principles**.
- Improves **API security** by providing the correct HTTP response semantics.
- Aligns with **OpenAPI standards** for authentication handling.
- Allows automated tooling to make better decisions (such as API Gateways, HTTP proxies, or service mesh tools)


#### **Potential Impact**

Some applications may currently rely on checking the `403 Forbidden` response in their logic. However, given FastAPI’s goals and philosophy, I believe keeping such a violation of REST principles and OpenAPI standards in the long run is likely worse.
