### PR TITLE
Add __str__ methods to RequestValidationError and WebSocketRequestValidationError

### DIFF
--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -167,9 +167,25 @@ class RequestValidationError(ValidationException):
         super().__init__(errors)
         self.body = body
 
+    def __str__(self) -> str:
+        message = f"{len(self._errors)} validation error"
+        if len(self._errors) > 1:
+            message += "s"
+        message += " for request:\n"
+        for err in self._errors:
+            message += f"  {err}\n"
+        return message
+
 
 class WebSocketRequestValidationError(ValidationException):
-    pass
+    def __str__(self) -> str:
+        message = f"{len(self._errors)} validation error"
+        if len(self._errors) > 1:
+            message += "s"
+        message += " for WebSocket request:\n"
+        for err in self._errors:
+            message += f"  {err}\n"
+        return message
 
 
 class ResponseValidationError(ValidationException):

--- a/tests/test_validation_error_str.py
+++ b/tests/test_validation_error_str.py
@@ -9,7 +9,13 @@ from fastapi.exceptions import (
 
 def test_request_validation_error_str_single_error():
     """Test string representation of RequestValidationError with single error."""
-    errors = [{"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"}]
+    errors = [
+        {
+            "type": "int_parsing",
+            "loc": ["query", "id"],
+            "msg": "Input should be a valid integer",
+        }
+    ]
     exc = RequestValidationError(errors)
     result = str(exc)
 
@@ -20,7 +26,11 @@ def test_request_validation_error_str_single_error():
 def test_request_validation_error_str_multiple_errors():
     """Test string representation of RequestValidationError with multiple errors."""
     errors = [
-        {"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"},
+        {
+            "type": "int_parsing",
+            "loc": ["query", "id"],
+            "msg": "Input should be a valid integer",
+        },
         {"type": "missing", "loc": ["query", "name"], "msg": "Field required"},
     ]
     exc = RequestValidationError(errors)
@@ -33,7 +43,13 @@ def test_request_validation_error_str_multiple_errors():
 
 def test_websocket_request_validation_error_str_single_error():
     """Test string representation of WebSocketRequestValidationError with single error."""
-    errors = [{"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"}]
+    errors = [
+        {
+            "type": "int_parsing",
+            "loc": ["query", "id"],
+            "msg": "Input should be a valid integer",
+        }
+    ]
     exc = WebSocketRequestValidationError(errors)
     result = str(exc)
 
@@ -44,7 +60,11 @@ def test_websocket_request_validation_error_str_single_error():
 def test_websocket_request_validation_error_str_multiple_errors():
     """Test string representation of WebSocketRequestValidationError with multiple errors."""
     errors = [
-        {"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"},
+        {
+            "type": "int_parsing",
+            "loc": ["query", "id"],
+            "msg": "Input should be a valid integer",
+        },
         {"type": "missing", "loc": ["query", "name"], "msg": "Field required"},
     ]
     exc = WebSocketRequestValidationError(errors)
@@ -57,7 +77,13 @@ def test_websocket_request_validation_error_str_multiple_errors():
 
 def test_response_validation_error_str_consistency():
     """Test that ResponseValidationError has similar __str__ behavior."""
-    errors = [{"type": "int_parsing", "loc": ["response", "id"], "msg": "Input should be a valid integer"}]
+    errors = [
+        {
+            "type": "int_parsing",
+            "loc": ["response", "id"],
+            "msg": "Input should be a valid integer",
+        }
+    ]
     exc = ResponseValidationError(errors)
     result = str(exc)
 

--- a/tests/test_validation_error_str.py
+++ b/tests/test_validation_error_str.py
@@ -1,0 +1,65 @@
+"""Tests for __str__ methods of validation exceptions."""
+
+from fastapi.exceptions import (
+    RequestValidationError,
+    ResponseValidationError,
+    WebSocketRequestValidationError,
+)
+
+
+def test_request_validation_error_str_single_error():
+    """Test string representation of RequestValidationError with single error."""
+    errors = [{"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"}]
+    exc = RequestValidationError(errors)
+    result = str(exc)
+
+    assert "1 validation error for request:" in result
+    assert "{'type': 'int_parsing'" in result
+
+
+def test_request_validation_error_str_multiple_errors():
+    """Test string representation of RequestValidationError with multiple errors."""
+    errors = [
+        {"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"},
+        {"type": "missing", "loc": ["query", "name"], "msg": "Field required"},
+    ]
+    exc = RequestValidationError(errors)
+    result = str(exc)
+
+    assert "2 validation errors for request:" in result
+    assert "int_parsing" in result
+    assert "missing" in result
+
+
+def test_websocket_request_validation_error_str_single_error():
+    """Test string representation of WebSocketRequestValidationError with single error."""
+    errors = [{"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"}]
+    exc = WebSocketRequestValidationError(errors)
+    result = str(exc)
+
+    assert "1 validation error for WebSocket request:" in result
+    assert "{'type': 'int_parsing'" in result
+
+
+def test_websocket_request_validation_error_str_multiple_errors():
+    """Test string representation of WebSocketRequestValidationError with multiple errors."""
+    errors = [
+        {"type": "int_parsing", "loc": ["query", "id"], "msg": "Input should be a valid integer"},
+        {"type": "missing", "loc": ["query", "name"], "msg": "Field required"},
+    ]
+    exc = WebSocketRequestValidationError(errors)
+    result = str(exc)
+
+    assert "2 validation errors for WebSocket request:" in result
+    assert "int_parsing" in result
+    assert "missing" in result
+
+
+def test_response_validation_error_str_consistency():
+    """Test that ResponseValidationError has similar __str__ behavior."""
+    errors = [{"type": "int_parsing", "loc": ["response", "id"], "msg": "Input should be a valid integer"}]
+    exc = ResponseValidationError(errors)
+    result = str(exc)
+
+    assert "1 validation error" in result
+    assert "{'type': 'int_parsing'" in result


### PR DESCRIPTION
  ## Description

  This PR adds `__str__` methods to `RequestValidationError` and `WebSocketRequestValidationError` to provide
  human-readable string representations, improving consistency with `ResponseValidationError` which already has this
  functionality.

  ## Motivation

  Currently, when debugging validation errors:
  - `ResponseValidationError` has a helpful `__str__` method that formats errors clearly
  - `RequestValidationError` and `WebSocketRequestValidationError` fall back to the default Python object
  representation
  - This inconsistency makes debugging request validation errors harder than necessary

  ## Changes

  - ✅ Added `__str__` method to `RequestValidationError`
  - ✅ Added `__str__` method to `WebSocketRequestValidationError`
  - ✅ Added comprehensive tests in `tests/test_validation_error_str.py`

  ## Example Output

  **Before:**
  ```python
  <fastapi.exceptions.RequestValidationError object at 0x7f8b8c0a3d90>

  After:
  2 validation errors for request:
    {'type': 'int_parsing', 'loc': ['query', 'id'], 'msg': 'Input should be a valid integer'}
    {'type': 'missing', 'loc': ['query', 'name'], 'msg': 'Field required'}

  Benefits

  - Better debugging experience - Error messages are immediately readable in logs and console output
  - Consistency - All validation error classes now have the same string representation behavior
  - Non-breaking - Existing code continues to work; this only enhances the developer experience when errors are
  converted to strings

  Testing

  All existing tests pass, and new tests verify:
  - Single error formatting
  - Multiple error formatting
  - Proper pluralization ("1 validation error" vs "2 validation errors")
  - Consistency across all validation error types

  Checklist

  - Tests added for the new functionality
  - All tests pass
  - Code follows existing style and patterns
  - Non-breaking change