### PR TITLE
🔨 Resolve Pydantic deprecation warnings in internal script

### DIFF
--- a/scripts/label_approved.py
+++ b/scripts/label_approved.py
@@ -27,7 +27,7 @@ if settings.debug:
     logging.basicConfig(level=logging.DEBUG)
 else:
     logging.basicConfig(level=logging.INFO)
-logging.debug(f"Using config: {settings.json()}")
+logging.debug(f"Using config: {settings.model_dump_json()}")
 g = Github(settings.token.get_secret_value())
 repo = g.get_repo(settings.github_repository)
 for pr in repo.get_pulls(state="open"):
@@ -48,7 +48,7 @@ for pr in repo.get_pulls(state="open"):
     ]
     config = settings.config or default_config
     for approved_label, conf in config.items():
-        logging.debug(f"Processing config: {conf.json()}")
+        logging.debug(f"Processing config: {conf.model_dump_json()}")
         if conf.await_label is None or (conf.await_label in pr_label_by_name):
             logging.debug(f"Processable PR: {pr.number}")
             if len(approved_reviews) >= conf.number:


### PR DESCRIPTION
# PR Summary
This small PR resolves the Pydantic deprecation warnings:
```python
/home/runner/work/fastapi/fastapi/./scripts/label_approved.py:30: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/

/home/runner/work/fastapi/fastapi/./scripts/label_approved.py:51: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```