### PR TITLE
docs: add BackgroundTasks usage example

### DIFF
--- a/docs/en/docs/tutorial/background-tasks.md
+++ b/docs/en/docs/tutorial/background-tasks.md
@@ -19,7 +19,7 @@ First, import `BackgroundTasks` and define a parameter in your *path operation f
 
 **FastAPI** will create the object of type `BackgroundTasks` for you and pass it as that parameter.
 
-### Example
+### Example { #example }
 
 ```python
 from fastapi import FastAPI, BackgroundTasks

--- a/docs/en/docs/tutorial/background-tasks.md
+++ b/docs/en/docs/tutorial/background-tasks.md
@@ -19,6 +19,25 @@ First, import `BackgroundTasks` and define a parameter in your *path operation f
 
 **FastAPI** will create the object of type `BackgroundTasks` for you and pass it as that parameter.
 
+### Example
+
+```python
+from fastapi import FastAPI, BackgroundTasks
+
+app = FastAPI()
+
+def write_log(message: str):
+    with open("log.txt", "a") as file:
+        file.write(message + "\n")
+
+@app.post("/send-message/")
+async def send_message(message: str, background_tasks: BackgroundTasks):
+    # This will run *after* sending the response
+    background_tasks.add_task(write_log, message)
+    return {"message": "Message received"}
+```
+
+
 ## Create a task function { #create-a-task-function }
 
 Create a function to be run as the background task.


### PR DESCRIPTION
This PR adds a simple example showing how to use BackgroundTasks
to write a message to a log file after sending the response.

- Demonstrates adding a task with `background_tasks.add_task`.
- Helps new users understand practical usage of BackgroundTasks.
