### PR TITLE
✅ Fix `test_exception_handler_body_access`

### DIFF
--- a/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
+++ b/tests/test_tutorial/test_custom_request_and_route/test_tutorial002.py
@@ -28,6 +28,20 @@ def test_exception_handler_body_access():
             }
         }
     ) | IsDict(
+        {
+            "detail": {
+                "errors": [
+                    {
+                        "type": "list_type",
+                        "loc": ["body"],
+                        "msg": "Input should be a valid list",
+                        "input": {"numbers": [1, 2, 3]},
+                    }
+                ],
+                "body": '{"numbers":[1,2,3]}',
+            }
+        }
+    ) | IsDict(
         # TODO: remove when deprecating Pydantic v1
         {
             "detail": {


### PR DESCRIPTION
Im honestly not certain what has changed, but in a recent Debian system, this tests fails.

the changes are minor, but given it's a string, space characters matter.