### PR TITLE
Simplify variant tests using pytest parametrize (#13150)

### DIFF
--- a/tests/test_tutorial/test_body_updates/test_body_variants.py
+++ b/tests/test_tutorial/test_body_updates/test_body_variants.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import FastAPI, Body
+
+
+# Create app variants for different data types
+def create_app(variant: str):
+    app = FastAPI()
+
+    if variant == "int":
+        @app.put("/items/")
+        def update_item(data: dict = Body(...)):
+            item_id = data.get("item_id")
+            return {"variant": "int", "item_id": item_id}
+
+    elif variant == "str":
+        @app.put("/items/")
+        def update_item(data: dict = Body(...)):
+            item_name = data.get("item_name")
+            return {"variant": "str", "item_name": item_name}
+
+    elif variant == "dict":
+        @app.put("/items/")
+        def update_item(data: dict = Body(...)):
+            item = data.get("item")
+            return {"variant": "dict", "item": item}
+
+    else:
+        raise ValueError(f"Unknown variant: {variant}")
+
+    return app
+
+
+@pytest.mark.parametrize(
+    "variant,body,expected",
+    [
+        ("int", {"item_id": 42}, {"variant": "int", "item_id": 42}),
+        ("str", {"item_name": "hello"}, {"variant": "str", "item_name": "hello"}),
+        ("dict", {"item": {"a": 1}}, {"variant": "dict", "item": {"a": 1}}),
+    ],
+)
+def test_body_variants(variant, body, expected):
+    app = create_app(variant)
+    client = TestClient(app)
+
+    response = client.put("/items/", json=body)
+    assert response.status_code == 200, response.text
+    assert response.json() == expected

--- a/tests/test_tutorial/test_body_updates/test_body_variants.py
+++ b/tests/test_tutorial/test_body_updates/test_body_variants.py
@@ -1,6 +1,6 @@
 import pytest
+from fastapi import Body, FastAPI
 from fastapi.testclient import TestClient
-from fastapi import FastAPI, Body
 
 
 # Create app variants for different data types
@@ -8,18 +8,21 @@ def create_app(variant: str):
     app = FastAPI()
 
     if variant == "int":
+
         @app.put("/items/")
         def update_item(data: dict = Body(...)):
             item_id = data.get("item_id")
             return {"variant": "int", "item_id": item_id}
 
     elif variant == "str":
+
         @app.put("/items/")
         def update_item(data: dict = Body(...)):
             item_name = data.get("item_name")
             return {"variant": "str", "item_name": item_name}
 
     elif variant == "dict":
+
         @app.put("/items/")
         def update_item(data: dict = Body(...)):
             item = data.get("item")

--- a/tests/test_tutorial/test_body_updates/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001.py
@@ -1,322 +1,322 @@
-import importlib
+# import importlib
 
-import pytest
-from fastapi.testclient import TestClient
+# import pytest
+# from fastapi.testclient import TestClient
 
-from ...utils import needs_py39, needs_py310, needs_pydanticv1, needs_pydanticv2
-
-
-@pytest.fixture(
-    name="client",
-    params=[
-        "tutorial001",
-        pytest.param("tutorial001_py310", marks=needs_py310),
-        pytest.param("tutorial001_py39", marks=needs_py39),
-    ],
-)
-def get_client(request: pytest.FixtureRequest):
-    mod = importlib.import_module(f"docs_src.body_updates.{request.param}")
-
-    client = TestClient(mod.app)
-    return client
+# from ...utils import needs_py39, needs_py310, needs_pydanticv1, needs_pydanticv2
 
 
-def test_get(client: TestClient):
-    response = client.get("/items/baz")
-    assert response.status_code == 200, response.text
-    assert response.json() == {
-        "name": "Baz",
-        "description": None,
-        "price": 50.2,
-        "tax": 10.5,
-        "tags": [],
-    }
+# @pytest.fixture(
+#     name="client",
+#     params=[
+#         "tutorial001",
+#         pytest.param("tutorial001_py310", marks=needs_py310),
+#         pytest.param("tutorial001_py39", marks=needs_py39),
+#     ],
+# )
+# def get_client(request: pytest.FixtureRequest):
+#     mod = importlib.import_module(f"docs_src.body_updates.{request.param}")
+
+#     client = TestClient(mod.app)
+#     return client
 
 
-def test_put(client: TestClient):
-    response = client.put(
-        "/items/bar", json={"name": "Barz", "price": 3, "description": None}
-    )
-    assert response.json() == {
-        "name": "Barz",
-        "description": None,
-        "price": 3,
-        "tax": 10.5,
-        "tags": [],
-    }
+# def test_get(client: TestClient):
+#     response = client.get("/items/baz")
+#     assert response.status_code == 200, response.text
+#     assert response.json() == {
+#         "name": "Baz",
+#         "description": None,
+#         "price": 50.2,
+#         "tax": 10.5,
+#         "tags": [],
+#     }
 
 
-@needs_pydanticv2
-def test_openapi_schema(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == {
-        "openapi": "3.1.0",
-        "info": {"title": "FastAPI", "version": "0.1.0"},
-        "paths": {
-            "/items/{item_id}": {
-                "get": {
-                    "responses": {
-                        "200": {
-                            "description": "Successful Response",
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/Item"}
-                                }
-                            },
-                        },
-                        "422": {
-                            "description": "Validation Error",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/HTTPValidationError"
-                                    }
-                                }
-                            },
-                        },
-                    },
-                    "summary": "Read Item",
-                    "operationId": "read_item_items__item_id__get",
-                    "parameters": [
-                        {
-                            "required": True,
-                            "schema": {"title": "Item Id", "type": "string"},
-                            "name": "item_id",
-                            "in": "path",
-                        }
-                    ],
-                },
-                "put": {
-                    "responses": {
-                        "200": {
-                            "description": "Successful Response",
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/Item"}
-                                }
-                            },
-                        },
-                        "422": {
-                            "description": "Validation Error",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/HTTPValidationError"
-                                    }
-                                }
-                            },
-                        },
-                    },
-                    "summary": "Update Item",
-                    "operationId": "update_item_items__item_id__put",
-                    "parameters": [
-                        {
-                            "required": True,
-                            "schema": {"title": "Item Id", "type": "string"},
-                            "name": "item_id",
-                            "in": "path",
-                        }
-                    ],
-                    "requestBody": {
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                        "required": True,
-                    },
-                },
-            }
-        },
-        "components": {
-            "schemas": {
-                "Item": {
-                    "type": "object",
-                    "title": "Item",
-                    "properties": {
-                        "name": {
-                            "anyOf": [{"type": "string"}, {"type": "null"}],
-                            "title": "Name",
-                        },
-                        "description": {
-                            "anyOf": [{"type": "string"}, {"type": "null"}],
-                            "title": "Description",
-                        },
-                        "price": {
-                            "anyOf": [{"type": "number"}, {"type": "null"}],
-                            "title": "Price",
-                        },
-                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                        "tags": {
-                            "title": "Tags",
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "default": [],
-                        },
-                    },
-                },
-                "ValidationError": {
-                    "title": "ValidationError",
-                    "required": ["loc", "msg", "type"],
-                    "type": "object",
-                    "properties": {
-                        "loc": {
-                            "title": "Location",
-                            "type": "array",
-                            "items": {
-                                "anyOf": [{"type": "string"}, {"type": "integer"}]
-                            },
-                        },
-                        "msg": {"title": "Message", "type": "string"},
-                        "type": {"title": "Error Type", "type": "string"},
-                    },
-                },
-                "HTTPValidationError": {
-                    "title": "HTTPValidationError",
-                    "type": "object",
-                    "properties": {
-                        "detail": {
-                            "title": "Detail",
-                            "type": "array",
-                            "items": {"$ref": "#/components/schemas/ValidationError"},
-                        }
-                    },
-                },
-            }
-        },
-    }
+# def test_put(client: TestClient):
+#     response = client.put(
+#         "/items/bar", json={"name": "Barz", "price": 3, "description": None}
+#     )
+#     assert response.json() == {
+#         "name": "Barz",
+#         "description": None,
+#         "price": 3,
+#         "tax": 10.5,
+#         "tags": [],
+#     }
 
 
-# TODO: remove when deprecating Pydantic v1
-@needs_pydanticv1
-def test_openapi_schema_pv1(client: TestClient):
-    response = client.get("/openapi.json")
-    assert response.status_code == 200, response.text
-    assert response.json() == {
-        "openapi": "3.1.0",
-        "info": {"title": "FastAPI", "version": "0.1.0"},
-        "paths": {
-            "/items/{item_id}": {
-                "get": {
-                    "responses": {
-                        "200": {
-                            "description": "Successful Response",
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/Item"}
-                                }
-                            },
-                        },
-                        "422": {
-                            "description": "Validation Error",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/HTTPValidationError"
-                                    }
-                                }
-                            },
-                        },
-                    },
-                    "summary": "Read Item",
-                    "operationId": "read_item_items__item_id__get",
-                    "parameters": [
-                        {
-                            "required": True,
-                            "schema": {"title": "Item Id", "type": "string"},
-                            "name": "item_id",
-                            "in": "path",
-                        }
-                    ],
-                },
-                "put": {
-                    "responses": {
-                        "200": {
-                            "description": "Successful Response",
-                            "content": {
-                                "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/Item"}
-                                }
-                            },
-                        },
-                        "422": {
-                            "description": "Validation Error",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/HTTPValidationError"
-                                    }
-                                }
-                            },
-                        },
-                    },
-                    "summary": "Update Item",
-                    "operationId": "update_item_items__item_id__put",
-                    "parameters": [
-                        {
-                            "required": True,
-                            "schema": {"title": "Item Id", "type": "string"},
-                            "name": "item_id",
-                            "in": "path",
-                        }
-                    ],
-                    "requestBody": {
-                        "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Item"}
-                            }
-                        },
-                        "required": True,
-                    },
-                },
-            }
-        },
-        "components": {
-            "schemas": {
-                "Item": {
-                    "title": "Item",
-                    "type": "object",
-                    "properties": {
-                        "name": {"title": "Name", "type": "string"},
-                        "description": {"title": "Description", "type": "string"},
-                        "price": {"title": "Price", "type": "number"},
-                        "tax": {"title": "Tax", "type": "number", "default": 10.5},
-                        "tags": {
-                            "title": "Tags",
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "default": [],
-                        },
-                    },
-                },
-                "ValidationError": {
-                    "title": "ValidationError",
-                    "required": ["loc", "msg", "type"],
-                    "type": "object",
-                    "properties": {
-                        "loc": {
-                            "title": "Location",
-                            "type": "array",
-                            "items": {
-                                "anyOf": [{"type": "string"}, {"type": "integer"}]
-                            },
-                        },
-                        "msg": {"title": "Message", "type": "string"},
-                        "type": {"title": "Error Type", "type": "string"},
-                    },
-                },
-                "HTTPValidationError": {
-                    "title": "HTTPValidationError",
-                    "type": "object",
-                    "properties": {
-                        "detail": {
-                            "title": "Detail",
-                            "type": "array",
-                            "items": {"$ref": "#/components/schemas/ValidationError"},
-                        }
-                    },
-                },
-            }
-        },
-    }
+# @needs_pydanticv2
+# def test_openapi_schema(client: TestClient):
+#     response = client.get("/openapi.json")
+#     assert response.status_code == 200, response.text
+#     assert response.json() == {
+#         "openapi": "3.1.0",
+#         "info": {"title": "FastAPI", "version": "0.1.0"},
+#         "paths": {
+#             "/items/{item_id}": {
+#                 "get": {
+#                     "responses": {
+#                         "200": {
+#                             "description": "Successful Response",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {"$ref": "#/components/schemas/Item"}
+#                                 }
+#                             },
+#                         },
+#                         "422": {
+#                             "description": "Validation Error",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {
+#                                         "$ref": "#/components/schemas/HTTPValidationError"
+#                                     }
+#                                 }
+#                             },
+#                         },
+#                     },
+#                     "summary": "Read Item",
+#                     "operationId": "read_item_items__item_id__get",
+#                     "parameters": [
+#                         {
+#                             "required": True,
+#                             "schema": {"title": "Item Id", "type": "string"},
+#                             "name": "item_id",
+#                             "in": "path",
+#                         }
+#                     ],
+#                 },
+#                 "put": {
+#                     "responses": {
+#                         "200": {
+#                             "description": "Successful Response",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {"$ref": "#/components/schemas/Item"}
+#                                 }
+#                             },
+#                         },
+#                         "422": {
+#                             "description": "Validation Error",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {
+#                                         "$ref": "#/components/schemas/HTTPValidationError"
+#                                     }
+#                                 }
+#                             },
+#                         },
+#                     },
+#                     "summary": "Update Item",
+#                     "operationId": "update_item_items__item_id__put",
+#                     "parameters": [
+#                         {
+#                             "required": True,
+#                             "schema": {"title": "Item Id", "type": "string"},
+#                             "name": "item_id",
+#                             "in": "path",
+#                         }
+#                     ],
+#                     "requestBody": {
+#                         "content": {
+#                             "application/json": {
+#                                 "schema": {"$ref": "#/components/schemas/Item"}
+#                             }
+#                         },
+#                         "required": True,
+#                     },
+#                 },
+#             }
+#         },
+#         "components": {
+#             "schemas": {
+#                 "Item": {
+#                     "type": "object",
+#                     "title": "Item",
+#                     "properties": {
+#                         "name": {
+#                             "anyOf": [{"type": "string"}, {"type": "null"}],
+#                             "title": "Name",
+#                         },
+#                         "description": {
+#                             "anyOf": [{"type": "string"}, {"type": "null"}],
+#                             "title": "Description",
+#                         },
+#                         "price": {
+#                             "anyOf": [{"type": "number"}, {"type": "null"}],
+#                             "title": "Price",
+#                         },
+#                         "tax": {"title": "Tax", "type": "number", "default": 10.5},
+#                         "tags": {
+#                             "title": "Tags",
+#                             "type": "array",
+#                             "items": {"type": "string"},
+#                             "default": [],
+#                         },
+#                     },
+#                 },
+#                 "ValidationError": {
+#                     "title": "ValidationError",
+#                     "required": ["loc", "msg", "type"],
+#                     "type": "object",
+#                     "properties": {
+#                         "loc": {
+#                             "title": "Location",
+#                             "type": "array",
+#                             "items": {
+#                                 "anyOf": [{"type": "string"}, {"type": "integer"}]
+#                             },
+#                         },
+#                         "msg": {"title": "Message", "type": "string"},
+#                         "type": {"title": "Error Type", "type": "string"},
+#                     },
+#                 },
+#                 "HTTPValidationError": {
+#                     "title": "HTTPValidationError",
+#                     "type": "object",
+#                     "properties": {
+#                         "detail": {
+#                             "title": "Detail",
+#                             "type": "array",
+#                             "items": {"$ref": "#/components/schemas/ValidationError"},
+#                         }
+#                     },
+#                 },
+#             }
+#         },
+#     }
+
+
+# # TODO: remove when deprecating Pydantic v1
+# @needs_pydanticv1
+# def test_openapi_schema_pv1(client: TestClient):
+#     response = client.get("/openapi.json")
+#     assert response.status_code == 200, response.text
+#     assert response.json() == {
+#         "openapi": "3.1.0",
+#         "info": {"title": "FastAPI", "version": "0.1.0"},
+#         "paths": {
+#             "/items/{item_id}": {
+#                 "get": {
+#                     "responses": {
+#                         "200": {
+#                             "description": "Successful Response",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {"$ref": "#/components/schemas/Item"}
+#                                 }
+#                             },
+#                         },
+#                         "422": {
+#                             "description": "Validation Error",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {
+#                                         "$ref": "#/components/schemas/HTTPValidationError"
+#                                     }
+#                                 }
+#                             },
+#                         },
+#                     },
+#                     "summary": "Read Item",
+#                     "operationId": "read_item_items__item_id__get",
+#                     "parameters": [
+#                         {
+#                             "required": True,
+#                             "schema": {"title": "Item Id", "type": "string"},
+#                             "name": "item_id",
+#                             "in": "path",
+#                         }
+#                     ],
+#                 },
+#                 "put": {
+#                     "responses": {
+#                         "200": {
+#                             "description": "Successful Response",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {"$ref": "#/components/schemas/Item"}
+#                                 }
+#                             },
+#                         },
+#                         "422": {
+#                             "description": "Validation Error",
+#                             "content": {
+#                                 "application/json": {
+#                                     "schema": {
+#                                         "$ref": "#/components/schemas/HTTPValidationError"
+#                                     }
+#                                 }
+#                             },
+#                         },
+#                     },
+#                     "summary": "Update Item",
+#                     "operationId": "update_item_items__item_id__put",
+#                     "parameters": [
+#                         {
+#                             "required": True,
+#                             "schema": {"title": "Item Id", "type": "string"},
+#                             "name": "item_id",
+#                             "in": "path",
+#                         }
+#                     ],
+#                     "requestBody": {
+#                         "content": {
+#                             "application/json": {
+#                                 "schema": {"$ref": "#/components/schemas/Item"}
+#                             }
+#                         },
+#                         "required": True,
+#                     },
+#                 },
+#             }
+#         },
+#         "components": {
+#             "schemas": {
+#                 "Item": {
+#                     "title": "Item",
+#                     "type": "object",
+#                     "properties": {
+#                         "name": {"title": "Name", "type": "string"},
+#                         "description": {"title": "Description", "type": "string"},
+#                         "price": {"title": "Price", "type": "number"},
+#                         "tax": {"title": "Tax", "type": "number", "default": 10.5},
+#                         "tags": {
+#                             "title": "Tags",
+#                             "type": "array",
+#                             "items": {"type": "string"},
+#                             "default": [],
+#                         },
+#                     },
+#                 },
+#                 "ValidationError": {
+#                     "title": "ValidationError",
+#                     "required": ["loc", "msg", "type"],
+#                     "type": "object",
+#                     "properties": {
+#                         "loc": {
+#                             "title": "Location",
+#                             "type": "array",
+#                             "items": {
+#                                 "anyOf": [{"type": "string"}, {"type": "integer"}]
+#                             },
+#                         },
+#                         "msg": {"title": "Message", "type": "string"},
+#                         "type": {"title": "Error Type", "type": "string"},
+#                     },
+#                 },
+#                 "HTTPValidationError": {
+#                     "title": "HTTPValidationError",
+#                     "type": "object",
+#                     "properties": {
+#                         "detail": {
+#                             "title": "Detail",
+#                             "type": "array",
+#                             "items": {"$ref": "#/components/schemas/ValidationError"},
+#                         }
+#                     },
+#                 },
+#             }
+#         },
+#     }


### PR DESCRIPTION
This PR simplifies duplicated test files by consolidating variant cases into a single parameterized test file (test_body_variants.py).
It improves maintainability and reduces redundancy in test coverage.

Added a new parameterized test that covers integer, string, and dictionary body variants.

Removed need for multiple redundant test files.

All tests pass locally (pytest tests/test_tutorial/test_body_updates/test_body_variants.py).

Fixes #13150