### PR TITLE
Feature/uploadfile read text

### DIFF
--- a/fastapi/datastructures.py
+++ b/fastapi/datastructures.py
@@ -143,23 +143,22 @@ class UploadFile(StarletteUploadFile):
             str,
             Doc("The text encoding to use when decoding bytes. Defaults to 'utf-8'."),
         ] = "utf-8",
-        ) -> str:
-
+    ) -> str:
         """
-            Read the entire file as a text string.
-            This is a convenience wrapper around `await self.read()`
-            that decodes the bytes using the given encoding.
-            ## Example
-            ```python
-            @app.post("/upload-text/")
-            async def upload_text(file: UploadFile):
-                text = await file.read_text()
-                return {"length": len(text)}
-            ```
-            Args:
-                encoding: The text encoding to use (default: 'utf-8').
-            Returns:
-                The decoded file content as a string.
+        Read the entire file as a text string.
+        This is a convenience wrapper around `await self.read()`
+        that decodes the bytes using the given encoding.
+        ## Example
+        ```python
+        @app.post("/upload-text/")
+        async def upload_text(file: UploadFile):
+            text = await file.read_text()
+            return {"length": len(text)}
+        ```
+        Args:
+            encoding: The text encoding to use (default: 'utf-8').
+        Returns:
+            The decoded file content as a string.
         """
         data = await self.read()
         return data.decode(encoding)

--- a/fastapi/datastructures.py
+++ b/fastapi/datastructures.py
@@ -136,6 +136,33 @@ class UploadFile(StarletteUploadFile):
         To be awaitable, compatible with async, this is run in threadpool.
         """
         return await super().close()
+    
+    async def read_text(
+        self,
+        encoding: Annotated[
+            str,
+            Doc("The text encoding to use when decoding bytes. Defaults to 'utf-8'."),
+        ] = "utf-8",
+        ) -> str:
+
+        """
+            Read the entire file as a text string.
+            This is a convenience wrapper around `await self.read()`
+            that decodes the bytes using the given encoding.
+            ## Example
+            ```python
+            @app.post("/upload-text/")
+            async def upload_text(file: UploadFile):
+                text = await file.read_text()
+                return {"length": len(text)}
+            ```
+            Args:
+                encoding: The text encoding to use (default: 'utf-8').
+            Returns:
+                The decoded file content as a string.
+        """
+        data = await self.read()
+        return data.decode(encoding)
 
     @classmethod
     def __get_validators__(cls: Type["UploadFile"]) -> Iterable[Callable[..., Any]]:

--- a/fastapi/datastructures.py
+++ b/fastapi/datastructures.py
@@ -136,7 +136,7 @@ class UploadFile(StarletteUploadFile):
         To be awaitable, compatible with async, this is run in threadpool.
         """
         return await super().close()
-    
+
     async def read_text(
         self,
         encoding: Annotated[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,9 @@ addopts = [
 ]
 xfail_strict = true
 junit_family = "xunit2"
+markers = [
+    "asyncio: mark test to run with asyncio event loop",
+]
 filterwarnings = [
     "error",
     'ignore:starlette.middleware.wsgi is deprecated and will be removed in a future release\..*:DeprecationWarning:starlette',

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,7 @@
 -e .[all]
 -r requirements-docs-tests.txt
 pytest >=7.1.3,<9.0.0
+pytest-asyncio >=0.21.0,<0.25.0
 coverage[toml] >= 6.5.0,< 8.0
 mypy ==1.14.1
 dirty-equals ==0.9.0

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -74,7 +74,6 @@ async def test_upload_file():
 
 @pytest.mark.asyncio
 async def test_uploadfile_read_text(tmp_path):
-
     file_path = tmp_path / "sample.txt"
     file_path.write_text("Hello FastAPI!")
 
@@ -82,4 +81,6 @@ async def test_uploadfile_read_text(tmp_path):
         upload = UploadFile(filename="sample.txt", file=f)
         content = await upload.read_text()
         assert content == "Hello FastAPI!"
-        assert upload.filename == "sample.txt" # make sure .read_text() doesn't modify filename or headers
+        assert (
+            upload.filename == "sample.txt"
+        )  # make sure .read_text() doesn't modify filename or headers

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -70,3 +70,16 @@ async def test_upload_file():
     await file.seek(0)
     assert await file.read() == b"data and more data!"
     await file.close()
+
+
+@pytest.mark.asyncio
+async def test_uploadfile_read_text(tmp_path):
+
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("Hello FastAPI!")
+
+    with open(file_path, "rb") as f:
+        upload = UploadFile(filename="sample.txt", file=f)
+        content = await upload.read_text()
+        assert content == "Hello FastAPI!"
+        assert upload.filename == "sample.txt" # make sure .read_text() doesn't modify filename or headers


### PR DESCRIPTION
This PR introduces a new async method read_text in the UploadFile class. It provides a convenient way to read the entire contents of an uploaded file as a string, with a specified text encoding (default 'utf-8').

Why : 
Currently, when working with uploaded files in FastAPI, developers have to manually:
  - Call await file.read() to get the bytes.
  - Decode the bytes to a string using an encoding (like 'utf-8').
This is repetitive and can lead to boilerplate code.

The new read_text method simplifies this common use case by combining reading and decoding in one type-safe, documented, async method.