### PR TITLE
Updated typo in header for Concurrency and Parallelism doc

### DIFF
--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -93,7 +93,7 @@ Instead of that, by being an "asynchronous" system, once finished, the task can 
 
 For "synchronous" (contrary to "asynchronous") they commonly also use the term "sequential", because the computer / program follows all the steps in sequence before switching to a different task, even if those steps involve waiting.
 
-### Concurrency and Burgers { #concurrency-and-burgers }
+### Concurrency and Parallelism { #concurrency-and-parallelism }
 
 This idea of **asynchronous** code described above is also sometimes called **"concurrency"**. It is different from **"parallelism"**.
 


### PR DESCRIPTION
Before: 
<img width="765" height="293" alt="image" src="https://github.com/user-attachments/assets/9e2d9516-085f-43b1-9591-38d96feefd49" />


After:
<img width="764" height="306" alt="image" src="https://github.com/user-attachments/assets/e8f29b28-e497-40b7-b51f-0775b26564f5" />
