### PR TITLE
✨ Relax HTTPBearer call requirement to support websockets

### DIFF
--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -8,7 +8,7 @@ from fastapi.openapi.models import HTTPBearer as HTTPBearerModel
 from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
-from starlette.requests import Request
+from starlette.requests import Request, HTTPConnection
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from typing_extensions import Annotated, Doc
 
@@ -299,7 +299,7 @@ class HTTPBearer(HTTPBase):
         self.auto_error = auto_error
 
     async def __call__(
-        self, request: Request
+        self, request: HTTPConnection
     ) -> Optional[HTTPAuthorizationCredentials]:
         authorization = request.headers.get("Authorization")
         scheme, credentials = get_authorization_scheme_param(authorization)

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -8,7 +8,7 @@ from fastapi.openapi.models import HTTPBearer as HTTPBearerModel
 from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
-from starlette.requests import Request, HTTPConnection
+from starlette.requests import HTTPConnection, Request
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from typing_extensions import Annotated, Doc
 


### PR DESCRIPTION
Currently, using `HTTPBearer` is not possible for websockets as it requires an HTTP request.

However, its functionality only ever uses the HTTP headers, which are also present in websockets, as both HTTP requests and websocket requests are based on the `HTTPConnection` class.

This PR relaxes the call requirement of `HTTPBearer` to only require a `HTTPConnection`, which allows using this feature in a type-safe manner for websockets.