### PR TITLE
Fix ModelField alias property

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -93,13 +93,18 @@ if PYDANTIC_V2:
 
         @property
         def alias(self) -> str:
-            match self.mode:
-                case "validation" if self.field_info.validation_alias is not None:
-                    a = self.field_info.validation_alias
-                case "serialization" if self.field_info.serialization_alias is not None:
-                    a = self.field_info.serialization_alias
-                case _:
-                    a = self.field_info.alias
+            if (
+                self.mode == "validation"
+                and self.field_info.validation_alias is not None
+            ):
+                a = self.field_info.validation_alias
+            elif (
+                self.mode == "serialization"
+                and self.field_info.serialization_alias is not None
+            ):
+                a = self.field_info.serialization_alias
+            else:
+                a = self.field_info.alias
             return a if a is not None else self.name
 
         @property

--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -93,7 +93,13 @@ if PYDANTIC_V2:
 
         @property
         def alias(self) -> str:
-            a = self.field_info.alias
+            match self.mode:
+                case "validation" if self.field_info.validation_alias is not None:
+                    a = self.field_info.validation_alias
+                case "serialization" if self.field_info.serialization_alias is not None:
+                    a = self.field_info.serialization_alias
+                case _:
+                    a = self.field_info.alias
             return a if a is not None else self.name
 
         @property

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -26,6 +26,61 @@ def test_model_field_default_required():
     assert field.default is Undefined
 
 
+@needs_pydanticv2
+def test_model_field_alias():
+    field_info = FieldInfo(annotation=str, alias="foo")
+    field = ModelField(name="bar", field_info=field_info)
+    assert field.alias == "foo"
+
+
+@needs_pydanticv2
+def test_model_field_serialization_alias():
+    field_info = FieldInfo(annotation=str, serialization_alias="foo")
+
+    field = ModelField(name="bar", field_info=field_info, mode="validation")
+    assert field.alias == "bar"
+
+    field = ModelField(name="bar", field_info=field_info, mode="serialization")
+    assert field.alias == "foo"
+
+
+@needs_pydanticv2
+def test_model_field_validation_alias():
+    field_info = FieldInfo(annotation=str, validation_alias="foo")
+
+    field = ModelField(name="bar", field_info=field_info, mode="validation")
+    assert field.alias == "foo"
+
+    field = ModelField(name="bar", field_info=field_info, mode="serialization")
+    assert field.alias == "bar"
+
+
+@needs_pydanticv2
+def test_model_field_both_specialized_alias():
+    field_info = FieldInfo(
+        annotation=str, validation_alias="bar", serialization_alias="baz"
+    )
+
+    field = ModelField(name="foo", field_info=field_info, mode="validation")
+    assert field.alias == "bar"
+
+    field = ModelField(name="foo", field_info=field_info, mode="serialization")
+    assert field.alias == "baz"
+
+
+@needs_pydanticv2
+def test_model_field_alias_and_both_specialized_alias():
+    field_info = FieldInfo(
+        annotation=str, alias="bar", validation_alias="baz", serialization_alias="qux"
+    )
+
+    field = ModelField(name="foo", field_info=field_info, mode="validation")
+    assert field.alias == "baz"
+
+    field = ModelField(name="foo", field_info=field_info, mode="serialization")
+    assert field.alias == "qux"
+
+
 @needs_pydanticv1
 def test_upload_file_dummy_with_info_plain_validator_function():
     # For coverage

--- a/tests/test_openapi_name_for_fields.py
+++ b/tests/test_openapi_name_for_fields.py
@@ -1,0 +1,208 @@
+from typing import Annotated
+
+from fastapi import FastAPI, Query
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field
+
+app = FastAPI()
+client = TestClient(app)
+
+
+class DataModelWithoutAlias(BaseModel):
+    foo: str = Field(...)
+
+
+@app.get(
+    "/without-alias",
+    response_model=DataModelWithoutAlias,
+)
+def without_alias(data: Annotated[DataModelWithoutAlias, Query(...)]):
+    return data
+
+
+def test_openapi_param_name_without_alias():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+
+    assert (
+        openapi_schema["paths"]["/without-alias"]["get"]["parameters"][0]["name"]
+        == "foo"
+    )
+    assert (
+        openapi_schema["paths"]["/without-alias"]["get"]["parameters"][0]["in"]
+        == "query"
+    )
+    assert openapi_schema["components"]["schemas"]["DataModelWithoutAlias"][
+        "properties"
+    ]["foo"] == {"title": "Foo", "type": "string"}
+
+
+class DataModelWithAlias(BaseModel):
+    foo: str = Field(..., alias="bar")
+
+
+@app.get(
+    "/with-alias",
+    response_model=DataModelWithAlias,
+)
+def with_alias(data: Annotated[DataModelWithAlias, Query(...)]):
+    return data
+
+
+def test_openapi_param_name_with_alias():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+
+    assert (
+        openapi_schema["paths"]["/with-alias"]["get"]["parameters"][0]["name"] == "bar"
+    )
+    assert (
+        openapi_schema["paths"]["/with-alias"]["get"]["parameters"][0]["in"] == "query"
+    )
+    assert openapi_schema["components"]["schemas"]["DataModelWithAlias"]["properties"][
+        "bar"
+    ] == {"title": "Bar", "type": "string"}
+
+
+class DataModelWithSerializationAlias(BaseModel):
+    foo: str = Field(..., serialization_alias="bar")
+
+
+@app.get(
+    "/with-serialization-alias",
+    response_model=DataModelWithSerializationAlias,
+)
+def with_serialization_alias(
+    data: Annotated[DataModelWithSerializationAlias, Query(...)],
+):
+    return data
+
+
+def test_openapi_param_name_with_serialization_alias():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+
+    assert (
+        openapi_schema["paths"]["/with-serialization-alias"]["get"]["parameters"][0][
+            "name"
+        ]
+        == "foo"
+    )
+    assert (
+        openapi_schema["paths"]["/with-serialization-alias"]["get"]["parameters"][0][
+            "in"
+        ]
+        == "query"
+    )
+    assert openapi_schema["components"]["schemas"]["DataModelWithSerializationAlias"][
+        "properties"
+    ]["bar"] == {"title": "Bar", "type": "string"}
+
+
+class DataModelWithValidationAlias(BaseModel):
+    foo: str = Field(..., validation_alias="bar")
+
+
+@app.get(
+    "/with-validation-alias",
+    response_model=DataModelWithValidationAlias,
+)
+def with_validation_alias(data: Annotated[DataModelWithValidationAlias, Query(...)]):
+    return data
+
+
+def test_openapi_param_name_with_validation_alias():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+
+    assert (
+        openapi_schema["paths"]["/with-validation-alias"]["get"]["parameters"][0][
+            "name"
+        ]
+        == "bar"
+    )
+    assert (
+        openapi_schema["paths"]["/with-validation-alias"]["get"]["parameters"][0]["in"]
+        == "query"
+    )
+    assert openapi_schema["components"]["schemas"]["DataModelWithValidationAlias"][
+        "properties"
+    ]["foo"] == {"title": "Foo", "type": "string"}
+
+
+class DataModelWithBothSpecializedAlias(BaseModel):
+    foo: str = Field(..., validation_alias="bar", serialization_alias="baz")
+
+
+@app.get(
+    "/with-both-specialized-alias",
+    response_model=DataModelWithBothSpecializedAlias,
+)
+def with_both_specialized_alias(
+    data: Annotated[DataModelWithBothSpecializedAlias, Query(...)],
+):
+    return data
+
+
+def test_openapi_param_name_with_both_specialized_alias():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+
+    assert (
+        openapi_schema["paths"]["/with-both-specialized-alias"]["get"]["parameters"][0][
+            "name"
+        ]
+        == "bar"
+    )
+    assert (
+        openapi_schema["paths"]["/with-both-specialized-alias"]["get"]["parameters"][0][
+            "in"
+        ]
+        == "query"
+    )
+    assert openapi_schema["components"]["schemas"]["DataModelWithBothSpecializedAlias"][
+        "properties"
+    ]["baz"] == {"title": "Baz", "type": "string"}
+
+
+class DataModelWithAliasAndBothSpecializedAlias(BaseModel):
+    foo: str = Field(
+        ..., alias="bar", validation_alias="baz", serialization_alias="qux"
+    )
+
+
+@app.get(
+    "/with-alias-and-both-specialized-alias",
+    response_model=DataModelWithAliasAndBothSpecializedAlias,
+)
+def with_alias_and_both_specialized_alias(
+    data: Annotated[DataModelWithAliasAndBothSpecializedAlias, Query(...)],
+):
+    return data
+
+
+def test_openapi_param_name_with_alias_and_both_specialized_alias():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+
+    assert (
+        openapi_schema["paths"]["/with-alias-and-both-specialized-alias"]["get"][
+            "parameters"
+        ][0]["name"]
+        == "baz"
+    )
+    assert (
+        openapi_schema["paths"]["/with-alias-and-both-specialized-alias"]["get"][
+            "parameters"
+        ][0]["in"]
+        == "query"
+    )
+    assert openapi_schema["components"]["schemas"][
+        "DataModelWithAliasAndBothSpecializedAlias"
+    ]["properties"]["qux"] == {"title": "Qux", "type": "string"}


### PR DESCRIPTION
Hello!

I've encountered an issue in FastAPI's `openapi.json` generation for parameter inputs (`Query`, `Header`, `Cookie`). When using `alias` for field names in Pydantic models, the alias appears correctly in the generated schema. However, when using `validation_alias`, it is ignored and the original field name is shown instead.

To demonstrate this behavior, I’ve included minimal reproducible examples along with corresponding Swagger UI screenshots.


### With alias
```python
from pydantic import BaseModel, Field
from typing import Annotated

from fastapi import FastAPI, Header, Query, Cookie


class DataModel(BaseModel):
    foo: str = Field(..., alias="bar")


app = FastAPI()


@app.get("/test")
def test(
        query: Annotated[DataModel, Query(...)],
        header: Annotated[DataModel, Header(...)],
        cookie: Annotated[DataModel, Cookie(...)]
):
    return "Received: " + str(query) + ", " + str(header) + ", " + str(cookie)
```
<img width="386" alt="image" src="https://github.com/user-attachments/assets/23487069-f62b-4848-82c9-9f124a20553c" />

### With validation_alias
```python
from pydantic import BaseModel, Field
from typing import Annotated

from fastapi import FastAPI, Header, Query, Cookie


class DataModel(BaseModel):
    foo: str = Field(..., validation_alias="bar")


app = FastAPI()


@app.get("/test")
def test(
        query: Annotated[DataModel, Query(...)],
        header: Annotated[DataModel, Header(...)],
        cookie: Annotated[DataModel, Cookie(...)]
):
    return "Received: " + str(query) + ", " + str(header) + ", " + str(cookie)
```
<img width="989" alt="image" src="https://github.com/user-attachments/assets/8737a452-2f4f-4c8b-a6a3-ff8426fb5284" />

As shown above, even though validation_alias="bar" is set, the OpenAPI schema still uses "foo".

Upon inspecting the parameter generation logic, I found that the name used in the schema is determined via the field alias:
https://github.com/fastapi/fastapi/blob/ebdeda2de6e17036e3048940b7a9e725ef6a95b7/fastapi/openapi/utils.py#L137

This uses Pydantic’s ModelField logic, where alias is returned if present; otherwise, the field name is used:
https://github.com/fastapi/fastapi/blob/ebdeda2de6e17036e3048940b7a9e725ef6a95b7/fastapi/_compat.py#L88-L97

### Proposed Change
This PR modifies the alias resolution logic in ModelField to prioritize validation_alias or serialization_alias, depending on mode, instead of defaulting to alias alone.

Thanks for taking the time to review this!