### PR TITLE
♻️ Avoid creating an intermediate container in `get_value_or_default` for efficiency

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -247,8 +247,9 @@ def get_value_or_default(
 
     Otherwise, the first item (a `DefaultPlaceholder`) will be returned.
     """
-    items = (first_item,) + extra_items
-    for item in items:
+    if not isinstance(first_item, DefaultPlaceholder):
+        return first_item
+    for item in extra_items:
         if not isinstance(item, DefaultPlaceholder):
             return item
     return first_item


### PR DESCRIPTION
Refactoring to improve efficiency of the code

create a items tuple by combining first_items with extra_items and is not used in the reminder of the code. To make it more efficient we can check the items directly