### PR TITLE
📝 Remove links to site callbackhell.com that doesn't exist anymore

### DIFF
--- a/docs/de/docs/async.md
+++ b/docs/de/docs/async.md
@@ -381,7 +381,7 @@ Davor war der Umgang mit asynchronem Code jedoch deutlich komplexer und schwieri
 
 In früheren Versionen von Python hätten Sie Threads oder <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a> verwenden können. Der Code ist jedoch viel komplexer zu verstehen, zu debuggen und nachzuvollziehen.
 
-In früheren Versionen von NodeJS / Browser JavaScript hätten Sie „Callbacks“ verwendet. Was zur <a href="http://callbackhell.com/" class="external-link" target="_blank">Callback-Hölle</a> führt.
+In früheren Versionen von NodeJS / Browser JavaScript hätten Sie „Callbacks“ verwendet. Was zur "Callback-Hölle" führt.
 
 ## Coroutinen
 

--- a/docs/em/docs/async.md
+++ b/docs/em/docs/async.md
@@ -381,7 +381,7 @@ async def read_burgers():
 
 ⏮️ ⏬ 🐍, 👆 💪 ✔️ ⚙️ 🧵 ⚖️ <a href="https://www.gevent.org/" class="external-link" target="_blank">🐁</a>. ✋️ 📟 🌌 🌖 🏗 🤔, ℹ, &amp; 💭 🔃.
 
-⏮️ ⏬ ✳ / 🖥 🕸, 👆 🔜 ✔️ ⚙️ "⏲". ❔ ↘️ <a href="http://callbackhell.com/" class="external-link" target="_blank">⏲ 🔥😈</a>.
+⏮️ ⏬ ✳ / 🖥 🕸, 👆 🔜 ✔️ ⚙️ "⏲". ❔ ↘️ "⏲ 🔥😈".
 
 ## 🔁
 

--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -383,7 +383,7 @@ But before that, handling asynchronous code was quite more complex and difficult
 
 In previous versions of Python, you could have used threads or <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>. But the code is way more complex to understand, debug, and think about.
 
-In previous versions of NodeJS / Browser JavaScript, you would have used "callbacks". Which leads to <a href="http://callbackhell.com/" class="external-link" target="_blank">callback hell</a>.
+In previous versions of NodeJS / Browser JavaScript, you would have used "callbacks". Which leads to "callback hell".
 
 ## Coroutines
 

--- a/docs/es/docs/async.md
+++ b/docs/es/docs/async.md
@@ -383,7 +383,7 @@ Pero antes de eso, manejar el código asíncrono era mucho más complejo y difí
 
 En versiones previas de Python, podrías haber usado hilos o <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>. Pero el código es mucho más complejo de entender, depurar y razonar.
 
-En versiones previas de NodeJS / JavaScript en el Navegador, habrías usado "callbacks". Lo que lleva al <a href="http://callbackhell.com/" class="external-link" target="_blank">callback hell</a>.
+En versiones previas de NodeJS / JavaScript en el Navegador, habrías usado "callbacks". Lo que lleva al "callback hell".
 
 ## Coroutines
 

--- a/docs/fa/docs/async.md
+++ b/docs/fa/docs/async.md
@@ -383,7 +383,7 @@ Starlette (و **FastAPI**) بر پایه <a href="https://anyio.readthedocs.io/e
 
 توی نسخه‌های قبلی پایتون، می‌تونستی از نخ‌ها یا <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a> استفاده کنی. ولی کد خیلی پیچیده‌تر می‌شه برای فهمیدن، دیباگ کردن و فکر کردن بهش.
 
-توی نسخه‌های قبلی NodeJS / جاوااسکریپت مرورگر، از "کال‌بک‌ها" استفاده می‌کردی. که می‌رسید به <a href="http://callbackhell.com/" class="external-link" target="_blank">جهان کال‌بک‌ها</a>.
+توی نسخه‌های قبلی NodeJS / جاوااسکریپت مرورگر، از "کال‌بک‌ها" استفاده می‌کردی. که می‌رسید به "جهان کال‌بک‌ها".
 
 ## کروتین‌ها
 

--- a/docs/fr/docs/async.md
+++ b/docs/fr/docs/async.md
@@ -372,7 +372,7 @@ Mais avant ça, gérer du code asynchrone était bien plus complexe et difficile
 
 Dans les versions précédentes de Python, vous auriez utilisé des *threads* ou <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>.  Mais le code aurait été bien plus difficile à comprendre, débugger, et concevoir.
 
-Dans les versions précédentes de Javascript NodeJS / Navigateur, vous auriez utilisé des "callbacks". Menant potentiellement à ce que l'on appelle <a href="http://callbackhell.com/" class="external-link" target="_blank">le "callback hell"</a>.
+Dans les versions précédentes de Javascript NodeJS / Navigateur, vous auriez utilisé des "callbacks". Menant potentiellement à ce que l'on appelle le "callback hell".
 
 
 ## Coroutines

--- a/docs/ja/docs/async.md
+++ b/docs/ja/docs/async.md
@@ -338,7 +338,7 @@ async def read_burgers():
 
 以前のバージョンのPythonでは、スレッドや<a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>が利用できました。しかし、コードは理解、デバック、そして、考察がはるかに複雑です。
 
-以前のバージョンのNodeJS / ブラウザJavaScriptでは、「コールバック」を使用していました。これは、<a href="http://callbackhell.com/" class="external-link" target="_blank">コールバック地獄</a>につながります。
+以前のバージョンのNodeJS / ブラウザJavaScriptでは、「コールバック」を使用していました。これは、「コールバック地獄」につながります。
 
 ## コルーチン
 

--- a/docs/ko/docs/async.md
+++ b/docs/ko/docs/async.md
@@ -349,7 +349,7 @@ FastAPI를 사용하지 않더라도, 높은 호환성 및 <a href="https://anyi
 
 파이썬의 예전 버전이라면, 스레드 또는 <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>를 사용할 수 있을 것입니다. 하지만 코드를 이해하고, 디버깅하고, 이에 대해 생각하는게 훨씬 복잡합니다.
 
-예전 버전의 NodeJS / 브라우저 자바스크립트라면, "콜백 함수"를 사용했을 것입니다. 그리고 이로 인해 <a href="http://callbackhell.com/" class="external-link" target="_blank">콜백 지옥</a>에 빠지게 될 수 있습니다.
+예전 버전의 NodeJS / 브라우저 자바스크립트라면, "콜백 함수"를 사용했을 것입니다. 그리고 이로 인해 "콜백 지옥"에 빠지게 될 수 있습니다.
 
 ## 코루틴
 

--- a/docs/pt/docs/async.md
+++ b/docs/pt/docs/async.md
@@ -348,7 +348,7 @@ Mas antes disso, controlar código assíncrono era bem mais complexo e difícil.
 
 Nas versões anteriores do Python, você poderia utilizar threads ou <a href="http://www.gevent.org/" class="external-link" target="_blank">Gevent</a>. Mas o código é bem mais complexo de entender, debugar, e pensar sobre.
 
-Nas versões anteriores do NodeJS / Navegador JavaScript, você utilizaria "callbacks". O que leva ao  <a href="http://callbackhell.com/" class="external-link" target="_blank">inferno do callback</a>.
+Nas versões anteriores do NodeJS / Navegador JavaScript, você utilizaria "callbacks". O que leva ao "inferno do callback".
 
 ## Corrotinas
 

--- a/docs/ru/docs/async.md
+++ b/docs/ru/docs/async.md
@@ -420,7 +420,7 @@ Starlette (и **FastAPI**) основаны на <a href="https://anyio.readthed
 
 Что касается JavaScript (в браузере и NodeJS), раньше там использовали для этой цели
 <abbr title="callback">"обратные вызовы"</abbr>. Что выливалось в
-<a href="http://callbackhell.ru/" class="external-link" target="_blank">ад обратных вызовов</a>.
+"ад обратных вызовов".
 
 ## Сопрограммы
 

--- a/docs/tr/docs/async.md
+++ b/docs/tr/docs/async.md
@@ -346,7 +346,7 @@ Ancak bundan önce, asenkron kodu işlemek oldukça karmaşık ve zordu.
 
 Python'un önceki sürümlerinde, threadlerı veya <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a> kullanıyor olabilirdin. Ancak kodu anlamak, hata ayıklamak ve düşünmek çok daha karmaşık olurdu.
 
-NodeJS / Browser JavaScript'in önceki sürümlerinde, "callback" kullanırdınız. Bu da <a href="http://callbackhell.com/" class="external-link" target="_blank">callbacks cehennemine</a> yol açar.
+NodeJS / Browser JavaScript'in önceki sürümlerinde, "callback" kullanırdınız. Bu da "callbacks cehennemine" yol açar.
 
 ## Coroutine'ler
 

--- a/docs/zh-hant/docs/async.md
+++ b/docs/zh-hant/docs/async.md
@@ -381,7 +381,7 @@ Starlette （和 **FastAPI**） 是基於 <a href="https://anyio.readthedocs.io/
 
 在較舊的 Python 版本中，你可能會使用多執行緒或 <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>。但這些程式碼要更難以理解、調試和思考。
 
-在較舊的 NodeJS / 瀏覽器 JavaScript 中，你會使用「回呼」，這可能會導致<a href="http://callbackhell.com/" class="external-link" target="_blank">回呼地獄</a>。
+在較舊的 NodeJS / 瀏覽器 JavaScript 中，你會使用「回呼」，這可能會導致“回呼地獄”。
 
 ## 協程
 

--- a/docs/zh/docs/async.md
+++ b/docs/zh/docs/async.md
@@ -383,7 +383,7 @@ Starlette （和 **FastAPI**） 是基于 <a href="https://anyio.readthedocs.io/
 
 在以前版本的 Python，你可以使用多线程或者 <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>。但代码的理解、调试和思考都要复杂许多。
 
-在以前版本的 NodeJS / 浏览器 JavaScript 中，你会使用"回调"，因此也可能导致<a href="http://callbackhell.com/" class="external-link" target="_blank">回调地狱</a>。
+在以前版本的 NodeJS / 浏览器 JavaScript 中，你会使用"回调"，因此也可能导致“回调地狱”。
 
 ## 协程
 


### PR DESCRIPTION
I noticed them walking through the "Learn" doc in the website. The website callbackhell.com does not exists anymore.

Links pointing to callbackhell.ru are still working, but if you want I can remove them as well for consistency.