### PR TITLE
🐛 Fix truncating the model's description with form feed (`\f`) character for Pydantic V2

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -231,6 +231,9 @@ if PYDANTIC_V2:
         field_mapping, definitions = schema_generator.generate_definitions(
             inputs=inputs
         )
+        for item_def in definitions.values():
+            if "description" in item_def:
+                item_def["description"] = item_def["description"].split("\f")[0]
         return field_mapping, definitions  # type: ignore[return-value]
 
     def is_scalar_field(field: ModelField) -> bool:

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -16,6 +16,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 
 from fastapi.exceptions import RequestErrorModel
@@ -231,9 +232,10 @@ if PYDANTIC_V2:
         field_mapping, definitions = schema_generator.generate_definitions(
             inputs=inputs
         )
-        for item_def in definitions.values():
+        for item_def in cast(Dict[str, Dict[str, Any]], definitions).values():
             if "description" in item_def:
-                item_def["description"] = item_def["description"].split("\f")[0]
+                item_description = cast(str, item_def["description"]).split("\f")[0]
+                item_def["description"] = item_description
         return field_mapping, definitions  # type: ignore[return-value]
 
     def is_scalar_field(field: ModelField) -> bool:

--- a/tests/test_openapi_model_description_trim_on_formfeed.py
+++ b/tests/test_openapi_model_description_trim_on_formfeed.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
+
 class MyModel(BaseModel):
     """
     A model with a form feed character in the title.
@@ -11,9 +12,11 @@ class MyModel(BaseModel):
     Text after form feed character.
     """
 
+
 @app.get("/foo")
 def foo(v: MyModel):
     pass
+
 
 client = TestClient(app)
 

--- a/tests/test_openapi_model_description_trim_on_formfeed.py
+++ b/tests/test_openapi_model_description_trim_on_formfeed.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class MyModel(BaseModel):
+    """
+    A model with a form feed character in the title.
+    \f
+    Text after form feed character.
+    """
+
+@app.get("/foo")
+def foo(v: MyModel):
+    pass
+
+client = TestClient(app)
+
+
+def test_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+
+    assert openapi_schema["components"]["schemas"]["MyModel"]["description"] == (
+        "A model with a form feed character in the title.\n"
+    )

--- a/tests/test_openapi_model_description_trim_on_formfeed.py
+++ b/tests/test_openapi_model_description_trim_on_formfeed.py
@@ -14,7 +14,7 @@ class MyModel(BaseModel):
 
 
 @app.get("/foo")
-def foo(v: MyModel):
+def foo(v: MyModel):  # pragma: no cover
     pass
 
 


### PR DESCRIPTION
## Problem description 

```python
app = FastAPI()

class MyModel(BaseModel):
    """
    A model with a form feed character in the title.
    \f
    Text after form feed character.
    """

@app.get("/foo")
def foo(v: MyModel):
    pass
```

The code above will produce different **description** for `MyModel` in schema depending on whether **Pydantic V1** or **Pydantic V2** is used.

With **Pydantic V1** the description will be truncated starting from `\f` character (only first line will be in schema).
With **Pydantic V2** it will not be truncated (all 3 lines will be in schema).

Feature was introduced in #3032 .
But when the support of **Pydantic V2** was added to FastAPI this feature wasn't added to the code related to Pydantic V2 (I think it was just oversight).

## Related discussion(s):
https://github.com/fastapi/fastapi/discussions/9038


## Remark about `cast`
I added commit that improves typing of new part of code by using `cast`. Not sure it's needed. If not, it can be easily reverted.
