### PR TITLE
test(forms): add failing test for issue #13399 (Form preloads defaults)

### DIFF
--- a/tests/test_issue_13399.py
+++ b/tests/test_issue_13399.py
@@ -1,0 +1,33 @@
+# tests/test_issue_13399.py
+from typing import Annotated
+from fastapi import FastAPI, Form
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+class ExampleModel(BaseModel):
+    field_1: bool = True
+
+app = FastAPI()
+
+@app.post("/body")
+async def body_endpoint(model: ExampleModel):
+    fields = getattr(model, "model_fields_set", set())
+    return {"fields_set": list(fields)}
+
+@app.post("/form")
+async def form_endpoint(model: Annotated[ExampleModel, Form()]):
+    fields = getattr(model, "model_fields_set", set())
+    return {"fields_set": list(fields)}
+
+client = TestClient(app)
+
+def test_body():
+    resp = client.post("/body", json={})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["fields_set"] == []
+
+def test_form():
+    resp = client.post("/form", data={})
+    assert resp.status_code == 200, resp.text
+    # the bug: this currently returns ['field_1'] instead of []
+    assert resp.json()["fields_set"] == []

--- a/tests/test_issue_13399.py
+++ b/tests/test_issue_13399.py
@@ -1,30 +1,38 @@
 # tests/test_issue_13399.py
 from typing import Annotated
+
 from fastapi import FastAPI, Form
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
+
 class ExampleModel(BaseModel):
     field_1: bool = True
 
+
 app = FastAPI()
+
 
 @app.post("/body")
 async def body_endpoint(model: ExampleModel):
     fields = getattr(model, "model_fields_set", set())
     return {"fields_set": list(fields)}
 
+
 @app.post("/form")
 async def form_endpoint(model: Annotated[ExampleModel, Form()]):
     fields = getattr(model, "model_fields_set", set())
     return {"fields_set": list(fields)}
 
+
 client = TestClient(app)
+
 
 def test_body():
     resp = client.post("/body", json={})
     assert resp.status_code == 200, resp.text
     assert resp.json()["fields_set"] == []
+
 
 def test_form():
     resp = client.post("/form", data={})


### PR DESCRIPTION
This adds a minimal failing test for issue #13399.

- Confirms that models created from Form inputs incorrectly preload defaults into `model_fields_set`.
- JSON bodies behave correctly (fields_set = []).
- Forms currently behave incorrectly (fields_set = ['field_1']).

This test currently fails (`test_form`), which demonstrates the bug.

Closes #13399
