### PR TITLE
🐛 Add underscore conversion for `BaseModel` fields

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -507,7 +507,10 @@ def analyze_param(
                     and getattr(field, "shape", 1) == 1
                 )
             )
-
+        if lenient_issubclass(field.type_, BaseModel) and getattr(field_info, "convert_underscores", None):
+            extracted_fields = _get_flat_fields_from_params([field])
+            for param_field in extracted_fields:
+                param_field.field_info.alias = param_field.name.replace("_", "-")
     return ParamDetails(type_annotation=type_annotation, depends=depends, field=field)
 
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -511,8 +511,7 @@ def analyze_param(
             field_info, "convert_underscores", None
         ):
             if PYDANTIC_V2:
-                extracted_fields = _get_flat_fields_from_params([field])
-                for param_field in extracted_fields:
+                for param_field in get_cached_model_fields(field.type_):
                     param_field.field_info.alias = param_field.name.replace("_", "-")
             else:
                 # For Pydantic v1
@@ -521,6 +520,7 @@ def analyze_param(
                     model_cls.__fields__[model_field[0]].alias = model_field[
                         1
                     ].name.replace("_", "-")
+                    model_cls.__fields__[model_field[0]].model_config.allow_population_by_field_name = True
 
     return ParamDetails(type_annotation=type_annotation, depends=depends, field=field)
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -510,9 +510,16 @@ def analyze_param(
         if lenient_issubclass(field.type_, BaseModel) and getattr(
             field_info, "convert_underscores", None
         ):
-            extracted_fields = _get_flat_fields_from_params([field])
-            for param_field in extracted_fields:
-                param_field.field_info.alias = param_field.name.replace("_", "-")
+            if PYDANTIC_V2:
+                extracted_fields = _get_flat_fields_from_params([field])
+                for param_field in extracted_fields:
+                    param_field.field_info.alias = param_field.name.replace("_", "-")
+            else:
+                # For Pydantic v1
+                model_cls: Type[BaseModel] = field.type_
+                for model_field in model_cls.__fields__.items():
+                    model_cls.__fields__[model_field[0]].alias = model_field[1].name.replace("_", "-")
+            
     return ParamDetails(type_annotation=type_annotation, depends=depends, field=field)
 
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -507,7 +507,9 @@ def analyze_param(
                     and getattr(field, "shape", 1) == 1
                 )
             )
-        if lenient_issubclass(field.type_, BaseModel) and getattr(field_info, "convert_underscores", None):
+        if lenient_issubclass(field.type_, BaseModel) and getattr(
+            field_info, "convert_underscores", None
+        ):
             extracted_fields = _get_flat_fields_from_params([field])
             for param_field in extracted_fields:
                 param_field.field_info.alias = param_field.name.replace("_", "-")

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -520,7 +520,9 @@ def analyze_param(
                     model_cls.__fields__[model_field[0]].alias = model_field[
                         1
                     ].name.replace("_", "-")
-                    model_cls.__fields__[model_field[0]].model_config.allow_population_by_field_name = True
+                    model_cls.__fields__[
+                        model_field[0]
+                    ].model_config.allow_population_by_field_name = True
 
     return ParamDetails(type_annotation=type_annotation, depends=depends, field=field)
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -518,8 +518,10 @@ def analyze_param(
                 # For Pydantic v1
                 model_cls: Type[BaseModel] = field.type_
                 for model_field in model_cls.__fields__.items():
-                    model_cls.__fields__[model_field[0]].alias = model_field[1].name.replace("_", "-")
-            
+                    model_cls.__fields__[model_field[0]].alias = model_field[
+                        1
+                    ].name.replace("_", "-")
+
     return ParamDetails(type_annotation=type_annotation, depends=depends, field=field)
 
 

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -515,14 +515,11 @@ def analyze_param(
                     param_field.field_info.alias = param_field.name.replace("_", "-")
             else:
                 # For Pydantic v1
-                model_cls: Type[BaseModel] = field.type_
-                for model_field in model_cls.__fields__.items():
-                    model_cls.__fields__[model_field[0]].alias = model_field[
-                        1
-                    ].name.replace("_", "-")
-                    model_cls.__fields__[
-                        model_field[0]
-                    ].model_config.allow_population_by_field_name = True
+                fields = field.type_.__fields__
+                if isinstance(fields, dict):
+                    for info in fields.values():
+                        info.alias = info.name.replace("_", "-")
+                        info.model_config.allow_population_by_field_name = True
 
     return ParamDetails(type_annotation=type_annotation, depends=depends, field=field)
 

--- a/tests/test_tutorial/test_header_param_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial001.py
@@ -2,10 +2,9 @@ import importlib
 
 import pytest
 from dirty_equals import IsDict
+from fastapi._compat import PYDANTIC_V2
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
-
-from fastapi._compat import PYDANTIC_V2
 
 from tests.utils import needs_py39, needs_py310
 
@@ -49,7 +48,7 @@ def test_header_param_model(client: TestClient):
             "x_tag": ["one", "two"],
         }
     else:
-         assert response.json() == {
+        assert response.json() == {
             "host": "testserver",
             "save-data": True,
             "if-modified-since": "yesterday",
@@ -70,7 +69,7 @@ def test_header_param_model_defaults(client: TestClient):
             "x_tag": [],
         }
     else:
-         assert response.json() == {
+        assert response.json() == {
             "host": "testserver",
             "save-data": True,
             "if-modified-since": None,
@@ -113,7 +112,7 @@ def test_header_param_model_invalid(client: TestClient):
             }
         )
     else:
-         assert response.json() == snapshot(
+        assert response.json() == snapshot(
             {
                 "detail": [
                     IsDict(
@@ -142,8 +141,6 @@ def test_header_param_model_invalid(client: TestClient):
                 ]
             }
         )
-            
-   
 
 
 def test_header_param_model_extra(client: TestClient):
@@ -162,7 +159,7 @@ def test_header_param_model_extra(client: TestClient):
             }
         )
     else:
-         assert response.json() == snapshot(
+        assert response.json() == snapshot(
             {
                 "host": "testserver",
                 "save-data": True,

--- a/tests/test_tutorial/test_header_param_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial001.py
@@ -129,26 +129,26 @@ def test_openapi_schema(client: TestClient):
                                 "schema": {"type": "string", "title": "Host"},
                             },
                             {
-                                "name": "save_data",
+                                "name": "save-data",
                                 "in": "header",
                                 "required": True,
-                                "schema": {"type": "boolean", "title": "Save Data"},
+                                "schema": {"type": "boolean", "title": "Save-Data"},
                             },
                             {
-                                "name": "if_modified_since",
+                                "name": "if-modified-since",
                                 "in": "header",
                                 "required": False,
                                 "schema": IsDict(
                                     {
                                         "anyOf": [{"type": "string"}, {"type": "null"}],
-                                        "title": "If Modified Since",
+                                        "title": "If-Modified-Since",
                                     }
                                 )
                                 | IsDict(
                                     # TODO: remove when deprecating Pydantic v1
                                     {
                                         "type": "string",
-                                        "title": "If Modified Since",
+                                        "title": "If-Modified-Since",
                                     }
                                 ),
                             },
@@ -171,14 +171,14 @@ def test_openapi_schema(client: TestClient):
                                 ),
                             },
                             {
-                                "name": "x_tag",
+                                "name": "x-tag",
                                 "in": "header",
                                 "required": False,
                                 "schema": {
                                     "type": "array",
                                     "items": {"type": "string"},
                                     "default": [],
-                                    "title": "X Tag",
+                                    "title": "X-Tag",
                                 },
                             },
                         ],

--- a/tests/test_tutorial/test_header_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial002.py
@@ -2,10 +2,9 @@ import importlib
 
 import pytest
 from dirty_equals import IsDict
+from fastapi._compat import PYDANTIC_V2
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
-
-from fastapi._compat import PYDANTIC_V2
 
 from tests.utils import needs_py39, needs_py310, needs_pydanticv1, needs_pydanticv2
 
@@ -75,7 +74,7 @@ def test_header_param_model_defaults(client: TestClient):
             "x_tag": [],
         }
     else:
-         assert response.json() == {
+        assert response.json() == {
             "host": "testserver",
             "save-data": True,
             "if-modified-since": None,

--- a/tests/test_tutorial/test_header_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial002.py
@@ -140,26 +140,26 @@ def test_openapi_schema(client: TestClient):
                                 "schema": {"type": "string", "title": "Host"},
                             },
                             {
-                                "name": "save_data",
+                                "name": "save-data",
                                 "in": "header",
                                 "required": True,
-                                "schema": {"type": "boolean", "title": "Save Data"},
+                                "schema": {"type": "boolean", "title": "Save-Data"},
                             },
                             {
-                                "name": "if_modified_since",
+                                "name": "if-modified-since",
                                 "in": "header",
                                 "required": False,
                                 "schema": IsDict(
                                     {
                                         "anyOf": [{"type": "string"}, {"type": "null"}],
-                                        "title": "If Modified Since",
+                                        "title": "If-Modified-Since",
                                     }
                                 )
                                 | IsDict(
                                     # TODO: remove when deprecating Pydantic v1
                                     {
                                         "type": "string",
-                                        "title": "If Modified Since",
+                                        "title": "If-Modified-Since",
                                     }
                                 ),
                             },
@@ -182,14 +182,14 @@ def test_openapi_schema(client: TestClient):
                                 ),
                             },
                             {
-                                "name": "x_tag",
+                                "name": "x-tag",
                                 "in": "header",
                                 "required": False,
                                 "schema": {
                                     "type": "array",
                                     "items": {"type": "string"},
                                     "default": [],
-                                    "title": "X Tag",
+                                    "title": "X-Tag",
                                 },
                             },
                         ],

--- a/tests/test_tutorial/test_header_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial002.py
@@ -5,6 +5,8 @@ from dirty_equals import IsDict
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
 
+from fastapi._compat import PYDANTIC_V2
+
 from tests.utils import needs_py39, needs_py310, needs_pydanticv1, needs_pydanticv2
 
 
@@ -43,52 +45,94 @@ def test_header_param_model(client: TestClient):
         ],
     )
     assert response.status_code == 200, response.text
-    assert response.json() == {
-        "host": "testserver",
-        "save_data": True,
-        "if_modified_since": "yesterday",
-        "traceparent": "123",
-        "x_tag": ["one", "two"],
-    }
+    if PYDANTIC_V2:
+        assert response.json() == {
+            "host": "testserver",
+            "save_data": True,
+            "if_modified_since": "yesterday",
+            "traceparent": "123",
+            "x_tag": ["one", "two"],
+        }
+    else:
+        assert response.json() == {
+            "host": "testserver",
+            "save-data": True,
+            "if-modified-since": "yesterday",
+            "traceparent": "123",
+            "x-tag": ["one", "two"],
+        }
 
 
 def test_header_param_model_defaults(client: TestClient):
     response = client.get("/items/", headers=[("save-data", "true")])
     assert response.status_code == 200
-    assert response.json() == {
-        "host": "testserver",
-        "save_data": True,
-        "if_modified_since": None,
-        "traceparent": None,
-        "x_tag": [],
-    }
+    if PYDANTIC_V2:
+        assert response.json() == {
+            "host": "testserver",
+            "save_data": True,
+            "if_modified_since": None,
+            "traceparent": None,
+            "x_tag": [],
+        }
+    else:
+         assert response.json() == {
+            "host": "testserver",
+            "save-data": True,
+            "if-modified-since": None,
+            "traceparent": None,
+            "x-tag": [],
+        }
 
 
 def test_header_param_model_invalid(client: TestClient):
     response = client.get("/items/")
     assert response.status_code == 422
-    assert response.json() == snapshot(
-        {
-            "detail": [
-                IsDict(
-                    {
-                        "type": "missing",
-                        "loc": ["header", "save_data"],
-                        "msg": "Field required",
-                        "input": {"x_tag": [], "host": "testserver"},
-                    }
-                )
-                | IsDict(
-                    # TODO: remove when deprecating Pydantic v1
-                    {
-                        "type": "value_error.missing",
-                        "loc": ["header", "save_data"],
-                        "msg": "field required",
-                    }
-                )
-            ]
-        }
-    )
+    if PYDANTIC_V2:
+        assert response.json() == snapshot(
+            {
+                "detail": [
+                    IsDict(
+                        {
+                            "type": "missing",
+                            "loc": ["header", "save_data"],
+                            "msg": "Field required",
+                            "input": {"x_tag": [], "host": "testserver"},
+                        }
+                    )
+                    | IsDict(
+                        # TODO: remove when deprecating Pydantic v1
+                        {
+                            "type": "value_error.missing",
+                            "loc": ["header", "save_data"],
+                            "msg": "field required",
+                        }
+                    )
+                ]
+            }
+        )
+    else:
+        assert response.json() == snapshot(
+            {
+                "detail": [
+                    IsDict(
+                        {
+                            "type": "missing",
+                            "loc": ["header", "save-data"],
+                            "msg": "Field required",
+                            "input": {"x_tag": [], "host": "testserver"},
+                        }
+                    )
+                    | IsDict(
+                        # TODO: remove when deprecating Pydantic v1
+                        {
+                            "type": "value_error.missing",
+                            "loc": ["header", "save-data"],
+                            "msg": "field required",
+                        }
+                    )
+                ]
+            }
+        )
 
 
 def test_header_param_model_extra(client: TestClient):


### PR DESCRIPTION
Fixes first half of issue #13400 