### PR TITLE
Improve error handling for item retrieval

### DIFF
--- a/docs_src/query_params_str_validations/tutorial015_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial015_an_py310.py
@@ -1,7 +1,7 @@
 import random
 from typing import Annotated
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import AfterValidator
 
 app = FastAPI()
@@ -25,6 +25,8 @@ async def read_items(
 ):
     if id:
         item = data.get(id)
+        if item is None:
+            raise HTTPException(status_code=404, detail=f"Item with id '{id}' not found")
     else:
         id, item = random.choice(list(data.items()))
     return {"id": id, "name": item}

--- a/docs_src/query_params_str_validations/tutorial015_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial015_an_py310.py
@@ -26,7 +26,9 @@ async def read_items(
     if id:
         item = data.get(id)
         if item is None:
-            raise HTTPException(status_code=404, detail=f"Item with id '{id}' not found")
+            raise HTTPException(
+                status_code=404, detail=f"Item with id '{id}' not found"
+            )
     else:
         id, item = random.choice(list(data.items()))
     return {"id": id, "name": item}


### PR DESCRIPTION
Fix: Return 404 for non-existent items instead of null response

Previously, valid ID formats with non-existent items returned 200 OK  with null values, creating ambiguous API responses. Now properly returns  404 Not Found when items don't exist in the database.