### PR TITLE
add constraint to request_body_to_args to allow new test case in test

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -894,9 +894,13 @@ async def request_body_to_args(
     body_to_process = received_body
 
     fields_to_extract: List[ModelField] = body_fields
- 
-    if single_not_embedded_field and lenient_issubclass(first_field.type_, BaseModel) and isinstance(received_body, FormData):
-       fields_to_extract = get_cached_model_fields(first_field.type_)
+
+    if (
+        single_not_embedded_field
+        and lenient_issubclass(first_field.type_, BaseModel)
+        and isinstance(received_body, FormData)
+    ):
+        fields_to_extract = get_cached_model_fields(first_field.type_)
 
     if isinstance(received_body, FormData):
         body_to_process = await _extract_form_body(fields_to_extract, received_body)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -894,9 +894,9 @@ async def request_body_to_args(
     body_to_process = received_body
 
     fields_to_extract: List[ModelField] = body_fields
-
-    if single_not_embedded_field and lenient_issubclass(first_field.type_, BaseModel):
-        fields_to_extract = get_cached_model_fields(first_field.type_)
+ 
+    if single_not_embedded_field and lenient_issubclass(first_field.type_, BaseModel) and isinstance(received_body, FormData):
+       fields_to_extract = get_cached_model_fields(first_field.type_)
 
     if isinstance(received_body, FormData):
         body_to_process = await _extract_form_body(fields_to_extract, received_body)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -124,6 +124,7 @@ def test_propagates_pydantic2_model_config():
         "embedded_value": "bar",
     }
 
+
 def test_is_bytes_sequence_annotation_union():
     # For coverage
     # TODO: in theory this would allow declaring types that could be lists of bytes

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -80,6 +80,50 @@ def test_complex():
     assert response2.json() == [1, 2]
 
 
+@needs_pydanticv2
+def test_propagates_pydantic2_model_config():
+    app = FastAPI()
+
+    class Missing:
+        def __bool__(self):
+            return False
+
+    class EmbeddedModel(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        value: Union[str, Missing] = Missing()
+
+    class Model(BaseModel):
+        model_config = ConfigDict(
+            arbitrary_types_allowed=True,
+        )
+        value: Union[str, Missing] = Missing()
+        embedded_model: EmbeddedModel = EmbeddedModel()
+
+    @app.post("/")
+    def foo(req: Model) -> Dict[str, Union[str, None]]:
+        return {
+            "value": req.value or None,
+            "embedded_value": req.embedded_model.value or None,
+        }
+
+    client = TestClient(app)
+
+    response = client.post("/", json={})
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "value": None,
+        "embedded_value": None,
+    }
+
+    response2 = client.post(
+        "/", json={"value": "foo", "embedded_model": {"value": "bar"}}
+    )
+    assert response2.status_code == 200, response2.text
+    assert response2.json() == {
+        "value": "foo",
+        "embedded_value": "bar",
+    }
+
 def test_is_bytes_sequence_annotation_union():
     # For coverage
     # TODO: in theory this would allow declaring types that could be lists of bytes


### PR DESCRIPTION
This fixes a problem with the test case from https://github.com/fastapi/fastapi/pull/12504

The change means the if statement in `request_body_to_args` that was added in [this](https://github.com/fastapi/fastapi/pull/12129) commit for Forms, doesn't run for non Form data.

Further discussion on the problem is [here](https://github.com/fastapi/fastapi/discussions/13690) and [here](https://github.com/fastapi/fastapi/discussions/12503)

The test case was pulled from the PR by @RB387 above.