### PR TITLE
fix: align type hints in api_route() decorators with add_api_route() implementations

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1147,7 +1147,7 @@ class FastAPI(Starlette):
         response_description: str = "Successful Response",
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
         deprecated: Optional[bool] = None,
-        methods: Optional[List[str]] = None,
+        methods: Optional[Union[Set[str], List[str]]] = None,
         operation_id: Optional[str] = None,
         response_model_include: Optional[IncEx] = None,
         response_model_exclude: Optional[IncEx] = None,
@@ -1161,9 +1161,9 @@ class FastAPI(Starlette):
         ),
         name: Optional[str] = None,
         openapi_extra: Optional[Dict[str, Any]] = None,
-        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
-            generate_unique_id
-        ),
+        generate_unique_id_function: Union[
+            Callable[[routing.APIRoute], str], DefaultPlaceholder
+        ] = Default(generate_unique_id),
     ) -> None:
         self.router.add_api_route(
             path,
@@ -1205,7 +1205,7 @@ class FastAPI(Starlette):
         response_description: str = "Successful Response",
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
         deprecated: Optional[bool] = None,
-        methods: Optional[List[str]] = None,
+        methods: Optional[Union[Set[str], List[str]]] = None,
         operation_id: Optional[str] = None,
         response_model_include: Optional[IncEx] = None,
         response_model_exclude: Optional[IncEx] = None,
@@ -1214,12 +1214,14 @@ class FastAPI(Starlette):
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
         include_in_schema: bool = True,
-        response_class: Type[Response] = Default(JSONResponse),
+        response_class: Union[Type[Response], DefaultPlaceholder] = Default(
+            JSONResponse
+        ),
         name: Optional[str] = None,
         openapi_extra: Optional[Dict[str, Any]] = None,
-        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
-            generate_unique_id
-        ),
+        generate_unique_id_function: Union[
+            Callable[[routing.APIRoute], str], DefaultPlaceholder
+        ] = Default(generate_unique_id),
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             self.router.add_api_route(

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1057,7 +1057,7 @@ class APIRouter(routing.Router):
         response_description: str = "Successful Response",
         responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
         deprecated: Optional[bool] = None,
-        methods: Optional[List[str]] = None,
+        methods: Optional[Union[Set[str], List[str]]] = None,
         operation_id: Optional[str] = None,
         response_model_include: Optional[IncEx] = None,
         response_model_exclude: Optional[IncEx] = None,
@@ -1066,13 +1066,15 @@ class APIRouter(routing.Router):
         response_model_exclude_defaults: bool = False,
         response_model_exclude_none: bool = False,
         include_in_schema: bool = True,
-        response_class: Type[Response] = Default(JSONResponse),
+        response_class: Union[Type[Response], DefaultPlaceholder] = Default(
+            JSONResponse
+        ),
         name: Optional[str] = None,
         callbacks: Optional[List[BaseRoute]] = None,
         openapi_extra: Optional[Dict[str, Any]] = None,
-        generate_unique_id_function: Callable[[APIRoute], str] = Default(
-            generate_unique_id
-        ),
+        generate_unique_id_function: Union[
+            Callable[[APIRoute], str], DefaultPlaceholder
+        ] = Default(generate_unique_id),
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             self.add_api_route(


### PR DESCRIPTION
This PR fixes several type hint inconsistencies between the `api_route()` 
decorators and the underlying `add_api_route()` implementations in both 
`APIRouter` and `FastAPI`.

### Summary of Issues
The decorator methods use narrower type hints than the actual implementation, 
which internally forwards these values to `add_api_route()`. This creates 
inconsistencies in the public API surface and can lead to false type-checking 
errors.

### 1. response_class Parameter
- `api_route()` decorator: Type[Response]
- `add_api_route()`: Union[Type[Response], DefaultPlaceholder]

Fix: Add `DefaultPlaceholder` to the decorator signature.

### 2. generate_unique_id_function Parameter
- `api_route()` decorator: Callable[[APIRoute], str]
- `add_api_route()`: Union[Callable[[APIRoute], str], DefaultPlaceholder]

Fix: Match the broader union used by `add_api_route()`.

### 3. methods Parameter
- `api_route()` decorator: Optional[List[str]]
- `add_api_route()`: Optional[Union[Set[str], List[str]]]
- `APIRoute.__init__()`: Optional[Union[Set[str], List[str]]]

Fix: Update the decorator to accept both `Set[str]` and `List[str]`.

### 4. FastAPI vs APIRouter mismatch
`FastAPI.add_api_route()` accepts only `Optional[List[str]]`, while 
`APIRouter.add_api_route()` supports both sets and lists. Since FastAPI 
delegates to the router, this PR al
