### PR TITLE
✨ Allow array values for OpenAPI schema `type` field

### DIFF
--- a/fastapi/openapi/constants.py
+++ b/fastapi/openapi/constants.py
@@ -1,13 +1,3 @@
-from typing import Literal
-
-from typing_extensions import Annotated
-
 METHODS_WITH_BODY = {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"}
 REF_PREFIX = "#/components/schemas/"
 REF_TEMPLATE = "#/components/schemas/{model}"
-
-
-TypeValue = Annotated[
-    Literal["array", "boolean", "integer", "null", "number", "object", "string"],
-    "Allowed type values of an object as specified in the JSON Schema https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.1",
-]

--- a/fastapi/openapi/constants.py
+++ b/fastapi/openapi/constants.py
@@ -1,3 +1,11 @@
+from typing import Annotated, Literal
+
 METHODS_WITH_BODY = {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"}
 REF_PREFIX = "#/components/schemas/"
 REF_TEMPLATE = "#/components/schemas/{model}"
+
+
+TypeValue = Annotated[
+    Literal["array", "boolean", "integer", "null", "number", "object", "string"],
+    "Allowed type values of an object as specified in the JSON Schema https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.1",
+]

--- a/fastapi/openapi/constants.py
+++ b/fastapi/openapi/constants.py
@@ -1,4 +1,6 @@
-from typing import Annotated, Literal
+from typing import Literal
+
+from typing_extensions import Annotated
 
 METHODS_WITH_BODY = {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"}
 REF_PREFIX = "#/components/schemas/"

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -10,7 +10,6 @@ from fastapi._compat import (
     with_info_plain_validator_function,
 )
 from fastapi.logger import logger
-from fastapi.openapi.constants import TypeValue
 from pydantic import AnyUrl, BaseModel, Field
 from typing_extensions import Annotated, Literal, TypedDict
 from typing_extensions import deprecated as typing_deprecated
@@ -122,6 +121,12 @@ class ExternalDocumentation(BaseModelWithConfig):
     url: AnyUrl
 
 
+# Ref JSON Schema 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation#name-type
+SchemaType = Literal[
+    "array", "boolean", "integer", "null", "number", "object", "string"
+]
+
+
 class Schema(BaseModelWithConfig):
     # Ref: JSON Schema 2020-12: https://json-schema.org/draft/2020-12/json-schema-core.html#name-the-json-schema-core-vocabu
     # Core Vocabulary
@@ -158,7 +163,7 @@ class Schema(BaseModelWithConfig):
     unevaluatedProperties: Optional["SchemaOrBool"] = None
     # Ref: JSON Schema Validation 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-structural
     # A Vocabulary for Structural Validation
-    type: Optional[Union[TypeValue, List[TypeValue]]] = None
+    type: Optional[Union[SchemaType, List[SchemaType]]] = None
     enum: Optional[List[Any]] = None
     const: Optional[Any] = None
     multipleOf: Optional[float] = Field(default=None, gt=0)

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -10,6 +10,7 @@ from fastapi._compat import (
     with_info_plain_validator_function,
 )
 from fastapi.logger import logger
+from fastapi.openapi.constants import TypeValue
 from pydantic import AnyUrl, BaseModel, Field
 from typing_extensions import Annotated, Literal, TypedDict
 from typing_extensions import deprecated as typing_deprecated
@@ -145,7 +146,7 @@ class Schema(BaseModelWithConfig):
     dependentSchemas: Optional[Dict[str, "SchemaOrBool"]] = None
     prefixItems: Optional[List["SchemaOrBool"]] = None
     # TODO: uncomment and remove below when deprecating Pydantic v1
-    # It generales a list of schemas for tuples, before prefixItems was available
+    # It generates a list of schemas for tuples, before prefixItems was available
     # items: Optional["SchemaOrBool"] = None
     items: Optional[Union["SchemaOrBool", List["SchemaOrBool"]]] = None
     contains: Optional["SchemaOrBool"] = None
@@ -157,7 +158,7 @@ class Schema(BaseModelWithConfig):
     unevaluatedProperties: Optional["SchemaOrBool"] = None
     # Ref: JSON Schema Validation 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-structural
     # A Vocabulary for Structural Validation
-    type: Optional[str] = None
+    type: Optional[Union[TypeValue, list[TypeValue]]] = None
     enum: Optional[List[Any]] = None
     const: Optional[Any] = None
     multipleOf: Optional[float] = Field(default=None, gt=0)

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -158,7 +158,7 @@ class Schema(BaseModelWithConfig):
     unevaluatedProperties: Optional["SchemaOrBool"] = None
     # Ref: JSON Schema Validation 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-structural
     # A Vocabulary for Structural Validation
-    type: Optional[Union[TypeValue, list[TypeValue]]] = None
+    type: Optional[Union[TypeValue, List[TypeValue]]] = None
     enum: Optional[List[Any]] = None
     const: Optional[Any] = None
     multipleOf: Optional[float] = Field(default=None, gt=0)

--- a/tests/test_openapi_schema_type.py
+++ b/tests/test_openapi_schema_type.py
@@ -1,8 +1,7 @@
 from typing import List, Optional, Union
 
 import pytest
-from fastapi.openapi.constants import TypeValue
-from fastapi.openapi.models import Schema
+from fastapi.openapi.models import Schema, SchemaType
 
 
 @pytest.mark.parametrize(
@@ -14,9 +13,9 @@ from fastapi.openapi.models import Schema
     ],
 )
 def test_allowed_schema_type(
-    type_value: Optional[Union[TypeValue, List[TypeValue]]],
+    type_value: Optional[Union[SchemaType, List[SchemaType]]],
 ) -> None:
-    """Test that Schema accepts TypeValue, List[TypeValue] and None for type field."""
+    """Test that Schema accepts SchemaType, List[SchemaType] and None for type field."""
     schema = Schema(type=type_value)
     assert schema.type == type_value
 

--- a/tests/test_openapi_schema_type.py
+++ b/tests/test_openapi_schema_type.py
@@ -1,50 +1,27 @@
-import itertools
-from typing import List
+from typing import List, Optional, Union
 
 import pytest
 from fastapi.openapi.constants import TypeValue
 from fastapi.openapi.models import Schema
 
-# Define all possible type values
-TYPE_VALUES: List[TypeValue] = [
-    "array",
-    "boolean",
-    "integer",
-    "null",
-    "number",
-    "object",
-    "string",
-]
 
-# Generate all combinations of 2 or more types
-TYPE_COMBINATIONS = [
-    list(combo)
-    for size in range(2, len(TYPE_VALUES) + 1)
-    for combo in itertools.combinations(TYPE_VALUES, size)
-]
+@pytest.mark.parametrize(
+    "type_value",
+    [
+        "array",
+        ["string", "null"],
+        None,
+    ],
+)
+def test_allowed_schema_type(
+    type_value: Optional[Union[TypeValue, List[TypeValue]]],
+) -> None:
+    """Test that Schema accepts TypeValue, List[TypeValue] and None for type field."""
+    schema = Schema(type=type_value)
+    assert schema.type == type_value
 
 
-@pytest.mark.parametrize("type_val", TYPE_VALUES)
-def test_schema_type_single_type_value(type_val: TypeValue) -> None:
-    """Test that Schema accepts single TypeValue for type field."""
-    schema = Schema(type=type_val)
-    assert schema.type == type_val
-
-
-@pytest.mark.parametrize("type_list", TYPE_COMBINATIONS)
-def test_schema_type_multiple_type_value(type_list: List[TypeValue]) -> None:
-    """Test all possible combinations of TypeValue for Schema type field."""
-    schema = Schema(type=type_list)
-    assert schema.type == type_list
-
-
-def test_schema_type_none_value() -> None:
-    """Test that Schema accepts None for type field (Optional)."""
-    schema = Schema(type=None)
-    assert schema.type is None
-
-
-def test_schema_default_type() -> None:
-    """Test that Schema defaults to None for type field if not specified."""
-    schema_default = Schema()
-    assert schema_default.type is None
+def test_invlid_type_value() -> None:
+    """Test that Schema raises ValueError for invalid type values."""
+    with pytest.raises(ValueError, match="2 validation errors for Schema"):
+        Schema(type=True)  # type: ignore[arg-type]

--- a/tests/test_openapi_schema_type.py
+++ b/tests/test_openapi_schema_type.py
@@ -21,7 +21,7 @@ def test_allowed_schema_type(
     assert schema.type == type_value
 
 
-def test_invlid_type_value() -> None:
+def test_invalid_type_value() -> None:
     """Test that Schema raises ValueError for invalid type values."""
     with pytest.raises(ValueError, match="2 validation errors for Schema"):
         Schema(type=True)  # type: ignore[arg-type]

--- a/tests/test_openapi_schema_type.py
+++ b/tests/test_openapi_schema_type.py
@@ -1,0 +1,50 @@
+import itertools
+from typing import List
+
+import pytest
+from fastapi.openapi.constants import TypeValue
+from fastapi.openapi.models import Schema
+
+# Define all possible type values
+TYPE_VALUES: List[TypeValue] = [
+    "array",
+    "boolean",
+    "integer",
+    "null",
+    "number",
+    "object",
+    "string",
+]
+
+# Generate all combinations of 2 or more types
+TYPE_COMBINATIONS = [
+    list(combo)
+    for size in range(2, len(TYPE_VALUES) + 1)
+    for combo in itertools.combinations(TYPE_VALUES, size)
+]
+
+
+@pytest.mark.parametrize("type_val", TYPE_VALUES)
+def test_schema_type_single_type_value(type_val: TypeValue) -> None:
+    """Test that Schema accepts single TypeValue for type field."""
+    schema = Schema(type=type_val)
+    assert schema.type == type_val
+
+
+@pytest.mark.parametrize("type_list", TYPE_COMBINATIONS)
+def test_schema_type_multiple_type_value(type_list: List[TypeValue]) -> None:
+    """Test all possible combinations of TypeValue for Schema type field."""
+    schema = Schema(type=type_list)
+    assert schema.type == type_list
+
+
+def test_schema_type_none_value() -> None:
+    """Test that Schema accepts None for type field (Optional)."""
+    schema = Schema(type=None)
+    assert schema.type is None
+
+
+def test_schema_default_type() -> None:
+    """Test that Schema defaults to None for type field if not specified."""
+    schema_default = Schema()
+    assert schema_default.type is None


### PR DESCRIPTION
# Allow Union Types in OpenAPI Schemas
This PR addresses an issue with how union types for the "type" field are validated in FastAPI's OpenAPI generation. Currently, only a string is allowed for the type definition even though the JSON Schema specification (Section 6.1.1) permits the value to be either a string or an array of unique string values. This discrepancy can lead to confusion or incorrect schema validation when using union types.

Example here that throws pydantic validation error:

```python
# example.py 
# uv run --no-project example.py
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     "fastapi",
#     "pydantic",
# ]
# ///


from fastapi.openapi.models import OpenAPI
from pydantic import ValidationError

openapi_dict = {
    "openapi": "3.1.0",
    "info": {"title": "Type Examples with Union Types", "version": "1.0.0"},
    "components": {
        "schemas": {
            "UnionStringOrNumber": {
                "type": ["string", "number"],
                "description": "An instance is valid if it is either a string or a number.",
                "example": "example as string",
            },
        }
    },
}


def test_openapi_type() -> None:
    try:
        _ = OpenAPI(**openapi_dict)
    except ValidationError as e:
        # Expecting this to raise a ValidationError
        print(f"Validation error: {e}")
        return

    raise NotImplementedError("This should not be reached.")


if __name__ == "__main__":
    test_openapi_type()
    print("Test passed!")
```

Addressed by introducing`TypeValue`, defined as an annotated literal that encompasses [the valid JSON Schema types.](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.1)

And updating the Schema model to use the literal values.

After these changes the validation error is removed.