### PR TITLE
📝 Rename functions for params tutorial and minor grammar tweaks

### DIFF
--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -10,7 +10,7 @@ To declare a **request** body, you use <a href="https://docs.pydantic.dev/" clas
 
 /// info
 
-To send data, you should use one of: `POST` (the more common), `PUT`, `DELETE` or `PATCH`.
+To send data, you should use one of: `POST` (the most common), `PUT`, `DELETE` or `PATCH`.
 
 Sending a body with a `GET` request has an undefined behavior in the specifications, nevertheless, it is supported by FastAPI, only for very complex/extreme use cases.
 

--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -72,7 +72,7 @@ With just that Python type declaration, **FastAPI** will:
 * Validate the data.
     * If the data is invalid, it will return a nice and clear error, indicating exactly where and what was the incorrect data.
 * Give you the received data in the parameter `item`.
-    * As you declared it in the function to be of type `Item`, you will also have all the editor support (completion, etc) for all of the attributes and their types.
+    * As you declared it in the function to be of type `Item`, you will also have editor support (completion, etc) for all of the attributes and their types.
 * Generate <a href="https://json-schema.org" class="external-link" target="_blank">JSON Schema</a> definitions for your model, you can also use them anywhere else you like if it makes sense for your project.
 * Those schemas will be part of the generated OpenAPI schema, and used by the automatic documentation <abbr title="User Interfaces">UIs</abbr>.
 
@@ -96,9 +96,9 @@ You also get error checks for incorrect type operations:
 
 <img src="/img/tutorial/body/image04.png">
 
-This is not by chance, the whole framework was built around that design.
+This is not by chance, the whole framework was built around this design.
 
-And it was thoroughly tested at the design phase, before any implementation, to ensure it would work with all the editors.
+And it was thoroughly tested at the design phase, before any implementation, to ensure it would work with all editors.
 
 There were even some changes to Pydantic itself to support this.
 

--- a/docs_src/query_params/tutorial006.py
+++ b/docs_src/query_params/tutorial006.py
@@ -6,7 +6,7 @@ app = FastAPI()
 
 
 @app.get("/items/{item_id}")
-async def read_user_item(
+async def read_item(
     item_id: str, needy: str, skip: int = 0, limit: Union[int, None] = None
 ):
     item = {"item_id": item_id, "needy": needy, "skip": skip, "limit": limit}

--- a/docs_src/query_params/tutorial006_py310.py
+++ b/docs_src/query_params/tutorial006_py310.py
@@ -4,8 +4,6 @@ app = FastAPI()
 
 
 @app.get("/items/{item_id}")
-async def read_item(
-    item_id: str, needy: str, skip: int = 0, limit: int | None = None
-):
+async def read_item(item_id: str, needy: str, skip: int = 0, limit: int | None = None):
     item = {"item_id": item_id, "needy": needy, "skip": skip, "limit": limit}
     return item

--- a/docs_src/query_params/tutorial006_py310.py
+++ b/docs_src/query_params/tutorial006_py310.py
@@ -4,7 +4,7 @@ app = FastAPI()
 
 
 @app.get("/items/{item_id}")
-async def read_user_item(
+async def read_item(
     item_id: str, needy: str, skip: int = 0, limit: int | None = None
 ):
     item = {"item_id": item_id, "needy": needy, "skip": skip, "limit": limit}

--- a/docs_src/query_params/tutorial006b.py
+++ b/docs_src/query_params/tutorial006b.py
@@ -6,7 +6,7 @@ app = FastAPI()
 
 
 @app.get("/items/{item_id}")
-async def read_user_item(
+async def read_item(
     item_id: str, needy: str, skip: int = 0, limit: Union[int, None] = None
 ):
     item = {"item_id": item_id, "needy": needy, "skip": skip, "limit": limit}


### PR DESCRIPTION
The functions in the [query parameter tutorial](https://fastapi.tiangolo.com/tutorial/query-params/) were renamed to read_user_item and then never changed back when user_id is no longer a parameter