### PR TITLE
📝 Add External Link: Getting started with logging in FastAPI

### DIFF
--- a/docs/en/data/external_links.yml
+++ b/docs/en/data/external_links.yml
@@ -1,5 +1,9 @@
 Articles:
   English:
+  - author: Apitally
+    author_link: https://apitally.io
+    link: https://apitally.io/blog/getting-started-with-logging-in-fastapi
+    title: Getting started with logging in FastAPI
   - author: Balthazar Rouberol
     author_link: https://balthazar-rouberol.com
     link: https://blog.balthazar-rouberol.com/how-to-profile-a-fastapi-asynchronous-request


### PR DESCRIPTION
I wrote an article on request logging and correlating application logs in FastAPI that I'd like to add to the External Links section in the docs. The topic is not covered by any of the existing links.