### PR TITLE
test: add test for default 404 response

### DIFF
--- a/tests/test_default_404.py
+++ b/tests/test_default_404.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_default_404():
+    app = FastAPI()
+    client = TestClient(app)
+
+    response = client.get("/non-existing-route")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Not Found"


### PR DESCRIPTION
This PR adds a small unit test for FastAPI's default 404 response when a non-existing route is requested.

- Added tests/test_default_404.py
- Verifies status_code == 404
- Verifies default JSON detail == "Not Found"

This improves test coverage for default error handling, with no changes to core functionality.
