### PR TITLE
📌 Pin `httpx` to `>=0.23.0,<1.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ Changelog = "https://fastapi.tiangolo.com/release-notes/"
 standard = [
     "fastapi-cli[standard] >=0.0.8",
     # For the test client
-    "httpx >=0.23.0",
+    "httpx >=0.23.0,<0.29.0",
     # For templates
     "jinja2 >=3.1.5",
     # For forms and file uploads
@@ -79,7 +79,7 @@ standard = [
 standard-no-fastapi-cloud-cli = [
     "fastapi-cli[standard-no-fastapi-cloud-cli] >=0.0.8",
     # For the test client
-    "httpx >=0.23.0",
+    "httpx >=0.23.0,<0.29.0",
     # For templates
     "jinja2 >=3.1.5",
     # For forms and file uploads
@@ -98,7 +98,7 @@ standard-no-fastapi-cloud-cli = [
 all = [
     "fastapi-cli[standard] >=0.0.8",
     # # For the test client
-    "httpx >=0.23.0",
+    "httpx >=0.23.0,<0.29.0",
     # For templates
     "jinja2 >=3.1.5",
     # For forms and file uploads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ Changelog = "https://fastapi.tiangolo.com/release-notes/"
 standard = [
     "fastapi-cli[standard] >=0.0.8",
     # For the test client
-    "httpx >=0.23.0,<0.29.0",
+    "httpx >=0.23.0,<1.0.0",
     # For templates
     "jinja2 >=3.1.5",
     # For forms and file uploads
@@ -79,7 +79,7 @@ standard = [
 standard-no-fastapi-cloud-cli = [
     "fastapi-cli[standard-no-fastapi-cloud-cli] >=0.0.8",
     # For the test client
-    "httpx >=0.23.0,<0.29.0",
+    "httpx >=0.23.0,<1.0.0",
     # For templates
     "jinja2 >=3.1.5",
     # For forms and file uploads
@@ -98,7 +98,7 @@ standard-no-fastapi-cloud-cli = [
 all = [
     "fastapi-cli[standard] >=0.0.8",
     # # For the test client
-    "httpx >=0.23.0,<0.29.0",
+    "httpx >=0.23.0,<1.0.0",
     # For templates
     "jinja2 >=3.1.5",
     # For forms and file uploads

--- a/requirements-docs-tests.txt
+++ b/requirements-docs-tests.txt
@@ -1,4 +1,4 @@
 # For mkdocstrings and tests
-httpx >=0.23.0,<0.29.0
+httpx >=0.23.0,<1.0.0
 # For linting and generating docs versions
 ruff ==0.12.7

--- a/requirements-github-actions.txt
+++ b/requirements-github-actions.txt
@@ -1,6 +1,6 @@
 PyGithub>=2.3.0,<3.0.0
 pydantic>=2.5.3,<3.0.0
 pydantic-settings>=2.1.0,<3.0.0
-httpx>=0.27.0,<0.29.0
+httpx>=0.27.0,<1.0.0
 pyyaml >=5.3.1,<7.0.0
 smokeshow


### PR DESCRIPTION
See discussion: https://github.com/fastapi/fastapi/discussions/14084

Currently we have `httpx >=0.23.0`, and impending httpx `1.x` release can break the api.

---

Also relaxed pins in dev dependencies and GH-actions


