### PR TITLE
📝 Fix internal anchor link in Spanish deployment docs

### DIFF
--- a/docs/es/docs/deployment/docker.md
+++ b/docs/es/docs/deployment/docker.md
@@ -6,7 +6,7 @@ Usar contenedores de Linux tiene varias ventajas, incluyendo **seguridad**, **re
 
 /// tip | Consejo
 
-¿Tienes prisa y ya conoces esto? Salta al [`Dockerfile` más abajo 👇](#build-a-docker-image-for-fastapi).
+¿Tienes prisa y ya conoces esto? Salta al [`Dockerfile` más abajo 👇](#construir-una-imagen-de-docker-para-fastapi).
 
 ///
 


### PR DESCRIPTION
Updated the anchor link in the Spanish version of the deployment documentation
to match the translated section header (#construir-una-imagen-de-docker-para-fastapi).