### PR TITLE
🐛 Fix unformatted `{type_}` in FastAPIError

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -110,7 +110,7 @@ def create_model_field(
         try:
             return v1.ModelField(**v1_kwargs)  # type: ignore[no-any-return]
         except RuntimeError:
-            raise fastapi.exceptions.FastAPIError(_invalid_args_message) from None
+            raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_)) from None
     elif PYDANTIC_V2:
         from ._compat import v2
 
@@ -121,7 +121,7 @@ def create_model_field(
         try:
             return v2.ModelField(**kwargs)  # type: ignore[return-value,arg-type]
         except PydanticSchemaGenerationError:
-            raise fastapi.exceptions.FastAPIError(_invalid_args_message) from None
+            raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_) from None
     # Pydantic v2 is not installed, but it's not a Pydantic v1 ModelField, it could be
     # a Pydantic v1 type, like a constrained int
     from fastapi._compat import v1
@@ -129,7 +129,7 @@ def create_model_field(
     try:
         return v1.ModelField(**v1_kwargs)  # type: ignore[no-any-return]
     except RuntimeError:
-        raise fastapi.exceptions.FastAPIError(_invalid_args_message) from None
+        raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_) from None
 
 
 def create_cloned_field(

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -110,7 +110,9 @@ def create_model_field(
         try:
             return v1.ModelField(**v1_kwargs)  # type: ignore[no-any-return]
         except RuntimeError:
-            raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_)) from None
+            raise fastapi.exceptions.FastAPIError(
+                _invalid_args_message.format(type_=type_)
+            ) from None
     elif PYDANTIC_V2:
         from ._compat import v2
 
@@ -121,7 +123,9 @@ def create_model_field(
         try:
             return v2.ModelField(**kwargs)  # type: ignore[return-value,arg-type]
         except PydanticSchemaGenerationError:
-            raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_)) from None
+            raise fastapi.exceptions.FastAPIError(
+                _invalid_args_message.format(type_=type_)
+            ) from None
     # Pydantic v2 is not installed, but it's not a Pydantic v1 ModelField, it could be
     # a Pydantic v1 type, like a constrained int
     from fastapi._compat import v1
@@ -129,7 +133,9 @@ def create_model_field(
     try:
         return v1.ModelField(**v1_kwargs)  # type: ignore[no-any-return]
     except RuntimeError:
-        raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_)) from None
+        raise fastapi.exceptions.FastAPIError(
+            _invalid_args_message.format(type_=type_)
+        ) from None
 
 
 def create_cloned_field(

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -121,7 +121,7 @@ def create_model_field(
         try:
             return v2.ModelField(**kwargs)  # type: ignore[return-value,arg-type]
         except PydanticSchemaGenerationError:
-            raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_) from None
+            raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_)) from None
     # Pydantic v2 is not installed, but it's not a Pydantic v1 ModelField, it could be
     # a Pydantic v1 type, like a constrained int
     from fastapi._compat import v1
@@ -129,7 +129,7 @@ def create_model_field(
     try:
         return v1.ModelField(**v1_kwargs)  # type: ignore[no-any-return]
     except RuntimeError:
-        raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_) from None
+        raise fastapi.exceptions.FastAPIError(_invalid_args_message.format(type_=type_)) from None
 
 
 def create_cloned_field(


### PR DESCRIPTION
## Overview

Previously when a complex type wasn't a pydantic `BaseModel` a FastAPI error with a message
that included `"...that {type_} is..."` instead of including the true argument / return type.

This made debugging the use of complex, non-pydantic types difficult, especially in deeply nested dependencies.

## Example

```py
from fastapi import FastAPI

class NonPydanticModel:
    user: str


app = FastAPI()

@app.post("/greet")
def get(query: NonPydanticModel):
    return {"message": f"Hello, {query.user}!"}
```

When this app is run using `fastapi dev ...`, it throws the following error:

```
FastAPIError: Invalid args for response field! Hint: check that {type_} is a valid Pydantic field type. If you are using a return type 
annotation that is not a valid Pydantic field (e.g. Union[Response, dict, None]) you can disable generating the response model from the 
type annotation with the path operation decorator parameter response_model=None. Read more: 
https://fastapi.tiangolo.com/tutorial/response-model/
```

However, this error does not provide mention the `NonPydanticModel`, instead mentioning `{type_}`.\
Whilst the `NonPydanticModel` is included in the stack trace, this may be difficult to interpret for beginners\
(when using more complex types than a non-pydantic class, I missed it when first looking at the trace... :P)

## System Details

- Operating System: `Ubuntu Linux 24.04`
- Python Version: `3.11`
- FastAPI Version: `1.22`