### PR TITLE
✨ Make `Depends` and `Security` hashable again

### DIFF
--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -762,13 +762,13 @@ class File(Form):  # type: ignore[misc]
         )
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class Depends:
     dependency: Optional[Callable[..., Any]] = None
     use_cache: bool = True
     scope: Union[Literal["function", "request"], None] = None
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class Security(Depends):
     scopes: Optional[Sequence[str]] = None


### PR DESCRIPTION
Cadwyn is currently broken on new FastAPI versions because `Depends` and `Security` have previously been hashable and we relied on this in our logic. 

Now they are unhashable dataclasses and I am a little stuck with how could fix it in Cadwyn. So I propose to make them hashable again. We have three options:

1. `frozen=True, eq=True` which will work but can be a breaking change for some users of FastAPI (though I don't expect it to be a problem for most) because it will become frozen
2. `unsafe_hash=True` which will work and shouldn't be a breaking change but having an object with a mutable hash is probably not a great idea
3. `def __hash__(self): return super().__hash__()` which should be roughly equivalent to prior behavior where there was a hash but it was the default object hash instead of anything meaningful

Any of these options would fix Cadwyn. Are you open to any of them?
