### PR TITLE
💄 Use font Fira Code to fix display of Rich panels in docs in Windows

### DIFF
--- a/docs/en/docs/css/custom.css
+++ b/docs/en/docs/css/custom.css
@@ -1,3 +1,11 @@
+/* Fira Code, including characters used by Rich output, like the "heavy right-pointing angle bracket ornament", not included in Google Fonts */
+@import url(https://cdn.jsdelivr.net/npm/firacode@6.2.0/distr/fira_code.css);
+
+/* Override default code font in Material for MkDocs to Fira Code */
+:root {
+    --md-code-font: "Fira Code", monospace;
+}
+
 .termynal-comment {
   color: #4a968f;
   font-style: italic;

--- a/docs/en/docs/css/termynal.css
+++ b/docs/en/docs/css/termynal.css
@@ -20,7 +20,7 @@
     /* font-size: 18px; */
     font-size: 15px;
     /* font-family: 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace; */
-    font-family: 'Roboto Mono', 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;
+    font-family: var(--md-code-font-family), 'Roboto Mono', 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;
     border-radius: 4px;
     padding: 75px 45px 35px;
     position: relative;


### PR DESCRIPTION
💄 Use font Fira Code to fix display of Rich panels in docs in Windows

Ref: https://github.com/fastapi/typer/pull/1419