### PR TITLE
✅ Enable test case for duplicated headers in `test_tutorial/test_header_params/test_tutorial003.py`

### DIFF
--- a/tests/test_tutorial/test_header_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial003.py
@@ -2,7 +2,6 @@ import importlib
 
 import pytest
 from dirty_equals import IsDict
-
 from fastapi.testclient import TestClient
 
 from ...utils import needs_py39, needs_py310
@@ -30,8 +29,12 @@ def get_client(request: pytest.FixtureRequest):
     [
         ("/items", None, 200, {"X-Token values": None}),
         ("/items", {"x-token": "foo"}, 200, {"X-Token values": ["foo"]}),
-        ("/items", [("x-token", "foo"), ("x-token", "bar")],
-         200, {"X-Token values": ["foo", "bar"]}),
+        (
+            "/items",
+            [("x-token", "foo"), ("x-token", "bar")],
+            200,
+            {"X-Token values": ["foo", "bar"]},
+        ),
     ],
 )
 def test(path, headers, expected_status, expected_response, client: TestClient):

--- a/tests/test_tutorial/test_header_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial003.py
@@ -2,6 +2,7 @@ import importlib
 
 import pytest
 from dirty_equals import IsDict
+
 from fastapi.testclient import TestClient
 
 from ...utils import needs_py39, needs_py310
@@ -29,8 +30,8 @@ def get_client(request: pytest.FixtureRequest):
     [
         ("/items", None, 200, {"X-Token values": None}),
         ("/items", {"x-token": "foo"}, 200, {"X-Token values": ["foo"]}),
-        # TODO: fix this, is it a bug?
-        # ("/items", [("x-token", "foo"), ("x-token", "bar")], 200, {"X-Token values": ["foo", "bar"]}),
+        ("/items", [("x-token", "foo"), ("x-token", "bar")],
+         200, {"X-Token values": ["foo", "bar"]}),
     ],
 )
 def test(path, headers, expected_status, expected_response, client: TestClient):


### PR DESCRIPTION
Add test coverage for multiple header values in TestClient

## Summary
This PR adds test coverage for multiple header values passed as a list of tuples to FastAPI's TestClient, resolving a long-standing TODO comment in the test suite.

## Background
The test file tests/test_tutorial/test_header_params/test_tutorial003.py contained a commented-out test case with a TODO comment questioning whether multiple header values were working correctly:

## Technical Details
When multiple headers with the same name are passed as a list of tuples like [("x-token", "foo"), ("x-token", "bar")], FastAPI correctly processes them as a list of values ["foo", "bar"]. This is the expected HTTP behavior for multiple headers with the same name.

## Type of Change:

- [ ] Bug fix
- [x] Test coverage improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist:

- [x] Tests pass locally
- [x] No breaking changes
- [x] Code follows project style guidelines
- [x] Self-review completed

