### PR TITLE
✨ Support passing context to Pydantic serializers via `jsonable_encoder`

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -453,6 +453,8 @@ else:
     def _model_dump(
         model: BaseModel, mode: Literal["json", "python"] = "json", **kwargs: Any
     ) -> Any:
+        if not PYDANTIC_V2:
+            kwargs.pop("context", None)
         return model.dict(**kwargs)
 
     def _get_model_config(model: BaseModel) -> Any:

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -126,6 +126,15 @@ def jsonable_encoder(
             """
         ),
     ] = None,
+    context: Annotated[
+        Optional[Any],
+        Doc(
+            """
+            Pydantic's `context` parameter, passed to Pydantic serializers.
+            This only works with Pydantic V2.
+            """
+        ),
+    ] = None,
     by_alias: Annotated[
         bool,
         Doc(
@@ -225,6 +234,7 @@ def jsonable_encoder(
             mode="json",
             include=include,
             exclude=exclude,
+            context=context,
             by_alias=by_alias,
             exclude_unset=exclude_unset,
             exclude_none=exclude_none,
@@ -234,6 +244,7 @@ def jsonable_encoder(
             obj_dict = obj_dict["__root__"]
         return jsonable_encoder(
             obj_dict,
+            context=context,
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             # TODO: remove when deprecating Pydantic v1
@@ -247,6 +258,7 @@ def jsonable_encoder(
             obj_dict,
             include=include,
             exclude=exclude,
+            context=context,
             by_alias=by_alias,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
@@ -281,6 +293,7 @@ def jsonable_encoder(
             ):
                 encoded_key = jsonable_encoder(
                     key,
+                    context=context,
                     by_alias=by_alias,
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
@@ -289,6 +302,7 @@ def jsonable_encoder(
                 )
                 encoded_value = jsonable_encoder(
                     value,
+                    context=context,
                     by_alias=by_alias,
                     exclude_unset=exclude_unset,
                     exclude_none=exclude_none,
@@ -305,6 +319,7 @@ def jsonable_encoder(
                     item,
                     include=include,
                     exclude=exclude,
+                    context=context,
                     by_alias=by_alias,
                     exclude_unset=exclude_unset,
                     exclude_defaults=exclude_defaults,
@@ -335,6 +350,7 @@ def jsonable_encoder(
         data,
         include=include,
         exclude=exclude,
+        context=context,
         by_alias=by_alias,
         exclude_unset=exclude_unset,
         exclude_defaults=exclude_defaults,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -5,6 +5,7 @@ from fastapi._compat import (
     ModelField,
     Undefined,
     _get_model_config,
+    _model_dump,
     get_cached_model_fields,
     get_model_fields,
     is_bytes_sequence_annotation,
@@ -163,3 +164,13 @@ def test_get_model_fields_cached():
 
     assert non_cached_fields is not non_cached_fields2
     assert cached_fields is cached_fields2
+
+
+@needs_pydanticv1
+def test_model_dump_remove_context_kwarg_in_pydanticv1() -> None:
+    class Model(BaseModel):
+        foo: str
+
+    # The following instruction would throw an error
+    # in pv1 if the context kwarg was not removed.
+    _model_dump(Model(foo="bar"), context=1)

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -335,9 +335,7 @@ def test_encode_with_context() -> None:
         @field_serializer("value")
         def serialize_value(value: int, info: SerializationInfo) -> int:
             if info.context is not None:
-                if isinstance(
-                    value_from_context := info.context.get("value"), int
-                ):
+                if isinstance(value_from_context := info.context.get("value"), int):
                     return value_from_context
 
             return value


### PR DESCRIPTION
It would be handy if we could pass some context to the Pydantic serializers through the `jsonable_encoder` function.

> You can pass a context object to the serialization methods which can be accessed from the `info` argument to decorated serializer functions. This is useful when you need to dynamically update the serialization behavior during runtime. For example, if you wanted a field to be dumped depending on a dynamically controllable set of allowed values, this could be done by passing the allowed values by context:

-- Pydantic docs on [Serialization Context](https://docs.pydantic.dev/latest/concepts/serialization/#serialization-context)
