### PR TITLE
⬆️ Upgrade Starlette supported version range to >=0.40.0,<0.49.0

### DIFF
--- a/docs_src/handling_errors/tutorial005.py
+++ b/docs_src/handling_errors/tutorial005.py
@@ -10,7 +10,7 @@ app = FastAPI()
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
     )
 

--- a/docs_src/handling_errors/tutorial005.py
+++ b/docs_src/handling_errors/tutorial005.py
@@ -10,8 +10,6 @@ app = FastAPI()
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return JSONResponse(
-        # 422 = fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
-        # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
         status_code=422,
         content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
     )

--- a/docs_src/handling_errors/tutorial005.py
+++ b/docs_src/handling_errors/tutorial005.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request, status
+from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -10,7 +10,9 @@ app = FastAPI()
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        # 422 = fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
+        # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
+        status_code=422,
         content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
     )
 

--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -5,7 +5,7 @@ from fastapi.websockets import WebSocket
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
-from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY, WS_1008_POLICY_VIOLATION
+from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT, WS_1008_POLICY_VIOLATION
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
@@ -21,7 +21,7 @@ async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
     return JSONResponse(
-        status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=HTTP_422_UNPROCESSABLE_CONTENT,
         content={"detail": jsonable_encoder(exc.errors())},
     )
 

--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -21,8 +21,6 @@ async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
     return JSONResponse(
-        # 422 = starlette.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
-        # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
         status_code=422,
         content={"detail": jsonable_encoder(exc.errors())},
     )

--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -5,7 +5,7 @@ from fastapi.websockets import WebSocket
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
-from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT, WS_1008_POLICY_VIOLATION
+from starlette.status import WS_1008_POLICY_VIOLATION
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
@@ -21,7 +21,9 @@ async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
     return JSONResponse(
-        status_code=HTTP_422_UNPROCESSABLE_CONTENT,
+        # 422 = starlette.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
+        # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
+        status_code=422,
         content={"detail": jsonable_encoder(exc.errors())},
     )
 

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -35,7 +35,6 @@ from fastapi.utils import (
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute
-from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 from typing_extensions import Literal
 
 validation_error_definition = {
@@ -416,7 +415,9 @@ def get_openapi_path(
                     )
                     deep_dict_update(openapi_response, process_response)
                     openapi_response["description"] = description
-            http422 = str(HTTP_422_UNPROCESSABLE_CONTENT)
+            # 422 = starlette.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
+            # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
+            http422 = "422"
             all_route_params = get_flat_params(route.dependant)
             if (all_route_params or route.body_field) and not any(
                 status in operation["responses"]

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -415,8 +415,6 @@ def get_openapi_path(
                     )
                     deep_dict_update(openapi_response, process_response)
                     openapi_response["description"] = description
-            # 422 = starlette.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
-            # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
             http422 = "422"
             all_route_params = get_flat_params(route.dependant)
             if (all_route_params or route.body_field) and not any(

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -35,7 +35,7 @@ from fastapi.utils import (
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute
-from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 from typing_extensions import Literal
 
 validation_error_definition = {
@@ -416,7 +416,7 @@ def get_openapi_path(
                     )
                     deep_dict_update(openapi_response, process_response)
                     openapi_response["description"] = description
-            http422 = str(HTTP_422_UNPROCESSABLE_ENTITY)
+            http422 = str(HTTP_422_UNPROCESSABLE_CONTENT)
             all_route_params = get_flat_params(route.dependant)
             if (all_route_params or route.body_field) and not any(
                 status in operation["responses"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.40.0,<0.48.0",
+    "starlette>=0.48.0,<0.49.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.48.0,<0.49.0",
+    "starlette>=0.40.0,<0.49.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
 ]

--- a/tests/test_enforce_once_required_parameter.py
+++ b/tests/test_enforce_once_required_parameter.py
@@ -102,7 +102,7 @@ def test_schema():
 
 def test_get_invalid():
     response = client.get("/foo")
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_get_valid():

--- a/tests/test_enforce_once_required_parameter.py
+++ b/tests/test_enforce_once_required_parameter.py
@@ -102,7 +102,9 @@ def test_schema():
 
 def test_get_invalid():
     response = client.get("/foo")
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    # 422 = fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
+    # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == 422
 
 
 def test_get_valid():

--- a/tests/test_enforce_once_required_parameter.py
+++ b/tests/test_enforce_once_required_parameter.py
@@ -102,8 +102,6 @@ def test_schema():
 
 def test_get_invalid():
     response = client.get("/foo")
-    # 422 = fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT (RFC 9110,
-    # Starlette >=0.48), previously HTTP_422_UNPROCESSABLE_ENTITY
     assert response.status_code == 422
 
 


### PR DESCRIPTION
Starlette 0.48.0 introduced `HTTP_422_UNPROCESSABLE_CONTENT` as a new name for `HTTP_422_UNPROCESSABLE_ENTITY` and deprecated the old name due to RFC 9110; see https://github.com/Kludex/starlette/pull/2939.

I updated all instances ~to the new name and increased the lower bound on the Starlette version~ to use the literal integer or string value `422`/`"422"` instead of either `HTTP_422_UNPROCESSABLE_CONTENT` or `HTTP_422_UNPROCESSABLE_ENTITY`, which makes FastAPI compatible with Starlette >=0.48 without deprecation warnings while preserving backwards compatibility with Starlette<0.48.

@Kludex, FYI.