### PR TITLE
📝 Clarify that OpenIdConnect does not perform token validation

### DIFF
--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -24,6 +24,12 @@ class APIKeyQuery(APIKeyBase):
     """
     API key authentication using a query parameter.
 
+    Note:
+    This class does **not** perform API key validation or decoding.
+    It only extracts the key from the request and provides OpenAPI integration.
+
+    You must implement the actual verification logic yourself (e.g., checking against a database or list of valid keys).
+
     This defines the name of the query parameter that should be provided in the request
     with the API key and integrates that into the OpenAPI documentation. It extracts
     the key value sent in the query parameter automatically and provides it as the
@@ -116,6 +122,12 @@ class APIKeyHeader(APIKeyBase):
     """
     API key authentication using a header.
 
+    Note:
+    This class does **not** perform API key validation or decoding.
+    It only extracts the key from the request and provides OpenAPI integration.
+
+    You must implement the actual verification logic yourself (e.g., checking against a database or list of valid keys).
+
     This defines the name of the header that should be provided in the request with
     the API key and integrates that into the OpenAPI documentation. It extracts
     the key value sent in the header automatically and provides it as the dependency
@@ -203,6 +215,12 @@ class APIKeyHeader(APIKeyBase):
 class APIKeyCookie(APIKeyBase):
     """
     API key authentication using a cookie.
+    
+    Note:
+    This class does **not** perform API key validation or decoding.
+    It only extracts the key from the request and provides OpenAPI integration.
+
+    You must implement the actual verification logic yourself (e.g., checking against a database or list of valid keys).
 
     This defines the name of the cookie that should be provided in the request with
     the API key and integrates that into the OpenAPI documentation. It extracts

--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -215,7 +215,7 @@ class APIKeyHeader(APIKeyBase):
 class APIKeyCookie(APIKeyBase):
     """
     API key authentication using a cookie.
-    
+
     Note:
     This class does **not** perform API key validation or decoding.
     It only extracts the key from the request and provides OpenAPI integration.

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -393,6 +393,11 @@ class OAuth2PasswordBearer(OAuth2):
     OAuth2 flow for authentication using a bearer token obtained with a password.
     An instance of it would be used as a dependency.
 
+    Note:
+    This class does **not** perform token validation or decoding.
+    It only extracts the `Authorization` header and includes metadata in the OpenAPI docs.
+    You must handle actual token validation separately (e.g. signature and claims verification).
+
     Read more about it in the
     [FastAPI docs for Simple OAuth2 with Password and Bearer](https://fastapi.tiangolo.com/tutorial/security/simple-oauth2/).
     """
@@ -489,6 +494,11 @@ class OAuth2AuthorizationCodeBearer(OAuth2):
     """
     OAuth2 flow for authentication using a bearer token obtained with an OAuth2 code
     flow. An instance of it would be used as a dependency.
+
+    Note:
+    This class does **not** perform token validation or decoding.
+    It only extracts the `Authorization` header and includes metadata in the OpenAPI docs.
+    You must handle actual token validation separately (e.g. signature and claims verification).
     """
 
     def __init__(

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -12,6 +12,13 @@ class OpenIdConnect(SecurityBase):
     """
     OpenID Connect authentication class. An instance of it would be used as a
     dependency.
+
+    Note:
+    This class **does not perform any token validation or decoding**.
+    It only extracts the `Authorization` header and includes metadata in the OpenAPI docs.
+
+    You must implement the actual authentication logic separately (e.g., verifying
+    the token signature, claims, and user handling).
     """
 
     def __init__(


### PR DESCRIPTION
This PR updates the docstring of the `OpenIdConnect` class to clarify that:

- It does **not** perform token validation or decoding.
- It only extracts the `Authorization` header and integrates with OpenAPI docs.
- Developers must implement actual authentication logic separately.

This change aims to prevent confusion and reduce the risk of unintentional misuse in production environments.