### PR TITLE
✨ Add a `default_status_code` attribute to FastAPI response classes

### DIFF
--- a/docs/en/docs/reference/responses.md
+++ b/docs/en/docs/reference/responses.md
@@ -20,6 +20,24 @@ from fastapi.responses import (
 )
 ```
 
+### Default status codes
+
+Each response class exposes a `default_status_code` class attribute with the HTTP
+status code used when no `status_code` is provided. FastAPI relies on this
+attribute when generating OpenAPI documentation.
+
+| Response class | Default status code |
+| -------------- | ------------------ |
+| `Response` | `200` |
+| `PlainTextResponse` | `200` |
+| `JSONResponse` | `200` |
+| `HTMLResponse` | `200` |
+| `FileResponse` | `200` |
+| `StreamingResponse` | `200` |
+| `RedirectResponse` | `307` |
+| `UJSONResponse` | `200` |
+| `ORJSONResponse` | `200` |
+
 ## FastAPI Responses
 
 There are a couple of custom FastAPI response classes, you can use them to optimize JSON performance.
@@ -29,6 +47,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
         members:
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -44,6 +63,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
         members:
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -62,6 +82,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
             - chunk_size
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -77,6 +98,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
         members:
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -92,6 +114,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
         members:
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -107,6 +130,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
         members:
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -122,6 +146,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
         members:
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -137,6 +162,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
         members:
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background
@@ -153,6 +179,7 @@ There are a couple of custom FastAPI response classes, you can use them to optim
             - body_iterator
             - charset
             - status_code
+            - default_status_code
             - media_type
             - body
             - background

--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -1,12 +1,52 @@
-from typing import Any
+from typing import Any, Optional
 
-from starlette.responses import FileResponse as FileResponse  # noqa
-from starlette.responses import HTMLResponse as HTMLResponse  # noqa
-from starlette.responses import JSONResponse as JSONResponse  # noqa
-from starlette.responses import PlainTextResponse as PlainTextResponse  # noqa
-from starlette.responses import RedirectResponse as RedirectResponse  # noqa
-from starlette.responses import Response as Response  # noqa
-from starlette.responses import StreamingResponse as StreamingResponse  # noqa
+from starlette.responses import FileResponse as StarletteFileResponse
+from starlette.responses import HTMLResponse as StarletteHTMLResponse
+from starlette.responses import JSONResponse as StarletteJSONResponse
+from starlette.responses import PlainTextResponse as StarlettePlainTextResponse
+from starlette.responses import RedirectResponse as StarletteRedirectResponse
+from starlette.responses import Response as StarletteResponse
+from starlette.responses import StreamingResponse as StarletteStreamingResponse
+
+
+class Response(StarletteResponse):
+    default_status_code: int = 200
+
+    def __init__(
+        self,
+        content: Any = None,
+        *,
+        status_code: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        if status_code is None:
+            status_code = self.default_status_code
+        super().__init__(content=content, status_code=status_code, **kwargs)
+
+
+class PlainTextResponse(StarlettePlainTextResponse):
+    default_status_code = 200
+
+
+class JSONResponse(StarletteJSONResponse):
+    default_status_code = 200
+
+
+class HTMLResponse(StarletteHTMLResponse):
+    default_status_code = 200
+
+
+class FileResponse(StarletteFileResponse):
+    default_status_code = 200
+
+
+class StreamingResponse(StarletteStreamingResponse):
+    default_status_code = 200
+
+
+class RedirectResponse(StarletteRedirectResponse):
+    default_status_code = 307
+
 
 try:
     import ujson
@@ -28,6 +68,8 @@ class UJSONResponse(JSONResponse):
     [FastAPI docs for Custom Response - HTML, Stream, File, others](https://fastapi.tiangolo.com/advanced/custom-response/).
     """
 
+    default_status_code = getattr(JSONResponse, "default_status_code", 200)
+
     def render(self, content: Any) -> bytes:
         assert ujson is not None, "ujson must be installed to use UJSONResponse"
         return ujson.dumps(content, ensure_ascii=False).encode("utf-8")
@@ -40,6 +82,8 @@ class ORJSONResponse(JSONResponse):
     Read more about it in the
     [FastAPI docs for Custom Response - HTML, Stream, File, others](https://fastapi.tiangolo.com/advanced/custom-response/).
     """
+
+    default_status_code = getattr(JSONResponse, "default_status_code", 200)
 
     def render(self, content: Any) -> bytes:
         assert orjson is not None, "orjson must be installed to use ORJSONResponse"

--- a/tests/test_response_class_default_status_code.py
+++ b/tests/test_response_class_default_status_code.py
@@ -1,0 +1,72 @@
+from fastapi import FastAPI
+from fastapi.responses import (
+    JSONResponse,
+    ORJSONResponse,
+    RedirectResponse,
+    Response,
+    UJSONResponse,
+)
+from fastapi.testclient import TestClient
+
+
+def test_response_classes_have_default_status_code_attribute() -> None:
+    assert Response.default_status_code == 200
+    assert JSONResponse.default_status_code == 200
+    assert RedirectResponse.default_status_code == 307
+
+
+def test_json_variants_default_status_code_attribute() -> None:
+    assert UJSONResponse.default_status_code == JSONResponse.default_status_code
+    assert ORJSONResponse.default_status_code == JSONResponse.default_status_code
+
+
+class CustomResponse(Response):
+    default_status_code = 204
+
+
+app = FastAPI()
+
+
+@app.get("/", response_class=CustomResponse)
+def read_root() -> str:
+    return "Hello"
+
+
+client = TestClient(app)
+
+
+def test_default_status_code_used_for_instances() -> None:
+    response = Response()
+    assert response.status_code == 200
+    custom_response = Response(status_code=201)
+    assert custom_response.status_code == 201
+    assert Response.default_status_code == 200
+
+
+def test_custom_response_status_code_handling_and_openapi() -> None:
+    response = client.get("/")
+    assert response.status_code == 204
+    openapi_schema = app.openapi()
+    assert "204" in openapi_schema["paths"]["/"]["get"]["responses"]
+    overridden = CustomResponse(status_code=202)
+    assert overridden.status_code == 202
+
+
+def test_default_status_code_inherited_in_subclass() -> None:
+    class ParentResponse(Response):
+        default_status_code = 203
+
+    class ChildResponse(ParentResponse):
+        pass
+
+    app = FastAPI()
+
+    @app.get("/child", response_class=ChildResponse)
+    def read_child() -> str:
+        return "Child"
+
+    child_client = TestClient(app)
+    response = child_client.get("/child")
+    assert response.status_code == 203
+    openapi_schema = app.openapi()
+    assert "203" in openapi_schema["paths"]["/child"]["get"]["responses"]


### PR DESCRIPTION
This PR adds explicit `default_status_code` attributes to all FastAPI response classes and updates the OpenAPI documentation generation logic to use these attributes safely.

The explicit `default_status_code` attributes also improve code clarity by making it obvious what status code each response type uses by default, and they're properly reflected in the generated OpenAPI schemas.