### PR TITLE
⬆️ Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.14"
           - "3.13"
           - "3.12"
           - "3.11"
@@ -55,6 +56,9 @@ jobs:
           - "3.9"
           - "3.8"
         pydantic-version: ["pydantic-v1", "pydantic-v2"]
+        exclude:
+          - python-version: "3.14"
+            pydantic-version: "pydantic-v1"
       fail-fast: false
     steps:
       - name: Dump GitHub context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP",
 ]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@ pytest >=7.1.3,<9.0.0
 coverage[toml] >= 6.5.0,< 8.0
 mypy ==1.14.1
 dirty-equals ==0.9.0
-sqlmodel==0.0.25
+sqlmodel==0.0.27
 flask >=1.1.2,<4.0.0
 anyio[trio] >=3.2.1,<5.0.0
 PyJWT==2.9.0

--- a/tests/test_tutorial/test_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial001.py
@@ -45,6 +45,8 @@ def get_client(request: pytest.FixtureRequest):
 
     with TestClient(mod.app) as c:
         yield c
+    # Clean up connection explicitely to avoid resource warning
+    mod.engine.dispose()
 
 
 def test_crud_app(client: TestClient):

--- a/tests/test_tutorial/test_sql_databases/test_tutorial002.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial002.py
@@ -45,6 +45,8 @@ def get_client(request: pytest.FixtureRequest):
 
     with TestClient(mod.app) as c:
         yield c
+    # Clean up connection explicitely to avoid resource warning
+    mod.engine.dispose()
 
 
 def test_crud_app(client: TestClient):


### PR DESCRIPTION
Add Python 3.14 to the test suite & `pyproject.toml`.

Note that Pydantic v1 won't be supported on Python 3.14: https://github.com/pydantic/pydantic/issues/11613#issuecomment-3242513660

Putting this in draft until:

- [x] A non-rc runner becomes available
- [x] Pydantic 2.12.0 is out
- [x] https://github.com/fastapi/fastapi/pull/14036 is merged for compatibility with Pydantic 2.12.0
- [x] https://github.com/fastapi/sqlmodel/pull/1578  is merged & released to fix Python 3.14 `mypy` errors
- [x] The "unraisable exception warnings" stuff is addressed