### PR TITLE
✨ Allow custom `JsonSchemaGenerator` for OpenAPI generation

### DIFF
--- a/fastapi/_compat/main.py
+++ b/fastapi/_compat/main.py
@@ -35,7 +35,7 @@ if PYDANTIC_V2:
 else:
     from .v1 import BaseConfig as BaseConfig  # type: ignore[assignment]
     from .v1 import FieldInfo as FieldInfo
-    from .v1 import GenerateJsonSchema as GenerateJsonSchema
+    from .v1 import GenerateJsonSchema as GenerateJsonSchema  # type: ignore[assignment]
     from .v1 import (  # type: ignore[assignment]
         PydanticSchemaGenerationError as PydanticSchemaGenerationError,
     )

--- a/fastapi/_compat/main.py
+++ b/fastapi/_compat/main.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Optional,
     Sequence,
     Tuple,
     Type,
@@ -19,6 +20,7 @@ from .model_field import ModelField
 if PYDANTIC_V2:
     from .v2 import BaseConfig as BaseConfig
     from .v2 import FieldInfo as FieldInfo
+    from .v2 import GenerateJsonSchema
     from .v2 import PydanticSchemaGenerationError as PydanticSchemaGenerationError
     from .v2 import RequiredParam as RequiredParam
     from .v2 import Undefined as Undefined
@@ -33,6 +35,7 @@ if PYDANTIC_V2:
 else:
     from .v1 import BaseConfig as BaseConfig  # type: ignore[assignment]
     from .v1 import FieldInfo as FieldInfo
+    from .v1 import GenerateJsonSchema
     from .v1 import (  # type: ignore[assignment]
         PydanticSchemaGenerationError as PydanticSchemaGenerationError,
     )
@@ -231,6 +234,7 @@ def get_definitions(
     fields: List[ModelField],
     model_name_map: ModelNameMap,
     separate_input_output_schemas: bool = True,
+    schema_generator: Optional[GenerateJsonSchema] = None,
 ) -> Tuple[
     Dict[Tuple[ModelField, Literal["validation", "serialization"]], v1.JsonSchemaValue],
     Dict[str, Dict[str, Any]],
@@ -251,6 +255,7 @@ def get_definitions(
             fields=v2_fields,
             model_name_map=model_name_map,
             separate_input_output_schemas=separate_input_output_schemas,
+            schema_generator=schema_generator,
         )
         all_definitions = {**v1_definitions, **v2_definitions}
         all_field_maps = {**v1_field_maps, **v2_field_maps}

--- a/fastapi/_compat/main.py
+++ b/fastapi/_compat/main.py
@@ -20,7 +20,7 @@ from .model_field import ModelField
 if PYDANTIC_V2:
     from .v2 import BaseConfig as BaseConfig
     from .v2 import FieldInfo as FieldInfo
-    from .v2 import GenerateJsonSchema
+    from .v2 import GenerateJsonSchema as GenerateJsonSchema
     from .v2 import PydanticSchemaGenerationError as PydanticSchemaGenerationError
     from .v2 import RequiredParam as RequiredParam
     from .v2 import Undefined as Undefined
@@ -35,7 +35,7 @@ if PYDANTIC_V2:
 else:
     from .v1 import BaseConfig as BaseConfig  # type: ignore[assignment]
     from .v1 import FieldInfo as FieldInfo
-    from .v1 import GenerateJsonSchema
+    from .v1 import GenerateJsonSchema as GenerateJsonSchema
     from .v1 import (  # type: ignore[assignment]
         PydanticSchemaGenerationError as PydanticSchemaGenerationError,
     )

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Optional,
     Sequence,
     Set,
     Tuple,
@@ -199,11 +200,12 @@ def get_definitions(
     fields: Sequence[ModelField],
     model_name_map: ModelNameMap,
     separate_input_output_schemas: bool = True,
+    schema_generator: Optional[GenerateJsonSchema] = None,
 ) -> Tuple[
     Dict[Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue],
     Dict[str, Dict[str, Any]],
 ]:
-    schema_generator = GenerateJsonSchema(ref_template=REF_TEMPLATE)
+    schema_generator = schema_generator or GenerateJsonSchema(ref_template=REF_TEMPLATE)
     override_mode: Union[Literal["validation"], None] = (
         None if separate_input_output_schemas else "validation"
     )

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union,
 
 from fastapi import routing
 from fastapi._compat import (
+    PYDANTIC_V2,
     JsonSchemaValue,
     ModelField,
     Undefined,
@@ -37,6 +38,11 @@ from starlette.routing import BaseRoute
 from typing_extensions import Literal
 
 from .._compat import _is_model_field
+
+if PYDANTIC_V2:
+    from .._compat.v2 import GenerateJsonSchema
+else:
+    from .._compat.v1 import GenerateJsonSchema
 
 validation_error_definition = {
     "title": "ValidationError",
@@ -480,6 +486,7 @@ def get_openapi(
     license_info: Optional[Dict[str, Union[str, Any]]] = None,
     separate_input_output_schemas: bool = True,
     external_docs: Optional[Dict[str, Any]] = None,
+    schema_generator: Optional[GenerateJsonSchema] = None,
 ) -> Dict[str, Any]:
     info: Dict[str, Any] = {"title": title, "version": version}
     if summary:
@@ -505,6 +512,7 @@ def get_openapi(
         fields=all_fields,
         model_name_map=model_name_map,
         separate_input_output_schemas=separate_input_output_schemas,
+        schema_generator=schema_generator,
     )
     for route in routes or []:
         if isinstance(route, routing.APIRoute):

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -40,9 +40,9 @@ from typing_extensions import Literal
 from .._compat import _is_model_field
 
 if PYDANTIC_V2:
-    from .._compat.v2 import GenerateJsonSchema
+    from .._compat.v2 import GenerateJsonSchema as GenerateJsonSchema
 else:
-    from .._compat.v1 import GenerateJsonSchema
+    from .._compat.v1 import GenerateJsonSchema as GenerateJsonSchema
 
 validation_error_definition = {
     "title": "ValidationError",

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -42,7 +42,9 @@ from .._compat import _is_model_field
 if PYDANTIC_V2:
     from .._compat.v2 import GenerateJsonSchema as GenerateJsonSchema
 else:
-    from .._compat.v1 import GenerateJsonSchema as GenerateJsonSchema
+    from .._compat.v1 import (  # type: ignore[assignment]
+        GenerateJsonSchema as GenerateJsonSchema,
+    )
 
 validation_error_definition = {
     "title": "ValidationError",

--- a/tests/test_openapi_custom_schema_generator.py
+++ b/tests/test_openapi_custom_schema_generator.py
@@ -1,0 +1,88 @@
+import pytest
+from fastapi import FastAPI
+from fastapi._compat import PYDANTIC_V2
+from fastapi.openapi.constants import REF_TEMPLATE
+from fastapi.openapi.utils import get_openapi
+
+if PYDANTIC_V2:
+    from fastapi._compat.v2 import GenerateJsonSchema
+else:
+    from fastapi._compat.v1 import GenerateJsonSchema  # type: ignore[assignment]
+
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    pass  # pragma: no cover
+
+
+# Custom schema generator that does nothing but tracks if it was called
+class CustomJsonSchemaGenerator(GenerateJsonSchema):
+    def __init__(self):
+        super().__init__(ref_template=REF_TEMPLATE)
+        self.called = False
+
+    def generate_definitions(self, *args, **kwargs):
+        self.called = True
+        return super().generate_definitions(*args, **kwargs)
+
+
+def test_custom_schema_generator_called():
+    custom_schema_generator = CustomJsonSchemaGenerator()
+    get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+        schema_generator=custom_schema_generator,
+    )
+
+    if PYDANTIC_V2:
+        assert custom_schema_generator.called is True
+    else:
+        assert (  # Pydantic v1 does not use custom schema generators
+            custom_schema_generator.called is False
+        )
+
+
+@pytest.mark.parametrize("use_custom_schema_generator", [True, False])
+def test_custom_schema_generator_openapi(use_custom_schema_generator: bool):
+    custom_schema_generator = (
+        CustomJsonSchemaGenerator() if use_custom_schema_generator else None
+    )
+    openapi = get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+        schema_generator=custom_schema_generator,
+    )
+
+    assert openapi == OPENAPI_SCHEMA
+
+
+OPENAPI_SCHEMA = {
+    "info": {
+        "title": "FastAPI",
+        "version": "0.1.0",
+    },
+    "openapi": "3.1.0",
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "read_root__get",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {},
+                            },
+                        },
+                        "description": "Successful Response",
+                    },
+                },
+                "summary": "Read Root",
+            },
+        },
+    },
+}


### PR DESCRIPTION
# Intro
OpenAPI generators have grom a lot by themselves and despite all comply with base OpenAPI specs, many have implemented extra features that would be good to have when getting the schema from `FastAPI`.

# Example use case:
```python
class Gender(IntEnum):
    male = auto()
    female = auto()
    other = auto()
    not_given = auto()

ta = TypeAdapter(Gender)
ta_schema = ta.json_schema()

# This generates the following
assert ta_schema == {
    "enum": [1, 2, 3, 4],
    "title": "Gender",
    "type": "integer"
}
```

The inconvenience here comes because OpenAPI specs does not hace naming for `IntEnum` class attributes and most be created by generators without any naming convention...
TypeScript generated code with `openapi-generator-cli` would look like this and is completely abstract:

```ts
export const Gender= {
    NUMBER_1: 1,
    NUMBER_2: 2,
    NUMBER_3: 3,
    NUMBER_4: 4
} as const;
export type Gender = typeof Gender[keyof typeof Gender];
```

These generators have implemented extra definitions to provide these attributes naming association. This varies depending on the generator but if we keep on with the one we are using already (`openapi-generator-cli`) that would be the `x-enum-varnames`.

With a simple implementation, as intended by `pydantic`, we could get this done in a blink of an eye.
```python
class CustomJsonSchemaGenerator(GenerateJsonSchema):
    def enum_schema(self, schema: EnumSchema) -> JsonSchemaValue:
        generated_schema = super().enum_schema(schema)
        generated_schema['x-enum-varnames'] = [enum.name for enum in schema['members']]

        return generated_schema
```
With the output being:
```ts
export const Gender= {
    MALE: 1,
    FEMALE: 2,
    OTHER: 3,
    NOT_GIVEN: 4
} as const;
export type Gender = typeof Gender[keyof typeof Gender];
```

# Conclusion
`FastAPI` already has the interface to make this, it just lacks the parameter of the generator to be used. So, adding that to its implementation would be all what is required to have this feature, as shown in the code changes. The rest of `FastAPI`-ways for openapi overrideshown in the doc will remain the same and the doc will not require update
