### PR TITLE
docs: clarify phrasing in estimation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The key features are:
 * **Robust**: Get production-ready code. With automatic interactive documentation.
 * **Standards-based**: Based on (and fully compatible with) the open standards for APIs: <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> (previously known as Swagger) and <a href="https://json-schema.org/" class="external-link" target="_blank">JSON Schema</a>.
 
-<small>* estimation based on tests on an internal development team, building production applications.</small>
+<small>* estimation based on tests conducted by an internal development team, building production applications.</small>
 
 ## Sponsors { #sponsors }
 


### PR DESCRIPTION
### Description
This PR improves the clarity of a documentation note by rephrasing a sentence:

- **Before:** "estimation based on tests on an internal development team, building production applications."
- **After:** "estimation based on tests conducted by an internal development team, building production applications."

The new phrasing avoids the ambiguity of "tests on a team" and makes it clear that the internal team performed the tests.

### Pull Request type
- [x] Documentation

### Notes
This is a minor language/clarity change and does not affect any code or functionality.
