### PR TITLE
📝 Add APIKeyHeader usage example to security documentation

### DIFF
--- a/docs/en/docs/reference/security/index.md
+++ b/docs/en/docs/reference/security/index.md
@@ -34,6 +34,35 @@ from fastapi.security import (
 
 ::: fastapi.security.APIKeyHeader
 
+### Using APIKeyHeader
+
+`APIKeyHeader` is a security tool for extracting API keys from HTTP headers.
+
+Here’s a simple example of how to use it in FastAPI:
+
+```python
+from fastapi import FastAPI, Security, HTTPException
+from fastapi.security import APIKeyHeader
+from starlette.status import HTTP_403_FORBIDDEN
+
+app = FastAPI()
+
+API_KEY = "mysecretapikey"
+API_KEY_NAME = "access_token"
+api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
+
+@app.get("/secure-data")
+async def secure_data(api_key: str = Security(api_key_header)):
+    if api_key == API_KEY:
+        return {"message": "Secure data accessed"}
+    else:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN, detail="Could not validate API key"
+        )
+
+
+
+
 ::: fastapi.security.APIKeyQuery
 
 ## HTTP Authentication Schemes


### PR DESCRIPTION
This PR adds a working example and explanation of how to use APIKeyHeader with the Security dependency in FastAPI.

It helps clarify usage for beginners and enhances the API Key Security Schemes section in the documentation.
