### PR TITLE
📝 Add APIKey Header documentation to the Security tutorial

### DIFF
--- a/docs/en/docs/tutorial/security/api-key.md
+++ b/docs/en/docs/tutorial/security/api-key.md
@@ -1,0 +1,28 @@
+# APIKey Header
+
+FastAPI supports using **API keys** as an alternative to OAuth2/JWT.
+
+This is useful when you want to quickly secure an endpoint with a simple key check.
+
+---
+
+## 📘 Example
+
+```python
+from fastapi import FastAPI, Security, HTTPException, Depends
+from fastapi.security.api_key import APIKeyHeader
+
+app = FastAPI()
+
+API_KEY = "supersecretapikey"
+api_key_header = APIKeyHeader(name="X-API-Key")
+
+def get_api_key(api_key: str = Security(api_key_header)):
+    if api_key != API_KEY:
+        raise HTTPException(status_code=403, detail="Could not validate API KEY")
+    return api_key
+
+@app.get("/secure-data/")
+def secure_data(api_key: str = Depends(get_api_key)):
+    return {"message": "You have access to secure data!"}
+```

--- a/docs/en/docs/tutorial/security/index.md
+++ b/docs/en/docs/tutorial/security/index.md
@@ -104,3 +104,5 @@ FastAPI provides several tools for each of these security schemes in the `fastap
 In the next chapters you will see how to add security to your API using those tools provided by **FastAPI**.
 
 And you will also see how it gets automatically integrated into the interactive documentation system.
+
+- [APIKey Header](api-key.md)


### PR DESCRIPTION
Added an example of `APIKeyHeader` for header-based API key authentication.

- Includes a clear example of header-based API key usage.
- Demonstrates the `auto_error=False` behavior for more control over error handling.
- Fills a documentation gap to help new users secure their endpoints.