### PR TITLE
[Fix] [Issue 13533]: Multiple regressions in the handling of forms & …

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -930,8 +930,9 @@ async def _extract_form_body(
             value = serialize_sequence_value(field=field, value=results)
         if value is not None:
             values[field.alias] = value
+    processed_fields = {field.alias for field in body_fields}
     for key, value in received_body.items():
-        if key not in values:
+        if key not in processed_fields and key not in values:
             values[key] = value
     return values
 

--- a/tests/test_form_regression.py
+++ b/tests/test_form_regression.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+import pytest
+from fastapi import FastAPI, File, Form
+from fastapi.testclient import TestClient
+from typing_extensions import Annotated
+
+app = FastAPI()
+
+
+@app.post("/")
+def root(
+    file: Annotated[Optional[bytes], File()] = None,
+    form: Annotated[Optional[str], Form(embed=True)] = None,
+):
+    return {"file": file, "form": form}
+
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "file_data, form_data, expected_response",
+    [
+        (None, None, {"file": None, "form": None}),
+        ("", None, {"file": None, "form": None}),
+        (None, "", {"file": None, "form": None}),
+        ("", "", {"file": None, "form": None}),
+        ("file", "form", {"file": "file", "form": "form"}),
+    ],
+)
+def test_empty_string_to_none(file_data, form_data, expected_response):
+    data = {}
+    if file_data is not None:
+        data["file"] = file_data
+    if form_data is not None:
+        data["form"] = form_data
+
+    response = client.post("/", data=data)
+    assert response.status_code == 200
+    assert response.json() == expected_response


### PR DESCRIPTION
Fixes #13533

### Summary
When form fields are empty strings (`""`), FastAPI currently passes them
as `""` instead of converting to `None`. This PR restores the previous
behavior for both `application/x-www-form-urlencoded` and `multipart/form-data`.

### Changes
- Updated `_extract_form_body` to normalize empty strings to `None`
- Added regression tests for optional form and file fields

### Tests
All tests pass locally (`pytest -v`).
