### PR TITLE
⬆️ Bump Starlette to <`0.51.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.40.0,<0.50.0",
+    "starlette>=0.40.0,<0.51.0",
     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
     "typing-extensions>=4.8.0",
     "annotated-doc>=0.0.2",


### PR DESCRIPTION
The key change in [Starlette 0.50.0](https://github.com/Kludex/starlette/releases/tag/0.50.0) is that it drops support for Python 3.9, which has now reached end-of-life.