### PR TITLE
Replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,4 +1,3 @@
-import asyncio
 import dataclasses
 import email.message
 import inspect

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -231,7 +231,7 @@ def get_request_handler(
     embed_body_fields: bool = False,
 ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
     assert dependant.call is not None, "dependant.call must be a function"
-    is_coroutine = asyncio.iscoroutinefunction(dependant.call)
+    is_coroutine = inspect.iscoroutinefunction(dependant.call)
     is_body_form = body_field and isinstance(body_field.field_info, params.Form)
     if isinstance(response_class, DefaultPlaceholder):
         actual_response_class: Type[Response] = response_class.value


### PR DESCRIPTION
Deprecated in Python 3.14 and will be removed in Python 3.16.
