### PR TITLE
🐛 Fix request body mediatype for form model with `File` fields

### DIFF
--- a/docs/en/docs/tutorial/request-form-models.md
+++ b/docs/en/docs/tutorial/request-form-models.md
@@ -36,6 +36,14 @@ You can verify it in the docs UI at `/docs`:
 <img src="/img/tutorial/request-form-models/image01.png">
 </div>
 
+## Including `File` Fields { #including-file-fields }
+
+You can also include **file fields** inside a form model by using `UploadFile` or `bytes` as field types and annotating them with `File`.
+
+If there is at least one `File` field in the form model, **FastAPI** will automatically set the request content media type to `multipart/form-data` for this path operation.
+
+{* ../../docs_src/request_form_models/tutorial001b_an_py39.py hl[3,12,16] *}
+
 ## Forbid Extra Form Fields { #forbid-extra-form-fields }
 
 In some special use cases (probably not very common), you might want to **restrict** the form fields to only those declared in the Pydantic model. And **forbid** any **extra** fields.
@@ -75,4 +83,4 @@ They will receive an error response telling them that the field `extra` is not a
 
 ## Summary { #summary }
 
-You can use Pydantic models to declare form fields in FastAPI. 😎
+You can use Pydantic models to declare form fields - including file uploads - in FastAPI. 😎

--- a/docs_src/request_form_models/tutorial001b.py
+++ b/docs_src/request_form_models/tutorial001b.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI, File, Form
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class FormData(BaseModel):
+    username: str
+    password: str
+    avatar: bytes = File()
+
+
+@app.post("/users/")
+async def create_user(data: FormData = Form()):
+    return {
+        "username": data.username,
+        "password": data.password,
+        "avatar_file_size": len(data.avatar),
+    }

--- a/docs_src/request_form_models/tutorial001b_an.py
+++ b/docs_src/request_form_models/tutorial001b_an.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI, File, Form
+from pydantic import BaseModel
+from typing_extensions import Annotated
+
+app = FastAPI()
+
+
+class FormData(BaseModel):
+    username: str
+    password: str
+    avatar: bytes = File()
+
+
+@app.post("/users/")
+async def create_user(data: Annotated[FormData, Form()]):
+    return {
+        "username": data.username,
+        "password": data.password,
+        "avatar_file_size": len(data.avatar),
+    }

--- a/docs_src/request_form_models/tutorial001b_an_py39.py
+++ b/docs_src/request_form_models/tutorial001b_an_py39.py
@@ -1,0 +1,21 @@
+from typing import Annotated
+
+from fastapi import FastAPI, File, Form
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class FormData(BaseModel):
+    username: str
+    password: str
+    avatar: bytes = File()
+
+
+@app.post("/users/")
+async def create_user(data: Annotated[FormData, Form()]):
+    return {
+        "username": data.username,
+        "password": data.password,
+        "avatar_file_size": len(data.avatar),
+    }

--- a/tests/test_forms_single_model.py
+++ b/tests/test_forms_single_model.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from dirty_equals import IsDict
-from fastapi import FastAPI, Form
+from fastapi import FastAPI, File, Form
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
@@ -17,9 +17,22 @@ class FormModel(BaseModel):
     alias_with: str = Field(alias="with", default="nothing")
 
 
+class FormWithFileModel(BaseModel):
+    comment: str
+    file_data: bytes = File()
+
+
 @app.post("/form/")
 def post_form(user: Annotated[FormModel, Form()]):
     return user
+
+
+@app.post("/form-with-file/")
+def post_form_(form_data: Annotated[FormWithFileModel, Form()]):
+    return {
+        "comment": form_data.comment,
+        "file_size": len(form_data.file_data),
+    }
 
 
 client = TestClient(app)
@@ -131,3 +144,74 @@ def test_no_data():
             ]
         }
     )
+
+
+def test_form_with_file():
+    file_content = b"Hello, this is a test file."
+    response = client.post(
+        "/form-with-file/",
+        data={"comment": "This is a comment."},
+        files={"file_data": ("test.txt", file_content, "text/plain")},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "comment": "This is a comment.",
+        "file_size": len(file_content),
+    }
+
+
+def test_form_with_file_missing_file():
+    response = client.post(
+        "/form-with-file/",
+        data={"comment": "This is a comment."},
+    )
+    assert response.status_code == 422, response.text
+    assert response.json() == IsDict(
+        {
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["body", "file_data"],
+                    "msg": "Field required",
+                    "input": {"comment": "This is a comment."},
+                }
+            ]
+        }
+    ) | IsDict(
+        # TODO: remove when deprecating Pydantic v1
+        {
+            "detail": [
+                {
+                    "loc": ["body", "file_data"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                }
+            ]
+        }
+    )
+
+
+def test_form_with_file_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+    assert openapi_schema["paths"]["/form-with-file/"]["post"]["requestBody"] == {
+        "content": {
+            "multipart/form-data": {
+                "schema": {
+                    "$ref": "#/components/schemas/FormWithFileModel",
+                },
+            },
+        },
+        "required": True,
+    }
+
+    assert openapi_schema["components"]["schemas"]["FormWithFileModel"] == {
+        "title": "FormWithFileModel",
+        "type": "object",
+        "properties": {
+            "file_data": {"title": "File Data", "type": "string", "format": "binary"},
+            "comment": {"title": "Comment", "type": "string"},
+        },
+        "required": ["comment", "file_data"],
+    }

--- a/tests/test_tutorial/test_request_form_models/test_tutorial001b.py
+++ b/tests/test_tutorial/test_request_form_models/test_tutorial001b.py
@@ -1,0 +1,188 @@
+import importlib
+
+import pytest
+from dirty_equals import IsDict
+from fastapi.testclient import TestClient
+
+from ...utils import needs_py39
+
+
+@pytest.fixture(
+    name="client",
+    params=[
+        "tutorial001b",
+        "tutorial001b_an",
+        pytest.param("tutorial001b_an_py39", marks=needs_py39),
+    ],
+)
+def get_client(request: pytest.FixtureRequest):
+    mod = importlib.import_module(f"docs_src.request_form_models.{request.param}")
+
+    client = TestClient(mod.app)
+    return client
+
+
+def test_post_body_form(client: TestClient):
+    response = client.post(
+        "/users/",
+        data={"username": "Foo", "password": "secret"},
+        files={"avatar": ("avatar.png", b"filebytes")},
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "username": "Foo",
+        "password": "secret",
+        "avatar_file_size": 9,
+    }
+
+
+def test_post_body_form_no_avatar(client: TestClient):
+    response = client.post("/users/", data={"username": "Foo", "password": "secret"})
+    assert response.status_code == 422
+    assert response.json() == IsDict(
+        {
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["body", "avatar"],
+                    "msg": "Field required",
+                    "input": {"username": "Foo", "password": "secret"},
+                }
+            ]
+        }
+    ) | IsDict(
+        # TODO: remove when deprecating Pydantic v1
+        {
+            "detail": [
+                {
+                    "loc": ["body", "avatar"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                }
+            ]
+        }
+    )
+
+
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "FastAPI",
+            "version": "0.1.0",
+        },
+        "paths": {
+            "/users/": {
+                "post": {
+                    "operationId": "create_user_users__post",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FormData",
+                                },
+                            },
+                        },
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {},
+                                },
+                            },
+                            "description": "Successful Response",
+                        },
+                        "422": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/HTTPValidationError",
+                                    },
+                                },
+                            },
+                            "description": "Validation Error",
+                        },
+                    },
+                    "summary": "Create User",
+                },
+            },
+        },
+        "components": {
+            "schemas": {
+                "FormData": {
+                    "properties": {
+                        "avatar": {
+                            "format": "binary",
+                            "title": "Avatar",
+                            "type": "string",
+                        },
+                        "password": {
+                            "title": "Password",
+                            "type": "string",
+                        },
+                        "username": {
+                            "title": "Username",
+                            "type": "string",
+                        },
+                    },
+                    "required": [
+                        "username",
+                        "password",
+                        "avatar",
+                    ],
+                    "title": "FormData",
+                    "type": "object",
+                },
+                "HTTPValidationError": {
+                    "properties": {
+                        "detail": {
+                            "items": {
+                                "$ref": "#/components/schemas/ValidationError",
+                            },
+                            "title": "Detail",
+                            "type": "array",
+                        },
+                    },
+                    "title": "HTTPValidationError",
+                    "type": "object",
+                },
+                "ValidationError": {
+                    "properties": {
+                        "loc": {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                    },
+                                    {
+                                        "type": "integer",
+                                    },
+                                ],
+                            },
+                            "title": "Location",
+                            "type": "array",
+                        },
+                        "msg": {
+                            "title": "Message",
+                            "type": "string",
+                        },
+                        "type": {
+                            "title": "Error Type",
+                            "type": "string",
+                        },
+                    },
+                    "required": [
+                        "loc",
+                        "msg",
+                        "type",
+                    ],
+                    "title": "ValidationError",
+                    "type": "object",
+                },
+            },
+        },
+    }


### PR DESCRIPTION
Currently if form parameter model contains `File` field, the content mediatype for this path operation in openapi will be wrong:

```py
from fastapi import FastAPI, Form, File
from pydantic import BaseModel

app = FastAPI()

class MyModel(BaseModel):
    file_model: bytes = File()

@app.post("/file-model")
async def create_item(item: MyModel = Form()):
    return {"file_size": len(item.file_model)}
```

Request body content mediatype in openapi will be `application/x-www-form-urlencoded` instead of `multipart/form-data`:
```json
        "requestBody": {
          "content": {
            "application/x-www-form-urlencoded": {
              "schema": {
                "$ref": "#/components/schemas/MyModel"
              }
            }
          },
          "required": true
        },
```

This PR enforces the content mediatype to be `multipart/form-data` for form parameter models that contain at least one `File` field.
I added `if request_media_type == "application/x-www-form-urlencoded"` condition to make it possible to override mediatype by passing a parameter to `Form`:

```
@app.post("/file-model")
async def create_item(item: MyModel = Form(media_type="whatever")):
    ...
```
