### PR TITLE
📄🪲 Fix: incorrect documentation on openapi-ts (Generating Typescript Clients)

### DIFF
--- a/docs/en/docs/advanced/generate-clients.md
+++ b/docs/en/docs/advanced/generate-clients.md
@@ -81,7 +81,7 @@ It could look like this:
   "description": "",
   "main": "index.js",
   "scripts": {
-    "generate-client": "openapi-ts --input http://localhost:8000/openapi.json --output ./src/client --client axios"
+    "generate-client": "openapi-ts --input http://localhost:8000/api/openapi.json --output ./src/client"
   },
   "author": "",
   "license": "",
@@ -100,12 +100,12 @@ After having that NPM `generate-client` script there, you can run it with:
 $ npm run generate-client
 
 frontend-app@1.0.0 generate-client /home/user/code/frontend-app
-> openapi-ts --input http://localhost:8000/openapi.json --output ./src/client --client axios
+> openapi-ts --input http://localhost:8000/api/openapi.json --output ./src/client
 ```
 
 </div>
 
-That command will generate code in `./src/client` and will use `axios` (the frontend HTTP library) internally.
+That command will generate code in `./src/client`.
 
 ### Try Out the Client Code
 


### PR DESCRIPTION
This PR fixes the incorrect command pointing to the wrong location for `openapi.json` on the FastAPI server. It also removes the need for needing to install additional axios plugin as it's not needed. fetch API is more than enough as default client.