### PR TITLE
Fix outdated redoc cdn link

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -189,7 +189,7 @@ def get_redoc_html(
             It is normally set to a CDN URL.
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+    ] = "https://unpkg.com/redoc@latest/bundles/redoc.standalone.js",
     redoc_favicon_url: Annotated[
         str,
         Doc(


### PR DESCRIPTION
Previously, redoc.standalone.js file was hosted in jsdelivr.net. This returns 404 now. To fix this, the hoster was changed to unpkg.com.

The same issue previously occured and was fixed [here](https://github.com/microsoft/presidio/pull/1796).

To recreate the issue locally, run the fastapi dev server and go to `/redoc`. Previously, the page would not render and just appeared a white screen with a 404 status code, now `/redoc` works as expected.