### PR TITLE
📝 Fix liblab client generation doc link

### DIFF
--- a/docs/en/docs/advanced/generate-clients.md
+++ b/docs/en/docs/advanced/generate-clients.md
@@ -24,7 +24,7 @@ For example, you might want to try:
 
 * <a href="https://speakeasy.com/?utm_source=fastapi+repo&utm_medium=github+sponsorship" class="external-link" target="_blank">Speakeasy</a>
 * <a href="https://www.stainlessapi.com/?utm_source=fastapi&utm_medium=referral" class="external-link" target="_blank">Stainless</a>
-* <a href="https://developers.liblab.com/tutorials/sdk-for-fastapi/?utm_source=fastapi" class="external-link" target="_blank">liblab</a>
+* <a href="https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi" class="external-link" target="_blank">liblab</a>
 
 There are also several other companies offering similar services that you can search and find online. 🤓
 


### PR DESCRIPTION
In [this section of the docs](https://fastapi.tiangolo.com/advanced/generate-clients/#client-and-sdk-generators-sponsor), currently clicking the liblab link gives a 'Page Not Found' response:

![Screenshot 2025-04-01 at 15 41 49](https://github.com/user-attachments/assets/47c0cd60-a05a-4d11-97ca-dc51db94344f)

The link in the docs is https://developers.liblab.com/tutorials/sdk-for-fastapi/?utm_source=fastapi but it would seem it should be https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi without the last `/` before the `?`. This modified link works as expected:

![Screenshot 2025-04-01 at 15 43 07](https://github.com/user-attachments/assets/828d1b9e-7d60-4858-adbc-0113c5d467e0)

