### PR TITLE
Change "/" to "or" in docs->security->first steps

### DIFF
--- a/docs/en/docs/tutorial/security/first-steps.md
+++ b/docs/en/docs/tutorial/security/first-steps.md
@@ -144,7 +144,7 @@ Using a relative URL is important to make sure your application keeps working ev
 
 ///
 
-This parameter doesn't create that endpoint / *path operation*, but declares that the URL `/token` will be the one that the client should use to get the token. That information is used in OpenAPI, and then in the interactive API documentation systems.
+This parameter doesn't create that endpoint or *path operation*, but declares that the URL `/token` will be the one that the client should use to get the token. That information is used in OpenAPI, and then in the interactive API documentation systems.
 
 We will soon also create the actual path operation.
 


### PR DESCRIPTION
[The following](https://fastapi.tiangolo.com/tutorial/security/first-steps/#fastapis-oauth2passwordbearer) confused me for a second:
> This parameter doesn't create that endpoint / path operation, but declares that the URL /token will be the one that the client should use to get the token. That information is used in OpenAPI, and then in the interactive API documentation systems.

In this context `/` could be easily interpreted as "root", guess better to use "or"? 
