### PR TITLE
📝 Clarify guidance on using `async def` without `await`

### DIFF
--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -40,7 +40,7 @@ def results():
 
 ---
 
-If your application doesn't need to communicate with anything else or await a response, it's still safe to use `async def` -- even if there's nothing to `await`.
+If your application (somehow) doesn't have to communicate with anything else and wait for it to respond, use `async def`, even if you don't need to use `await` inside.
 
 ---
 

--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -40,7 +40,7 @@ def results():
 
 ---
 
-If your application (somehow) doesn't have to communicate with anything else and wait for it to respond, use `async def`.
+If your application doesn't need to communicate with anything else or await a response, it's still safe to use `async def` -- even if there's nothing to `await`.
 
 ---
 


### PR DESCRIPTION
### Summary
This PR improves the clarity of the **"Concurrency and async/await"** section in the documentation.

The original sentence: *"If your application (somehow) doesn't have to communicate with anything else and wait for it to respond, use async def."*

has been updated to:

*"If your application doesn't need to communicate with anything else or await a response, it's still safe to use `async def` -- even if there's nothing to `await`."*

### Why this change?
The original phrasing could be misinterpreted as recommending `async def` *even when it’s not useful*. The new wording keeps the reassuring tone but clarifies that using `async def` without `await` is safe — not required.

 Notes
- This update aims to reduce confusion, especially for developers new to asynchronous programming in Python.
- No functional or structural changes were made to the documentation layout.