### PR TITLE
📌 Pin `bcrypt` to `<5.0.0` in `requirements-tests.txt`

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,6 +9,7 @@ flask >=1.1.2,<4.0.0
 anyio[trio] >=3.2.1,<5.0.0
 PyJWT==2.9.0
 pyyaml >=5.3.1,<7.0.0
+bcrypt <5.0.0
 passlib[bcrypt] >=1.7.2,<2.0.0
 inline-snapshot>=0.21.1
 # types


### PR DESCRIPTION
Latest `bcrypt` release ([5.0.0](https://github.com/pyca/bcrypt/releases/tag/5.0.0)) breaks our tests: https://github.com/fastapi/fastapi/actions/runs/17999300935

I guess that's because of `passlib` is not maintained and has conflicts with latest bcrypt..

We should probably add the note in security section of docs about it. Or, better, get rid of `passlib` dependency