### PR TITLE
⚡️ Cache callable inspection result

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
     cast,
 )
+from weakref import WeakKeyDictionary
 
 import anyio
 from fastapi import params
@@ -50,10 +51,7 @@ from fastapi._compat import (
 )
 from fastapi._compat.shared import annotation_is_pydantic_v1
 from fastapi.background import BackgroundTasks
-from fastapi.concurrency import (
-    asynccontextmanager,
-    contextmanager_in_threadpool,
-)
+from fastapi.concurrency import asynccontextmanager, contextmanager_in_threadpool
 from fastapi.dependencies.models import Dependant, SecurityRequirement
 from fastapi.logger import logger
 from fastapi.security.base import SecurityBase
@@ -98,6 +96,33 @@ multipart_incorrect_install_error = (
 )
 
 
+class CallableInfo:
+    __slots__ = (
+        "typed_signature",
+        "is_gen_callable",
+        "is_async_gen_callable",
+        "is_coroutine_callable",
+    )
+
+    def __init__(
+        self,
+        typed_signature: inspect.Signature,
+        is_gen_callable: bool,
+        is_async_gen_callable: bool,
+        is_coroutine_callable: bool,
+    ) -> None:
+        self.typed_signature = typed_signature
+        self.is_gen_callable = is_gen_callable
+        self.is_async_gen_callable = is_async_gen_callable
+        self.is_coroutine_callable = is_coroutine_callable
+
+
+if sys.version_info < (3, 9):
+    CallableInfoCache = WeakKeyDictionary
+else:
+    CallableInfoCache = WeakKeyDictionary[Callable[..., Any], CallableInfo]
+
+
 def ensure_multipart_is_installed() -> None:
     try:
         from python_multipart import __version__
@@ -125,7 +150,12 @@ def ensure_multipart_is_installed() -> None:
             raise RuntimeError(multipart_not_installed_error) from None
 
 
-def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> Dependant:
+def get_parameterless_sub_dependant(
+    *,
+    depends: params.Depends,
+    path: str,
+    callable_info_cache: CallableInfoCache,
+) -> Dependant:
     assert callable(depends.dependency), (
         "A parameter-less dependency must have a callable dependency"
     )
@@ -133,7 +163,10 @@ def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> De
     if isinstance(depends, params.Security) and depends.scopes:
         use_security_scopes.extend(depends.scopes)
     return get_dependant(
-        path=path, call=depends.dependency, security_scopes=use_security_scopes
+        path=path,
+        call=depends.dependency,
+        security_scopes=use_security_scopes,
+        callable_info_cache=callable_info_cache,
     )
 
 
@@ -206,7 +239,16 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
         )
         for param in signature.parameters.values()
     ]
-    typed_signature = inspect.Signature(typed_params)
+    return_annotation = signature.return_annotation
+    if return_annotation is inspect.Signature.empty:
+        return_annotation = None
+    else:
+        return_annotation = get_typed_annotation(return_annotation, globalns)
+
+    typed_signature = inspect.Signature(
+        typed_params,
+        return_annotation=return_annotation,
+    )
     return typed_signature
 
 
@@ -219,17 +261,6 @@ def get_typed_annotation(annotation: Any, globalns: Dict[str, Any]) -> Any:
     return annotation
 
 
-def get_typed_return_annotation(call: Callable[..., Any]) -> Any:
-    signature = inspect.signature(call)
-    annotation = signature.return_annotation
-
-    if annotation is inspect.Signature.empty:
-        return None
-
-    globalns = getattr(call, "__globals__", {})
-    return get_typed_annotation(annotation, globalns)
-
-
 def get_dependant(
     *,
     path: str,
@@ -237,6 +268,7 @@ def get_dependant(
     name: Optional[str] = None,
     security_scopes: Optional[List[str]] = None,
     use_cache: bool = True,
+    callable_info_cache: Optional[CallableInfoCache] = None,
 ) -> Dependant:
     dependant = Dependant(
         call=call,
@@ -246,8 +278,14 @@ def get_dependant(
         use_cache=use_cache,
     )
     path_param_names = get_path_param_names(path)
-    endpoint_signature = get_typed_signature(call)
-    signature_params = endpoint_signature.parameters
+    callable_info_cache = prepare_callable_info_cache(
+        existing_cache=callable_info_cache,
+    )
+    callable_info = get_cached_callable_info(
+        call=call,
+        callable_info_cache=callable_info_cache,
+    )
+    signature_params = callable_info.typed_signature.parameters
     if isinstance(call, SecurityBase):
         use_scopes: List[str] = []
         if isinstance(call, (OAuth2, OpenIdConnect)):
@@ -276,6 +314,7 @@ def get_dependant(
                 name=param_name,
                 security_scopes=use_security_scopes,
                 use_cache=param_details.depends.use_cache,
+                callable_info_cache=callable_info_cache,
             )
             dependant.dependencies.append(sub_dependant)
             continue
@@ -532,6 +571,43 @@ def add_param_to_fields(*, field: ModelField, dependant: Dependant) -> None:
         dependant.cookie_params.append(field)
 
 
+def prepare_callable_info_cache(
+    existing_cache: Optional[CallableInfoCache] = None,
+) -> CallableInfoCache:
+    if existing_cache is None:
+        existing_cache = WeakKeyDictionary()
+    return existing_cache
+
+
+def get_cached_callable_info(
+    call: Callable[..., Any],
+    callable_info_cache: CallableInfoCache,
+) -> CallableInfo:
+    try:
+        support_weakref = True
+        callable_info = callable_info_cache.get(call)
+    except TypeError:
+        support_weakref = False
+        callable_info = None
+
+    if callable_info is not None:
+        return callable_info
+
+    callable_info = inspect_callable(call)
+    if support_weakref:
+        callable_info_cache[call] = callable_info
+    return callable_info
+
+
+def inspect_callable(call: Callable[..., Any]) -> CallableInfo:
+    return CallableInfo(
+        typed_signature=get_typed_signature(call),
+        is_gen_callable=is_gen_callable(call),
+        is_async_gen_callable=is_async_gen_callable(call),
+        is_coroutine_callable=is_coroutine_callable(call),
+    )
+
+
 def is_coroutine_callable(call: Callable[..., Any]) -> bool:
     if inspect.isroutine(call):
         return iscoroutinefunction(call)
@@ -556,11 +632,15 @@ def is_gen_callable(call: Callable[..., Any]) -> bool:
 
 
 async def solve_generator(
-    *, call: Callable[..., Any], stack: AsyncExitStack, sub_values: Dict[str, Any]
+    *,
+    call: Callable[..., Any],
+    callable_info: CallableInfo,
+    stack: AsyncExitStack,
+    sub_values: Dict[str, Any],
 ) -> Any:
-    if is_gen_callable(call):
+    if callable_info.is_gen_callable:
         cm = contextmanager_in_threadpool(contextmanager(call)(**sub_values))
-    elif is_async_gen_callable(call):
+    elif callable_info.is_async_gen_callable:
         cm = asynccontextmanager(call)(**sub_values)
     return await stack.enter_async_context(cm)
 
@@ -583,11 +663,13 @@ async def solve_dependencies(
     response: Optional[Response] = None,
     dependency_overrides_provider: Optional[Any] = None,
     dependency_cache: Optional[Dict[Tuple[Callable[..., Any], Tuple[str]], Any]] = None,
+    callable_info_cache: Optional[CallableInfoCache] = None,
     async_exit_stack: AsyncExitStack,
     embed_body_fields: bool,
 ) -> SolvedDependency:
     values: Dict[str, Any] = {}
     errors: List[Any] = []
+    callable_info_cache = prepare_callable_info_cache(callable_info_cache)
     if response is None:
         response = Response()
         del response.headers["content-length"]
@@ -616,6 +698,8 @@ async def solve_dependencies(
                 call=call,
                 name=sub_dependant.name,
                 security_scopes=sub_dependant.security_scopes,
+                use_cache=sub_dependant.use_cache,
+                callable_info_cache=callable_info_cache,
             )
 
         solved_result = await solve_dependencies(
@@ -626,6 +710,7 @@ async def solve_dependencies(
             response=response,
             dependency_overrides_provider=dependency_overrides_provider,
             dependency_cache=dependency_cache,
+            callable_info_cache=callable_info_cache,
             async_exit_stack=async_exit_stack,
             embed_body_fields=embed_body_fields,
         )
@@ -635,14 +720,22 @@ async def solve_dependencies(
             continue
         if sub_dependant.use_cache and sub_dependant.cache_key in dependency_cache:
             solved = dependency_cache[sub_dependant.cache_key]
-        elif is_gen_callable(call) or is_async_gen_callable(call):
-            solved = await solve_generator(
-                call=call, stack=async_exit_stack, sub_values=solved_result.values
-            )
-        elif is_coroutine_callable(call):
-            solved = await call(**solved_result.values)
         else:
-            solved = await run_in_threadpool(call, **solved_result.values)
+            callable_info = get_cached_callable_info(
+                call=call,
+                callable_info_cache=callable_info_cache,
+            )
+            if callable_info.is_gen_callable or callable_info.is_async_gen_callable:
+                solved = await solve_generator(
+                    call=call,
+                    callable_info=callable_info,
+                    stack=async_exit_stack,
+                    sub_values=solved_result.values,
+                )
+            elif callable_info.is_coroutine_callable:
+                solved = await call(**solved_result.values)
+            else:
+                solved = await run_in_threadpool(call, **solved_result.values)
         if sub_dependant.name is not None:
             values[sub_dependant.name] = solved
         if sub_dependant.cache_key not in dependency_cache:

--- a/tests/test_callable_info.py
+++ b/tests/test_callable_info.py
@@ -1,0 +1,126 @@
+from dataclasses import dataclass
+from typing import AsyncGenerator, Generator
+from unittest.mock import call, patch
+
+from fastapi import Depends, FastAPI
+from fastapi.dependencies.utils import inspect_callable
+from fastapi.testclient import TestClient
+
+
+def direct_dependency() -> str:
+    return "direct dependency"
+
+
+async def async_dependency() -> str:
+    return "async dependency"
+
+
+def sync_dependency() -> str:
+    return "sync dependency"
+
+
+async def async_generator() -> AsyncGenerator[str, None]:
+    yield "async generator"
+
+
+def sync_generator() -> Generator[str, None, None]:
+    yield "generator"
+
+
+@dataclass
+class class_dependency:
+    pass
+
+
+# Nested dependency
+async def async_nested_dependency(
+    via_sync_dependency: dict = Depends(sync_dependency),
+    via_async_dependency: str = Depends(async_dependency),
+    via_async_generator: str = Depends(async_generator),
+    via_sync_generator: str = Depends(sync_generator),
+    via_class_dependency: class_dependency = Depends(),
+) -> dict:
+    return {
+        "via_sync_dependency": via_sync_dependency,
+        "via_async_dependency": via_async_dependency,
+        "via_async_generator": via_async_generator,
+        "via_sync_generator": via_sync_generator,
+        "via_class_dependency": via_class_dependency,
+    }
+
+
+def test_get_callable_info():
+    async_dependency_info = inspect_callable(async_dependency)
+    assert not async_dependency_info.is_gen_callable
+    assert not async_dependency_info.is_async_gen_callable
+    assert async_dependency_info.is_coroutine_callable
+
+    sync_dependency_info = inspect_callable(sync_dependency)
+    assert not sync_dependency_info.is_gen_callable
+    assert not sync_dependency_info.is_async_gen_callable
+    assert not sync_dependency_info.is_coroutine_callable
+
+    async_generator_info = inspect_callable(async_generator)
+    assert not async_generator_info.is_gen_callable
+    assert async_generator_info.is_async_gen_callable
+    assert not async_generator_info.is_coroutine_callable
+
+    sync_generator_info = inspect_callable(sync_generator)
+    assert sync_generator_info.is_gen_callable
+    assert not sync_generator_info.is_async_gen_callable
+    assert not sync_generator_info.is_coroutine_callable
+
+    class_dependency_info = inspect_callable(class_dependency)
+    assert not class_dependency_info.is_gen_callable
+    assert not class_dependency_info.is_async_gen_callable
+    assert not class_dependency_info.is_coroutine_callable
+
+
+def test_callable_info_is_cached():
+    with patch(
+        "fastapi.dependencies.utils.inspect_callable",
+        side_effect=inspect_callable,
+    ) as inspect_callable_mock:
+        app = FastAPI()
+        inspect_callable_mock.assert_not_called()
+
+        @app.get("/items/{item_id}", dependencies=[Depends(direct_dependency)])
+        async def endpoint(
+            item_id: str,
+            context: dict = Depends(async_nested_dependency),
+        ) -> dict:
+            return {"item_id": item_id, "context": context}
+
+        # endpoint and direct dependency info is cached immediately.
+        # nested dependencies require additional resolution
+        inspect_callable_mock.assert_has_calls(
+            [
+                call(endpoint),
+                call(async_nested_dependency),
+                call(sync_dependency),
+                call(async_dependency),
+                call(async_generator),
+                call(sync_generator),
+                call(class_dependency),
+                call(direct_dependency),
+            ],
+        )
+
+        # first call of endpoint
+        inspect_callable_mock.reset_mock()
+        client = TestClient(app)
+        response = client.get("/items/via-query")
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "item_id": "via-query",
+            "context": {
+                "via_sync_dependency": "sync dependency",
+                "via_async_dependency": "async dependency",
+                "via_async_generator": "async generator",
+                "via_sync_generator": "generator",
+                "via_class_dependency": {},
+            },
+        }
+
+        # inspection is performed only once
+        inspect_callable_mock.assert_not_called()


### PR DESCRIPTION
Currently FastAPI calls `inspect.signature`, `inspect.isgeneratorfunction`, `inspect.isasyncgenfunction`, `inspect.iscoroutinefunction`, etc for each callable found in dependency tree, and this is done for each received request.

This can be avoided by introducing a cache for methods result. As callable objects are usually created once and never change after that, this cache can be bound to endpoint or even whole application. Using WeakKeyDictionary helps to avoid memory leaks then callables are created in runtime (e.g. by using `functools.partial`).

This cache is different from dependency cache - dependency cache stores values of resolved dependencies (non reusable between requests), then callable info cache stores signatures and other information about code  (reusable between requests).

Before - `app (fastapi/routing.py)` takes 68.27% of all method calls:
![profile_proxy_with_auth_and_cache](https://github.com/user-attachments/assets/40824f9d-2464-46be-a2ce-a89ce55bd274)

After - `app (fastapi/routing.py)` takes 54.52% of all method calls:
![profile_proxy_with_auth_and_cache_fastapi_inspect_patch](https://github.com/user-attachments/assets/cf7fc9e6-2a46-4fc1-b194-1f504f67b8aa)

The code is ugly as walking on dependency tree requires passing cache deep into dependency resolvers. Also lots of intermediate functions have default argument values, which are not used in most cases, but I have to follow this pattern.