### PR TITLE
⬆️ Bump Starlette to allow up to 0.47.0: `>=0.40.0,<0.48.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.40.0,<0.47.0",
+    "starlette>=0.40.0,<0.48.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
 ]


### PR DESCRIPTION
The [release notes for Starlette 0.47.0](https://github.com/encode/starlette/releases/tag/0.47.0) do not mention any changes that should be incompatible, and FastAPI’s test suite still passes.

Mentioning @Kludex just to keep him in the loop.