### PR TITLE
Docs: Corrected `RequestValidationError` inheritance detail

### DIFF
--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -178,7 +178,7 @@ async def response_validation_exception_handler(request, exc):
     ...
 ```
 
-### FastAPI validation errors vs Pydantic `ValidationError` { #requestvalidationerror-vs-validationerror }
+### FastAPI validation errors vs Pydantic `ValidationError` { #fastapi-validation-errors-vs-pydantic-validationerror }
 
 /// warning
 

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -178,7 +178,7 @@ async def response_validation_exception_handler(request, exc):
     ...
 ```
 
-### `RequestValidationError` vs `ValidationError` { #requestvalidationerror-vs-validationerror }
+### FastAPI validation errors vs Pydantic `ValidationError` { #requestvalidationerror-vs-validationerror }
 
 /// warning
 

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -162,7 +162,7 @@ These are technical details that you might skip if it's not important for you no
 
 ///
 
-`RequestValidationError` is a sub-class of Pydantic's <a href="https://docs.pydantic.dev/latest/concepts/models/#error-handling" class="external-link" target="_blank">`ValidationError`</a>.
+`RequestValidationError` is a **FastAPI-specific exception** (it inherits from `fastapi.exceptions.ValidationException`). It is **not** a sub-class of Pydantic's <a href="https://docs.pydantic.dev/latest/concepts/models/#error-handling" class="external-link" target="_blank">`ValidationError`</a>.
 
 **FastAPI** uses it so that, if you use a Pydantic model in `response_model`, and your data has an error, you will see the error in your log.
 


### PR DESCRIPTION
### What Changed

- Corrected the documentation: `RequestValidationError` is *not* a subclass of Pydantic’s `ValidationError`.  
- Updated the explanation to reflect that it inherits from `fastapi.exceptions.ValidationException`, making it a FastAPI-specific exception.  
- Added context on why this matters, since they are different exception types, a handler for `ValidationError` won’t catch `RequestValidationError`.

### Why This Matters

- The previous docs were misleading: users might think that catching `ValidationError` will also capture request validation issues, which is incorrect.  
- Because they’re distinct, developers need to explicitly register an exception handler for `RequestValidationError` if they want to customize handling of invalid client requests.  
- This improves clarity about FastAPI’s validation behavior and prevents potential confusion or bugs in error-handling logic.

### Related Issue

Closes https://github.com/fastapi/fastapi/issues/10424

**Note:**  
This PR targets **English docs only**. Please let me know if we need to update translations in other languages as well.
