### PR TITLE
🐛 Fix `generate_unique_id` to produce consistent IDs for operations with multiple methods

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -179,8 +179,15 @@ def generate_operation_id_for_path(
 def generate_unique_id(route: "APIRoute") -> str:
     operation_id = f"{route.name}{route.path_format}"
     operation_id = re.sub(r"\W", "_", operation_id)
+    # Ensure deterministic generation of the operation_id
+    # Sets are unordered, so converting directly to a list could give
+    # different results between runs, causing unstable OpenAPI specs.
+    # Sort the HTTP methods to guarantee a consistent order and pick the first
+    # one. This keeps the original behaviour (choosing one method) while
+    # making the result predictable.
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    method = sorted(route.methods)[0].lower()
+    operation_id = f"{operation_id}_{method}"
     return operation_id
 
 


### PR DESCRIPTION
## Description
[generate_unique_id](cci:1://file:///d:/Github/fastapi/fastapi/utils.py:178:0-183:23) picked `list(route.methods)[0]`, which depends on the internal,
non-deterministic order of a `set`.  
The resulting `operationId`s could oscillate between launches (e.g. `get_items_get`
vs `get_items_post`), breaking caches and client generation.

The fix sorts the HTTP methods first and then selects the first value, ensuring a
stable, predictable `operationId` across runs while preserving the original logic.