### PR TITLE
🐛 Fix support for functools wraps and partial combined, for async and regular functions and classes in path operations and dependencies

### DIFF
--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -15,7 +15,7 @@ else:  # pragma: no cover
     from asyncio import iscoroutinefunction
 
 
-def _unwrapped_call(call: Optional[Callable[..., Any]]) -> Optional[Callable[..., Any]]:
+def _unwrapped_call(call: Optional[Callable[..., Any]]) -> Any:
     if call is None:
         return call  # pragma: no cover
     unwrapped = inspect.unwrap(_impartial(call))

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -91,14 +91,14 @@ class Dependant:
     @cached_property
     def is_gen_callable(self) -> bool:
         if self.call is None:
-            return False
+            return False  # pragma: no cover
         if inspect.isgeneratorfunction(
             _impartial(self.call)
         ) or inspect.isgeneratorfunction(_unwrapped_call(self.call)):
             return True
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
-            return False
+            return False  # pragma: no cover
         return inspect.isgeneratorfunction(
             _impartial(dunder_call)
         ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call))
@@ -106,14 +106,14 @@ class Dependant:
     @cached_property
     def is_async_gen_callable(self) -> bool:
         if self.call is None:
-            return False
+            return False  # pragma: no cover
         if inspect.isasyncgenfunction(
             _impartial(self.call)
         ) or inspect.isasyncgenfunction(_unwrapped_call(self.call)):
             return True
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
-            return False
+            return False  # pragma: no cover
         return inspect.isasyncgenfunction(
             _impartial(dunder_call)
         ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call))
@@ -121,7 +121,7 @@ class Dependant:
     @cached_property
     def is_coroutine_callable(self) -> bool:
         if self.call is None:
-            return False
+            return False  # pragma: no cover
         if inspect.isroutine(_impartial(self.call)) and iscoroutinefunction(
             _impartial(self.call)
         ):
@@ -132,7 +132,7 @@ class Dependant:
             return True
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
-            return False
+            return False  # pragma: no cover
         if iscoroutinefunction(_impartial(dunder_call)) or iscoroutinefunction(
             _unwrapped_call(dunder_call)
         ):

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -15,6 +15,19 @@ else:  # pragma: no cover
     from asyncio import iscoroutinefunction
 
 
+def _unwrapped_call(call: Optional[Callable[..., Any]]) -> Optional[Callable[..., Any]]:
+    if call is None:
+        return call  # pragma: no cover
+    unwrapped = inspect.unwrap(_impartial(call))
+    return unwrapped
+
+
+def _impartial(func: Callable[..., Any]) -> Callable[..., Any]:
+    while isinstance(func, partial):
+        func = func.func
+    return func
+
+
 @dataclass
 class SecurityRequirement:
     security_scheme: SecurityBase
@@ -76,36 +89,56 @@ class Dependant:
         return False
 
     @cached_property
-    def _unwrapped_call(self) -> Any:
-        if self.call is None:
-            return self.call  # pragma: no cover
-        unwrapped = inspect.unwrap(self.call)
-        if isinstance(unwrapped, partial):
-            unwrapped = unwrapped.func
-        return unwrapped
-
-    @cached_property
     def is_gen_callable(self) -> bool:
-        if inspect.isgeneratorfunction(self._unwrapped_call):
+        if self.call is None:
+            return False
+        if inspect.isgeneratorfunction(
+            _impartial(self.call)
+        ) or inspect.isgeneratorfunction(_unwrapped_call(self.call)):
             return True
-        dunder_call = getattr(self._unwrapped_call, "__call__", None)  # noqa: B004
-        return inspect.isgeneratorfunction(dunder_call)
+        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+        if dunder_call is None:
+            return False
+        return inspect.isgeneratorfunction(
+            _impartial(dunder_call)
+        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call))
 
     @cached_property
     def is_async_gen_callable(self) -> bool:
-        if inspect.isasyncgenfunction(self._unwrapped_call):
+        if self.call is None:
+            return False
+        if inspect.isasyncgenfunction(
+            _impartial(self.call)
+        ) or inspect.isasyncgenfunction(_unwrapped_call(self.call)):
             return True
-        dunder_call = getattr(self._unwrapped_call, "__call__", None)  # noqa: B004
-        return inspect.isasyncgenfunction(dunder_call)
+        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+        if dunder_call is None:
+            return False
+        return inspect.isasyncgenfunction(
+            _impartial(dunder_call)
+        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call))
 
     @cached_property
     def is_coroutine_callable(self) -> bool:
-        if inspect.isroutine(self._unwrapped_call):
-            return iscoroutinefunction(self._unwrapped_call)
-        if inspect.isclass(self._unwrapped_call):
+        if self.call is None:
             return False
-        dunder_call = getattr(self._unwrapped_call, "__call__", None)  # noqa: B004
-        return iscoroutinefunction(dunder_call)
+        if inspect.isroutine(_impartial(self.call)) and iscoroutinefunction(
+            _impartial(self.call)
+        ):
+            return True
+        if inspect.isroutine(_unwrapped_call(self.call)) and iscoroutinefunction(
+            _unwrapped_call(self.call)
+        ):
+            return True
+        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+        if dunder_call is None:
+            return False
+        if iscoroutinefunction(_impartial(dunder_call)) or iscoroutinefunction(
+            _unwrapped_call(dunder_call)
+        ):
+            return True
+        # if inspect.isclass(self.call): False, covered by default return
+        return False
 
     @cached_property
     def computed_scope(self) -> Union[str, None]:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -99,9 +99,18 @@ class Dependant:
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
             return False  # pragma: no cover
-        return inspect.isgeneratorfunction(
+        if inspect.isgeneratorfunction(
             _impartial(dunder_call)
-        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call))
+        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call)):
+            return True
+        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+        if dunder_unwrapped_call is None:
+            return False  # pragma: no cover
+        if inspect.isgeneratorfunction(
+            _impartial(dunder_unwrapped_call)
+        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_unwrapped_call)):
+            return True
+        return False
 
     @cached_property
     def is_async_gen_callable(self) -> bool:
@@ -114,9 +123,18 @@ class Dependant:
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
             return False  # pragma: no cover
-        return inspect.isasyncgenfunction(
+        if inspect.isasyncgenfunction(
             _impartial(dunder_call)
-        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call))
+        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call)):
+            return True
+        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+        if dunder_unwrapped_call is None:
+            return False  # pragma: no cover
+        if inspect.isasyncgenfunction(
+            _impartial(dunder_unwrapped_call)
+        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_unwrapped_call)):
+            return True
+        return False
 
     @cached_property
     def is_coroutine_callable(self) -> bool:
@@ -136,6 +154,13 @@ class Dependant:
         if iscoroutinefunction(_impartial(dunder_call)) or iscoroutinefunction(
             _unwrapped_call(dunder_call)
         ):
+            return True
+        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+        if dunder_unwrapped_call is None:
+            return False  # pragma: no cover
+        if iscoroutinefunction(
+            _impartial(dunder_unwrapped_call)
+        ) or iscoroutinefunction(_unwrapped_call(dunder_unwrapped_call)):
             return True
         # if inspect.isclass(self.call): False, covered by default return
         return False

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -548,10 +548,10 @@ async def _solve_generator(
     *, dependant: Dependant, stack: AsyncExitStack, sub_values: Dict[str, Any]
 ) -> Any:
     assert dependant.call
-    if dependant.is_gen_callable:
-        cm = contextmanager_in_threadpool(contextmanager(dependant.call)(**sub_values))
-    elif dependant.is_async_gen_callable:
+    if dependant.is_async_gen_callable:
         cm = asynccontextmanager(dependant.call)(**sub_values)
+    elif dependant.is_gen_callable:
+        cm = contextmanager_in_threadpool(contextmanager(dependant.call)(**sub_values))
     return await stack.enter_async_context(cm)
 
 

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -149,8 +149,8 @@ async def get_wrapped_class_instance_async_dependency(
 
 
 @app.get("/wrapped-class-dependency/")
-async def get_wrapped_class_dependency(value: bool = Depends(wrapped_class_dep)):
-    return value
+async def get_wrapped_class_dependency(value: ClassDep = Depends(wrapped_class_dep)):
+    return value.value
 
 
 @app.get("/wrapped-endpoint/")
@@ -232,9 +232,9 @@ async def get_wrapped_class_instance_async_dependency_async_wrapper(
 
 @app.get("/wrapped-class-dependency-async-wrapper/")
 async def get_wrapped_class_dependency_async_wrapper(
-    value: bool = Depends(wrapped_class_dep_async_wrapper),
+    value: ClassDep = Depends(wrapped_class_dep_async_wrapper),
 ):
-    return value
+    return value.value
 
 
 @app.get("/wrapped-endpoint-async-wrapper/")

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -83,6 +83,24 @@ class ClassInstanceWrappedAsyncDep:
 class_instance_wrapped_async_dep = ClassInstanceWrappedAsyncDep()
 
 
+class ClassInstanceWrappedGenDep:
+    @noop_wrap
+    def __call__(self):
+        yield True
+
+
+class_instance_wrapped_gen_dep = ClassInstanceWrappedGenDep()
+
+
+class ClassInstanceWrappedAsyncGenDep:
+    @noop_wrap_async
+    def __call__(self):
+        yield True
+
+
+class_instance_wrapped_async_gen_dep = ClassInstanceWrappedAsyncGenDep()
+
+
 class ClassDep:
     def __init__(self):
         self.value = True
@@ -121,6 +139,23 @@ class ClassInstanceAsyncWrappedAsyncDep:
 
 class_instance_async_wrapped_async_dep = ClassInstanceAsyncWrappedAsyncDep()
 
+
+class ClassInstanceAsyncWrappedGenDep:
+    @noop_wrap
+    async def __call__(self):
+        yield True
+
+
+class_instance_async_wrapped_gen_dep = ClassInstanceAsyncWrappedGenDep()
+
+
+class ClassInstanceAsyncWrappedGenAsyncDep:
+    @noop_wrap_async
+    async def __call__(self):
+        yield True
+
+
+class_instance_async_wrapped_gen_async_dep = ClassInstanceAsyncWrappedGenAsyncDep()
 
 app = FastAPI()
 
@@ -207,6 +242,34 @@ async def get_class_instance_async_wrapped_dependency(
 @app.get("/class-instance-async-wrapped-async-dependency/")
 async def get_class_instance_async_wrapped_async_dependency(
     value: bool = Depends(class_instance_async_wrapped_async_dep),
+):
+    return value
+
+
+@app.get("/class-instance-wrapped-gen-dependency/")
+async def get_class_instance_wrapped_gen_dependency(
+    value: bool = Depends(class_instance_wrapped_gen_dep),
+):
+    return value
+
+
+@app.get("/class-instance-wrapped-async-gen-dependency/")
+async def get_class_instance_wrapped_async_gen_dependency(
+    value: bool = Depends(class_instance_wrapped_async_gen_dep),
+):
+    return value
+
+
+@app.get("/class-instance-async-wrapped-gen-dependency/")
+async def get_class_instance_async_wrapped_gen_dependency(
+    value: bool = Depends(class_instance_async_wrapped_gen_dep),
+):
+    return value
+
+
+@app.get("/class-instance-async-wrapped-gen-async-dependency/")
+async def get_class_instance_async_wrapped_gen_async_dependency(
+    value: bool = Depends(class_instance_async_wrapped_gen_async_dep),
 ):
     return value
 
@@ -328,6 +391,10 @@ client = TestClient(app)
         "/class-instance-wrapped-async-dependency/",
         "/class-instance-async-wrapped-dependency/",
         "/class-instance-async-wrapped-async-dependency/",
+        "/class-instance-wrapped-gen-dependency/",
+        "/class-instance-wrapped-async-gen-dependency/",
+        "/class-instance-async-wrapped-gen-dependency/",
+        "/class-instance-async-wrapped-gen-async-dependency/",
         "/wrapped-class-dependency/",
         "/wrapped-endpoint/",
         "/async-wrapped-endpoint/",

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -65,6 +65,24 @@ wrapped_class_instance_dep = noop_wrap(class_instance_dep)
 wrapped_class_instance_dep_async_wrapper = noop_wrap_async(class_instance_dep)
 
 
+class ClassInstanceWrappedDep:
+    @noop_wrap
+    def __call__(self):
+        return True
+
+
+class_instance_wrapped_dep = ClassInstanceWrappedDep()
+
+
+class ClassInstanceWrappedAsyncDep:
+    @noop_wrap_async
+    def __call__(self):
+        return True
+
+
+class_instance_wrapped_async_dep = ClassInstanceWrappedAsyncDep()
+
+
 class ClassDep:
     def __init__(self):
         self.value = True
@@ -79,10 +97,30 @@ class ClassInstanceAsyncDep:
         return True
 
 
-wrapped_class_instance_async_dep = noop_wrap(ClassInstanceAsyncDep())
+class_instance_async_dep = ClassInstanceAsyncDep()
+wrapped_class_instance_async_dep = noop_wrap(class_instance_async_dep)
 wrapped_class_instance_async_dep_async_wrapper = noop_wrap_async(
-    ClassInstanceAsyncDep()
+    class_instance_async_dep
 )
+
+
+class ClassInstanceAsyncWrappedDep:
+    @noop_wrap
+    async def __call__(self):
+        return True
+
+
+class_instance_async_wrapped_dep = ClassInstanceAsyncWrappedDep()
+
+
+class ClassInstanceAsyncWrappedAsyncDep:
+    @noop_wrap_async
+    async def __call__(self):
+        return True
+
+
+class_instance_async_wrapped_async_dep = ClassInstanceAsyncWrappedAsyncDep()
+
 
 app = FastAPI()
 
@@ -141,6 +179,34 @@ async def get_wrapped_class_instance_dependency(
 @app.get("/wrapped-class-instance-async-dependency/")
 async def get_wrapped_class_instance_async_dependency(
     value: bool = Depends(wrapped_class_instance_async_dep),
+):
+    return value
+
+
+@app.get("/class-instance-wrapped-dependency/")
+async def get_class_instance_wrapped_dependency(
+    value: bool = Depends(class_instance_wrapped_dep),
+):
+    return value
+
+
+@app.get("/class-instance-wrapped-async-dependency/")
+async def get_class_instance_wrapped_async_dependency(
+    value: bool = Depends(class_instance_wrapped_async_dep),
+):
+    return value
+
+
+@app.get("/class-instance-async-wrapped-dependency/")
+async def get_class_instance_async_wrapped_dependency(
+    value: bool = Depends(class_instance_async_wrapped_dep),
+):
+    return value
+
+
+@app.get("/class-instance-async-wrapped-async-dependency/")
+async def get_class_instance_async_wrapped_async_dependency(
+    value: bool = Depends(class_instance_async_wrapped_async_dep),
 ):
     return value
 
@@ -258,6 +324,10 @@ client = TestClient(app)
         "/async-wrapped-gen-dependency/",
         "/wrapped-class-instance-dependency/",
         "/wrapped-class-instance-async-dependency/",
+        "/class-instance-wrapped-dependency/",
+        "/class-instance-wrapped-async-dependency/",
+        "/class-instance-async-wrapped-dependency/",
+        "/class-instance-async-wrapped-async-dependency/",
         "/wrapped-class-dependency/",
         "/wrapped-endpoint/",
         "/async-wrapped-endpoint/",

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -55,15 +55,37 @@ def noop_wrap_async(func):
     return wrapper
 
 
-class ClassDep:
+class ClassInstanceDep:
     def __call__(self):
         return True
 
 
-class_dep = ClassDep()
-wrapped_class_dep = noop_wrap(class_dep)
-wrapped_class_dep_async_wrapper = noop_wrap_async(class_dep)
+class_instance_dep = ClassInstanceDep()
+wrapped_class_instance_dep = noop_wrap(class_instance_dep)
+wrapped_class_instance_dep_async_wrapper = noop_wrap_async(class_instance_dep)
 
+
+class ClassDep:
+    def __init__(self):
+        self.value = True
+
+    def __bool__(self):
+        return True
+
+
+wrapped_class_dep = noop_wrap(ClassDep)
+wrapped_class_dep_async_wrapper = noop_wrap_async(ClassDep)
+
+
+class ClassInstanceAsyncDep:
+    async def __call__(self):
+        return True
+
+
+wrapped_class_instance_async_dep = noop_wrap(ClassInstanceAsyncDep())
+wrapped_class_instance_async_dep_async_wrapper = noop_wrap_async(
+    ClassInstanceAsyncDep()
+)
 
 app = FastAPI()
 
@@ -108,6 +130,20 @@ async def get_async_wrapped_dependency(value: bool = Depends(async_wrapped_depen
 @app.get("/async-wrapped-gen-dependency/")
 async def get_async_wrapped_gen_dependency(
     value: bool = Depends(async_wrapped_gen_dependency),
+):
+    return value
+
+
+@app.get("/wrapped-class-instance-dependency/")
+async def get_wrapped_class_instance_dependency(
+    value: bool = Depends(wrapped_class_instance_dep),
+):
+    return value
+
+
+@app.get("/wrapped-class-instance-async-dependency/")
+async def get_wrapped_class_instance_async_dependency(
+    value: bool = Depends(wrapped_class_instance_async_dep),
 ):
     return value
 
@@ -180,6 +216,20 @@ async def get_async_wrapped_gen_dependency_async_wrapper(
     return value
 
 
+@app.get("/wrapped-class-instance-dependency-async-wrapper/")
+async def get_wrapped_class_instance_dependency_async_wrapper(
+    value: bool = Depends(wrapped_class_instance_dep_async_wrapper),
+):
+    return value
+
+
+@app.get("/wrapped-class-instance-async-dependency-async-wrapper/")
+async def get_wrapped_class_instance_async_dependency_async_wrapper(
+    value: bool = Depends(wrapped_class_instance_async_dep_async_wrapper),
+):
+    return value
+
+
 @app.get("/wrapped-class-dependency-async-wrapper/")
 async def get_wrapped_class_dependency_async_wrapper(
     value: bool = Depends(wrapped_class_dep_async_wrapper),
@@ -209,6 +259,8 @@ client = TestClient(app)
         "/wrapped-gen-dependency/",
         "/async-wrapped-dependency/",
         "/async-wrapped-gen-dependency/",
+        "/wrapped-class-instance-dependency/",
+        "/wrapped-class-instance-async-dependency/",
         "/wrapped-class-dependency/",
         "/wrapped-endpoint/",
         "/async-wrapped-endpoint/",
@@ -216,6 +268,8 @@ client = TestClient(app)
         "/wrapped-gen-dependency-async-wrapper/",
         "/async-wrapped-dependency-async-wrapper/",
         "/async-wrapped-gen-dependency-async-wrapper/",
+        "/wrapped-class-instance-dependency-async-wrapper/",
+        "/wrapped-class-instance-async-dependency-async-wrapper/",
         "/wrapped-class-dependency-async-wrapper/",
         "/wrapped-endpoint-async-wrapper/",
         "/async-wrapped-endpoint-async-wrapper/",

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -1,5 +1,5 @@
 import inspect
-from asyncio import iscoroutinefunction
+import sys
 from functools import wraps
 from typing import AsyncGenerator, Generator
 
@@ -7,6 +7,11 @@ import pytest
 from fastapi import Depends, FastAPI
 from fastapi.concurrency import iterate_in_threadpool, run_in_threadpool
 from fastapi.testclient import TestClient
+
+if sys.version_info >= (3, 13):  # pragma: no cover
+    from inspect import iscoroutinefunction
+else:  # pragma: no cover
+    from asyncio import iscoroutinefunction
 
 
 def noop_wrap(func):

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -69,9 +69,6 @@ class ClassDep:
     def __init__(self):
         self.value = True
 
-    def __bool__(self):
-        return True
-
 
 wrapped_class_dep = noop_wrap(ClassDep)
 wrapped_class_dep_async_wrapper = noop_wrap_async(ClassDep)

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -65,6 +65,15 @@ wrapped_class_instance_dep = noop_wrap(class_instance_dep)
 wrapped_class_instance_dep_async_wrapper = noop_wrap_async(class_instance_dep)
 
 
+class ClassInstanceGenDep:
+    def __call__(self):
+        yield True
+
+
+class_instance_gen_dep = ClassInstanceGenDep()
+wrapped_class_instance_gen_dep = noop_wrap(class_instance_gen_dep)
+
+
 class ClassInstanceWrappedDep:
     @noop_wrap
     def __call__(self):
@@ -120,6 +129,15 @@ wrapped_class_instance_async_dep = noop_wrap(class_instance_async_dep)
 wrapped_class_instance_async_dep_async_wrapper = noop_wrap_async(
     class_instance_async_dep
 )
+
+
+class ClassInstanceAsyncGenDep:
+    async def __call__(self):
+        yield True
+
+
+class_instance_async_gen_dep = ClassInstanceAsyncGenDep()
+wrapped_class_instance_async_gen_dep = noop_wrap(class_instance_async_gen_dep)
 
 
 class ClassInstanceAsyncWrappedDep:
@@ -214,6 +232,20 @@ async def get_wrapped_class_instance_dependency(
 @app.get("/wrapped-class-instance-async-dependency/")
 async def get_wrapped_class_instance_async_dependency(
     value: bool = Depends(wrapped_class_instance_async_dep),
+):
+    return value
+
+
+@app.get("/wrapped-class-instance-gen-dependency/")
+async def get_wrapped_class_instance_gen_dependency(
+    value: bool = Depends(wrapped_class_instance_gen_dep),
+):
+    return value
+
+
+@app.get("/wrapped-class-instance-async-gen-dependency/")
+async def get_wrapped_class_instance_async_gen_dependency(
+    value: bool = Depends(wrapped_class_instance_async_gen_dep),
 ):
     return value
 
@@ -387,6 +419,8 @@ client = TestClient(app)
         "/async-wrapped-gen-dependency/",
         "/wrapped-class-instance-dependency/",
         "/wrapped-class-instance-async-dependency/",
+        "/wrapped-class-instance-gen-dependency/",
+        "/wrapped-class-instance-async-gen-dependency/",
         "/class-instance-wrapped-dependency/",
         "/class-instance-wrapped-async-dependency/",
         "/class-instance-async-wrapped-dependency/",


### PR DESCRIPTION
🐛 Fix support for functools wraps and partial combined, for async and regular functions and classes in path operations and dependencies

This also uses and extends the tests created by @YuriiMotov :raised_hands: 

Should fix / related to: https://github.com/fastapi/fastapi/issues/14444

The new tests simulate the multiple combinations of how decorators could affect dependencies and path operation functions (endpoints).

The logic to analyze if a function is an async, generator, async generator,  callable instance, etc. now also checks and unwraps and extracts partials in all those levels.

The main case is when the callable is an _async_ something (function, generator, etc) because then it needs to be awaited.

But the original function could be async or not, the wrapper could be async or not. if either is async, then it has to be awaited, no matter if the other is not async. So, analyzing only the last point in the chain is not enough, it's necessary to analyze the function but also the wrapper.

This PR implements and tests all that, all those combinations.