### PR TITLE
♻️ Refactor sponsor image handling

### DIFF
--- a/docs/en/docs/css/custom.css
+++ b/docs/en/docs/css/custom.css
@@ -102,7 +102,15 @@ a.announce-link:hover {
   align-items: center;
 }
 
-.announce-wrapper div.item {
+.announce-wrapper #announce-left div.item {
+  display: none;
+}
+
+.announce-wrapper #announce-right {
+  display: none;
+}
+
+.announce-wrapper #announce-right div.item {
   display: none;
 }
 
@@ -112,7 +120,7 @@ a.announce-link:hover {
   top: -10px;
   right: 0;
   font-size: 0.5rem;
-  color: #999;
+  color: #e6e6e6;
   background-color: #666;
   border-radius: 10px;
   padding: 0 10px;

--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -136,12 +136,10 @@ async function showRandomAnnouncement(groupId, timeInterval) {
 }
 
 function handleSponsorImages() {
-    const sponsorImages = document.querySelectorAll('.sponsor-image');
     const announceRight = document.getElementById('announce-right');
-
-    if (announceRight) {
-        announceRight.style.display = 'none';
-    }
+    if(!announceRight) return;
+    
+    const sponsorImages = document.querySelectorAll('.sponsor-image');
 
     const imagePromises = Array.from(sponsorImages).map(img => {
         return new Promise((resolve, reject) => {
@@ -156,10 +154,8 @@ function handleSponsorImages() {
 
     Promise.all(imagePromises)
         .then(() => {
-            if (announceRight) {
-                announceRight.style.display = 'block';
-                showRandomAnnouncement('announce-right', 10000);
-            }
+            announceRight.style.display = 'block';
+            showRandomAnnouncement('announce-right', 10000);
         })
         .catch(() => {
             // do nothing

--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -143,10 +143,16 @@ function handleSponsorImages() {
 
     const imagePromises = Array.from(sponsorImages).map(img => {
         return new Promise((resolve, reject) => {
-            if (img.complete) {
+            if (img.complete && img.naturalHeight !== 0) {
                 resolve();
             } else {
-                img.addEventListener('load', resolve);
+                img.addEventListener('load', () => {
+                    if (img.naturalHeight !== 0) {
+                        resolve();
+                    } else {
+                        reject();
+                    }
+                });
                 img.addEventListener('error', reject);
             }
         });

--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -135,28 +135,41 @@ async function showRandomAnnouncement(groupId, timeInterval) {
     }
 }
 
-function hideSponsorOnImageError() {
+function handleSponsorImages() {
     const sponsorImages = document.querySelectorAll('.sponsor-image');
     const announceRight = document.getElementById('announce-right');
 
-    function hideAnnounceRight() {
-        if (announceRight) {
-            announceRight.style.display = 'none';
-        }
+    if (announceRight) {
+        announceRight.style.display = 'none';
     }
 
-    sponsorImages.forEach(function(img) {
-        img.addEventListener('error', function() {
-            hideAnnounceRight();
+    const imagePromises = Array.from(sponsorImages).map(img => {
+        return new Promise((resolve, reject) => {
+            if (img.complete) {
+                resolve();
+            } else {
+                img.addEventListener('load', resolve);
+                img.addEventListener('error', reject);
+            }
         });
     });
+
+    Promise.all(imagePromises)
+        .then(() => {
+            if (announceRight) {
+                announceRight.style.display = 'block';
+                showRandomAnnouncement('announce-right', 10000);
+            }
+        })
+        .catch(() => {
+            // do nothing
+        });
 }
 
 async function main() {
     setupTermynal();
     showRandomAnnouncement('announce-left', 5000)
-    showRandomAnnouncement('announce-right', 10000)
-    hideSponsorOnImageError();
+    handleSponsorImages();
 }
 document$.subscribe(() => {
     main()

--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -138,7 +138,7 @@ async function showRandomAnnouncement(groupId, timeInterval) {
 function handleSponsorImages() {
     const announceRight = document.getElementById('announce-right');
     if(!announceRight) return;
-    
+
     const sponsorImages = document.querySelectorAll('.sponsor-image');
 
     const imagePromises = Array.from(sponsorImages).map(img => {


### PR DESCRIPTION
♻️ Refactor sponsor image handling

Hide the sponsor announcement area by default, wait for all sponsor images to load successfully, and only show the area if all images load properly