### PR TITLE
Update .gitignore commands in virtual-environments.md

### DIFF
--- a/docs/en/docs/virtual-environments.md
+++ b/docs/en/docs/virtual-environments.md
@@ -261,7 +261,7 @@ Do this **once**, right after you create the virtual environment.
 <div class="termy">
 
 ```console
-$ echo "*" > .venv/.gitignore
+$ echo ".venv" > .gitignore
 ```
 
 </div>


### PR DESCRIPTION
The documentation instructs users to create a .gitignore file inside the .venv folder. This is unnecessary and potentially confusing, because the virtual environment should be ignored from the project root .gitignore. Creating a .gitignore inside .venv is not standard Git/Python practice and can mislead users.