### PR TITLE
Add helper function get_query_param to safely fetch query parameters

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -4444,7 +4444,8 @@ class APIRouter(routing.Router):
             return func
 
         return decorator
-    
+
+
 def get_query_param(request, name: str, default: str | None = None) -> str | None:
     """
     Utility function to safely fetch a query parameter from a request.

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -4444,3 +4444,20 @@ class APIRouter(routing.Router):
             return func
 
         return decorator
+    
+def get_query_param(request, name: str, default: str | None = None) -> str | None:
+    """
+    Utility function to safely fetch a query parameter from a request.
+
+    Args:
+        request: The request object.
+        name (str): The name of the query parameter to retrieve.
+        default (str | None, optional): The value to return if the parameter is missing. Defaults to None.
+
+    Returns:
+        str | None: The query parameter value, or the default if not found.
+    """
+    try:
+        return request.query_params.get(name, default)
+    except Exception:
+        return default

--- a/tests/test_get_query_param.py
+++ b/tests/test_get_query_param.py
@@ -1,15 +1,16 @@
-import pytest
-from starlette.requests import Request
-from fastapi.routing import get_query_param
-from starlette.testclient import TestClient
 from fastapi import FastAPI
+from fastapi.routing import get_query_param
+from starlette.requests import Request
+from starlette.testclient import TestClient
 
 app = FastAPI()
+
 
 @app.get("/demo")
 async def demo(request: Request):
     value = get_query_param(request, "name", default="guest")
     return {"name": value}
+
 
 client = TestClient(app)
 

--- a/tests/test_get_query_param.py
+++ b/tests/test_get_query_param.py
@@ -1,0 +1,24 @@
+import pytest
+from starlette.requests import Request
+from fastapi.routing import get_query_param
+from starlette.testclient import TestClient
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/demo")
+async def demo(request: Request):
+    value = get_query_param(request, "name", default="guest")
+    return {"name": value}
+
+client = TestClient(app)
+
+
+def test_existing_query_param():
+    response = client.get("/demo?name=josh")
+    assert response.json() == {"name": "josh"}
+
+
+def test_missing_query_param_returns_default():
+    response = client.get("/demo")
+    assert response.json() == {"name": "guest"}


### PR DESCRIPTION
### Summary

This PR introduces a new helper function `get_query_param` in `fastapi.routing`.  
It provides a safe and convenient way to fetch query parameters from a request, with support for a default fallback.

### Motivation

Currently, developers need to manually fetch query parameters and handle missing values.  
This helper improves ergonomics by centralizing the logic into one reusable utility.

### Implementation

- Added `get_query_param(request, name: str, default: str | None = None) -> str | None`
- Returns the query parameter value if present, otherwise returns the provided default.

### Tests

- Added `tests/test_get_query_param.py`
- Covers both:
  - parameter exists (`/demo?name=josh`)
  - parameter missing → returns default

All new tests pass locally 

### Notes

- This change does not break existing APIs.
- Provides a small but useful developer experience improvement.
