### PR TITLE
✏️ Fix syntax error in `docs/en/docs/tutorial/handling-errors.md`

### DIFF
--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -252,4 +252,4 @@ If you want to use the exception along with the same default exception handlers 
 
 {* ../../docs_src/handling_errors/tutorial006.py hl[2:5,15,21] *}
 
-In this example you are just `print`ing the error with a very expressive message, but you get the idea. You can use the exception and then just reuse the default exception handlers.
+In this example you are just printing the error with a very expressive message, but you get the idea. You can use the exception and then just reuse the default exception handlers.

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -35,7 +35,7 @@ Because it's a Python exception, you don't `return` it, you `raise` it.
 
 This also means that if you are inside a utility function that you are calling inside of your *path operation function*, and you raise the `HTTPException` from inside of that utility function, it won't run the rest of the code in the *path operation function*, it will terminate that request right away and send the HTTP error from the `HTTPException` to the client.
 
-The benefit of raising an exception over `return`ing a value will be more evident in the section about Dependencies and Security.
+The benefit of raising an exception over returning a value will be more evident in the section about Dependencies and Security.
 
 In this example, when the client requests an item by an ID that doesn't exist, raise an exception with a status code of `404`:
 


### PR DESCRIPTION
- Fixed a minor error I saw in the docs