### PR TITLE
✨ Add descriptions for ValidationError and HTTPValidationError in OpenAPI

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -41,6 +41,7 @@ from typing_extensions import Literal
 validation_error_definition = {
     "title": "ValidationError",
     "type": "object",
+    "description": "A message detailing how and where the input diverges from the schema.",
     "properties": {
         "loc": {
             "title": "Location",
@@ -48,7 +49,11 @@ validation_error_definition = {
             "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
         },
         "msg": {"title": "Message", "type": "string"},
-        "type": {"title": "Error Type", "type": "string"},
+        "type": {
+            "title": "Error Type",
+            "type": "string",
+            "description": "Free-form; when type is 'missing', it pertains to absent required fields.",
+        },
     },
     "required": ["loc", "msg", "type"],
 }
@@ -56,6 +61,7 @@ validation_error_definition = {
 validation_error_response_definition = {
     "title": "HTTPValidationError",
     "type": "object",
+    "description": "A collection of messages detailing errors in the input.",
     "properties": {
         "detail": {
             "title": "Detail",


### PR DESCRIPTION
Descriptions for ValidationError and HTTPValidationError in OpenAPI schema.

When schemata are used for codegen downstream, this alleviates the need to modify the `ValidationError` and `HTTPValidationError` models to satisfy linters that require descriptions on modules/classes.

I'm not sure the descriptions here are necessarily the best, but it would be really nice to have *a* description. Suggestions for improvements very welcome. :-)