### PR TITLE
:book: Update typing import for `Global Dependencies` example

### DIFF
--- a/docs_src/dependencies/tutorial012_an_py39.py
+++ b/docs_src/dependencies/tutorial012_an_py39.py
@@ -1,5 +1,6 @@
-from fastapi import Depends, FastAPI, Header, HTTPException
 from typing import Annotated
+
+from fastapi import Depends, FastAPI, Header, HTTPException
 
 
 async def verify_token(x_token: Annotated[str, Header()]):

--- a/docs_src/dependencies/tutorial012_an_py39.py
+++ b/docs_src/dependencies/tutorial012_an_py39.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, FastAPI, Header, HTTPException
-from typing_extensions import Annotated
+from typing import Annotated
 
 
 async def verify_token(x_token: Annotated[str, Header()]):


### PR DESCRIPTION
This PR updates an example from the tutorial to import `Annotated` from `typing` instead of `typing_extensions` for Python 3.9+. `typing.Annotated` was made available since 3.9.