### PR TITLE
📝 Use lifespan events instead of @app.on_event annotation in sql example code

### DIFF
--- a/docs_src/sql_databases/tutorial001.py
+++ b/docs_src/sql_databases/tutorial001.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import List, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -27,12 +28,13 @@ def get_session():
         yield session
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_an.py
+++ b/docs_src/sql_databases/tutorial001_an.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import List, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -30,12 +31,13 @@ def get_session():
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
-app = FastAPI()
 
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_an.py
+++ b/docs_src/sql_databases/tutorial001_an.py
@@ -37,6 +37,7 @@ async def lifespan(app: FastAPI):
     create_db_and_tables()
     yield
 
+
 app = FastAPI(lifespan=lifespan)
 
 

--- a/docs_src/sql_databases/tutorial001_an_py310.py
+++ b/docs_src/sql_databases/tutorial001_an_py310.py
@@ -36,6 +36,7 @@ async def lifespan(app: FastAPI):
     create_db_and_tables()
     yield
 
+
 app = FastAPI(lifespan=lifespan)
 
 

--- a/docs_src/sql_databases/tutorial001_an_py310.py
+++ b/docs_src/sql_databases/tutorial001_an_py310.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -29,12 +30,13 @@ def get_session():
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
-app = FastAPI()
 
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_an_py39.py
+++ b/docs_src/sql_databases/tutorial001_an_py39.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import Annotated, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -29,12 +30,14 @@ def get_session():
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
-app = FastAPI()
 
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_py310.py
+++ b/docs_src/sql_databases/tutorial001_py310.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 
@@ -25,12 +27,13 @@ def get_session():
         yield session
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_py39.py
+++ b/docs_src/sql_databases/tutorial001_py39.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -27,12 +28,12 @@ def get_session():
         yield session
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_py39.py
+++ b/docs_src/sql_databases/tutorial001_py39.py
@@ -33,6 +33,7 @@ async def lifespan(app: FastAPI):
     create_db_and_tables()
     yield
 
+
 app = FastAPI(lifespan=lifespan)
 
 

--- a/docs_src/sql_databases/tutorial002.py
+++ b/docs_src/sql_databases/tutorial002.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import List, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -44,12 +45,13 @@ def get_session():
         yield session
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/", response_model=HeroPublic)

--- a/docs_src/sql_databases/tutorial002_an.py
+++ b/docs_src/sql_databases/tutorial002_an.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import List, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -46,12 +47,15 @@ def get_session():
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
-app = FastAPI()
 
 
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/", response_model=HeroPublic)

--- a/docs_src/sql_databases/tutorial002_an_py310.py
+++ b/docs_src/sql_databases/tutorial002_an_py310.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -45,12 +46,15 @@ def get_session():
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
-app = FastAPI()
 
 
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/", response_model=HeroPublic)

--- a/docs_src/sql_databases/tutorial002_an_py39.py
+++ b/docs_src/sql_databases/tutorial002_an_py39.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import Annotated, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -45,12 +46,15 @@ def get_session():
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
-app = FastAPI()
 
 
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/", response_model=HeroPublic)

--- a/docs_src/sql_databases/tutorial002_py310.py
+++ b/docs_src/sql_databases/tutorial002_py310.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 
@@ -42,12 +44,13 @@ def get_session():
         yield session
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/", response_model=HeroPublic)

--- a/docs_src/sql_databases/tutorial002_py39.py
+++ b/docs_src/sql_databases/tutorial002_py39.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from typing import Union
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -44,12 +45,13 @@ def get_session():
         yield session
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/", response_model=HeroPublic)


### PR DESCRIPTION
I started to learn about FastAPI and followed the docs when I found that on_event annotation is deprecated. This PR changes the example codes for SQL databases to use the suggested lifespan event handlers.