### PR TITLE
♻️ Make the result of `Depends()` and `Security()` hashable, as a workaround for other tools interacting with these internal parts

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import inspect
 from contextlib import AsyncExitStack, contextmanager
 from copy import copy, deepcopy
@@ -428,7 +429,7 @@ def analyze_param(
     if depends is not None and depends.dependency is None:
         # Copy `depends` before mutating it
         depends = copy(depends)
-        depends.dependency = type_annotation
+        depends = dataclasses.replace(depends, dependency=type_annotation)
 
     # Handle non-param type annotations like Request
     if lenient_issubclass(

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -762,13 +762,13 @@ class File(Form):  # type: ignore[misc]
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class Depends:
     dependency: Optional[Callable[..., Any]] = None
     use_cache: bool = True
     scope: Union[Literal["function", "request"], None] = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class Security(Depends):
     scopes: Optional[Sequence[str]] = None

--- a/tests/test_depends_hashable.py
+++ b/tests/test_depends_hashable.py
@@ -1,0 +1,25 @@
+# This is more or less a workaround to make Depends and Security hashable
+# as other tools that use them depend on that
+# Ref: https://github.com/fastapi/fastapi/pull/14320
+
+from fastapi import Depends, Security
+
+
+def dep():
+    pass
+
+
+def test_depends_hashable():
+    dep()  # just for coverage
+    d1 = Depends(dep)
+    d2 = Depends(dep)
+    d3 = Depends(dep, scope="function")
+    d4 = Depends(dep, scope="function")
+
+    s1 = Security(dep)
+    s2 = Security(dep)
+
+    assert hash(d1) == hash(d2)
+    assert hash(s1) == hash(s2)
+    assert hash(d1) != hash(d3)
+    assert hash(d3) == hash(d4)


### PR DESCRIPTION
♻️ Make the result of `Depends()` and `Security()` hashable, as a workaround for other tools interacting with these internal parts

---

This comes from https://github.com/fastapi/fastapi/pull/14320

As a note, FastAPI doesn't really have official support for extending its internals in ways that are not documented in the docs.

So this is not a long-term commitment to keep some specific behavior, but a quick workaround to make things easier for current tools that interact with FastAPI internals in some way.

---

At some point in the future, I'll refactor the internals of FastAPI to make them more explicitly private, and then also figure out the right ways to expose any points of connection with external components that currently need to interact with the internals in some way, and formalize that better.

---

Before that, I need to handle a few issues, bugs, features, refactors, deprecations, etc. And then I'll be able to come back to this idea of figuring out how and what to expose. :nerd_face: 