### PR TITLE
✨ Allow including custom scripts to Swagger UI

### DIFF
--- a/docs/de/docs/how-to/configure-swagger-ui.md
+++ b/docs/de/docs/how-to/configure-swagger-ui.md
@@ -61,7 +61,7 @@ FastAPI umfasst auch diese Nur-JavaScript-`presets`-Einstellungen:
 ```JavaScript
 presets: [
     SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
+    SwaggerUIStandalonePreset
 ]
 ```
 

--- a/docs/en/docs/how-to/configure-swagger-ui.md
+++ b/docs/en/docs/how-to/configure-swagger-ui.md
@@ -61,7 +61,7 @@ FastAPI also includes these JavaScript-only `presets` settings:
 ```JavaScript
 presets: [
     SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
+    SwaggerUIStandalonePreset
 ]
 ```
 

--- a/docs/es/docs/how-to/configure-swagger-ui.md
+++ b/docs/es/docs/how-to/configure-swagger-ui.md
@@ -61,7 +61,7 @@ FastAPI también incluye estas configuraciones `presets` solo de JavaScript:
 ```JavaScript
 presets: [
     SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
+    SwaggerUIStandalonePreset
 ]
 ```
 

--- a/docs/ko/docs/how-to/configure-swagger-ui.md
+++ b/docs/ko/docs/how-to/configure-swagger-ui.md
@@ -61,7 +61,7 @@ FastAPI는 이러한 JavaScript 전용 `presets` 설정을 포함하고 있습�
 ```JavaScript
 presets: [
     SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
+    SwaggerUIStandalonePreset
 ]
 ```
 

--- a/docs/pt/docs/how-to/configure-swagger-ui.md
+++ b/docs/pt/docs/how-to/configure-swagger-ui.md
@@ -61,7 +61,7 @@ O FastAPI também inclui estas configurações de `predefinições` somente para
 ```JavaScript
 presets: [
     SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
+    SwaggerUIStandalonePreset
 ]
 ```
 

--- a/docs/zh/docs/how-to/configure-swagger-ui.md
+++ b/docs/zh/docs/how-to/configure-swagger-ui.md
@@ -61,7 +61,7 @@ FastAPI 包含这些 JavaScript-only 的 `presets` 设置：
 ```JavaScript
 presets: [
     SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
+    SwaggerUIStandalonePreset
 ]
 ```
 

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -1,10 +1,9 @@
 import json
 from typing import Any, Dict, Optional, Set
 
+from fastapi.encoders import jsonable_encoder
 from starlette.responses import HTMLResponse
 from typing_extensions import Annotated, Doc
-
-from fastapi.encoders import jsonable_encoder
 
 swagger_ui_default_parameters: Annotated[
     Dict[str, Any],

--- a/tests/test_tutorial/test_configure_swagger_ui/test_tutorial001.py
+++ b/tests/test_tutorial/test_configure_swagger_ui/test_tutorial001.py
@@ -18,7 +18,7 @@ def test_swagger_ui():
     assert "SwaggerUIBundle.presets.apis," in response.text, (
         "default configs should be preserved"
     )
-    assert "SwaggerUIBundle.SwaggerUIStandalonePreset" in response.text, (
+    assert "SwaggerUIStandalonePreset" in response.text, (
         "default configs should be preserved"
     )
     assert '"layout": "BaseLayout",' in response.text, (

--- a/tests/test_tutorial/test_configure_swagger_ui/test_tutorial002.py
+++ b/tests/test_tutorial/test_configure_swagger_ui/test_tutorial002.py
@@ -21,7 +21,7 @@ def test_swagger_ui():
     assert "SwaggerUIBundle.presets.apis," in response.text, (
         "default configs should be preserved"
     )
-    assert "SwaggerUIBundle.SwaggerUIStandalonePreset" in response.text, (
+    assert "SwaggerUIStandalonePreset" in response.text, (
         "default configs should be preserved"
     )
     assert '"layout": "BaseLayout",' in response.text, (

--- a/tests/test_tutorial/test_configure_swagger_ui/test_tutorial003.py
+++ b/tests/test_tutorial/test_configure_swagger_ui/test_tutorial003.py
@@ -24,7 +24,7 @@ def test_swagger_ui():
     assert "SwaggerUIBundle.presets.apis," in response.text, (
         "default configs should be preserved"
     )
-    assert "SwaggerUIBundle.SwaggerUIStandalonePreset" in response.text, (
+    assert "SwaggerUIStandalonePreset" in response.text, (
         "default configs should be preserved"
     )
     assert '"layout": "BaseLayout",' in response.text, (


### PR DESCRIPTION
This fix the "StandaloneLayout" layout + enable user to add any other scripts to the Swagger UI through **swagger_ui_scripts**.


Before this PR, this code would never loaded
```
from fastapi import FastAPI

app = FastAPI(
    swagger_ui_parameters={
        "layout": "StandaloneLayout",
    },
)


@app.get("/")
async def root():
    return {"message": "Hello World"}
```

Now it will show the Swagger layout:
![image](https://github.com/user-attachments/assets/e912fbd2-e2d0-4acd-8e9a-fbad2320846d)


NOTE: The main bug comes from bad copy-paste of https://swagger.io/docs/open-source-tools/swagger-ui/usage/installation. The example used in FastAPI come from pure node. The actual example that must be used (JS Vanilla) includes **swagger-ui-standalone-preset.js**
