### PR TITLE
⬆ Bump `mkdocs-macros-plugin` from 1.3.7 to 1.3.9

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -15,5 +15,5 @@ mkdocstrings[python]==0.26.1
 griffe-typingdoc==0.2.8
 # For griffe, it formats with black
 black==25.1.0
-mkdocs-macros-plugin==1.3.7
+mkdocs-macros-plugin==1.3.9
 markdown-include-variants==0.0.4


### PR DESCRIPTION
Bump `mkdocs-macros-plugin` from 1.3.7 to 1.3.9