### PR TITLE
Fix Pylance typing warnings in tutorial examples

### DIFF
--- a/docs_src/query_params_str_validations/tutorial001.py
+++ b/docs_src/query_params_str_validations/tutorial001.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI
 

--- a/docs_src/query_params_str_validations/tutorial001.py
+++ b/docs_src/query_params_str_validations/tutorial001.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Union[str, None] = None):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial001_py310.py
+++ b/docs_src/query_params_str_validations/tutorial001_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI
 
 app = FastAPI()
@@ -5,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str | None = None):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial002.py
+++ b/docs_src/query_params_str_validations/tutorial002.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Union[str, None] = Query(default=None, max_length=50)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial002.py
+++ b/docs_src/query_params_str_validations/tutorial002.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial002_an.py
+++ b/docs_src/query_params_str_validations/tutorial002_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -8,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[Union[str, None], Query(max_length=50)] = None):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial002_an.py
+++ b/docs_src/query_params_str_validations/tutorial002_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial002_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial002_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[str | None, Query(max_length=50)] = None):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial002_py310.py
+++ b/docs_src/query_params_str_validations/tutorial002_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -5,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str | None = Query(default=None, max_length=50)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial003.py
+++ b/docs_src/query_params_str_validations/tutorial003.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial003.py
+++ b/docs_src/query_params_str_validations/tutorial003.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -9,7 +9,7 @@ app = FastAPI()
 async def read_items(
     q: Union[str, None] = Query(default=None, min_length=3, max_length=50),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial003_an.py
+++ b/docs_src/query_params_str_validations/tutorial003_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -10,7 +10,7 @@ app = FastAPI()
 async def read_items(
     q: Annotated[Union[str, None], Query(min_length=3, max_length=50)] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial003_an.py
+++ b/docs_src/query_params_str_validations/tutorial003_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial003_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial003_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -9,7 +9,7 @@ app = FastAPI()
 async def read_items(
     q: Annotated[str | None, Query(min_length=3, max_length=50)] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial003_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial003_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial003_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial003_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -9,7 +9,7 @@ app = FastAPI()
 async def read_items(
     q: Annotated[Union[str, None], Query(min_length=3, max_length=50)] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial003_py310.py
+++ b/docs_src/query_params_str_validations/tutorial003_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -5,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str | None = Query(default=None, min_length=3, max_length=50)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial004.py
+++ b/docs_src/query_params_str_validations/tutorial004.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -11,7 +11,7 @@ async def read_items(
         default=None, min_length=3, max_length=50, pattern="^fixedquery$"
     ),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial004.py
+++ b/docs_src/query_params_str_validations/tutorial004.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial004_an.py
+++ b/docs_src/query_params_str_validations/tutorial004_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -12,7 +12,7 @@ async def read_items(
         Union[str, None], Query(min_length=3, max_length=50, pattern="^fixedquery$")
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial004_an.py
+++ b/docs_src/query_params_str_validations/tutorial004_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial004_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial004_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -11,7 +11,7 @@ async def read_items(
         str | None, Query(min_length=3, max_length=50, pattern="^fixedquery$")
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial004_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial004_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial004_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial004_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -11,7 +11,7 @@ async def read_items(
         Union[str, None], Query(min_length=3, max_length=50, pattern="^fixedquery$")
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial004_py310.py
+++ b/docs_src/query_params_str_validations/tutorial004_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -9,7 +11,7 @@ async def read_items(
         default=None, min_length=3, max_length=50, pattern="^fixedquery$"
     ),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial004_regex_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial004_regex_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -11,7 +11,7 @@ async def read_items(
         str | None, Query(min_length=3, max_length=50, regex="^fixedquery$")
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial005.py
+++ b/docs_src/query_params_str_validations/tutorial005.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -5,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str = Query(default="fixedquery", min_length=3)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial005_an.py
+++ b/docs_src/query_params_str_validations/tutorial005_an.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
 
@@ -6,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[str, Query(min_length=3)] = "fixedquery"):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial005_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial005_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[str, Query(min_length=3)] = "fixedquery"):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006.py
+++ b/docs_src/query_params_str_validations/tutorial006.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -5,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str = Query(min_length=3)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006_an.py
+++ b/docs_src/query_params_str_validations/tutorial006_an.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
 
@@ -6,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[str, Query(min_length=3)]):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial006_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[str, Query(min_length=3)]):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006c.py
+++ b/docs_src/query_params_str_validations/tutorial006c.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Union[str, None] = Query(min_length=3)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006c.py
+++ b/docs_src/query_params_str_validations/tutorial006c.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial006c_an.py
+++ b/docs_src/query_params_str_validations/tutorial006c_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -8,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[Union[str, None], Query(min_length=3)]):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006c_an.py
+++ b/docs_src/query_params_str_validations/tutorial006c_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial006c_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial006c_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[str | None, Query(min_length=3)]):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006c_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial006c_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial006c_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial006c_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[Union[str, None], Query(min_length=3)]):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial006c_py310.py
+++ b/docs_src/query_params_str_validations/tutorial006c_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -5,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str | None = Query(min_length=3)):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial007.py
+++ b/docs_src/query_params_str_validations/tutorial007.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -9,7 +9,7 @@ app = FastAPI()
 async def read_items(
     q: Union[str, None] = Query(default=None, title="Query string", min_length=3),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial007.py
+++ b/docs_src/query_params_str_validations/tutorial007.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial007_an.py
+++ b/docs_src/query_params_str_validations/tutorial007_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -10,7 +10,7 @@ app = FastAPI()
 async def read_items(
     q: Annotated[Union[str, None], Query(title="Query string", min_length=3)] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial007_an.py
+++ b/docs_src/query_params_str_validations/tutorial007_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial007_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial007_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -9,7 +9,7 @@ app = FastAPI()
 async def read_items(
     q: Annotated[str | None, Query(title="Query string", min_length=3)] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial007_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial007_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial007_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial007_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -9,7 +9,7 @@ app = FastAPI()
 async def read_items(
     q: Annotated[Union[str, None], Query(title="Query string", min_length=3)] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial007_py310.py
+++ b/docs_src/query_params_str_validations/tutorial007_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -7,7 +9,7 @@ app = FastAPI()
 async def read_items(
     q: str | None = Query(default=None, title="Query string", min_length=3),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial008.py
+++ b/docs_src/query_params_str_validations/tutorial008.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial008.py
+++ b/docs_src/query_params_str_validations/tutorial008.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -14,7 +14,7 @@ async def read_items(
         min_length=3,
     ),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial008_an.py
+++ b/docs_src/query_params_str_validations/tutorial008_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -17,7 +17,7 @@ async def read_items(
         ),
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial008_an.py
+++ b/docs_src/query_params_str_validations/tutorial008_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial008_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial008_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -16,7 +16,7 @@ async def read_items(
         ),
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial008_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial008_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial008_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial008_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -16,7 +16,7 @@ async def read_items(
         ),
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial008_py310.py
+++ b/docs_src/query_params_str_validations/tutorial008_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -12,7 +14,7 @@ async def read_items(
         min_length=3,
     ),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial009.py
+++ b/docs_src/query_params_str_validations/tutorial009.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Union[str, None] = Query(default=None, alias="item-query")):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial009.py
+++ b/docs_src/query_params_str_validations/tutorial009.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial009_an.py
+++ b/docs_src/query_params_str_validations/tutorial009_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -8,7 +8,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[Union[str, None], Query(alias="item-query")] = None):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial009_an.py
+++ b/docs_src/query_params_str_validations/tutorial009_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial009_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial009_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[str | None, Query(alias="item-query")] = None):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial009_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial009_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial009_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial009_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -7,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: Annotated[Union[str, None], Query(alias="item-query")] = None):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial009_py310.py
+++ b/docs_src/query_params_str_validations/tutorial009_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -5,7 +7,7 @@ app = FastAPI()
 
 @app.get("/items/")
 async def read_items(q: str | None = Query(default=None, alias="item-query")):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial010.py
+++ b/docs_src/query_params_str_validations/tutorial010.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -18,7 +18,7 @@ async def read_items(
         deprecated=True,
     ),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial010.py
+++ b/docs_src/query_params_str_validations/tutorial010.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial010_an.py
+++ b/docs_src/query_params_str_validations/tutorial010_an.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated
@@ -21,7 +21,7 @@ async def read_items(
         ),
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial010_an.py
+++ b/docs_src/query_params_str_validations/tutorial010_an.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 from fastapi import FastAPI, Query
 from typing_extensions import Annotated

--- a/docs_src/query_params_str_validations/tutorial010_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial010_an_py310.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query
 
@@ -20,7 +20,7 @@ async def read_items(
         ),
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial010_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial010_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated, Union, Any
 
 from fastapi import FastAPI, Query
 
@@ -20,7 +20,7 @@ async def read_items(
         ),
     ] = None,
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results

--- a/docs_src/query_params_str_validations/tutorial010_an_py39.py
+++ b/docs_src/query_params_str_validations/tutorial010_an_py39.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union, Any
+from typing import Annotated, Any, Union
 
 from fastapi import FastAPI, Query
 

--- a/docs_src/query_params_str_validations/tutorial010_py310.py
+++ b/docs_src/query_params_str_validations/tutorial010_py310.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI, Query
 
 app = FastAPI()
@@ -16,7 +18,7 @@ async def read_items(
         deprecated=True,
     ),
 ):
-    results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
+    results: dict[str, Any] = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
-        results.update({"q": q})
+        results["q"] = q
     return results


### PR DESCRIPTION
### Summary
Fix Pylance type checking warnings in several tutorial examples by explicitly typing `results` as `dict[str, Any]` and using direct assignment instead of `.update()`.

### Reason
Recent versions of Python and Pylance infer `results` as `dict[str, list[dict[str, str]]]`,
causing false positives when adding a `str` value.

### Changes
- Updated multiple `docs_src/query_params_str_validations/*.py` files to fix Pylance typing warnings.
