### PR TITLE
📝 Clarify the difference between an empty string and `None` query parameter

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -265,7 +265,9 @@ You can declare that a parameter can accept `None`, but that it's still required
 To do that, you can declare that `None` is a valid type but simply do not declare a default value:
 
 {* ../../docs_src/query_params_str_validations/tutorial006c_an_py310.py hl[9] *}
-
+!!! note
+<'None" = parametter omitted from URL
+?q= is a empty string, not None>
 ## Query parameter list / multiple values { #query-parameter-list-multiple-values }
 
 When you define a query parameter explicitly with `Query` you can also declare it to receive a list of values, or said in another way, to receive multiple values.


### PR DESCRIPTION
Problem: Readers expect ?q= to pass None, but it passes empty string.

Change: Add note clarifying omission (None) vs empty string.

Why: Matches HTTP semantics & FastAPI behavior; reduces confusion.

Testing: Built docs locally; ran tutorial tests subset.