### PR TITLE
⚡️Improve caching of callable inspection result

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -616,21 +616,16 @@ async def solve_dependencies(
         dependency_cache = {}
     if _uses_scopes_cache is None:
         _uses_scopes_cache = {}
+    dependency_overrides: dict[Callable[..., Any], Callable[..., Any]] = getattr(
+        dependency_overrides_provider, "dependency_overrides", {}
+    )
     for sub_dependant in dependant.dependencies:
-        sub_dependant.call = cast(Callable[..., Any], sub_dependant.call)
-        call = sub_dependant.call
+        call = cast(Callable[..., Any], sub_dependant.call)
         use_sub_dependant = sub_dependant
-        if (
-            dependency_overrides_provider
-            and dependency_overrides_provider.dependency_overrides
-        ):
-            original_call = sub_dependant.call
-            call = getattr(
-                dependency_overrides_provider, "dependency_overrides", {}
-            ).get(original_call, original_call)
-            use_path: str = sub_dependant.path  # type: ignore
+        if dependency_overrides and (overridden_call := dependency_overrides.get(call)):
+            call = overridden_call
             use_sub_dependant = get_dependant(
-                path=use_path,
+                path=cast(str, sub_dependant.path),
                 call=call,
                 name=sub_dependant.name,
                 parent_oauth_scopes=_get_oauth_scopes(dependant=sub_dependant),


### PR DESCRIPTION
Motivation
----------

Currently if `app.depedendency_overrides` is not empty then each request generates new Dependant, instead of reusing one build while declaring a route. This affects performance of all requests, even if specific dependency is not actually overridden. I'm personally use dependency overrides on production apps (see #13913), so all my applications are affected.

Change description
------------------

If dependency is not overridden, reuse existing Dependant with cached `inspect` results. This avoids performance hit, in my case 460RPS -> 630RPS.

Also simplified check of `dependency_overrides` makes resolution of complex dependency trees faster, even when no dependency overrides used in the first place.

Microbenckmark:
<details>

```python
import asyncio
import time
from typing import Annotated

from pydantic import BaseModel

from fastapi import FastAPI, Depends, Query, Response
from httpx import AsyncClient, ASGITransport


async def test_no_dependency_override_performance(loop_count: int = 100_000):
    app = FastAPI()

    async def sub_sub_dependency(more_nested: Annotated[int, Query()]) -> int:
        return more_nested

    class SubDependency(BaseModel):
        value: Annotated[int, Query()]
        other: Annotated[int, Depends(sub_sub_dependency)]

    async def some_dependency(nested: Annotated[SubDependency, Depends()]) -> int:
        return nested.value + nested.other

    @app.get("/data")
    async def get(
        one: int = Depends(some_dependency),
    ):
        return Response(content=f'{{"value": {one}}}'.encode(), status_code=200)

    async with AsyncClient(
        transport=ASGITransport(app=app),
        base_url="http://localhost",
    ) as client:
        start_time = time.perf_counter()

        for _ in range(loop_count):
            response = await client.get("/data", params={"value": 1, "more_nested": 2})
            assert response.status_code == 200, response.text
            assert response.text == '{"value": 3}'

        duration = time.perf_counter() - start_time

    print(f"Performed GET /data requests without dependency override: {loop_count:,} times in {duration:.4f}s")
    print(f"Average per call: {duration / loop_count * 1e6:.2f} µs")


async def test_dependency_override_nonempty_performance(loop_count: int = 100_000):
    app = FastAPI()

    async def sub_sub_dependency(more_nested: Annotated[int, Query()]) -> int:
        return more_nested

    class SubDependency(BaseModel):
        value: Annotated[int, Query()]
        other: Annotated[int, Depends(sub_sub_dependency)]

    async def some_dependency(nested: Annotated[SubDependency, Depends()]) -> int:
        return nested.value + nested.other

    async def unused_dependency(nested: Annotated[SubDependency, Depends()]) -> int:
        return nested.value + nested.other + 1

    @app.get("/data")
    async def get(
        one: int = Depends(some_dependency),
    ):
        return Response(content=f'{{"value": {one}}}'.encode(), status_code=200)

    async def override_unused_dependency() -> int:
        return 22

    app.dependency_overrides[unused_dependency] = override_unused_dependency

    async with AsyncClient(
        transport=ASGITransport(app=app),
        base_url="http://localhost",
    ) as client:
        start_time = time.perf_counter()

        for _ in range(loop_count):
            response = await client.get("/data", params={"value": 1, "more_nested": 2})
            assert response.status_code == 200, response.text
            assert response.text == '{"value": 3}'

        duration = time.perf_counter() - start_time

    print(f"Performed GET /data requests with non-empty dependency overrides: {loop_count:,} times in {duration:.4f}s")
    print(f"Average per call: {duration / loop_count * 1e6:.2f} µs")


async def test_dependency_override_performance(loop_count: int = 100_000):
    app = FastAPI()

    async def sub_sub_dependency(more_nested: Annotated[int, Query()]) -> int:
        return more_nested

    class SubDependency(BaseModel):
        value: Annotated[int, Query()]
        other: Annotated[int, Depends(sub_sub_dependency)]

    async def some_dependency(nested: Annotated[SubDependency, Depends()]) -> int:
        return nested.value + nested.other

    @app.get("/data")
    async def get(
        one: int = Depends(some_dependency),
    ):
        return Response(content=f'{{"value": {one}}}'.encode(), status_code=200)

    async def sub_sub_dependency_override(more_nested: Annotated[int, Query()]) -> int:
        return 11

    app.dependency_overrides[sub_sub_dependency] = sub_sub_dependency_override

    async with AsyncClient(
        transport=ASGITransport(app=app),
        base_url="http://localhost",
    ) as client:
        start_time = time.perf_counter()

        for _ in range(loop_count):
            response = await client.get("/data", params={"value": 1, "more_nested": 2})
            assert response.status_code == 200, response.text
            assert response.text == '{"value": 12}', response.text

        duration = time.perf_counter() - start_time

    print(f"Performed GET /data requests with actual dependency override: {loop_count:,} times in {duration:.4f}s")
    print(f"Average per call: {duration / loop_count * 1e6:.2f} µs")

if __name__ == "__main__":
    asyncio.run(test_no_dependency_override_performance())
    print("==" * 20)
    asyncio.run(test_dependency_override_nonempty_performance())
    print("==" * 20)
    asyncio.run(test_dependency_override_performance())
    print("==" * 20)
```
</details>

Before
------

Performed GET /data requests without dependency override: 100,000 times in 65.9816s
Average per call: 659.82 µs
<details>
<summary>Flamegraph</summary>

![before_no_dependency_override](https://github.com/user-attachments/assets/58dfd6da-5b2d-4b51-b979-e94fbfec34d2)
</details>

Performed GET /data requests with non-empty dependency overrides: 100,000 times in 263.8371s
Average per call: 2638.37 µs
<details>
<summary>Flamegraph</summary>

![before_dependency_override_nonempty](https://github.com/user-attachments/assets/1644d011-a707-4399-8db9-29164018db8d)
</details>

Performed GET /data requests with actual dependency override: 100,000 times in 252.7148s
Average per call: 2527.15 µs
<details>
<summary>Flamegraph</summary>

![before_dependency_override](https://github.com/user-attachments/assets/d38b96a8-402f-4011-8d9a-fcc01b585d49)
</details>

After:
------

Performed GET /data requests without dependency override: 100,000 times in 66.0966s
Average per call: 660.97 µs
<details>
<summary>Flamegraph</summary>

![after_no_dependency_override](https://github.com/user-attachments/assets/17aef572-cba1-43d6-b5f1-12a31fe25750)
</details>

Performed GET /data requests with non-empty dependency overrides: 100,000 times in 67.9596s
Average per call: 679.60 µs
<details>
<summary>Flamegraph</summary>

![after_dependency_override_nonempty](https://github.com/user-attachments/assets/564a218c-9822-4fb8-b560-12250e3dd972)
</details>

Performed GET /data requests with actual dependency override: 100,000 times in 106.0456s
Average per call: 1060.46 µs
<details>
<summary>Flamegraph</summary>

![after_dependency_override](https://github.com/user-attachments/assets/f50a89e3-b073-4e42-b21d-de69fe2a5f06)
</details>