### PR TITLE
🔧 Add `license` and `license-files` to `pyproject.toml`, remove `License` from `classifiers`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ name = "fastapi"
 dynamic = ["version"]
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 authors = [
     { name = "Sebastián Ramírez", email = "tiangolo@gmail.com" },
@@ -31,7 +33,6 @@ classifiers = [
     "Framework :: Pydantic :: 1",
     "Framework :: Pydantic :: 2",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
> The use of `License ::` classifiers is deprecated and tools MAY issue a warning informing users about that. 

Source: https://packaging.python.org/en/latest/specifications/pyproject-toml/#classifiers

I updated `pyproject.toml` to specify `license` ([docs](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license)) and `license-files` ([docs](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license-files)) instead.