### PR TITLE
Docs: Update outdated Pydantic v1 example in tutorial to Pydantic v2

### DIFF
--- a/docs_src/body/tutorial002_py310.py
+++ b/docs_src/body/tutorial002_py310.py
@@ -14,7 +14,7 @@ app = FastAPI()
 
 @app.post("/items/")
 async def create_item(item: Item):
-    item_dict = item.dict()
+    item_dict = item.model_dump()
     if item.tax is not None:
         price_with_tax = item.price + item.tax
         item_dict.update({"price_with_tax": price_with_tax})

--- a/docs_src/body/tutorial003_py310.py
+++ b/docs_src/body/tutorial003_py310.py
@@ -14,4 +14,4 @@ app = FastAPI()
 
 @app.put("/items/{item_id}")
 async def update_item(item_id: int, item: Item):
-    return {"item_id": item_id, **item.dict()}
+    return {"item_id": item_id, **item.model_dump()}

--- a/docs_src/body/tutorial004_py310.py
+++ b/docs_src/body/tutorial004_py310.py
@@ -14,7 +14,7 @@ app = FastAPI()
 
 @app.put("/items/{item_id}")
 async def update_item(item_id: int, item: Item, q: str | None = None):
-    result = {"item_id": item_id, **item.dict()}
+    result = {"item_id": item_id, **item.model_dump()}
     if q:
         result.update({"q": q})
     return result


### PR DESCRIPTION
This PR updates outdated Pydantic v1 example code in the tutorial section by replacing
`.dict()` with the correct Pydantic v2 method `.model_dump()`.

These examples still contained v1-style serialization, and this update ensures full
consistency with FastAPI’s default Pydantic v2 behavior.

I verified the documentation locally using `mkdocs serve` and confirmed that the pages
render correctly without warnings.

Files updated:
- docs_src/body/tutorial002_py310.py
- docs_src/body/tutorial003_py310.py
- docs_src/body/tutorial004_py310.py
