### PR TITLE
⚡️ Reuse coroutine inspection result

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -3,7 +3,6 @@ import email.message
 import functools
 import inspect
 import json
-import sys
 from contextlib import AsyncExitStack, asynccontextmanager
 from enum import Enum, IntEnum
 from typing import (
@@ -78,11 +77,6 @@ from starlette.routing import Mount as Mount  # noqa
 from starlette.types import AppType, ASGIApp, Lifespan, Receive, Scope, Send
 from starlette.websockets import WebSocket
 from typing_extensions import Annotated, deprecated
-
-if sys.version_info >= (3, 13):  # pragma: no cover
-    from inspect import iscoroutinefunction
-else:  # pragma: no cover
-    from asyncio import iscoroutinefunction
 
 
 # Copy of starlette.routing.request_response modified to include the
@@ -308,7 +302,7 @@ def get_request_handler(
     embed_body_fields: bool = False,
 ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
     assert dependant.call is not None, "dependant.call must be a function"
-    is_coroutine = iscoroutinefunction(dependant.call)
+    is_coroutine = dependant.is_coroutine_callable
     is_body_form = body_field and isinstance(
         body_field.field_info, (params.Form, temp_pydantic_v1_params.Form)
     )


### PR DESCRIPTION
#14262 implemented caching of `inspect` module calls within `Dependant` class, but it left one clause outside, and it is called on every request.

Reusing `inspect.iscoroutinefunction` result reduces time spent in `get_route_handler` from 2.23 µs to 1.33 µs:
<details>
<summary>perf.py</summary>

```python
import asyncio
import time
from fastapi import FastAPI, Depends, Header, Query
from fastapi.routing import APIRoute
from typing import Optional


# -----------------------
# Dependencies
# -----------------------

# Sync dependency
def get_token_header(x_token: str = Header(...)) -> str:
    if x_token != "secret-token":
        raise ValueError("Invalid token")
    return x_token


# Async dependency
async def get_query_param(q: Optional[str] = Query(None)) -> str:
    await asyncio.sleep(0.001)  # simulate small async delay
    return q or "default"


# Nested dependency (sync)
def get_user(token: str = Depends(get_token_header)) -> dict:
    return {"username": "test_user", "token": token}


# Nested dependency (async)
async def get_full_context(
    user: dict = Depends(get_user),
    query: str = Depends(get_query_param),
) -> dict:
    await asyncio.sleep(0.001)
    return {"user": user, "query": query}


# -----------------------
# App & route definition
# -----------------------

app = FastAPI()


@app.get("/items/{item_id}", dependencies=[Depends(get_token_header)])
async def read_item(
    item_id: int,
    context: dict = Depends(get_full_context),
) -> dict:
    return {"item_id": item_id, "context": context}


# -----------------------
# Performance test
# -----------------------

def test_get_route_handler_performance(loop_count: int = 50_000_000):
    route: APIRoute = app.routes[-1]
    assert route.path == '/items/{item_id}'

    start_time = time.perf_counter()

    for _ in range(loop_count):
        route.get_route_handler()

    duration = time.perf_counter() - start_time

    print(f"Called get_route_handler() {loop_count:,} times in {duration:.4f}s")
    print(f"Average per call: {duration / loop_count * 1e6:.2f} µs")


if __name__ == "__main__":
    test_get_route_handler_performance()
```
</details>

Before:
![callable_cache_fastapi_0 121](https://github.com/user-attachments/assets/52356b08-c47b-45a3-8e80-a58d45e6498d)

After:
![callable_cache_fastapi_0 121_half_patched](https://github.com/user-attachments/assets/72f072cf-7c93-4736-a8f4-ba661536e3cb)
