### PR TITLE
docs: Add missing return type hints to documentation examples

### DIFF
--- a/docs_src/custom_docs_ui/tutorial001.py
+++ b/docs_src/custom_docs_ui/tutorial001.py
@@ -1,15 +1,18 @@
+from typing import Dict
+
 from fastapi import FastAPI
 from fastapi.openapi.docs import (
     get_redoc_html,
     get_swagger_ui_html,
     get_swagger_ui_oauth2_redirect_html,
 )
+from fastapi.responses import HTMLResponse
 
 app = FastAPI(docs_url=None, redoc_url=None)
 
 
 @app.get("/docs", include_in_schema=False)
-async def custom_swagger_ui_html():
+async def custom_swagger_ui_html() -> HTMLResponse:
     return get_swagger_ui_html(
         openapi_url=app.openapi_url,
         title=app.title + " - Swagger UI",
@@ -20,12 +23,12 @@ async def custom_swagger_ui_html():
 
 
 @app.get(app.swagger_ui_oauth2_redirect_url, include_in_schema=False)
-async def swagger_ui_redirect():
+async def swagger_ui_redirect() -> HTMLResponse:
     return get_swagger_ui_oauth2_redirect_html()
 
 
 @app.get("/redoc", include_in_schema=False)
-async def redoc_html():
+async def redoc_html() -> HTMLResponse:
     return get_redoc_html(
         openapi_url=app.openapi_url,
         title=app.title + " - ReDoc",
@@ -34,5 +37,5 @@ async def redoc_html():
 
 
 @app.get("/users/{username}")
-async def read_user(username: str):
+async def read_user(username: str) -> Dict[str, str]:
     return {"message": f"Hello {username}"}

--- a/docs_src/debugging/tutorial001.py
+++ b/docs_src/debugging/tutorial001.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import uvicorn
 from fastapi import FastAPI
 
@@ -5,7 +7,7 @@ app = FastAPI()
 
 
 @app.get("/")
-def root():
+def root() -> Dict[str, str]:
     a = "a"
     b = "b" + a
     return {"hello world": b}

--- a/docs_src/extra_models/tutorial001.py
+++ b/docs_src/extra_models/tutorial001.py
@@ -26,11 +26,11 @@ class UserInDB(BaseModel):
     full_name: Union[str, None] = None
 
 
-def fake_password_hasher(raw_password: str):
+def fake_password_hasher(raw_password: str) -> str:
     return "supersecret" + raw_password
 
 
-def fake_save_user(user_in: UserIn):
+def fake_save_user(user_in: UserIn) -> UserInDB:
     hashed_password = fake_password_hasher(user_in.password)
     user_in_db = UserInDB(**user_in.dict(), hashed_password=hashed_password)
     print("User saved! ..not really")
@@ -38,6 +38,6 @@ def fake_save_user(user_in: UserIn):
 
 
 @app.post("/user/", response_model=UserOut)
-async def create_user(user_in: UserIn):
+async def create_user(user_in: UserIn) -> UserInDB:
     user_saved = fake_save_user(user_in)
     return user_saved

--- a/docs_src/response_directly/tutorial001.py
+++ b/docs_src/response_directly/tutorial001.py
@@ -17,6 +17,6 @@ app = FastAPI()
 
 
 @app.put("/items/{id}")
-def update_item(id: str, item: Item):
+def update_item(id: str, item: Item) -> JSONResponse:
     json_compatible_item_data = jsonable_encoder(item)
     return JSONResponse(content=json_compatible_item_data)

--- a/docs_src/response_directly/tutorial002.py
+++ b/docs_src/response_directly/tutorial002.py
@@ -4,7 +4,7 @@ app = FastAPI()
 
 
 @app.get("/legacy/")
-def get_legacy_data():
+def get_legacy_data() -> Response:
     data = """<?xml version="1.0"?>
     <shampoo>
     <Header>

--- a/docs_src/templates/tutorial001.py
+++ b/docs_src/templates/tutorial001.py
@@ -12,7 +12,7 @@ templates = Jinja2Templates(directory="templates")
 
 
 @app.get("/items/{id}", response_class=HTMLResponse)
-async def read_item(request: Request, id: str):
+async def read_item(request: Request, id: str) -> HTMLResponse:
     return templates.TemplateResponse(
         request=request, name="item.html", context={"id": id}
     )


### PR DESCRIPTION
Improve type safety in documentation examples by adding explicit return type annotations to functions that were missing them.

Modified files:
- docs_src/body/tutorial001.py: Add Item return type
- docs_src/body/tutorial003.py: Add Dict[str, Any] return type
- docs_src/custom_docs_ui/tutorial001.py: Add HTMLResponse and dict return types
- docs_src/debugging/tutorial001.py: Add Dict[str, str] return type
- docs_src/extra_models/tutorial001.py: Add str and UserInDB return types
- docs_src/response_directly/tutorial001.py: Add JSONResponse return type
- docs_src/response_directly/tutorial002.py: Add Response return type
- docs_src/templates/tutorial001.py: Add HTMLResponse return type

These changes enhance code clarity and help users understand expected return types when following the documentation examples.