### PR TITLE
🚨 Install pydantic.mypy plugin

### DIFF
--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -100,7 +100,7 @@ class APIKeyQuery(APIKeyBase):
         ] = True,
     ):
         self.model: APIKey = APIKey(
-            **{"in": APIKeyIn.query},  # type: ignore[arg-type]
+            **{"in": APIKeyIn.query},
             name=name,
             description=description,
         )
@@ -188,7 +188,7 @@ class APIKeyHeader(APIKeyBase):
         ] = True,
     ):
         self.model: APIKey = APIKey(
-            **{"in": APIKeyIn.header},  # type: ignore[arg-type]
+            **{"in": APIKeyIn.header},
             name=name,
             description=description,
         )
@@ -276,7 +276,7 @@ class APIKeyCookie(APIKeyBase):
         ] = True,
     ):
         self.model: APIKey = APIKey(
-            **{"in": APIKeyIn.cookie},  # type: ignore[arg-type]
+            **{"in": APIKeyIn.cookie},
             name=name,
             description=description,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ source-includes = [
 name = "fastapi-slim"
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 strict = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Functionality taken from https://github.com/fastapi/fastapi/pull/12970 by @tamird. 

This PR adds the Pydantic mypy plugin which improves the mypy type checking: https://docs.pydantic.dev/latest/integrations/mypy/

This allows us to remove a few `ignore` statements.