### PR TITLE
🚨 Upgrade matching versions for uvicorn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ standard = [
     # To validate email fields
     "email-validator >=2.0.0",
     # Uvicorn with uvloop
-    "uvicorn[standard] >0.32.0< 0.33.0",
+    "uvicorn[standard]>0.32.0,<0.33.0",
     # TODO: this should be part of some pydantic optional extra dependencies
     # # Settings management
     # "pydantic-settings >=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ standard = [
     # To validate email fields
     "email-validator >=2.0.0",
     # Uvicorn with uvloop
-    "uvicorn[standard] >=0.12.0",
+    "uvicorn[standard] >0.32.0< 0.33.0",
     # TODO: this should be part of some pydantic optional extra dependencies
     # # Settings management
     # "pydantic-settings >=2.0.0",


### PR DESCRIPTION
My specs for reference:

MacOS: Sequoia 15.5
Python Version: 3.13
uv: 0.7.3 (3c413f74b 2025-05-07)
pip: 25.0.1
Docker: no

Even though `fastapi` supports Python 3.13, it seems some dependencies are not. Today when I tried to run a `uv sync` for a new project I've started, I faced the following error:

```bash
  main is 📦 v1.0.0 via 🐍 v3.13.3 (joby)
❯ uv sync
Resolved 147 packages in 1ms
  × Failed to build `httptools==0.6.1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stdout]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.macosx-15.5-arm64-cpython-313/httptools
      copying httptools/_version.py -> build/lib.macosx-15.5-arm64-cpython-313/httptools
      copying httptools/__init__.py -> build/lib.macosx-15.5-arm64-cpython-313/httptools
      creating build/lib.macosx-15.5-arm64-cpython-313/httptools/parser
      copying httptools/parser/__init__.py -> build/lib.macosx-15.5-arm64-cpython-313/httptools/parser
      copying httptools/parser/errors.py -> build/lib.macosx-15.5-arm64-cpython-313/httptools/parser
      running egg_info
      writing httptools.egg-info/PKG-INFO
      writing dependency_links to httptools.egg-info/dependency_links.txt
      writing requirements to httptools.egg-info/requires.txt
      writing top-level names to httptools.egg-info/top_level.txt
      reading manifest file 'httptools.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      adding license file 'LICENSE'
      writing manifest file 'httptools.egg-info/SOURCES.txt'
      running build_ext
      building 'httptools.parser.parser' extension
      creating build/temp.macosx-15.5-arm64-cpython-313/httptools/parser
      creating build/temp.macosx-15.5-arm64-cpython-313/vendor/llhttp/src
      clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall -I/Users/mazulo/.cache/uv/sdists-v9/pypi/httptools/0.6.1/E1SxqtN2Ww2CSskAlQH18/src/vendor/llhttp/include -I/Users/mazulo/.cache/uv/sdists-v9/pypi/httptools/0.6.1/E1SxqtN2Ww2CSskAlQH18/src/vendor/llhttp/sr
c
      -I/Users/mazulo/.cache/uv/builds-v0/.tmpCLBw0t/include -I/Users/mazulo/.pyenv/versions/3.13.3/include/python3.13 -c httptools/parser/parser.c -o build/temp.macosx-15.5-arm64-cpython-313/httptools/parser/parser.o -O2

      [stderr]
      /Users/mazulo/.cache/uv/builds-v0/.tmpCLBw0t/lib/python3.13/site-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'test_suite'
        warnings.warn(msg)
      /Users/mazulo/.cache/uv/builds-v0/.tmpCLBw0t/lib/python3.13/site-packages/setuptools/dist.py:761: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: MIT License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        self._finalize_license_expression()
      httptools/parser/parser.c:849:59: warning: 'Py_UNICODE' is deprecated [-Wdeprecated-declarations]
        849 | static CYTHON_INLINE size_t __Pyx_Py_UNICODE_strlen(const Py_UNICODE *u) {
            |                                                           ^
      /Users/mazulo/.pyenv/versions/3.13.3/include/python3.13/cpython/unicodeobject.h:10:1: note: 'Py_UNICODE' has been explicitly marked deprecated here
         10 | Py_DEPRECATED(3.13) typedef wchar_t Py_UNICODE;
            | ^
      /Users/mazulo/.pyenv/versions/3.13.3/include/python3.13/pyport.h:251:54: note: expanded from macro 'Py_DEPRECATED'
        251 | #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
            |                                                      ^
      httptools/parser/parser.c:850:11: warning: 'Py_UNICODE' is deprecated [-Wdeprecated-declarations]
        850 |     const Py_UNICODE *u_end = u;
            |           ^
      /Users/mazulo/.pyenv/versions/3.13.3/include/python3.13/cpython/unicodeobject.h:10:1: note: 'Py_UNICODE' has been explicitly marked deprecated here
         10 | Py_DEPRECATED(3.13) typedef wchar_t Py_UNICODE;
            | ^
      /Users/mazulo/.pyenv/versions/3.13.3/include/python3.13/pyport.h:251:54: note: expanded from macro 'Py_DEPRECATED'
        251 | #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
            |                                                      ^
      httptools/parser/parser.c:3531:23: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
       3531 |       __pyx_v_err_pos = llhttp_get_error_pos(__pyx_v_self->_cparser);
            |                       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      httptools/parser/parser.c:9940:70: error: too few arguments to function call, expected 6, have 5
       9938 |                 int ret = _PyLong_AsByteArray((PyLongObject *)v,
            |                           ~~~~~~~~~~~~~~~~~~~
       9939 |                                               bytes, sizeof(val),
       9940 |                                               is_little, !is_unsigned);
            |                                                                      ^
      /Users/mazulo/.pyenv/versions/3.13.3/include/python3.13/cpython/longobject.h:111:17: note: '_PyLong_AsByteArray' declared here
        111 | PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
            |                 ^                   ~~~~~~~~~~~~~~~~
        112 |     unsigned char* bytes, size_t n,
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        113 |     int little_endian, int is_signed, int with_exceptions);
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      httptools/parser/parser.c:10136:70: error: too few arguments to function call, expected 6, have 5
       10134 |                 int ret = _PyLong_AsByteArray((PyLongObject *)v,
             |                           ~~~~~~~~~~~~~~~~~~~
       10135 |                                               bytes, sizeof(val),
       10136 |                                               is_little, !is_unsigned);
             |                                                                      ^
      /Users/mazulo/.pyenv/versions/3.13.3/include/python3.13/cpython/longobject.h:111:17: note: '_PyLong_AsByteArray' declared here
        111 | PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
            |                 ^                   ~~~~~~~~~~~~~~~~
        112 |     unsigned char* bytes, size_t n,
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        113 |     int little_endian, int is_signed, int with_exceptions);
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      3 warnings and 2 errors generated.
      error: command '/usr/bin/clang' failed with exit code 1

      hint: This usually indicates a problem with the package or the build environment.
  help: `httptools` (v0.6.1) was included because `joby` (v1.0.0) depends on `fastapi[standard]` (v0.115.12) which depends on `uvicorn[standard]` (v0.30.6) which depends on `httptools`
```

`httptools` added support for Python 3.13 on [v0.6.2](https://github.com/MagicStack/httptools/blob/v0.6.2/.github/workflows/tests.yml#L17) and uvicorn on [v0.32.1](https://github.com/encode/uvicorn/blob/0.32.1/pyproject.toml#L42). In order to mitigate that issue, this update will do the job.

I tried to follow the [contributing guidelines](https://fastapi.tiangolo.com/contributing/) the best I can, but let me know if I'm missing something or did something wrong! 😄 