### PR TITLE
Fix usage of deprecated Pydantic methods in tutorial

### DIFF
--- a/docs_src/body/tutorial002.py
+++ b/docs_src/body/tutorial002.py
@@ -16,7 +16,7 @@ app = FastAPI()
 
 @app.post("/items/")
 async def create_item(item: Item):
-    item_dict = item.dict()
+    item_dict = item.model_dump()
     if item.tax is not None:
         price_with_tax = item.price + item.tax
         item_dict.update({"price_with_tax": price_with_tax})

--- a/docs_src/body/tutorial002_py310.py
+++ b/docs_src/body/tutorial002_py310.py
@@ -14,7 +14,7 @@ app = FastAPI()
 
 @app.post("/items/")
 async def create_item(item: Item):
-    item_dict = item.dict()
+    item_dict = item.model_dump()
     if item.tax is not None:
         price_with_tax = item.price + item.tax
         item_dict.update({"price_with_tax": price_with_tax})

--- a/docs_src/body/tutorial003.py
+++ b/docs_src/body/tutorial003.py
@@ -16,4 +16,4 @@ app = FastAPI()
 
 @app.put("/items/{item_id}")
 async def update_item(item_id: int, item: Item):
-    return {"item_id": item_id, **item.dict()}
+    return {"item_id": item_id, **item.model_dump()}

--- a/docs_src/body/tutorial003_py310.py
+++ b/docs_src/body/tutorial003_py310.py
@@ -14,4 +14,4 @@ app = FastAPI()
 
 @app.put("/items/{item_id}")
 async def update_item(item_id: int, item: Item):
-    return {"item_id": item_id, **item.dict()}
+    return {"item_id": item_id, **item.model_dump()}

--- a/docs_src/body/tutorial004.py
+++ b/docs_src/body/tutorial004.py
@@ -16,7 +16,7 @@ app = FastAPI()
 
 @app.put("/items/{item_id}")
 async def update_item(item_id: int, item: Item, q: Union[str, None] = None):
-    result = {"item_id": item_id, **item.dict()}
+    result = {"item_id": item_id, **item.model_dump()}
     if q:
         result.update({"q": q})
     return result

--- a/docs_src/body/tutorial004_py310.py
+++ b/docs_src/body/tutorial004_py310.py
@@ -14,7 +14,7 @@ app = FastAPI()
 
 @app.put("/items/{item_id}")
 async def update_item(item_id: int, item: Item, q: str | None = None):
-    result = {"item_id": item_id, **item.dict()}
+    result = {"item_id": item_id, **item.model_dump()}
     if q:
         result.update({"q": q})
     return result

--- a/docs_src/path_operation_advanced_configuration/tutorial007_pv1.py
+++ b/docs_src/path_operation_advanced_configuration/tutorial007_pv1.py
@@ -28,7 +28,7 @@ async def create_item(request: Request):
     except yaml.YAMLError:
         raise HTTPException(status_code=422, detail="Invalid YAML")
     try:
-        item = Item.parse_obj(data)
+        item = Item.model_validate(data)
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors())
     return item


### PR DESCRIPTION
Hi, I'm new to FastAPI.

I'm learning FastAPI through the fantastic documentation.

While trying the example at https://fastapi.tiangolo.com/tutorial/body/#use-the-model on my local environment, I noticed the following **deprecation warning** in VS Code:
<img width="1119" height="433" alt="image" src="https://github.com/user-attachments/assets/c0e978ed-c0f9-4858-8cba-89c3b45c08f9" />

Upon checking the Pydantic source code, I confirmed that the `dict` method of `BaseModel` is indeed deprecated in Pydantic V2. It appears the documentation needs to be updated.

I then referred to the Pydantic V2 migration guide: https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel

I have searched all deprecated methods listed there within the `docs_src` path and replaced them with their corresponding methods for Pydantic V2 (e.g., replacing `.dict()` with `.model_dump()`).