### PR TITLE
🐛 Fix non-deterministic openapi schema in case of schema name duplication

### DIFF
--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -302,7 +302,10 @@ def _remap_definitions_and_field_mappings(
     Dict[str, Any],
 ]:
     old_name_to_new_name_map = {}
-    for field_key, schema in field_mapping.items():
+    for field_key, schema in sorted(
+        field_mapping.items(),
+        key=lambda x: model_name_map.get(x[0][0].type_),
+    ):
         model = field_key[0].type_
         if model not in model_name_map:
             continue

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -304,7 +304,7 @@ def _remap_definitions_and_field_mappings(
     old_name_to_new_name_map = {}
     for field_key, schema in sorted(
         field_mapping.items(),
-        key=lambda x: model_name_map.get(x[0][0].type_),
+        key=lambda x: model_name_map.get(x[0][0].type_, ""),
     ):
         model = field_key[0].type_
         if model not in model_name_map:


### PR DESCRIPTION
See https://github.com/fastapi/fastapi/discussions/14376

During field remapping stage of openapi schema generation the order of iteration is not consistent across runs. This leads to non-deterministic schema generation

Preserve the order of this iteration across runs by sorting by the "new_name", i.e. the value inserted in this mapping

