### PR TITLE
♻️ Refactor internals of dependencies, simplify using dataclasses

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -160,8 +160,8 @@ def get_sub_dependant(
     security_requirement = None
     security_scopes = security_scopes or []
     if isinstance(depends, params.Security):
-        dependency_scopes = depends.scopes
-        security_scopes.extend(dependency_scopes)
+        if depends.scopes:
+            security_scopes.extend(depends.scopes)
     if isinstance(dependency, SecurityBase):
         use_scopes: List[str] = []
         if isinstance(dependency, (OAuth2, OpenIdConnect)):

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -1,10 +1,11 @@
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from fastapi.openapi.models import Example
 from pydantic.fields import FieldInfo
-from typing_extensions import Annotated, deprecated
+from typing_extensions import Annotated, Literal, deprecated
 
 from ._compat import (
     PYDANTIC_V2,
@@ -761,26 +762,13 @@ class File(Form):  # type: ignore[misc]
         )
 
 
+@dataclass
 class Depends:
-    def __init__(
-        self, dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
-    ):
-        self.dependency = dependency
-        self.use_cache = use_cache
-
-    def __repr__(self) -> str:
-        attr = getattr(self.dependency, "__name__", type(self.dependency).__name__)
-        cache = "" if self.use_cache else ", use_cache=False"
-        return f"{self.__class__.__name__}({attr}{cache})"
+    dependency: Optional[Callable[..., Any]] = None
+    use_cache: bool = True
+    scope: Literal["function", "request", "lifespan"] = "request"
 
 
+@dataclass
 class Security(Depends):
-    def __init__(
-        self,
-        dependency: Optional[Callable[..., Any]] = None,
-        *,
-        scopes: Optional[Sequence[str]] = None,
-        use_cache: bool = True,
-    ):
-        super().__init__(dependency=dependency, use_cache=use_cache)
-        self.scopes = scopes or []
+    scopes: Optional[Sequence[str]] = None

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from fastapi.openapi.models import Example
 from pydantic.fields import FieldInfo
-from typing_extensions import Annotated, Literal, deprecated
+from typing_extensions import Annotated, deprecated
 
 from ._compat import (
     PYDANTIC_V2,
@@ -766,7 +766,6 @@ class File(Form):  # type: ignore[misc]
 class Depends:
     dependency: Optional[Callable[..., Any]] = None
     use_cache: bool = True
-    scope: Literal["function", "request", "lifespan"] = "request"
 
 
 @dataclass

--- a/tests/test_params_repr.py
+++ b/tests/test_params_repr.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from dirty_equals import IsOneOf
-from fastapi.params import Body, Cookie, Depends, Header, Param, Path, Query
+from fastapi.params import Body, Cookie, Header, Param, Path, Query
 
 test_data: List[Any] = ["teststr", None, ..., 1, []]
 
@@ -141,12 +141,3 @@ def test_body_repr_number():
 
 def test_body_repr_list():
     assert repr(Body([])) == "Body([])"
-
-
-def test_depends_repr():
-    assert repr(Depends()) == "Depends(NoneType)"
-    assert repr(Depends(get_user)) == "Depends(get_user)"
-    assert repr(Depends(use_cache=False)) == "Depends(NoneType, use_cache=False)"
-    assert (
-        repr(Depends(get_user, use_cache=False)) == "Depends(get_user, use_cache=False)"
-    )


### PR DESCRIPTION
♻️ Refactor internals of dependencies, simplify using dataclasses

---

As dataclasses come with their own `repr()` there's no need for custom logic nor tests for that.