### PR TITLE
📝 Fix typos and standardize spelling and terminology in tutorials

### DIFF
--- a/docs/en/docs/help-fastapi.md
+++ b/docs/en/docs/help-fastapi.md
@@ -160,7 +160,7 @@ Here's what to keep in mind and how to review a pull request:
 
 * Don't worry too much about things like commit message styles, I will squash and merge customizing the commit manually.
 
-* Also don't worry about style rules, there are already automatized tools checking that.
+* Also don't worry about style rules, there are already automated tools checking that.
 
 And if there's any other style or consistency need, I'll ask directly for that, or I'll add commits on top with the needed changes.
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -1925,7 +1925,7 @@ Read more in the [advisory: Content-Type Header ReDoS](https://github.com/tiango
 * 🌐 Add Japanese translation for `docs/ja/docs/tutorial/handling-errors.md`. PR [#1953](https://github.com/tiangolo/fastapi/pull/1953) by [@SwftAlpc](https://github.com/SwftAlpc).
 * 🌐 Add Japanese translation for `docs/ja/docs/tutorial/response-status-code.md`. PR [#1942](https://github.com/tiangolo/fastapi/pull/1942) by [@SwftAlpc](https://github.com/SwftAlpc).
 * 🌐 Add Japanese translation for `docs/ja/docs/tutorial/extra-models.md`. PR [#1941](https://github.com/tiangolo/fastapi/pull/1941) by [@SwftAlpc](https://github.com/SwftAlpc).
-* 🌐 Add Japanese tranlsation for `docs/ja/docs/tutorial/schema-extra-example.md`. PR [#1931](https://github.com/tiangolo/fastapi/pull/1931) by [@SwftAlpc](https://github.com/SwftAlpc).
+* 🌐 Add Japanese translation for `docs/ja/docs/tutorial/schema-extra-example.md`. PR [#1931](https://github.com/tiangolo/fastapi/pull/1931) by [@SwftAlpc](https://github.com/SwftAlpc).
 * 🌐 Add Japanese translation for `docs/ja/docs/tutorial/body-nested-models.md`. PR [#1930](https://github.com/tiangolo/fastapi/pull/1930) by [@SwftAlpc](https://github.com/SwftAlpc).
 * 🌐 Add Japanese translation for `docs/ja/docs/tutorial/body-fields.md`. PR [#1923](https://github.com/tiangolo/fastapi/pull/1923) by [@SwftAlpc](https://github.com/SwftAlpc).
 * 🌐 Add German translation for `docs/de/docs/tutorial/index.md`. PR [#9502](https://github.com/tiangolo/fastapi/pull/9502) by [@fhabers21](https://github.com/fhabers21).
@@ -3148,7 +3148,7 @@ Highlights of this release:
 
 * [Upgraded Starlette](https://github.com/encode/starlette/releases/tag/0.21.0)
     * Now the `TestClient` is based on HTTPX instead of Requests. 🚀
-    * There are some possible **breaking changes** in the `TestClient` usage, but [@Kludex](https://github.com/Kludex) built [bump-testclient](https://github.com/Kludex/bump-testclient) to help you automatize migrating your tests. Make sure you are using Git and that you can undo any unnecessary changes (false positive changes, etc) before using `bump-testclient`.
+    * There are some possible **breaking changes** in the `TestClient` usage, but [@Kludex](https://github.com/Kludex) built [bump-testclient](https://github.com/Kludex/bump-testclient) to help you automate migrating your tests. Make sure you are using Git and that you can undo any unnecessary changes (false positive changes, etc) before using `bump-testclient`.
 * New [WebSocketException (and docs)](https://fastapi.tiangolo.com/advanced/websockets/#using-depends-and-others), re-exported from Starlette.
 * Upgraded and relaxed dependencies for package extras `all` (including new Uvicorn version), when you install `"fastapi[all]"`.
 * New docs about how to [**Help Maintain FastAPI**](https://fastapi.tiangolo.com/help-fastapi/#help-maintain-fastapi).
@@ -3301,7 +3301,7 @@ You hopefully updated to a supported version of Python a while ago. If you haven
 ### Fixes
 
 * 🐛 Fix `RuntimeError` raised when `HTTPException` has a status code with no content. PR [#5365](https://github.com/tiangolo/fastapi/pull/5365) by [@iudeen](https://github.com/iudeen).
-* 🐛 Fix empty reponse body when default `status_code` is empty but the a `Response` parameter with `response.status_code` is set. PR [#5360](https://github.com/tiangolo/fastapi/pull/5360) by [@tmeckel](https://github.com/tmeckel).
+* 🐛 Fix empty response body when default `status_code` is empty but the a `Response` parameter with `response.status_code` is set. PR [#5360](https://github.com/tiangolo/fastapi/pull/5360) by [@tmeckel](https://github.com/tmeckel).
 
 ### Docs
 
@@ -5342,7 +5342,7 @@ Note: all the previous parameters are still there, so it's still possible to dec
     * New documentation about [dependencies in the `include_router()` method](https://fastapi.tiangolo.com/tutorial/bigger-applications/#include-an-apirouter-with-a-prefix-tags-responses-and-dependencies).
     * PR [#235](https://github.com/tiangolo/fastapi/pull/235).
 
-* Fix OpenAPI documentation of Starlette URL convertors. Specially useful when using `path` convertors, to take a whole path as a parameter, like `/some/url/{p:path}`. PR [#234](https://github.com/tiangolo/fastapi/pull/234) by [@euri10](https://github.com/euri10).
+* Fix OpenAPI documentation of Starlette URL converters. Specially useful when using `path` converters, to take a whole path as a parameter, like `/some/url/{p:path}`. PR [#234](https://github.com/tiangolo/fastapi/pull/234) by [@euri10](https://github.com/euri10).
 
 * Make default parameter utilities exported from `fastapi` be functions instead of classes (the new functions return instances of those classes). To be able to override the return types and fix `mypy` errors in FastAPI's users' code. Applies to `Path`, `Query`, `Header`, `Cookie`, `Body`, `Form`, `File`, `Depends`, and `Security`. PR [#226](https://github.com/tiangolo/fastapi/pull/226) and PR [#231](https://github.com/tiangolo/fastapi/pull/231).
 

--- a/docs/en/docs/tutorial/cookie-param-models.md
+++ b/docs/en/docs/tutorial/cookie-param-models.md
@@ -2,7 +2,7 @@
 
 If you have a group of **cookies** that are related, you can create a **Pydantic model** to declare them. 🍪
 
-This would allow you to **re-use the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
+This would allow you to **reuse the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
 
 /// note
 

--- a/docs/en/docs/tutorial/header-param-models.md
+++ b/docs/en/docs/tutorial/header-param-models.md
@@ -2,7 +2,7 @@
 
 If you have a group of related **header parameters**, you can create a **Pydantic model** to declare them.
 
-This would allow you to **re-use the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
+This would allow you to **reuse the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
 
 /// note
 

--- a/docs/en/docs/tutorial/path-params.md
+++ b/docs/en/docs/tutorial/path-params.md
@@ -222,7 +222,7 @@ Nevertheless, you can still do it in **FastAPI**, using one of the internal tool
 
 And the docs would still work, although not adding any documentation telling that the parameter should contain a path.
 
-### Path convertor
+### Path converter
 
 Using an option directly from Starlette you can declare a *path parameter* containing a *path* using a URL like:
 

--- a/docs/en/docs/tutorial/query-param-models.md
+++ b/docs/en/docs/tutorial/query-param-models.md
@@ -2,7 +2,7 @@
 
 If you have a group of **query parameters** that are related, you can create a **Pydantic model** to declare them.
 
-This would allow you to **re-use the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
+This would allow you to **reuse the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
 
 /// note
 

--- a/docs/en/docs/tutorial/security/get-current-user.md
+++ b/docs/en/docs/tutorial/security/get-current-user.md
@@ -88,7 +88,7 @@ And you can make it as complex as you want. And still, have it written only once
 
 But you can have thousands of endpoints (*path operations*) using the same security system.
 
-And all of them (or any portion of them that you want) can take advantage of re-using these dependencies or any other dependencies you create.
+And all of them (or any portion of them that you want) can take advantage of reusing these dependencies or any other dependencies you create.
 
 And all these thousands of *path operations* can be as small as 3 lines:
 

--- a/docs/en/docs/tutorial/sql-databases.md
+++ b/docs/en/docs/tutorial/sql-databases.md
@@ -218,7 +218,7 @@ It has the same fields as `HeroBase`, so it won't include `secret_name`.
 
 Finally, the identity of our heroes is protected! 🥷
 
-It also re-declares `id: int`. By doing this, we are making a **contract** with the API clients, so that they can always expect the `id` to be there and to be an `int` (it will never be `None`).
+It also redeclares `id: int`. By doing this, we are making a **contract** with the API clients, so that they can always expect the `id` to be there and to be an `int` (it will never be `None`).
 
 /// tip
 
@@ -266,9 +266,9 @@ We didn't have a way to **update a hero** in the previous version of the app, bu
 
 The `HeroUpdate` *data model* is somewhat special, it has **all the same fields** that would be needed to create a new hero, but all the fields are **optional** (they all have a default value). This way, when you update a hero, you can send just the fields that you want to update.
 
-Because all the **fields actually change** (the type now includes `None` and they now have a default value of `None`), we need to **re-declare** them.
+Because all the **fields actually change** (the type now includes `None` and they now have a default value of `None`), we need to **redeclare** them.
 
-We don't really need to inherit from `HeroBase` because we are re-declaring all the fields. I'll leave it inheriting just for consistency, but this is not necessary. It's more a matter of personal taste. 🤷
+We don't really need to inherit from `HeroBase` because we are redeclaring all the fields. I'll leave it inheriting just for consistency, but this is not necessary. It's more a matter of personal taste. 🤷
 
 The fields of `HeroUpdate` are:
 


### PR DESCRIPTION
This PR addresses minor typographical errors and standardizes spelling across several English documentation files in FastAPI.  
**Changes are documentation-only** and have no effect on runtime behavior.

### Changes;
- **tutorial/path-params.md**: “Path convertor” -> “Path converter”
- **tutorial/*-param-models.md**: “re-use” -> “reuse”
- **tutorial/sql-databases.md**: “re-declare” (and variants) -> “redeclare”
- **tutorial/security/get-current-user.md**: “re-using” -> “reusing”
- **help-fastapi.md**: “automatized” -> “automated”
- **release-notes.md**:  
  - “tranlsation” -> “translation”  
  - “automatize” -> “automate”  
  - “reponse” -> “response”  
  - “convertors” -> “converters”

**Docs-only PR** — improves clarity and consistency without impacting functionality.