### PR TITLE
✨ Support mounting `StaticFiles` to sub-routers

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1133,10 +1133,8 @@ class FastAPI(Starlette):
             scope["root_path"] = self.root_path
         await super().__call__(scope, receive, send)
 
-
     def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:
         self.router._mount(path, app=app, name=name)
-
 
     def add_api_route(
         self,

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1133,6 +1133,11 @@ class FastAPI(Starlette):
             scope["root_path"] = self.root_path
         await super().__call__(scope, receive, send)
 
+
+    def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:
+        self.router._mount(path, app=app, name=name)
+
+
     def add_api_route(
         self,
         path: str,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1003,7 +1003,7 @@ class APIRouter(routing.Router):
             raise FastAPIError(
                 "APIRouter does not support mounting ASGI applications other than StaticFiles."
             )
-        self._mount(path=path, app=app, name=name)
+        self._mount(path=self.prefix + path, app=app, name=name)
 
     def _mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:
         super().mount(path=path, app=app, name=name)

--- a/tests/test_apirouter_mount.py
+++ b/tests/test_apirouter_mount.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import FastAPIError
@@ -5,18 +7,19 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
 
-def test_mount_static_files_to_apirouter(tmp_path):
+@pytest.mark.parametrize("root_path", ["", "/v1"])
+def test_mount_static_files_to_apirouter(tmp_path: Path, root_path: str):
     static_asset = tmp_path / "index.html"
     static_asset.write_text("Hello, World!")
 
     router = APIRouter()
     router.mount("/static", StaticFiles(directory=tmp_path), name="static")
 
-    app = FastAPI()
+    app = FastAPI(root_path=root_path or None)
     app.include_router(router)
 
     client = TestClient(app)
-    response = client.get("/static/index.html")
+    response = client.get(f"{root_path}/static/index.html")
     assert response.status_code == 200
     assert response.text == "Hello, World!"
 

--- a/tests/test_apirouter_mount.py
+++ b/tests/test_apirouter_mount.py
@@ -8,18 +8,33 @@ from fastapi.testclient import TestClient
 
 
 @pytest.mark.parametrize("root_path", ["", "/v1"])
-def test_mount_static_files_to_apirouter(tmp_path: Path, root_path: str):
+@pytest.mark.parametrize(
+    ("router_prefix", "include_prefix", "request_prefix"),
+    [
+        ("", "", ""),
+        ("/router", "", "/router"),
+        ("", "/router_1", "/router_1"),
+        ("/router", "/router_1", "/router_1/router"),
+    ],
+)
+def test_mount_static_files_to_apirouter(
+    tmp_path: Path,
+    root_path: str,
+    router_prefix: str,
+    include_prefix: str,
+    request_prefix: str,
+):
     static_asset = tmp_path / "index.html"
     static_asset.write_text("Hello, World!")
 
-    router = APIRouter()
+    router = APIRouter(prefix=router_prefix)
     router.mount("/static", StaticFiles(directory=tmp_path), name="static")
 
     app = FastAPI(root_path=root_path or None)
-    app.include_router(router)
+    app.include_router(router, prefix=include_prefix)
 
     client = TestClient(app)
-    response = client.get(f"{root_path}/static/index.html")
+    response = client.get(f"{root_path}{request_prefix}/static/index.html")
     assert response.status_code == 200
     assert response.text == "Hello, World!"
 

--- a/tests/test_apirouter_mount.py
+++ b/tests/test_apirouter_mount.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.exceptions import FastAPIError
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+
+def test_mount_static_files_to_apirouter(tmp_path):
+    static_asset = tmp_path / "index.html"
+    static_asset.write_text("Hello, World!")
+
+    router = APIRouter()
+    router.mount("/static", StaticFiles(directory=tmp_path), name="static")
+
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+    response = client.get("/static/index.html")
+    assert response.status_code == 200
+    assert response.text == "Hello, World!"
+
+
+def test_mount_app_to_apirouter_raises():
+    router = APIRouter()
+    sub_app = FastAPI()
+
+    with pytest.raises(
+        FastAPIError,
+        match="APIRouter does not support mounting ASGI applications other than StaticFiles.",
+    ):
+        router.mount("/sub", sub_app)


### PR DESCRIPTION
For now if you try mounting the sub-application to `APIRouter` it will be silently ignored.

See issue: https://github.com/fastapi/fastapi/issues/10180

This PR makes it working for `StaticFiles` only. At the same time mounting other apps to APIRouter will raise `FastAPIError` with clear error message:

```
APIRouter does not support mounting ASGI applications other than StaticFiles.
```

For non-`StaticFiles` sub-apps it's recommended to mount them to root app instead of router.