### PR TITLE
docs: clarify auto-reload behavior in FastAPI CLI docs

### DIFF
--- a/docs/en/docs/fastapi-cli.md
+++ b/docs/en/docs/fastapi-cli.md
@@ -58,7 +58,7 @@ Internally, **FastAPI CLI** uses <a href="https://www.uvicorn.org" class="extern
 
 Running `fastapi dev` initiates development mode.
 
-By default, **auto-reload** is enabled, automatically reloading the server when you make changes to your code. This is resource-intensive and could be less stable than when it's disabled. You should only use it for development. It also listens on the IP address `127.0.0.1`, which is the IP for your machine to communicate with itself alone (`localhost`).
+By default, **auto-reload** is enabled which automatically reloads the server when you make changes to your code. This is resource-intensive and could be less stable than when it's disabled. You should only use it for development. It also listens on the IP address `127.0.0.1`, which is the IP for your machine to communicate with itself alone (`localhost`).
 
 ## `fastapi run` { #fastapi-run }
 


### PR DESCRIPTION
### Description
Reworded a sentence in the documentation for clarity:

- Changed: "estimation based on tests on an internal development team"
- To: "estimation based on tests conducted by an internal development team"

This avoids the awkward phrasing "tests on a team" and makes the meaning clearer without altering the intent.
