### PR TITLE
🐛 Ensure that ASGIApp is mounted correctly to the sub-routes

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1355,6 +1355,8 @@ class APIRouter(routing.Router):
                 self.add_websocket_route(
                     prefix + route.path, route.endpoint, name=route.name
                 )
+            elif isinstance(route, routing.Mount):
+                self.mount(prefix + route.path, route.app, name=route.name)
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/tests/test_additional_response_extra.py
+++ b/tests/test_additional_response_extra.py
@@ -1,4 +1,7 @@
+from pathlib import Path as libPath
+
 from fastapi import APIRouter, FastAPI
+from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
 router = APIRouter()
@@ -6,6 +9,11 @@ router = APIRouter()
 sub_router = APIRouter()
 
 app = FastAPI()
+
+
+sub_router.mount(
+    "/static", StaticFiles(directory=libPath(__file__).resolve().parent), name="static"
+)
 
 
 @sub_router.get("/")
@@ -18,6 +26,14 @@ router.include_router(sub_router, prefix="/items")
 app.include_router(router)
 
 client = TestClient(app)
+
+
+def test_sub_router_mount():
+    response = client.get(f"/items/static/{libPath(__file__).resolve().stem}.py")
+    assert response.status_code == 200, response.text
+
+
+test_sub_router_mount()
 
 
 def test_path_operation():


### PR DESCRIPTION
During the use of FastAPI, I noticed a problem with sub-routes, My project structure is as follows:
```
┌─example
│ ├─main.py
│ └─sub_dir
│   ├─__init__.py
│   └─static
│     └─index.html
```
The code is as follows:

```python
# example/main.py
from fastapi import FastAPI

from sub_dir import sub_dir

app = FastAPI()
app.include_router(sub_dir, prefix="/app")

if __name__ == "__main__":
    import uvicorn

    uvicorn.run(app, host="127.0.0.1", port=8000)

```

```python
# example/sub_dir/__init__.py
from pathlib import Path as libPath

from fastapi import APIRouter
from fastapi.staticfiles import StaticFiles

skip = APIRouter()
skip.mount("/static", StaticFiles(directory=libPath(__file__).resolve().parent / "static"), name="skip")

__all__ = ["skip"]
```

After running `main.py` and accessing `http://127.0.0.1:8000/app/sub_dir/index.html`, one should have seen the content of `example/sub_dir/static/index.html`. However, it did not display as expected, Log entry as follows:
```
INFO:     Started server process [60576]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:59030 - "GET /app/sub_dir/index.html HTTP/1.1" 404 Not Found
```

By examining the source code, it was discovered that `APIRouter.include_router` failed to properly handle `routing.Mount`.

After the repair, we ran `main.py`, and we could see that the content in `example/sub_dir/static/index.html` could be displayed normally. The log is as follows:
```
INFO:     Started server process [78196]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:58825 - "GET /app/sub_dir/index.html HTTP/1.1" 200 OK
```

This will be extremely useful in complex routing scenarios!!!