### PR TITLE
Add API key header example to security tutorial

### DIFF
--- a/docs/en/docs/tutorial/security/index.md
+++ b/docs/en/docs/tutorial/security/index.md
@@ -107,7 +107,7 @@ And you will also see how it gets automatically integrated into the interactive 
 
 ## API Key in Header
 
-An API key is a simple secret string that a client sends with every request.  
+An API key is a simple secret string that a client sends with every request.
 It is often used for:
 
 - machine-to-machine communication,
@@ -120,7 +120,7 @@ FastAPI provides tools for these in the `fastapi.security` module, including `AP
 
 ### Define an API key in a header
 
-In this example, the client must send an API key in the HTTP header `X-API-Key`.  
+In this example, the client must send an API key in the HTTP header `X-API-Key`.
 We’ll require the exact value `"supersecret"` to access a protected route.
 
 ```Python
@@ -135,5 +135,3 @@ API_KEY = "supersecret"
 API_KEY_NAME = "X-API-Key"
 
 api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
-
-

--- a/docs/en/docs/tutorial/security/index.md
+++ b/docs/en/docs/tutorial/security/index.md
@@ -104,3 +104,36 @@ FastAPI provides several tools for each of these security schemes in the `fastap
 In the next chapters you will see how to add security to your API using those tools provided by **FastAPI**.
 
 And you will also see how it gets automatically integrated into the interactive documentation system.
+
+## API Key in Header
+
+An API key is a simple secret string that a client sends with every request.  
+It is often used for:
+
+- machine-to-machine communication,
+- internal services,
+- simple “service access” authentication instead of full user accounts.
+
+In OpenAPI, this is represented with the `apiKey` security scheme, and it can be sent in a **query parameter**, a **header**, or a **cookie**.
+
+FastAPI provides tools for these in the `fastapi.security` module, including `APIKeyHeader` for header-based API keys.
+
+### Define an API key in a header
+
+In this example, the client must send an API key in the HTTP header `X-API-Key`.  
+We’ll require the exact value `"supersecret"` to access a protected route.
+
+```Python
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+app = FastAPI()
+
+API_KEY = "supersecret"
+API_KEY_NAME = "X-API-Key"
+
+api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
+
+

--- a/docs/es/docs/tutorial/security/index.md
+++ b/docs/es/docs/tutorial/security/index.md
@@ -103,3 +103,36 @@ FastAPI proporciona varias herramientas para cada uno de estos esquemas de segur
 En los siguientes capítulos verás cómo agregar seguridad a tu API usando esas herramientas proporcionadas por **FastAPI**.
 
 Y también verás cómo se integra automáticamente en el sistema de documentación interactiva.
+
+
+## API Key en el Header
+
+Una API key es una cadena secreta sencilla que un cliente envía con cada petición.  
+Suele utilizarse para:
+
+- comunicación entre servicios,
+- servicios internos,
+- autenticación simple por “acceso al servicio” en lugar de cuentas de usuario completas.
+
+En OpenAPI, esto se representa con el esquema de seguridad `apiKey`, que puede enviarse en un **parámetro de consulta**, un **header**, o una **cookie**.
+
+FastAPI incluye utilidades para esto en el módulo `fastapi.security`, incluyendo `APIKeyHeader` para API keys basadas en headers.
+
+### Definir la API key en un header
+
+En este ejemplo, el cliente debe enviar una API key en el header HTTP `X-API-Key`.  
+Requeriremos que el valor sea exactamente `"supersecret"` para acceder a una ruta protegida.
+
+```Python
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+app = FastAPI()
+
+API_KEY = "supersecret"
+API_KEY_NAME = "X-API-Key"
+
+api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
+

--- a/docs/es/docs/tutorial/security/index.md
+++ b/docs/es/docs/tutorial/security/index.md
@@ -107,7 +107,7 @@ Y también verás cómo se integra automáticamente en el sistema de documentaci
 
 ## API Key en el Header
 
-Una API key es una cadena secreta sencilla que un cliente envía con cada petición.  
+Una API key es una cadena secreta sencilla que un cliente envía con cada petición.
 Suele utilizarse para:
 
 - comunicación entre servicios,
@@ -120,7 +120,7 @@ FastAPI incluye utilidades para esto en el módulo `fastapi.security`, incluyend
 
 ### Definir la API key en un header
 
-En este ejemplo, el cliente debe enviar una API key en el header HTTP `X-API-Key`.  
+En este ejemplo, el cliente debe enviar una API key en el header HTTP `X-API-Key`.
 Requeriremos que el valor sea exactamente `"supersecret"` para acceder a una ruta protegida.
 
 ```Python
@@ -135,4 +135,3 @@ API_KEY = "supersecret"
 API_KEY_NAME = "X-API-Key"
 
 api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
-

--- a/docs_src/security/tutorial_api_key_header.py
+++ b/docs_src/security/tutorial_api_key_header.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+app = FastAPI()
+
+API_KEY = "supersecret"
+API_KEY_NAME = "X-API-Key"
+
+api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
+
+
+async def get_api_key(api_key: Optional[str] = Security(api_key_header)) -> str:
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authenticated",
+        )
+    if api_key != API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid API key",
+        )
+    return api_key
+
+
+@app.get("/protected-route")
+async def protected_route(api_key: str = Security(get_api_key)):
+    return {"message": "You are authorized"}

--- a/tests/test_tutorial/test_security/test_tutorial_api_key_header.py
+++ b/tests/test_tutorial/test_security/test_tutorial_api_key_header.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(name="client")
+def get_client() -> TestClient:
+    from docs_src.security.tutorial_api_key_header import app
+
+    return TestClient(app)
+
+
+def test_no_api_key(client: TestClient) -> None:
+    response = client.get("/protected-route")
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_invalid_api_key(client: TestClient) -> None:
+    response = client.get(
+        "/protected-route",
+        headers={"X-API-Key": "wrong"},
+    )
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "Invalid API key"}
+
+
+def test_valid_api_key(client: TestClient) -> None:
+    response = client.get(
+        "/protected-route",
+        headers={"X-API-Key": "supersecret"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "You are authorized"}


### PR DESCRIPTION
This PR adds a concrete example to the security tutorial showing how to use an API key passed in an HTTP header and how to validate it in FastAPI.
Fixes #142.

## Summary

The new example demonstrates:

* Using an **API key** sent in the `X-API-Key` header.
* Validating the API key with a **dependency** using `APIKeyHeader` and `Security`.
* Returning different **`403` error messages** for:
    * missing/empty header: `{"detail": "Not authenticated"}`
    * wrong header value: `{"detail": "Invalid API key"}`
* Protecting a route `GET /protected-route` that returns `{"message": "You are authorized"}` when the API key is correct.

The documentation is updated both in **English and Spanish** to keep the tutorials in sync.

---

## Changes

### Example app

Added a new example:

* `docs_src/security/tutorial_api_key_header.py`

Key points:

* Defines the API key and header name:

    ```python
    API_KEY = "supersecret"
    API_KEY_NAME = "X-API-Key"
    ```

* Uses `APIKeyHeader` with `auto_error=False`:

    ```python
    api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
    ```

* Defines a dependency that distinguishes between missing and invalid keys:

    ```python
    async def get_api_key(
        api_key: Optional[str] = Security(api_key_header),
    ) -> str:
        if api_key is None:
            raise HTTPException(
                status_code=status.HTTP_403_FORBIDDEN,
                detail="Not authenticated",
            )
        if api_key != API_KEY:
            raise HTTPException(
                status_code=status.HTTP_403_FORBIDDEN,
                detail="Invalid API key",
            )
        return api_key
    ```

* Protects the route:

    ```python
    @app.get("/protected-route")
    async def protected_route(api_key: str = Security(get_api_key)):
        return {"message": "You are authorized"}
    ```

### Documentation

Updated the security tutorial in both languages to include the new section.

**English**

* `docs/en/docs/tutorial/security/index.md`
* New section: `## API Key in Header`
* It explains:
    * What an API key is and when to use it.
    * How to define `APIKeyHeader` and the constants `API_KEY` and `API_KEY_NAME`.
    * How the `get_api_key` dependency returns different `403` errors for missing vs invalid keys.
    * How to use the dependency in `/protected-route`.
    * `curl` examples for:
        * no header,
        * wrong header value,
        * correct header value.

**Spanish**

* `docs/es/docs/tutorial/security/index.md`
* New section: `## API Key en el header`
* This mirrors the English section, with the same code and `curl` examples, translated text.

### Tests

Added tests for the new example:

* `tests/test_tutorial/test_security/test_tutorial_api_key_header.py`

The tests cover the three main cases:

1.  **No `X-API-Key` header**
    * `GET /protected-route`
    * Response: `403`
    * Body: `{"detail": "Not authenticated"}`
2.  **Invalid API key**
    * `GET /protected-route` with `X-API-Key: wrong`
    * Response: `403`
    * Body: `{"detail": "Invalid API key"}`
3.  **Valid API key**
    * `GET /protected-route` with `X-API-Key: supersecret`
    * Response: `200`
    * Body: `{"message": "You are authorized"}`

### How to run the tests

From the project root:

```bash
pytest tests/test_tutorial/test_security/test_tutorial_api_key_header.py
Checklist
[x] New example added under docs_src/security.

[x] Documentation updated in English and Spanish.

[x] Tests added for the new example.

[x] Tests passing locally.