### PR TITLE
Simplifying control flow and tests for jsonable_encoder

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -210,13 +210,11 @@ def jsonable_encoder(
     [FastAPI docs for JSON Compatible Encoder](https://fastapi.tiangolo.com/tutorial/encoder/).
     """
     custom_encoder = custom_encoder or {}
-    if custom_encoder:
-        if type(obj) in custom_encoder:
-            return custom_encoder[type(obj)](obj)
-        else:
-            for encoder_type, encoder_instance in custom_encoder.items():
-                if isinstance(obj, encoder_type):
-                    return encoder_instance(obj)
+    if type(obj) in custom_encoder:
+        return custom_encoder[type(obj)](obj)
+    for encoder_type, encoder_instance in custom_encoder.items():
+        if isinstance(obj, encoder_type):
+            return encoder_instance(obj)
     if include is not None and not isinstance(include, (set, dict)):
         include = set(include)
     if exclude is not None and not isinstance(exclude, (set, dict)):

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -181,6 +181,7 @@ def test_encode_model_with_default():
         "bla": "bla",
     }
 
+
 def test_custom_enum_encoders():
     def custom_enum_encoder(v: Enum):
         return v.value.lower()


### PR DESCRIPTION
Changes:

1. Reduced unnecessary nesting in jsonable_encoder making logic appear simpler
2. Removed any pydanticv1 references in tests given we're on pydanticV2.