### PR TITLE
⬆️ Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
           - "3.9"
           - "3.8"
         pydantic-version: ["pydantic-v1", "pydantic-v2"]
+        exclude:
+          - python-version: "3.14"
+            pydantic-version: "pydantic-v1"
       fail-fast: false
     steps:
       - name: Dump GitHub context

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,8 +85,11 @@ jobs:
         if: matrix.pydantic-version == 'pydantic-v1'
         run: uv pip install "pydantic>=1.10.0,<2.0.0"
       - name: Install Pydantic v2
-        if: matrix.pydantic-version == 'pydantic-v2'
+        if: matrix.pydantic-version == 'pydantic-v2' && matrix.python-version != '3.14'
         run: uv pip install --upgrade "pydantic>=2.0.2,<3.0.0"
+      - name: Install Pydantic v2.12.0a1 for Python 3.14
+        if: matrix.pydantic-version == 'pydantic-v2' && matrix.python-version == '3.14'
+        run: uv pip install --upgrade "pydantic==2.12.0a1"
       # TODO: Remove this once Python 3.8 is no longer supported
       - name: Install older AnyIO in Python 3.8
         if: matrix.python-version == '3.8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.14"
           - "3.13"
           - "3.12"
           - "3.11"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,9 @@ jobs:
           cache-dependency-glob: |
             requirements**.txt
             pyproject.toml
+      - name: Preinstall Pydantic 2.12.0a1 for Python 3.14
+        if: matrix.python-version == '3.14'
+        run: uv pip install --pre "pydantic==2.12.0a1"
       - name: Install Dependencies
         run: uv pip install -r requirements-tests.txt
       - name: Install Pydantic v1
@@ -87,9 +90,6 @@ jobs:
       - name: Install Pydantic v2
         if: matrix.pydantic-version == 'pydantic-v2' && matrix.python-version != '3.14'
         run: uv pip install --upgrade "pydantic>=2.0.2,<3.0.0"
-      - name: Install Pydantic v2.12.0a1 for Python 3.14
-        if: matrix.pydantic-version == 'pydantic-v2' && matrix.python-version == '3.14'
-        run: uv pip install --upgrade "pydantic==2.12.0a1"
       # TODO: Remove this once Python 3.8 is no longer supported
       - name: Install older AnyIO in Python 3.8
         if: matrix.python-version == '3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP",
 ]


### PR DESCRIPTION
Python 3.14.0 is supposed to be released on October 7th, 2 weeks from now.

We'll need to merge this PR with https://github.com/fastapi/fastapi/pull/14036

Note: probably requires https://github.com/fastapi/sqlmodel/pull/1578 first