### PR TITLE
tests: add empty - string ('?q=') case --> 422 for regex validated qu…

### DIFF
--- a/tests/test_regex_deprecated_params.py
+++ b/tests/test_regex_deprecated_params.py
@@ -70,7 +70,38 @@ def test_query_params_str_validations_item_query_nonregexquery():
             ]
         }
     )
-
+    
+@needs_py310
+def test_query_params_str_validations_item_query_empty():
+    client = get_client()
+    response = client.get("/items/", params = {"q": ""})
+    assert response.status_code == 422
+    assert response.json() == IsDict(
+          {
+            "detail": [
+                {
+                    "type": "string_pattern_mismatch",
+                    "loc": ["query", "q"],
+                    "msg": "String should match pattern '^fixedquery$'",
+                    "input": "",
+                    "ctx": {"pattern": "^fixedquery$"},
+                }
+            ]
+        }
+    ) | IsDict(
+        # TODO: remove when deprecating Pydantic v1
+        {
+            "detail": [
+                {
+                    "ctx": {"pattern": "^fixedquery$"},
+                    "loc": ["query", "q"],
+                    "msg": 'string does not match regex "^fixedquery$"',
+                    "type": "value_error.str.regex",
+                }
+            ]
+        }
+    
+    )
 
 @needs_py310
 def test_openapi_schema():

--- a/tests/test_regex_deprecated_params.py
+++ b/tests/test_regex_deprecated_params.py
@@ -70,14 +70,15 @@ def test_query_params_str_validations_item_query_nonregexquery():
             ]
         }
     )
-    
+
+
 @needs_py310
 def test_query_params_str_validations_item_query_empty():
     client = get_client()
-    response = client.get("/items/", params = {"q": ""})
+    response = client.get("/items/", params={"q": ""})
     assert response.status_code == 422
     assert response.json() == IsDict(
-          {
+        {
             "detail": [
                 {
                     "type": "string_pattern_mismatch",
@@ -100,8 +101,8 @@ def test_query_params_str_validations_item_query_empty():
                 }
             ]
         }
-    
     )
+
 
 @needs_py310
 def test_openapi_schema():


### PR DESCRIPTION
Problem: ?q= sends an empty string (not None) and should fail ^fixedquery$ → 422.

Change: Add a test next to existing “no_query” and “fixedquery” cases.

Why: Complements docs clarification; prevents regressions.

Testing: Ran file-only and tutorial subset locally.