### PR TITLE
Replace `applications.py` asserts with if...raise

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -908,8 +908,10 @@ class FastAPI(Starlette):
         ] = "3.1.0"
         self.openapi_schema: Optional[Dict[str, Any]] = None
         if self.openapi_url:
-            assert self.title, "A title must be provided for OpenAPI, e.g.: 'My API'"
-            assert self.version, "A version must be provided for OpenAPI, e.g.: '2.1.0'"
+            if not self.title:
+                raise ValueError("A title must be provided for OpenAPI, e.g.: 'My API'")
+            if not self.version:
+                raise ValueError("A version must be provided for OpenAPI, e.g.: '2.1.0'")
         # TODO: remove when discarding the openapi_prefix parameter
         if openapi_prefix:
             logger.warning(

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -911,7 +911,9 @@ class FastAPI(Starlette):
             if not self.title:
                 raise ValueError("A title must be provided for OpenAPI, e.g.: 'My API'")
             if not self.version:
-                raise ValueError("A version must be provided for OpenAPI, e.g.: '2.1.0'")
+                raise ValueError(
+                    "A version must be provided for OpenAPI, e.g.: '2.1.0'"
+                )
         # TODO: remove when discarding the openapi_prefix parameter
         if openapi_prefix:
             logger.warning(

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -1,0 +1,19 @@
+"""Tests for initialization of FastAPI app instance."""
+import pytest
+
+from fastapi import FastAPI
+
+
+def test_open_api_url_no_title():
+    """An error should be raised if an openapi URL is provided without a title."""
+    with pytest.raises(ValueError):
+        FastAPI(openapi_url="/openapi.json", title=None)
+
+def test_open_api_url_no_version():
+    """An error should be raised if an openapi URL is provided without a version."""
+    with pytest.raises(ValueError):
+        FastAPI(openapi_url="/openapi.json", version=None)
+
+def test_open_api_url_title_and_version():
+    """No error should be raised if an openapi URL is provided with a title and version."""
+    FastAPI(openapi_url="/openapi.json", title="Title", version="0.1")

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -1,7 +1,6 @@
 """Tests for initialization of FastAPI app instance."""
 
 import pytest
-
 from fastapi import FastAPI
 
 

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -1,4 +1,5 @@
 """Tests for initialization of FastAPI app instance."""
+
 import pytest
 
 from fastapi import FastAPI
@@ -9,10 +10,12 @@ def test_open_api_url_no_title():
     with pytest.raises(ValueError):
         FastAPI(openapi_url="/openapi.json", title=None)
 
+
 def test_open_api_url_no_version():
     """An error should be raised if an openapi URL is provided without a version."""
     with pytest.raises(ValueError):
         FastAPI(openapi_url="/openapi.json", version=None)
+
 
 def test_open_api_url_title_and_version():
     """No error should be raised if an openapi URL is provided with a title and version."""


### PR DESCRIPTION
Previously, the checks for a title and version when an `openapi_url` is declared were done using _asserts_.

Since asserts can be disabled if running Python in optimized mode (i.e., with the `-O` flag), we probably don't want them here -- otherwise some validations might not occur when an app is run in optimized mode. 

I could be wrong, though 🤔.