### PR TITLE
📝 Update `docs/en/docs/advanced/generate-clients.md`

### DIFF
--- a/docs/en/docs/advanced/generate-clients.md
+++ b/docs/en/docs/advanced/generate-clients.md
@@ -10,7 +10,7 @@ There are many tools to generate clients from **OpenAPI**.
 
 A common tool is <a href="https://openapi-generator.tech/" class="external-link" target="_blank">OpenAPI Generator</a>.
 
-If you are building a **frontend**, a very interesting alternative is <a href="https://github.com/hey-api/openapi-ts" class="external-link" target="_blank">openapi-ts</a>.
+If you are building a **TypeScript client**, another open-source alternative is <a href="https://github.com/hey-api/openapi-ts" class="external-link" target="_blank">@hey-api/openapi-ts</a>.
 
 ## Client and SDK Generators - Sponsor
 
@@ -23,7 +23,7 @@ And it shows their true commitment to FastAPI and its **community** (you), as th
 For example, you might want to try:
 
 * <a href="https://speakeasy.com/editor?utm_source=fastapi+repo&utm_medium=github+sponsorship" class="external-link" target="_blank">Speakeasy</a>
-* <a href="https://www.stainlessapi.com/?utm_source=fastapi&utm_medium=referral" class="external-link" target="_blank">Stainless</a>
+* <a href="https://www.stainless.com/?utm_source=fastapi&utm_medium=referral" class="external-link" target="_blank">Stainless</a>
 * <a href="https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi" class="external-link" target="_blank">liblab</a>
 
 There are also several other companies offering similar services that you can search and find online. 🤓
@@ -50,11 +50,11 @@ And that same information from the models that is included in OpenAPI is what ca
 
 ### Generate a TypeScript Client
 
-Now that we have the app with the models, we can generate the client code for the frontend.
+Now that we have the app with the models, we can generate a TypeScript client.
 
-#### Install `openapi-ts`
+#### Install `@hey-api/openapi-ts`
 
-You can install `openapi-ts` in your frontend code with:
+You can install `@hey-api/openapi-ts` in your TypeScript project with:
 
 <div class="termy">
 
@@ -81,18 +81,18 @@ It could look like this:
   "description": "",
   "main": "index.js",
   "scripts": {
-    "generate-client": "openapi-ts --input http://localhost:8000/openapi.json --output ./src/client --client axios"
+    "generate-client": "openapi-ts -i http://localhost:8000/openapi.json -o ./src/client"
   },
   "author": "",
   "license": "",
   "devDependencies": {
-    "@hey-api/openapi-ts": "^0.27.38",
-    "typescript": "^4.6.2"
+    "@hey-api/openapi-ts": "^0.73.0",
+    "typescript": "^5.8.3"
   }
 }
 ```
 
-After having that NPM `generate-client` script there, you can run it with:
+After having that npm `generate-client` script there, you can run it with:
 
 <div class="termy">
 
@@ -100,12 +100,12 @@ After having that NPM `generate-client` script there, you can run it with:
 $ npm run generate-client
 
 frontend-app@1.0.0 generate-client /home/user/code/frontend-app
-> openapi-ts --input http://localhost:8000/openapi.json --output ./src/client --client axios
+> openapi-ts -i http://localhost:8000/openapi.json -o ./src/client
 ```
 
 </div>
 
-That command will generate code in `./src/client` and will use `axios` (the frontend HTTP library) internally.
+That command will generate code in `./src/client` and will use [`Fetch API`](https://developer.mozilla.org/docs/Web/API/Fetch_API) internally.
 
 ### Try Out the Client Code
 
@@ -229,7 +229,7 @@ Now as the end result is in a file `openapi.json`, you would modify the `package
   "description": "",
   "main": "index.js",
   "scripts": {
-    "generate-client": "openapi-ts --input ./openapi.json --output ./src/client --client axios"
+    "generate-client": "openapi-ts -i ./openapi.json -o ./src/client"
   },
   "author": "",
   "license": "",

--- a/docs/en/docs/advanced/generate-clients.md
+++ b/docs/en/docs/advanced/generate-clients.md
@@ -4,13 +4,13 @@ Because **FastAPI** is based on the **OpenAPI** specification, its APIs can be d
 
 This makes it easy to generate up-to-date **documentation**, client libraries (<abbr title="Software Development Kits">**SDKs**</abbr>) in multiple languages, and **testing** or **automation workflows** that stay in sync with your code.
 
-In this guide, you’ll learn how to generate a **TypeScript SDK** for your FastAPI backend.
+In this guide, you'll learn how to generate a **TypeScript SDK** for your FastAPI backend.
 
 ## Open Source SDK Generators
 
 A versatile option is the <a href="https://openapi-generator.tech/" class="external-link" target="_blank">OpenAPI Generator</a>, which supports **many programming languages** and can generate SDKs from your OpenAPI specification.
 
-For **TypeScript clients**, <a href="https://heyapi.dev/" class="external-link" target="_blank">Hey API</a> (sponsored by FastAPI) is a purpose-built solution, providing an optimized experience for the TypeScript ecosystem.
+For **TypeScript clients**, <a href="https://heyapi.dev/" class="external-link" target="_blank">Hey API</a> is a purpose-built solution, providing an optimized experience for the TypeScript ecosystem.
 
 You can discover more SDK generators on <a href="https://openapi.tools/#sdk" class="external-link" target="_blank">OpenAPI.Tools</a>.
 
@@ -37,12 +37,6 @@ For example, you might want to try:
 Some of these solutions may also be open source or offer free tiers, so you can try them without a financial commitment. Other commercial SDK generators are available and can be found online. 🤓
 
 ## Create a TypeScript SDK
-
-/// tip
-
-Parts of this tutorial might not be up-to-date. If you spot a problem, please open a <a href="https://github.com/fastapi/fastapi/issues" class="external-link" target="_blank">GitHub issue</a>.
-
-///
 
 Let's start with a simple FastAPI application:
 
@@ -100,7 +94,7 @@ The response object will also have autocompletion:
 
 ## FastAPI App with Tags
 
-In many cases your FastAPI app will be bigger, and you will probably use tags to separate different groups of *path operations*.
+In many cases, your FastAPI app will be bigger, and you will probably use tags to separate different groups of *path operations*.
 
 For example, you could have a section for **items** and another section for **users**, and they could be separated by tags:
 
@@ -110,18 +104,18 @@ For example, you could have a section for **items** and another section for **us
 
 If you generate a client for a FastAPI app using tags, it will normally also separate the client code based on the tags.
 
-This way you will be able to have things ordered and grouped correctly for the client code:
+This way, you will be able to have things ordered and grouped correctly for the client code:
 
 <img src="/img/tutorial/generate-clients/image06.png">
 
-In this case you have:
+In this case, you have:
 
 * `ItemsService`
 * `UsersService`
 
 ### Client Method Names
 
-Right now the generated method names like `createItemItemsPost` don't look very clean:
+Right now, the generated method names like `createItemItemsPost` don't look very clean:
 
 ```TypeScript
 ItemsService.createItemItemsPost({name: "Plumbus", price: 5})
@@ -137,13 +131,13 @@ But I'll show you how to improve that next. 🤓
 
 You can **modify** the way these operation IDs are **generated** to make them simpler and have **simpler method names** in the clients.
 
-In this case you will have to ensure that each operation ID is **unique** in some other way.
+In this case, you will have to ensure that each operation ID is **unique** in some other way.
 
 For example, you could make sure that each *path operation* has a tag, and then generate the operation ID based on the **tag** and the *path operation* **name** (the function name).
 
 ### Custom Generate Unique ID Function
 
-FastAPI uses a **unique ID** for each *path operation*, it is used for the **operation ID** and also for the names of any needed custom models, for requests or responses.
+FastAPI uses a **unique ID** for each *path operation*, which is used for the **operation ID** and also for the names of any needed custom models, for requests or responses.
 
 You can customize that function. It takes an `APIRoute` and outputs a string.
 
@@ -155,7 +149,7 @@ You can then pass that custom function to **FastAPI** as the `generate_unique_id
 
 ### Generate a TypeScript Client with Custom Operation IDs
 
-Now if you generate the client again, you will see that it has the improved method names:
+Now, if you generate the client again, you will see that it has the improved method names:
 
 <img src="/img/tutorial/generate-clients/image07.png">
 
@@ -169,7 +163,7 @@ We already know that this method is related to the **items** because that word i
 
 We will probably still want to keep it for OpenAPI in general, as that will ensure that the operation IDs are **unique**.
 
-But for the generated client we could **modify** the OpenAPI operation IDs right before generating the clients, just to make those method names nicer and **cleaner**.
+But for the generated client, we could **modify** the OpenAPI operation IDs right before generating the clients, just to make those method names nicer and **cleaner**.
 
 We could download the OpenAPI JSON to a file `openapi.json` and then we could **remove that prefixed tag** with a script like this:
 
@@ -199,7 +193,7 @@ After generating the new client, you would now have **clean method names**, with
 
 ## Benefits
 
-When using the automatically generated clients you would get **autocompletion** for:
+When using the automatically generated clients, you would get **autocompletion** for:
 
 * Methods.
 * Request payloads in the body, query parameters, etc.
@@ -209,6 +203,6 @@ You would also have **inline errors** for everything.
 
 And whenever you update the backend code, and **regenerate** the frontend, it would have any new *path operations* available as methods, the old ones removed, and any other change would be reflected on the generated code. 🤓
 
-This also means that if something changed it will be **reflected** on the client code automatically. And if you **build** the client it will error out if you have any **mismatch** in the data used.
+This also means that if something changed, it will be **reflected** on the client code automatically. And if you **build** the client, it will error out if you have any **mismatch** in the data used.
 
 So, you would **detect many errors** very early in the development cycle instead of having to wait for the errors to show up to your final users in production and then trying to debug where the problem is. ✨

--- a/docs/en/docs/advanced/generate-clients.md
+++ b/docs/en/docs/advanced/generate-clients.md
@@ -1,24 +1,32 @@
-# Generate Clients
+# Generating SDKs
 
-As **FastAPI** is based on the OpenAPI specification, you get automatic compatibility with many tools, including the automatic API docs (provided by Swagger UI).
+Because **FastAPI** is based on the **OpenAPI** specification, its APIs can be described in a standard format that many tools understand.
 
-One particular advantage that is not necessarily obvious is that you can **generate clients** (sometimes called <abbr title="Software Development Kits">**SDKs**</abbr> ) for your API, for many different **programming languages**.
+This makes it easy to generate up-to-date **documentation**, client libraries (<abbr title="Software Development Kits">**SDKs**</abbr>) in multiple languages, and **testing** or **automation workflows** that stay in sync with your code.
 
-## OpenAPI Client Generators
+In this guide, you’ll learn how to generate a **TypeScript SDK** for your FastAPI backend.
 
-There are many tools to generate clients from **OpenAPI**.
+## Open Source SDK Generators
 
-A common tool is <a href="https://openapi-generator.tech/" class="external-link" target="_blank">OpenAPI Generator</a>.
+A versatile option is the <a href="https://openapi-generator.tech/" class="external-link" target="_blank">OpenAPI Generator</a>, which supports **many programming languages** and can generate SDKs from your OpenAPI specification.
 
-If you are building a **TypeScript client**, another open-source alternative is <a href="https://github.com/hey-api/openapi-ts" class="external-link" target="_blank">@hey-api/openapi-ts</a>.
+For **TypeScript clients**, <a href="https://heyapi.dev/" class="external-link" target="_blank">Hey API</a> (sponsored by FastAPI) is a purpose-built solution, providing an optimized experience for the TypeScript ecosystem.
 
-## Client and SDK Generators - Sponsor
+You can discover more SDK generators on <a href="https://openapi.tools/#sdk" class="external-link" target="_blank">OpenAPI.Tools</a>.
 
-There are also some **company-backed** Client and SDK generators based on OpenAPI (FastAPI), in some cases they can offer you **additional features** on top of high-quality generated SDKs/clients.
+/// tip
 
-Some of them also ✨ [**sponsor FastAPI**](../help-fastapi.md#sponsor-the-author){.internal-link target=_blank} ✨, this ensures the continued and healthy **development** of FastAPI and its **ecosystem**.
+FastAPI automatically generates **OpenAPI 3.1** specifications, so any tool you use must support this version.
 
-And it shows their true commitment to FastAPI and its **community** (you), as they not only want to provide you a **good service** but also want to make sure you have a **good and healthy framework**, FastAPI. 🙇
+///
+
+## SDK Generators from FastAPI Sponsors
+
+This section highlights **venture-backed** and **company-supported** solutions from companies that sponsor FastAPI. These products provide **additional features** and **integrations** on top of high-quality generated SDKs.
+
+By ✨ [**sponsoring FastAPI**](../help-fastapi.md#sponsor-the-author){.internal-link target=_blank} ✨, these companies help ensure the framework and its **ecosystem** remain healthy and **sustainable**.
+
+Their sponsorship also demonstrates a strong commitment to the FastAPI **community** (you), showing that they care not only about offering a **great service** but also about supporting a **robust and thriving framework**, FastAPI. 🙇
 
 For example, you might want to try:
 
@@ -26,9 +34,15 @@ For example, you might want to try:
 * <a href="https://www.stainless.com/?utm_source=fastapi&utm_medium=referral" class="external-link" target="_blank">Stainless</a>
 * <a href="https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi" class="external-link" target="_blank">liblab</a>
 
-There are also several other companies offering similar services that you can search and find online. 🤓
+Some of these solutions may also be open source or offer free tiers, so you can try them without a financial commitment. Other commercial SDK generators are available and can be found online. 🤓
 
-## Generate a TypeScript Frontend Client
+## Create a TypeScript SDK
+
+/// tip
+
+Parts of this tutorial might not be up-to-date. If you spot a problem, please open a <a href="https://github.com/fastapi/fastapi/issues" class="external-link" target="_blank">GitHub issue</a>.
+
+///
 
 Let's start with a simple FastAPI application:
 
@@ -38,78 +52,31 @@ Notice that the *path operations* define the models they use for request payload
 
 ### API Docs
 
-If you go to the API docs, you will see that it has the **schemas** for the data to be sent in requests and received in responses:
+If you go to `/docs`, you will see that it has the **schemas** for the data to be sent in requests and received in responses:
 
 <img src="/img/tutorial/generate-clients/image01.png">
 
 You can see those schemas because they were declared with the models in the app.
 
-That information is available in the app's **OpenAPI schema**, and then shown in the API docs (by Swagger UI).
+That information is available in the app's **OpenAPI schema**, and then shown in the API docs.
 
-And that same information from the models that is included in OpenAPI is what can be used to **generate the client code**.
+That same information from the models that is included in OpenAPI is what can be used to **generate the client code**.
 
-### Generate a TypeScript Client
+### Hey API
 
-Now that we have the app with the models, we can generate a TypeScript client.
+Once we have a FastAPI app with the models, we can use Hey API to generate a TypeScript client. The fastest way to do that is via npx.
 
-#### Install `@hey-api/openapi-ts`
-
-You can install `@hey-api/openapi-ts` in your TypeScript project with:
-
-<div class="termy">
-
-```console
-$ npm install @hey-api/openapi-ts --save-dev
-
----> 100%
+```sh
+npx @hey-api/openapi-ts -i http://localhost:8000/openapi.json -o src/client
 ```
 
-</div>
+This will generate a TypeScript SDK in `./src/client`.
 
-#### Generate Client Code
+You can learn how to <a href="https://heyapi.dev/openapi-ts/get-started" class="external-link" target="_blank">install `@hey-api/openapi-ts`</a> and read about the <a href="https://heyapi.dev/openapi-ts/output" class="external-link" target="_blank">generated output</a> on their website.
 
-To generate the client code you can use the command line application `openapi-ts` that would now be installed.
+### Using the SDK
 
-Because it is installed in the local project, you probably wouldn't be able to call that command directly, but you would put it on your `package.json` file.
-
-It could look like this:
-
-```JSON  hl_lines="7"
-{
-  "name": "frontend-app",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "generate-client": "openapi-ts -i http://localhost:8000/openapi.json -o ./src/client"
-  },
-  "author": "",
-  "license": "",
-  "devDependencies": {
-    "@hey-api/openapi-ts": "^0.73.0",
-    "typescript": "^5.8.3"
-  }
-}
-```
-
-After having that npm `generate-client` script there, you can run it with:
-
-<div class="termy">
-
-```console
-$ npm run generate-client
-
-frontend-app@1.0.0 generate-client /home/user/code/frontend-app
-> openapi-ts -i http://localhost:8000/openapi.json -o ./src/client
-```
-
-</div>
-
-That command will generate code in `./src/client` and will use [`Fetch API`](https://developer.mozilla.org/docs/Web/API/Fetch_API) internally.
-
-### Try Out the Client Code
-
-Now you can import and use the client code, it could look like this, notice that you get autocompletion for the methods:
+Now you can import and use the client code. It could look like this, notice that you get autocompletion for the methods:
 
 <img src="/img/tutorial/generate-clients/image02.png">
 
@@ -220,24 +187,10 @@ With that, the operation IDs would be renamed from things like `items-get_items`
 
 ### Generate a TypeScript Client with the Preprocessed OpenAPI
 
-Now as the end result is in a file `openapi.json`, you would modify the `package.json` to use that local file, for example:
+Since the end result is now in an `openapi.json` file, you need to update your input location:
 
-```JSON  hl_lines="7"
-{
-  "name": "frontend-app",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "generate-client": "openapi-ts -i ./openapi.json -o ./src/client"
-  },
-  "author": "",
-  "license": "",
-  "devDependencies": {
-    "@hey-api/openapi-ts": "^0.27.38",
-    "typescript": "^4.6.2"
-  }
-}
+```sh
+npx @hey-api/openapi-ts -i ./openapi.json -o src/client
 ```
 
 After generating the new client, you would now have **clean method names**, with all the **autocompletion**, **inline errors**, etc:


### PR DESCRIPTION
I've made the following changes to improve this guide.
- update title to reference "SDKs" over "clients" as people are more familiar with this term
- highlight other use cases for OpenAPI beyond generating SDKs
- add a link to OpenAPI.Tools so people can discover more tools
- highlight that FastAPI uses OpenAPI 3.1, so tooling needs to support that version
- clarify the sponsors section
- update Stainless domain
- use the `npx` command for `@hey-api/openapi-ts` so it's faster to get started
- fix broken "copy to clipboard" buttons
- simplify right-hand side navigation from 3 to 2 levels
- reference Hey API docs for more details, so it's hopefully easier to maintain this guide
- add a note encouraging people to open an issue if they want us to update the remaining out-of-date references