### PR TITLE
🐛 Fix optional sequence handling with new union syntax from Python 3.10

### DIFF
--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -3,7 +3,6 @@ import warnings
 from copy import copy, deepcopy
 from dataclasses import dataclass
 from enum import Enum
-from types import UnionType
 from typing import (
     Any,
     Dict,
@@ -18,7 +17,7 @@ from typing import (
 
 from fastapi._compat import may_v1, shared
 from fastapi.openapi.constants import REF_TEMPLATE
-from fastapi.types import IncEx, ModelNameMap
+from fastapi.types import IncEx, ModelNameMap, UnionType
 from pydantic import BaseModel, TypeAdapter, create_model
 from pydantic import PydanticSchemaGenerationError as PydanticSchemaGenerationError
 from pydantic import PydanticUndefinedAnnotation as PydanticUndefinedAnnotation

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -3,6 +3,7 @@ import warnings
 from copy import copy, deepcopy
 from dataclasses import dataclass
 from enum import Enum
+from types import UnionType
 from typing import (
     Any,
     Dict,
@@ -371,7 +372,7 @@ def copy_field_info(*, field_info: FieldInfo, annotation: Any) -> FieldInfo:
 
 def serialize_sequence_value(*, field: ModelField, value: Any) -> Sequence[Any]:
     origin_type = get_origin(field.field_info.annotation) or field.field_info.annotation
-    if origin_type is Union:  # Handle optional sequences
+    if origin_type is Union or origin_type is UnionType:  # Handle optional sequences
         union_args = get_args(field.field_info.annotation)
         for union_arg in union_args:
             if union_arg is type(None):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,3 +1,6 @@
+import sys
+import pytest
+
 from typing import Any, Dict, List, Union
 
 from fastapi import FastAPI, UploadFile
@@ -142,6 +145,22 @@ def test_serialize_sequence_value_with_optional_list():
     from fastapi._compat import v2
 
     field_info = FieldInfo(annotation=Union[List[str], None])
+    field = v2.ModelField(name="items", field_info=field_info)
+    result = v2.serialize_sequence_value(field=field, value=["a", "b", "c"])
+    assert result == ["a", "b", "c"]
+    assert isinstance(result, list)
+
+
+@needs_pydanticv2
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason='Requires new union syntax',
+)
+def test_serialize_sequence_value_with_optional_list_pipe_union():
+    """Test that serialize_sequence_value handles optional lists correctly (with new syntax)."""
+    from fastapi._compat import v2
+
+    field_info = FieldInfo(annotation=list[str] | None)
     field = v2.ModelField(name="items", field_info=field_info)
     result = v2.serialize_sequence_value(field=field, value=["a", "b", "c"])
     assert result == ["a", "b", "c"]

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,7 +1,5 @@
-import sys
 from typing import Any, Dict, List, Union
 
-import pytest
 from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
     Undefined,
@@ -16,7 +14,7 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel, ConfigDict
 from pydantic.fields import FieldInfo
 
-from .utils import needs_py_lt_314, needs_pydanticv2
+from .utils import needs_py310, needs_py_lt_314, needs_pydanticv2
 
 
 @needs_pydanticv2
@@ -151,10 +149,7 @@ def test_serialize_sequence_value_with_optional_list():
 
 
 @needs_pydanticv2
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="Requires new union syntax",
-)
+@needs_py310
 def test_serialize_sequence_value_with_optional_list_pipe_union():
     """Test that serialize_sequence_value handles optional lists correctly (with new syntax)."""
     from fastapi._compat import v2

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,8 +1,7 @@
 import sys
-import pytest
-
 from typing import Any, Dict, List, Union
 
+import pytest
 from fastapi import FastAPI, UploadFile
 from fastapi._compat import (
     Undefined,
@@ -154,7 +153,7 @@ def test_serialize_sequence_value_with_optional_list():
 @needs_pydanticv2
 @pytest.mark.skipif(
     sys.version_info < (3, 10),
-    reason='Requires new union syntax',
+    reason="Requires new union syntax",
 )
 def test_serialize_sequence_value_with_optional_list_pipe_union():
     """Test that serialize_sequence_value handles optional lists correctly (with new syntax)."""


### PR DESCRIPTION
https://github.com/fastapi/fastapi/pull/14297 is only taking one union type into account. I can only recommend using https://github.com/pydantic/typing-inspection for these kind of checks (see https://typing-inspection.pydantic.dev/latest/usage/ for motivation).