### PR TITLE
✨ Extract descriptions of parameters and responses from docstring

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -141,7 +141,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 '''
                 A description of the API. Supports Markdown (using

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1064,7 +1064,7 @@ class FastAPI(Starlette):
         dependencies: Optional[Sequence[Depends]] = None,
         summary: Optional[str] = None,
         description: Optional[str] = None,
-        response_description: str = "Successful Response",
+        response_description: Optional[str] = None,
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
         deprecated: Optional[bool] = None,
         methods: Optional[List[str]] = None,
@@ -1122,7 +1122,7 @@ class FastAPI(Starlette):
         dependencies: Optional[Sequence[Depends]] = None,
         summary: Optional[str] = None,
         description: Optional[str] = None,
-        response_description: str = "Successful Response",
+        response_description: Optional[str] = None,
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
         deprecated: Optional[bool] = None,
         methods: Optional[List[str]] = None,
@@ -1574,7 +1574,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -1582,7 +1582,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(
@@ -1947,7 +1947,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -1955,7 +1955,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(
@@ -2325,7 +2325,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -2333,7 +2333,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(
@@ -2703,7 +2703,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -2711,7 +2711,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(
@@ -3076,7 +3076,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -3084,7 +3084,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(
@@ -3449,7 +3449,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -3457,7 +3457,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(
@@ -3822,7 +3822,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -3830,7 +3830,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(
@@ -4200,7 +4200,7 @@ class FastAPI(Starlette):
             ),
         ] = None,
         response_description: Annotated[
-            str,
+            Optional[str],
             Doc(
                 """
                 The description for the default response.
@@ -4208,7 +4208,7 @@ class FastAPI(Starlette):
                 It will be added to the generated OpenAPI (e.g. visible at `/docs`).
                 """
             ),
-        ] = "Successful Response",
+        ] = None,
         responses: Annotated[
             Optional[Dict[Union[int, str], Dict[str, Any]]],
             Doc(

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -100,7 +100,7 @@ def _get_openapi_operation_parameters(
     field_mapping: Dict[
         Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
     ],
-    field_docstring: Dict[str, str] | None = None,
+    field_docstring: Optional[Dict[str, str]] = None,
     separate_input_output_schemas: bool = True,
 ) -> List[Dict[str, Any]]:
     parameters = []
@@ -240,9 +240,12 @@ def get_openapi_operation_metadata(
         operation["description"] = "\n\n".join(
             [i.value for i in route.parsed_docstring if i.kind == "text"]
         )
+        operation["description"] = operation["description"].split("\f")[0].strip()
+        if not operation["description"]:
+            del operation["description"]
     if route.description:
         operation["description"] = route.description
-    operation["description"] = operation["description"].split("\f")[0].strip()
+        operation["description"] = operation["description"].split("\f")[0].strip()
 
     operation_id = route.operation_id or route.unique_id
     if operation_id in operation_ids:

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -100,6 +100,7 @@ def _get_openapi_operation_parameters(
     field_mapping: Dict[
         Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
     ],
+    field_docstring: Dict[str, str] | None = None,
     separate_input_output_schemas: bool = True,
 ) -> List[Dict[str, Any]]:
     parameters = []
@@ -115,6 +116,7 @@ def _get_openapi_operation_parameters(
         (ParamTypes.cookie, cookie_params),
     ]
     default_convert_underscores = True
+    field_docstring = field_docstring or {}
     if len(flat_dependant.header_params) == 1:
         first_field = flat_dependant.header_params[0]
         if lenient_issubclass(first_field.type_, BaseModel):
@@ -155,6 +157,8 @@ def _get_openapi_operation_parameters(
             }
             if field_info.description:
                 parameter["description"] = field_info.description
+            elif param.name in field_docstring:
+                parameter["description"] = field_docstring[param.name]
             openapi_examples = getattr(field_info, "openapi_examples", None)
             example = getattr(field_info, "example", None)
             if openapi_examples:
@@ -232,8 +236,14 @@ def get_openapi_operation_metadata(
     if route.tags:
         operation["tags"] = route.tags
     operation["summary"] = generate_operation_summary(route=route, method=method)
+    if route.parsed_docstring:
+        operation["description"] = "\n\n".join(
+            [i.value for i in route.parsed_docstring if i.kind == "text"]
+        )
     if route.description:
         operation["description"] = route.description
+    operation["description"] = operation["description"].split("\f")[0].strip()
+
     operation_id = route.operation_id or route.unique_id
     if operation_id in operation_ids:
         message = (
@@ -273,6 +283,10 @@ def get_openapi_path(
     assert current_response_class, "A response class is needed to generate OpenAPI"
     route_response_media_type: Optional[str] = current_response_class.media_type
     if route.include_in_schema:
+        args = [i.value for i in route.parsed_docstring if i.kind == "parameters"]
+        args_docstring_mapping = (
+            {a.name: a.description for a in args[0]} if len(args) == 1 else {}
+        )
         for method in route.methods:
             operation = get_openapi_operation_metadata(
                 route=route, method=method, operation_ids=operation_ids
@@ -292,6 +306,7 @@ def get_openapi_path(
                 model_name_map=model_name_map,
                 field_mapping=field_mapping,
                 separate_input_output_schemas=separate_input_output_schemas,
+                field_docstring=args_docstring_mapping,
             )
             parameters.extend(operation_parameters)
             if parameters:
@@ -348,9 +363,19 @@ def get_openapi_path(
                 if status_code_param is not None:
                     if isinstance(status_code_param.default, int):
                         status_code = str(status_code_param.default)
+            response_description = ""
+            if route.parsed_docstring:
+                ret = [i.value for i in route.parsed_docstring if i.kind == "returns"]
+                response_description = (
+                    ",".join(x.description for x in ret[0])
+                    if len(ret) == 1
+                    else "Successful Response"
+                )
+            if route.response_description:
+                response_description = route.response_description
             operation.setdefault("responses", {}).setdefault(status_code, {})[
                 "description"
-            ] = route.response_description
+            ] = response_description
             if route_response_media_type and is_body_allowed_for_status_code(
                 route.status_code
             ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "starlette>=0.40.0,<0.47.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
+    "griffe>=1.7.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "starlette>=0.40.0,<0.47.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
-    "griffe>=1.7.0",
+    "griffe>=1.4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This pull request implements parsing docstrings via griffe and sets the relevant openapi descriptions to the corresponding docstring part.

The openapi has 3 description fields: the route itself, each parameter and the response.
With docstrings, you can only set one: The route itself. You can set the description for parameter and response using attributes in the router or annotations.
If I describe the function with all arguments, e.g. to build a documentation via mkdocs, the arguments that get autofilled by depends will appear in the openapi spec. If I want the description in the openapi spec and in the docstring there will be redundancy. Doing it only in the fastapi part, it will not be part of mkdocs (or similar).
As described by #3225, using docstrings is complicated, because the structure is not standardized. So I solve this using griffe, which can parse the most common formats (google, numpy, sphinx). Currently i set it to google format, but the plan is to make this configurable. However, if the description is set by fastapi attributes, this will take precedence.

```python
@router.get(
    "/events/{eventId}",
    status_code=status.HTTP_200_OK,
    summary="Get event details",
)
@alog
async def get_event_details(
    auth: Annotated[Auth, Depends(authorize(AuthStrategy.HYBRID))],
    db: Annotated[AsyncSession, Depends(get_db)],
    event_id: Annotated[int | uuid.UUID, Path(alias="eventId")],
) -> AddEditGetEventResponse:
    """Retrieve details of a specific event either by its event ID, or via its UUID.

    args:
        auth: the user's authentification status
        db: the current database
        event_id: the ID or UUID of the event

    returns:
        the event details
    """
    return await _get_event_details(db, event_id, auth.user)
```

will be converted to:

![image](https://github.com/user-attachments/assets/43767a4b-3594-40f6-9c61-01d0ace72613)

Before i continue to work on this, i want to know if adding a dependency is ok. If so, i would allow to set the parse format of the docstring (griffe supports google, numpy and sphinx). 