### PR TITLE
docs: clarify unsupported QUERY method + test

### DIFF
--- a/docs/en/docs/advanced/path-operation-advanced-configuration.md
+++ b/docs/en/docs/advanced/path-operation-advanced-configuration.md
@@ -202,3 +202,9 @@ Here we reuse the same Pydantic model.
 But the same way, we could have validated it in some other way.
 
 ///
+
+### Unsupported HTTP Methods
+
+FastAPI supports all standard HTTP methods defined by RFC 7231 (GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD).
+
+⚠️ Non-standard methods such as `QUERY` are **not supported** by FastAPI and will not be added, as they are not part of the HTTP specification.

--- a/tests/test_query_method.py
+++ b/tests/test_query_method.py
@@ -1,0 +1,11 @@
+import pytest
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+def test_no_query_method():
+    with pytest.raises(AttributeError):
+        getattr(app, "query")
+
+

--- a/tests/test_query_method.py
+++ b/tests/test_query_method.py
@@ -6,6 +6,4 @@ app = FastAPI()
 
 def test_no_query_method():
     with pytest.raises(AttributeError):
-        getattr(app, "query")
-
-
+        app.query


### PR DESCRIPTION
This PR clarifies that FastAPI only supports standard HTTP methods (RFC 7231).

- Added a note in docs about unsupported non-standard methods like QUERY
- Added a small test to confirm that app.query is invalid

Related to issue #12965
