### PR TITLE
docs: add nox and lint instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing! 🎉
 
-Please refer to the complete guide at:  
+Please refer to the complete guide at:
 👉 [Development - Contributing](https://fastapi.tiangolo.com/contributing/)
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,28 @@
-Please read the [Development - Contributing](https://fastapi.tiangolo.com/contributing/) guidelines in the documentation site.
+# Contributing to FastAPI
+
+Thank you for your interest in contributing! 🎉
+
+Please refer to the complete guide at:  
+👉 [Development - Contributing](https://fastapi.tiangolo.com/contributing/)
+
+---
+
+## Code Style and Formatting
+
+Before submitting a Pull Request, please make sure your code matches the project's style guidelines.
+
+### Install `nox`
+
+We use [nox](https://nox.thea.codes/) to run automated sessions like linters and formatters.
+
+Install it using pip:
+
+```bash
+pip install nox
+```
+Then, run the linting session with:
+
+```bash
+nox -s lint
+```
+This command runs the same checks used in the continuous integration (CI) process to ensure your code follows the style conventions of the project.


### PR DESCRIPTION
This PR adds instructions to the CONTRIBUTING.md file on how to install `nox` and run `nox -s lint` locally.

These steps help contributors run the same formatting and style checks used in the CI pipeline before submitting a pull request.

Fixes #13399.
