### PR TITLE
Fix CORSMiddleware example in tutorial

### DIFF
--- a/docs_src/cors/tutorial001.py
+++ b/docs_src/cors/tutorial001.py
@@ -11,11 +11,12 @@ origins = [
 ]
 
 app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    CORSMiddleware(
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"]
+    )
 )
 
 

--- a/docs_src/cors/tutorial001.py
+++ b/docs_src/cors/tutorial001.py
@@ -15,7 +15,7 @@ app.add_middleware(
         allow_origins=origins,
         allow_credentials=True,
         allow_methods=["*"],
-        allow_headers=["*"]
+        allow_headers=["*"],
     )
 )
 


### PR DESCRIPTION
~~I've been working through the FastAPI tutorial and noticed an error in the CORS Middleware example. The parameters should be passed to the CORSMiddleware class, not add_middleware.~~

Actually nevermind, I just copied it wrong. Apologies and feel free to close / delete this MR.