### PR TITLE
🔧 Configure labeler to exclude files that start from underscore for `lang-all` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,6 +17,7 @@ lang-all:
         - docs/*/docs/**
       - all-globs-to-all-files:
         - '!docs/en/docs/**'
+        - '!docs/*/**/_*.md'
         - '!fastapi/**'
         - '!pyproject.toml'
 


### PR DESCRIPTION
This is to avoid automatically putting `lang-all` label to PRs that update llm-prompt file and re-generate `_llm-test.md` file.
See #14189 for example.


---
**Side note:** I think we can simplify config by removing redundant `- '!fastapi/**'`, `'- !pyproject.toml'`, and probably some others (only paths inside `docs/*/docs/` are included, there is no need to exclude paths that are outside of it)