### PR TITLE
docs: add quick pytest example for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,16 @@ Additional optional FastAPI dependencies:
 * <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
 * <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Required if you want to use `UJSONResponse`.
 
+## Quick Test for Contributors
+
+After installing the dependencies, you can verify that FastAPI is working correctly
+by running a subset of the test suite:
+
+```bash
+pytest -q fastapi/tests/test_tutorial
+
+```
+
 ## License
 
 This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
This pull request adds a short “Quick Test for Contributors” section to README.md.

It provides a pytest command example to help new contributors verify their FastAPI setup locally:

    pytest -q fastapi/tests/test_tutorial

This improves the onboarding experience by allowing first-time contributors
to confirm that FastAPI and its test suite are working correctly before making deeper contributions.