### PR TITLE
✨ Add support for dependencies with scopes, support `scope="request"` for dependencies with `yield` that exit before the response is sent

### DIFF
--- a/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
+++ b/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
@@ -184,6 +184,51 @@ If you raise any exception in the code from the *path operation function*, it wi
 
 ///
 
+## Early exit and `scope` { #early-exit-and-scope }
+
+Normally the exit code of dependencies with `yield` is executed **after the response** is sent to the client.
+
+But if you know that you won't need to use the dependency after returning from the *path operation function*, you can use `Depends(scope="function")` to tell FastAPI that it should close the dependency after the *path operation function* returns, but **before** the **response is sent**.
+
+{* ../../docs_src/dependencies/tutorial008e_an_py39.py hl[12,16] *}
+
+`Depends()` receives a `scope` parameter that can be:
+
+* `"function"`: start the dependency before the *path operation function* that handles the request, end the dependency after the *path operation function* ends, but **before** the response is sent back to the client. So, the dependency function will be executed **around** the *path operation **function***.
+* `"request"`: start the dependency before the *path operation function* that handles the request (similar to when using `"function"`), but end **after** the response is sent back to the client. So, the dependency function will be executed **around** the **request** and response cycle.
+
+If not specified and the dependency has `yield`, it will have a `scope` of `"request"` by default.
+
+### `scope` for sub-dependencies { #scope-for-sub-dependencies }
+
+When you declare a dependency with a `scope="request"` (the default), any sub-dependency needs to also have a `scope` of `"request"`.
+
+But a dependency with `scope` of `"function"` can have dependencies with `scope` of `"function"` and `scope` of `"request"`.
+
+This is because any dependency needs to be able to run its exit code before the sub-dependencies, as it might need to still use them during its exit code.
+
+```mermaid
+sequenceDiagram
+
+participant client as Client
+participant dep_req as Dep scope="request"
+participant dep_func as Dep scope="function"
+participant operation as Path Operation
+
+    client ->> dep_req: Start request
+    Note over dep_req: Run code up to yield
+    dep_req ->> dep_func: 
+    Note over dep_func: Run code up to yield
+    dep_func ->> operation: Run path operation
+    operation ->> dep_func: Return from path operation
+    Note over dep_func: Run code after yield
+    Note over dep_func: ✅ Dependency closed
+    dep_func ->> client: Send response to client
+    Note over client: Response sent
+    Note over dep_req: Run code after yield
+    Note over dep_req: ✅ Dependency closed
+```
+
 ## Dependencies with `yield`, `HTTPException`, `except` and Background Tasks { #dependencies-with-yield-httpexception-except-and-background-tasks }
 
 Dependencies with `yield` have evolved over time to cover different use cases and fix some issues.

--- a/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
+++ b/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
@@ -217,7 +217,7 @@ participant operation as Path Operation
 
     client ->> dep_req: Start request
     Note over dep_req: Run code up to yield
-    dep_req ->> dep_func: 
+    dep_req ->> dep_func:
     Note over dep_func: Run code up to yield
     dep_func ->> operation: Run path operation
     operation ->> dep_func: Return from path operation

--- a/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
+++ b/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
@@ -217,9 +217,9 @@ participant operation as Path Operation
 
     client ->> dep_req: Start request
     Note over dep_req: Run code up to yield
-    dep_req ->> dep_func:
+    dep_req ->> dep_func: Pass dependency
     Note over dep_func: Run code up to yield
-    dep_func ->> operation: Run path operation
+    dep_func ->> operation: Run path operation with dependency
     operation ->> dep_func: Return from path operation
     Note over dep_func: Run code after yield
     Note over dep_func: ✅ Dependency closed

--- a/docs_src/dependencies/tutorial008e.py
+++ b/docs_src/dependencies/tutorial008e.py
@@ -1,0 +1,15 @@
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_username():
+    try:
+        yield "Rick"
+    finally:
+        print("Cleanup up before response is sent")
+
+
+@app.get("/users/me")
+def get_user_me(username: str = Depends(get_username, scope="function")):
+    return username

--- a/docs_src/dependencies/tutorial008e_an.py
+++ b/docs_src/dependencies/tutorial008e_an.py
@@ -1,0 +1,16 @@
+from fastapi import Depends, FastAPI
+from typing_extensions import Annotated
+
+app = FastAPI()
+
+
+def get_username():
+    try:
+        yield "Rick"
+    finally:
+        print("Cleanup up before response is sent")
+
+
+@app.get("/users/me")
+def get_user_me(username: Annotated[str, Depends(get_username, scope="function")]):
+    return username

--- a/docs_src/dependencies/tutorial008e_an_py39.py
+++ b/docs_src/dependencies/tutorial008e_an_py39.py
@@ -1,0 +1,17 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+
+def get_username():
+    try:
+        yield "Rick"
+    finally:
+        print("Cleanup up before response is sent")
+
+
+@app.get("/users/me")
+def get_user_me(username: Annotated[str, Depends(get_username, scope="function")]):
+    return username

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional, Sequence, Tuple
+from functools import cached_property
+from typing import Any, Callable, List, Optional, Sequence, Union
 
 from fastapi._compat import ModelField
 from fastapi.security.base import SecurityBase
+from fastapi.types import DependencyCacheKey
 from typing_extensions import Literal
 
 
@@ -32,14 +34,12 @@ class Dependant:
     security_scopes: Optional[List[str]] = None
     use_cache: bool = True
     path: Optional[str] = None
-    scope: Literal["function", "request"] = "request"
-    cache_key: Tuple[Optional[Callable[..., Any]], Tuple[str, ...], str] = field(
-        init=False
-    )
+    scope: Union[Literal["function", "request"], None] = None
 
-    def __post_init__(self) -> None:
-        self.cache_key = (
+    @cached_property
+    def cache_key(self) -> DependencyCacheKey:
+        return (
             self.call,
             tuple(sorted(set(self.security_scopes or []))),
-            self.scope,
+            self.scope or "",
         )

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 from fastapi._compat import ModelField
 from fastapi.security.base import SecurityBase
+from typing_extensions import Literal
 
 
 @dataclass
@@ -31,7 +32,12 @@ class Dependant:
     security_scopes: Optional[List[str]] = None
     use_cache: bool = True
     path: Optional[str] = None
-    cache_key: Tuple[Optional[Callable[..., Any]], Tuple[str, ...]] = field(init=False)
+    scope: Literal["function", "request"] = "request"
+    cache_key: Tuple[Optional[Callable[..., Any]], Tuple[str, ...], str] = field(init=False)
 
     def __post_init__(self) -> None:
-        self.cache_key = (self.call, tuple(sorted(set(self.security_scopes or []))))
+        self.cache_key = (
+            self.call,
+            tuple(sorted(set(self.security_scopes or []))),
+            self.scope,
+        )

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -33,7 +33,9 @@ class Dependant:
     use_cache: bool = True
     path: Optional[str] = None
     scope: Literal["function", "request"] = "request"
-    cache_key: Tuple[Optional[Callable[..., Any]], Tuple[str, ...], str] = field(init=False)
+    cache_key: Tuple[Optional[Callable[..., Any]], Tuple[str, ...], str] = field(
+        init=False
+    )
 
     def __post_init__(self) -> None:
         self.cache_key = (

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -1,3 +1,5 @@
+import inspect
+import sys
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any, Callable, List, Optional, Sequence, Union
@@ -6,6 +8,11 @@ from fastapi._compat import ModelField
 from fastapi.security.base import SecurityBase
 from fastapi.types import DependencyCacheKey
 from typing_extensions import Literal
+
+if sys.version_info >= (3, 13):  # pragma: no cover
+    from inspect import iscoroutinefunction
+else:  # pragma: no cover
+    from asyncio import iscoroutinefunction
 
 
 @dataclass
@@ -41,5 +48,36 @@ class Dependant:
         return (
             self.call,
             tuple(sorted(set(self.security_scopes or []))),
-            self.scope or "",
+            self.computed_scope or "",
         )
+
+    @cached_property
+    def is_gen_callable(self) -> bool:
+        if inspect.isgeneratorfunction(self.call):
+            return True
+        dunder_call = getattr(self.call, "__call__", None)  # noqa: B004
+        return inspect.isgeneratorfunction(dunder_call)
+
+    @cached_property
+    def is_async_gen_callable(self) -> bool:
+        if inspect.isasyncgenfunction(self.call):
+            return True
+        dunder_call = getattr(self.call, "__call__", None)  # noqa: B004
+        return inspect.isasyncgenfunction(dunder_call)
+
+    @cached_property
+    def is_coroutine_callable(self) -> bool:
+        if inspect.isroutine(self.call):
+            return iscoroutinefunction(self.call)
+        if inspect.isclass(self.call):
+            return False
+        dunder_call = getattr(self.call, "__call__", None)  # noqa: B004
+        return iscoroutinefunction(dunder_call)
+
+    @cached_property
+    def computed_scope(self) -> Union[str, None]:
+        if self.scope:
+            return self.scope
+        if self.is_gen_callable or self.is_async_gen_callable:
+            return "request"
+        return None

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,5 +1,4 @@
 import inspect
-import sys
 from contextlib import AsyncExitStack, contextmanager
 from copy import copy, deepcopy
 from dataclasses import dataclass
@@ -79,11 +78,6 @@ from starlette.websockets import WebSocket
 from typing_extensions import Annotated, Literal, get_args, get_origin
 
 from .. import temp_pydantic_v1_params
-
-if sys.version_info >= (3, 13):  # pragma: no cover
-    pass
-else:  # pragma: no cover
-    pass
 
 multipart_not_installed_error = (
     'Form data requires "python-multipart" to be installed. \n'

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -266,9 +266,10 @@ def get_dependant(
                 and dependant.computed_scope == "request"
                 and param_details.depends.scope == "function"
             ):
+                assert dependant.call
                 raise DependencyScopeError(
-                    f'The dependency {dependant} has a scope of "request", it'
-                    'cannot depend on dependencies with scope "function".'
+                    f'The dependency "{dependant.call.__name__}" has a scope of '
+                    '"request", it cannot depend on dependencies with scope "function".'
                 )
             use_security_scopes = security_scopes or []
             if isinstance(param_details.depends, params.Security):

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -129,39 +129,12 @@ def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> De
     assert callable(depends.dependency), (
         "A parameter-less dependency must have a callable dependency"
     )
-    return get_sub_dependant(depends=depends, dependency=depends.dependency, path=path)
-
-
-def get_sub_dependant(
-    *,
-    depends: params.Depends,
-    dependency: Callable[..., Any],
-    path: str,
-    name: Optional[str] = None,
-    security_scopes: Optional[List[str]] = None,
-) -> Dependant:
-    security_requirement = None
-    security_scopes = security_scopes or []
-    if isinstance(depends, params.Security):
-        if depends.scopes:
-            security_scopes.extend(depends.scopes)
-    if isinstance(dependency, SecurityBase):
-        use_scopes: List[str] = []
-        if isinstance(dependency, (OAuth2, OpenIdConnect)):
-            use_scopes = security_scopes
-        security_requirement = SecurityRequirement(
-            security_scheme=dependency, scopes=use_scopes
-        )
-    sub_dependant = get_dependant(
-        path=path,
-        call=dependency,
-        name=name,
-        security_scopes=security_scopes,
-        use_cache=depends.use_cache,
+    use_security_scopes = []
+    if isinstance(depends, params.Security) and depends.scopes:
+        use_security_scopes.extend(depends.scopes)
+    return get_dependant(
+        path=path, call=depends.dependency, security_scopes=use_security_scopes
     )
-    if security_requirement:
-        sub_dependant.security_requirements.append(security_requirement)
-    return sub_dependant
 
 
 CacheKey = Tuple[Optional[Callable[..., Any]], Tuple[str, ...]]
@@ -285,13 +258,27 @@ def get_dependant(
         )
         if param_details.depends is not None:
             assert param_details.depends.dependency
-            sub_dependant = get_sub_dependant(
-                depends=param_details.depends,
-                dependency=param_details.depends.dependency,
+            use_security_scopes = security_scopes or []
+            if isinstance(param_details.depends, params.Security):
+                if param_details.depends.scopes:
+                    use_security_scopes.extend(param_details.depends.scopes)
+            sub_dependant = get_dependant(
                 path=path,
+                call=param_details.depends.dependency,
                 name=param_name,
-                security_scopes=security_scopes,
+                security_scopes=use_security_scopes,
+                use_cache=param_details.depends.use_cache,
             )
+            if isinstance(param_details.depends.dependency, SecurityBase):
+                use_scopes: List[str] = []
+                if isinstance(
+                    param_details.depends.dependency, (OAuth2, OpenIdConnect)
+                ):
+                    use_scopes = use_security_scopes
+                security_requirement = SecurityRequirement(
+                    security_scheme=param_details.depends.dependency, scopes=use_scopes
+                )
+                sub_dependant.security_requirements.append(security_requirement)
             dependant.dependencies.append(sub_dependant)
             continue
         if add_non_field_param_to_dependency(

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -160,8 +160,8 @@ def get_sub_dependant(
     security_requirement = None
     security_scopes = security_scopes or []
     if isinstance(depends, params.Security):
-        dependency_scopes = depends.scopes
-        security_scopes.extend(dependency_scopes)
+        if depends.scopes:
+            security_scopes.extend(depends.scopes)
     if isinstance(dependency, SecurityBase):
         use_scopes: List[str] = []
         if isinstance(dependency, (OAuth2, OpenIdConnect)):

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -153,6 +153,7 @@ class DependencyScopeError(FastAPIError):
     (narrower) scope.
     """
 
+
 class ValidationException(Exception):
     def __init__(self, errors: Sequence[Any]) -> None:
         self._errors = errors

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -147,6 +147,12 @@ class FastAPIError(RuntimeError):
     """
 
 
+class DependencyScopeError(FastAPIError):
+    """
+    A dependency declared that it depends on another dependency with an invalid
+    (narrower) scope.
+    """
+
 class ValidationException(Exception):
     def __init__(self, errors: Sequence[Any]) -> None:
         self._errors = errors

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -2256,12 +2256,12 @@ def Depends(  # noqa: N802
             * `"function"`: start the dependency before the *path operation function*
                 that handles the request, end the dependency after the *path operation
                 function* ends, but **before** the response is sent back to the client.
-                So, the dependency function will be executed *around* the *path operation
+                So, the dependency function will be executed **around** the *path operation
                 **function***.
             * `"request"`: start the dependency before the *path operation function*
                 that handles the request (similar to when using `"function"`), but end
                 **after** the response is sent back to the client. So, the dependency
-                function will be executed *around* the **request** and response cycle.
+                function will be executed **around** the **request** and response cycle.
             """
         ),
     ] = None,

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -2246,7 +2246,7 @@ def Depends(  # noqa: N802
         ),
     ] = True,
     scope: Annotated[
-        Literal["function", "request"],
+        Union[Literal["function", "request"], None],
         Doc(
             """
             Mainly for dependencies with `yield`, define when the dependency function
@@ -2264,7 +2264,7 @@ def Depends(  # noqa: N802
                 function will be executed *around* the **request** and response cycle.
             """
         ),
-    ] = "request",
+    ] = None,
 ) -> Any:
     """
     Declare a FastAPI dependency.

--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -4,7 +4,7 @@ from annotated_doc import Doc
 from fastapi import params
 from fastapi._compat import Undefined
 from fastapi.openapi.models import Example
-from typing_extensions import Annotated, deprecated
+from typing_extensions import Annotated, Literal, deprecated
 
 _Unset: Any = Undefined
 
@@ -2245,6 +2245,26 @@ def Depends(  # noqa: N802
             """
         ),
     ] = True,
+    scope: Annotated[
+        Literal["function", "request"],
+        Doc(
+            """
+            Mainly for dependencies with `yield`, define when the dependency function
+            should start (the code before `yield`) and when it should end (the code
+            after `yield`).
+
+            * `"function"`: start the dependency before the *path operation function*
+                that handles the request, end the dependency after the *path operation
+                function* ends, but **before** the response is sent back to the client.
+                So, the dependency function will be executed *around* the *path operation
+                **function***.
+            * `"request"`: start the dependency before the *path operation function*
+                that handles the request (similar to when using `"function"`), but end
+                **after** the response is sent back to the client. So, the dependency
+                function will be executed *around* the **request** and response cycle.
+            """
+        ),
+    ] = "request",
 ) -> Any:
     """
     Declare a FastAPI dependency.
@@ -2275,7 +2295,7 @@ def Depends(  # noqa: N802
         return commons
     ```
     """
-    return params.Depends(dependency=dependency, use_cache=use_cache)
+    return params.Depends(dependency=dependency, use_cache=use_cache, scope=scope)
 
 
 def Security(  # noqa: N802

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -1,10 +1,11 @@
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from fastapi.openapi.models import Example
 from pydantic.fields import FieldInfo
-from typing_extensions import Annotated, deprecated
+from typing_extensions import Annotated, Literal, deprecated
 
 from ._compat import (
     PYDANTIC_V2,
@@ -761,26 +762,13 @@ class File(Form):  # type: ignore[misc]
         )
 
 
+@dataclass
 class Depends:
-    def __init__(
-        self, dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
-    ):
-        self.dependency = dependency
-        self.use_cache = use_cache
-
-    def __repr__(self) -> str:
-        attr = getattr(self.dependency, "__name__", type(self.dependency).__name__)
-        cache = "" if self.use_cache else ", use_cache=False"
-        return f"{self.__class__.__name__}({attr}{cache})"
+    dependency: Optional[Callable[..., Any]] = None
+    use_cache: bool = True
+    scope: Literal["function", "request", "lifespan"] = "request"
 
 
+@dataclass
 class Security(Depends):
-    def __init__(
-        self,
-        dependency: Optional[Callable[..., Any]] = None,
-        *,
-        scopes: Optional[Sequence[str]] = None,
-        use_cache: bool = True,
-    ):
-        super().__init__(dependency=dependency, use_cache=use_cache)
-        self.scopes = scopes or []
+    scopes: Optional[Sequence[str]] = None

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from fastapi.openapi.models import Example
 from pydantic.fields import FieldInfo
-from typing_extensions import Annotated, deprecated
+from typing_extensions import Annotated, Literal, deprecated
 
 from ._compat import (
     PYDANTIC_V2,
@@ -766,6 +766,7 @@ class File(Form):  # type: ignore[misc]
 class Depends:
     dependency: Optional[Callable[..., Any]] = None
     use_cache: bool = True
+    scope: Literal["function", "request"] = "request"
 
 
 @dataclass

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from fastapi.openapi.models import Example
 from pydantic.fields import FieldInfo
-from typing_extensions import Annotated, Literal, deprecated
+from typing_extensions import Annotated, deprecated
 
 from ._compat import (
     PYDANTIC_V2,
@@ -766,7 +766,6 @@ class File(Form):  # type: ignore[misc]
 class Depends:
     dependency: Optional[Callable[..., Any]] = None
     use_cache: bool = True
-    scope: Literal["function", "request", "lifespan"] = "request"
 
 
 @dataclass

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -766,7 +766,7 @@ class File(Form):  # type: ignore[misc]
 class Depends:
     dependency: Optional[Callable[..., Any]] = None
     use_cache: bool = True
-    scope: Literal["function", "request"] = "request"
+    scope: Union[Literal["function", "request"], None] = None
 
 
 @dataclass

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -104,10 +104,12 @@ def request_response(
         async def app(scope: Scope, receive: Receive, send: Send) -> None:
             # Starts customization
             response_awaited = False
-            async with AsyncExitStack() as stack:
-                scope["fastapi_inner_astack"] = stack
-                # Same as in Starlette
-                response = await f(request)
+            async with AsyncExitStack() as request_stack:
+                scope["fastapi_inner_astack"] = request_stack
+                async with AsyncExitStack() as function_stack:
+                    scope["fastapi_function_astack"] = function_stack
+                    # Same as in Starlette
+                    response = await f(request)
                 await response(scope, receive, send)
                 # Continues customization
                 response_awaited = True
@@ -140,10 +142,10 @@ def websocket_session(
         session = WebSocket(scope, receive=receive, send=send)
 
         async def app(scope: Scope, receive: Receive, send: Send) -> None:
-            # Starts customization
-            async with AsyncExitStack() as stack:
-                scope["fastapi_inner_astack"] = stack
-                # Same as in Starlette
+            async with AsyncExitStack() as request_stack:
+                scope["fastapi_inner_astack"] = request_stack
+                async with AsyncExitStack() as function_stack:
+                    scope["fastapi_function_astack"] = function_stack
                 await func(session)
 
         # Same as in Starlette
@@ -479,7 +481,9 @@ class APIWebSocketRoute(routing.WebSocketRoute):
         self.name = get_name(endpoint) if name is None else name
         self.dependencies = list(dependencies or [])
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
-        self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+        self.dependant = get_dependant(
+            path=self.path_format, call=self.endpoint, scope="function"
+        )
         for depends in self.dependencies[::-1]:
             self.dependant.dependencies.insert(
                 0,
@@ -630,7 +634,9 @@ class APIRoute(routing.Route):
             self.response_fields = {}
 
         assert callable(endpoint), "An endpoint must be a callable"
-        self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+        self.dependant = get_dependant(
+            path=self.path_format, call=self.endpoint, scope="function"
+        )
         for depends in self.dependencies[::-1]:
             self.dependant.dependencies.insert(
                 0,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -146,7 +146,7 @@ def websocket_session(
                 scope["fastapi_inner_astack"] = request_stack
                 async with AsyncExitStack() as function_stack:
                     scope["fastapi_function_astack"] = function_stack
-                await func(session)
+                    await func(session)
 
         # Same as in Starlette
         await wrap_app_handling_exceptions(app, session)(scope, receive, send)

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -108,7 +108,6 @@ def request_response(
                 scope["fastapi_inner_astack"] = request_stack
                 async with AsyncExitStack() as function_stack:
                     scope["fastapi_function_astack"] = function_stack
-                    # Same as in Starlette
                     response = await f(request)
                 await response(scope, receive, send)
                 # Continues customization

--- a/fastapi/types.py
+++ b/fastapi/types.py
@@ -1,6 +1,6 @@
 import types
 from enum import Enum
-from typing import Any, Callable, Dict, Set, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Type, TypeVar, Union
 
 from pydantic import BaseModel
 
@@ -8,3 +8,4 @@ DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
 UnionType = getattr(types, "UnionType", Union)
 ModelNameMap = Dict[Union[Type[BaseModel], Type[Enum]], str]
 IncEx = Union[Set[int], Set[str], Dict[int, Any], Dict[str, Any]]
+DependencyCacheKey = Tuple[Optional[Callable[..., Any]], Tuple[str, ...], str]

--- a/tests/test_dependency_yield_scope.py
+++ b/tests/test_dependency_yield_scope.py
@@ -1,0 +1,78 @@
+import json
+from typing import Any
+
+from fastapi import Depends, FastAPI
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+from typing_extensions import Annotated
+
+
+class Session:
+    def __init__(self) -> None:
+        self.open = True
+
+
+def dep_session() -> Any:
+    s = Session()
+    yield s
+    s.open = False
+
+
+SessionFuncDep = Annotated[Session, Depends(dep_session, scope="function")]
+SessionRequestDep = Annotated[Session, Depends(dep_session, scope="request")]
+
+
+app = FastAPI()
+
+
+@app.get("/function-scope")
+def function_scope(session: SessionFuncDep) -> Any:
+    def iter_data():
+        yield json.dumps({"is_open": session.open})
+
+    return StreamingResponse(iter_data())
+
+
+@app.get("/request-scope")
+def request_scope(session: SessionRequestDep) -> Any:
+    def iter_data():
+        yield json.dumps({"is_open": session.open})
+
+    return StreamingResponse(iter_data())
+
+
+@app.get("/two-scopes")
+def get_stream_session(
+    function_session: SessionFuncDep, request_session: SessionRequestDep
+) -> Any:
+    def iter_data():
+        yield json.dumps(
+            {"func_is_open": function_session.open, "req_is_open": request_session.open}
+        )
+
+    return StreamingResponse(iter_data())
+
+
+client = TestClient(app)
+
+
+def test_function_scope() -> None:
+    response = client.get("/function-scope")
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert data["is_open"] is False
+
+
+def test_request_scope() -> None:
+    response = client.get("/request-scope")
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert data["is_open"] is True
+
+
+def test_two_scopes() -> None:
+    response = client.get("/two-scopes")
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert data["func_is_open"] is False
+    assert data["req_is_open"] is True

--- a/tests/test_dependency_yield_scope.py
+++ b/tests/test_dependency_yield_scope.py
@@ -130,21 +130,21 @@ client = TestClient(app)
 def test_function_scope() -> None:
     response = client.get("/function-scope")
     assert response.status_code == 200
-    data = json.loads(response.content)
+    data = response.json()
     assert data["is_open"] is False
 
 
 def test_request_scope() -> None:
     response = client.get("/request-scope")
     assert response.status_code == 200
-    data = json.loads(response.content)
+    data = response.json()
     assert data["is_open"] is True
 
 
 def test_two_scopes() -> None:
     response = client.get("/two-scopes")
     assert response.status_code == 200
-    data = json.loads(response.content)
+    data = response.json()
     assert data["func_is_open"] is False
     assert data["req_is_open"] is True
 
@@ -152,7 +152,7 @@ def test_two_scopes() -> None:
 def test_sub() -> None:
     response = client.get("/sub")
     assert response.status_code == 200
-    data = json.loads(response.content)
+    data = response.json()
     assert data["named_session_open"] is True
     assert data["session_open"] is True
 
@@ -171,7 +171,7 @@ def test_broken_scope() -> None:
 def test_named_function_scope() -> None:
     response = client.get("/named-function-scope")
     assert response.status_code == 200
-    data = json.loads(response.content)
+    data = response.json()
     assert data["named_session_open"] is False
     assert data["session_open"] is False
 
@@ -179,6 +179,6 @@ def test_named_function_scope() -> None:
 def test_regular_function_scope() -> None:
     response = client.get("/regular-function-scope")
     assert response.status_code == 200
-    data = json.loads(response.content)
+    data = response.json()
     assert data["named_session_open"] is True
     assert data["session_open"] is False

--- a/tests/test_dependency_yield_scope_websockets.py
+++ b/tests/test_dependency_yield_scope_websockets.py
@@ -15,7 +15,7 @@ class Session:
         self.open = True
 
 
-def dep_session() -> Any:
+async def dep_session() -> Any:
     s = Session()
     yield s
     s.open = False

--- a/tests/test_dependency_yield_scope_websockets.py
+++ b/tests/test_dependency_yield_scope_websockets.py
@@ -1,0 +1,172 @@
+from typing import Any, Tuple
+
+import pytest
+from fastapi import Depends, FastAPI, WebSocket
+from fastapi.exceptions import FastAPIError
+from fastapi.testclient import TestClient
+from typing_extensions import Annotated
+
+
+class Session:
+    def __init__(self) -> None:
+        self.open = True
+
+
+def dep_session() -> Any:
+    s = Session()
+    yield s
+    s.open = False
+
+
+SessionFuncDep = Annotated[Session, Depends(dep_session, scope="function")]
+SessionRequestDep = Annotated[Session, Depends(dep_session, scope="request")]
+SessionDefaultDep = Annotated[Session, Depends(dep_session)]
+
+
+class NamedSession:
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+        self.open = True
+
+
+def get_named_session(session: SessionRequestDep, session_b: SessionDefaultDep) -> Any:
+    assert session is session_b
+    named_session = NamedSession(name="named")
+    yield named_session, session_b
+    named_session.open = False
+
+
+NamedSessionsDep = Annotated[Tuple[NamedSession, Session], Depends(get_named_session)]
+
+
+def get_named_func_session(session: SessionFuncDep) -> Any:
+    named_session = NamedSession(name="named")
+    yield named_session, session
+    named_session.open = False
+
+
+def get_named_regular_func_session(session: SessionFuncDep) -> Any:
+    named_session = NamedSession(name="named")
+    return named_session, session
+
+
+BrokenSessionsDep = Annotated[
+    Tuple[NamedSession, Session], Depends(get_named_func_session)
+]
+NamedSessionsFuncDep = Annotated[
+    Tuple[NamedSession, Session], Depends(get_named_func_session, scope="function")
+]
+
+RegularSessionsDep = Annotated[
+    Tuple[NamedSession, Session], Depends(get_named_regular_func_session)
+]
+
+app = FastAPI()
+
+
+@app.websocket("/function-scope")
+async def function_scope(websocket: WebSocket, session: SessionFuncDep) -> Any:
+    await websocket.accept()
+    await websocket.send_json({"is_open": session.open})
+
+
+@app.websocket("/request-scope")
+async def request_scope(websocket: WebSocket, session: SessionRequestDep) -> Any:
+    await websocket.accept()
+    await websocket.send_json({"is_open": session.open})
+
+
+@app.websocket("/two-scopes")
+async def get_stream_session(
+    websocket: WebSocket,
+    function_session: SessionFuncDep,
+    request_session: SessionRequestDep,
+) -> Any:
+    await websocket.accept()
+    await websocket.send_json(
+        {"func_is_open": function_session.open, "req_is_open": request_session.open}
+    )
+
+
+@app.websocket("/sub")
+async def get_sub(websocket: WebSocket, sessions: NamedSessionsDep) -> Any:
+    await websocket.accept()
+    await websocket.send_json(
+        {"named_session_open": sessions[0].open, "session_open": sessions[1].open}
+    )
+
+
+@app.websocket("/named-function-scope")
+async def get_named_function_scope(
+    websocket: WebSocket, sessions: NamedSessionsFuncDep
+) -> Any:
+    await websocket.accept()
+    await websocket.send_json(
+        {"named_session_open": sessions[0].open, "session_open": sessions[1].open}
+    )
+
+
+@app.websocket("/regular-function-scope")
+async def get_regular_function_scope(
+    websocket: WebSocket, sessions: RegularSessionsDep
+) -> Any:
+    await websocket.accept()
+    await websocket.send_json(
+        {"named_session_open": sessions[0].open, "session_open": sessions[1].open}
+    )
+
+
+client = TestClient(app)
+
+
+def test_function_scope() -> None:
+    with client.websocket_connect("/function-scope") as websocket:
+        data = websocket.receive_json()
+    assert data["is_open"] is True
+
+
+def test_request_scope() -> None:
+    with client.websocket_connect("/request-scope") as websocket:
+        data = websocket.receive_json()
+    assert data["is_open"] is True
+
+
+def test_two_scopes() -> None:
+    with client.websocket_connect("/two-scopes") as websocket:
+        data = websocket.receive_json()
+    assert data["func_is_open"] is True
+    assert data["req_is_open"] is True
+
+
+def test_sub() -> None:
+    with client.websocket_connect("/sub") as websocket:
+        data = websocket.receive_json()
+    assert data["named_session_open"] is True
+    assert data["session_open"] is True
+
+
+def test_broken_scope() -> None:
+    with pytest.raises(
+        FastAPIError,
+        match='The dependency "get_named_func_session" has a scope of "request", it cannot depend on dependencies with scope "function"',
+    ):
+
+        @app.websocket("/broken-scope")
+        async def get_broken(
+            websocket: WebSocket, sessions: BrokenSessionsDep
+        ) -> Any:  # pragma: no cover
+            pass
+
+
+def test_named_function_scope() -> None:
+    with client.websocket_connect("/named-function-scope") as websocket:
+        data = websocket.receive_json()
+    assert data["named_session_open"] is True
+    assert data["session_open"] is True
+
+
+def test_regular_function_scope() -> None:
+    with client.websocket_connect("/regular-function-scope") as websocket:
+        data = websocket.receive_json()
+    assert data["named_session_open"] is True
+    assert data["session_open"] is True

--- a/tests/test_params_repr.py
+++ b/tests/test_params_repr.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from dirty_equals import IsOneOf
-from fastapi.params import Body, Cookie, Depends, Header, Param, Path, Query
+from fastapi.params import Body, Cookie, Header, Param, Path, Query
 
 test_data: List[Any] = ["teststr", None, ..., 1, []]
 
@@ -141,12 +141,3 @@ def test_body_repr_number():
 
 def test_body_repr_list():
     assert repr(Body([])) == "Body([])"
-
-
-def test_depends_repr():
-    assert repr(Depends()) == "Depends(NoneType)"
-    assert repr(Depends(get_user)) == "Depends(get_user)"
-    assert repr(Depends(use_cache=False)) == "Depends(NoneType, use_cache=False)"
-    assert (
-        repr(Depends(get_user, use_cache=False)) == "Depends(get_user, use_cache=False)"
-    )

--- a/tests/test_tutorial/test_dependencies/test_tutorial008e.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial008e.py
@@ -1,0 +1,27 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ...utils import needs_py39
+
+
+@pytest.fixture(
+    name="client",
+    params=[
+        "tutorial008e",
+        "tutorial008e_an",
+        pytest.param("tutorial008e_an_py39", marks=needs_py39),
+    ],
+)
+def get_client(request: pytest.FixtureRequest):
+    mod = importlib.import_module(f"docs_src.dependencies.{request.param}")
+
+    client = TestClient(mod.app)
+    return client
+
+
+def test_get_users_me(client: TestClient):
+    response = client.get("/users/me")
+    assert response.status_code == 200, response.text
+    assert response.json() == "Rick"


### PR DESCRIPTION
✨ Add support for dependencies with scopes, support `scope="request"` for dependencies with `yield` that exit before the response is sent

This adds support for

* `Depends(func, scope="request")`, the default.
* `Depends(func, scope="function")`, early exit, after the function, but before sending the response back.

---

I'm considering an alternative name for the `scope` parameter of `mode`, to avoid any confusion with OAuth scopes, e.g. `Security(scopes=["blah"])`, which is a completely different idea.

Or a potential future `Depends(oauth_scopes=["blah"])` to replace `Security(scopes=["blah"])`.

That's the only reason to consider `mode` over `scope`.

---

I'm also considering the values, currently they are:

* `"function"`: start before the *path operation function*, exit after the function returns but **before** the response is sent.
* `"request"`: start before the *path operation function* (same as above), exit **after** the response is sent back.

I'm considering an alternative name for `"request"` of `"response"`, with the same behavior.

The rationale for using `"request"` as the value is that the dependency runs around (start and end) of the *request* cycle.

The rationale for using `"response"` as the value is that the main difference with `"function"` is when the exit code is run, in `"function"` it is run *after* the function is done, in this second form (`"request"` or `"response"`) it is run *after* the *response* is sent back.

---

I'm using this interface design because I also plan on (potentially, possibly) add a new `scope="lifespan"` that would allow using dependencies (or equivalent) functions that are run only once per app, and closed when the app ends. This way the same functionality for dependencies could be used for the app lifespan (ASGI `startup` and `shutdown` events). It should be more intuitive for users to work with. But these are future plans.

---

### 2025-10-03 Edit

After asking in several places, I concluded to keep the parameter name as `scope`.

I'll also keep the current values of `"function"`, similar to pytest, and `"request"`, to avoid confusing users who could think that the dependency will start running when the response is being sent, but it starts when the request starts.