### PR TITLE
♻️ Refactor tests in `tests/test_tutorial/test_background_tasks`

### DIFF
--- a/tests/test_tutorial/test_background_tasks/conftest.py
+++ b/tests/test_tutorial/test_background_tasks/conftest.py
@@ -1,6 +1,7 @@
 import os
-import pytest
 from pathlib import Path
+
+import pytest
 
 
 @pytest.fixture(name="path_to_log_file")

--- a/tests/test_tutorial/test_background_tasks/conftest.py
+++ b/tests/test_tutorial/test_background_tasks/conftest.py
@@ -1,0 +1,11 @@
+import os
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture(name="path_to_log_file")
+def log_path():
+    log = Path("log.txt")
+    yield log
+    if log.is_file():
+        os.remove(log)  # pragma: no cover

--- a/tests/test_tutorial/test_background_tasks/test_tutorial001.py
+++ b/tests/test_tutorial/test_background_tasks/test_tutorial001.py
@@ -1,6 +1,3 @@
-import os
-from pathlib import Path
-
 from fastapi.testclient import TestClient
 
 from docs_src.background_tasks.tutorial001 import app
@@ -8,10 +5,7 @@ from docs_src.background_tasks.tutorial001 import app
 client = TestClient(app)
 
 
-def test():
-    log = Path("log.txt")
-    if log.is_file():
-        os.remove(log)  # pragma: no cover
+def test(path_to_log_file):
     response = client.post("/send-notification/foo@example.com")
     assert response.status_code == 200, response.text
     assert response.json() == {"message": "Notification sent in the background"}

--- a/tests/test_tutorial/test_background_tasks/test_tutorial002.py
+++ b/tests/test_tutorial/test_background_tasks/test_tutorial002.py
@@ -1,6 +1,4 @@
 import importlib
-import os
-from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -25,10 +23,7 @@ def get_client(request: pytest.FixtureRequest):
     return client
 
 
-def test(client: TestClient):
-    log = Path("log.txt")
-    if log.is_file():
-        os.remove(log)  # pragma: no cover
+def test(client: TestClient, path_to_log_file):
     response = client.post("/send-notification/foo@example.com?q=some-query")
     assert response.status_code == 200, response.text
     assert response.json() == {"message": "Message sent"}


### PR DESCRIPTION
Currently when running tests from the `tests/test_tutorial/test_background_tasks` a `log.txt` file is created.

This PR proposes a cleaner solution, that allows to remove the `log.txt` after the execution of every single test (located in the `tests/test_tutorial/test_background_tasks` directory):

- Created a file `conftest.py` containing a pytest fixture, that performs a tear down task.
-  The fixture is re-used in both tests: `tests/test_tutorial/test_background_tasks/test_tutorial001.py`,   `tests/test_tutorial/test_background_tasks/test_tutorial002.py`,  