### PR TITLE
👷 Use `wrangler-action` v3

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,10 +62,7 @@ jobs:
         env:
           PROJECT_NAME: fastapitiangolo
           BRANCH: ${{ ( github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'master' && 'main' ) || ( github.event.workflow_run.head_sha ) }}
-        # TODO: Use v3 when it's fixed, probably in v3.11
-        # https://github.com/cloudflare/wrangler-action/issues/307
-        uses: cloudflare/wrangler-action@v3.14
-        # uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The fix to the wrangler-action was released already and dependabot has been updating it couple of times to newest version already, so should be OK to switch back to the @v3 and get rid of the TODO about it.