### PR TITLE
🐛 Fix `inspect.getcoroutinefunction()` can break testing with `unittest.mock.patch()`

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 from contextlib import AsyncExitStack, contextmanager
 from copy import copy, deepcopy
 from dataclasses import dataclass
@@ -72,6 +73,11 @@ from starlette.requests import HTTPConnection, Request
 from starlette.responses import Response
 from starlette.websockets import WebSocket
 from typing_extensions import Annotated, get_args, get_origin
+
+if sys.version_info >= (3, 13):  # pragma: no cover
+    from inspect import iscoroutinefunction
+else:  # pragma: no cover
+    from asyncio import iscoroutinefunction
 
 multipart_not_installed_error = (
     'Form data requires "python-multipart" to be installed. \n'
@@ -529,11 +535,11 @@ def add_param_to_fields(*, field: ModelField, dependant: Dependant) -> None:
 
 def is_coroutine_callable(call: Callable[..., Any]) -> bool:
     if inspect.isroutine(call):
-        return inspect.iscoroutinefunction(call)
+        return iscoroutinefunction(call)
     if inspect.isclass(call):
         return False
     dunder_call = getattr(call, "__call__", None)  # noqa: B004
-    return inspect.iscoroutinefunction(dunder_call)
+    return iscoroutinefunction(dunder_call)
 
 
 def is_async_gen_callable(call: Callable[..., Any]) -> bool:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -3,6 +3,7 @@ import dataclasses
 import email.message
 import inspect
 import json
+import sys
 from contextlib import AsyncExitStack, asynccontextmanager
 from enum import Enum, IntEnum
 from typing import (
@@ -76,6 +77,10 @@ from starlette.types import AppType, ASGIApp, Lifespan, Scope
 from starlette.websockets import WebSocket
 from typing_extensions import Annotated, Doc, deprecated
 
+if sys.version_info >= (3, 13):  # pragma: no cover
+    from inspect import iscoroutinefunction
+else:  # pragma: no cover
+    from asyncio import iscoroutinefunction    
 
 def _prepare_response_content(
     res: Any,
@@ -231,7 +236,7 @@ def get_request_handler(
     embed_body_fields: bool = False,
 ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
     assert dependant.call is not None, "dependant.call must be a function"
-    is_coroutine = asyncio.iscoroutinefunction(dependant.call)
+    is_coroutine = iscoroutinefunction(dependant.call)
     is_body_form = body_field and isinstance(body_field.field_info, params.Form)
     if isinstance(response_class, DefaultPlaceholder):
         actual_response_class: Type[Response] = response_class.value

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1,4 +1,3 @@
-import asyncio
 import dataclasses
 import email.message
 import inspect
@@ -80,7 +79,8 @@ from typing_extensions import Annotated, Doc, deprecated
 if sys.version_info >= (3, 13):  # pragma: no cover
     from inspect import iscoroutinefunction
 else:  # pragma: no cover
-    from asyncio import iscoroutinefunction    
+    from asyncio import iscoroutinefunction
+
 
 def _prepare_response_content(
     res: Any,


### PR DESCRIPTION
### Description

This issue is related to a known Python bug that was fixed in Python 3.13 but has not been backported to earlier versions: https://github.com/python/cpython/issues/94924
As a workaround for versions prior to Python 3.13, we could consider using conditional imports based on the Python version:

Resolves https://github.com/fastapi/fastapi/discussions/14021

```
if sys.version_info < (3, 13):
    from asyncio import iscoroutinefunction
else:
    from inspect import iscoroutinefunction
```


### Example Code

```python
import sys
import asyncio
import inspect
from unittest.mock import create_autospec, patch

print(f"Python version: {sys.version_info[:2]}") # (3, 12)

async def foo():
    pass

mock_autospec = create_autospec(foo)
print(asyncio.iscoroutinefunction(mock_autospec)) # True
print(inspect.iscoroutinefunction(mock_autospec)) # False

with patch('__main__.foo', autospec=True) as mock_foo:
    print(asyncio.iscoroutinefunction(mock_foo)) # True
    print(inspect.iscoroutinefunction(mock_foo)) # False
```