### PR TITLE
🐛 Fix using class (not instance) dependency that has `__call__` method

### DIFF
--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -96,6 +96,8 @@ class Dependant:
             _impartial(self.call)
         ) or inspect.isgeneratorfunction(_unwrapped_call(self.call)):
             return True
+        if inspect.isclass(_unwrapped_call(self.call)):
+            return False
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
             return False  # pragma: no cover
@@ -120,6 +122,8 @@ class Dependant:
             _impartial(self.call)
         ) or inspect.isasyncgenfunction(_unwrapped_call(self.call)):
             return True
+        if inspect.isclass(_unwrapped_call(self.call)):
+            return False
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
             return False  # pragma: no cover
@@ -148,6 +152,8 @@ class Dependant:
             _unwrapped_call(self.call)
         ):
             return True
+        if inspect.isclass(_unwrapped_call(self.call)):
+            return False
         dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
         if dunder_call is None:
             return False  # pragma: no cover
@@ -162,7 +168,6 @@ class Dependant:
             _impartial(dunder_unwrapped_call)
         ) or iscoroutinefunction(_unwrapped_call(dunder_unwrapped_call)):
             return True
-        # if inspect.isclass(self.call): False, covered by default return
         return False
 
     @cached_property

--- a/tests/test_dependency_class.py
+++ b/tests/test_dependency_class.py
@@ -48,6 +48,34 @@ async_callable_gen_dependency = AsyncCallableGenDependency()
 methods_dependency = MethodsDependency()
 
 
+@app.get("/callable-dependency-class")
+async def get_callable_dependency_class(
+    value: str, instance: CallableDependency = Depends()
+):
+    return instance(value)
+
+
+@app.get("/callable-gen-dependency-class")
+async def get_callable_gen_dependency_class(
+    value: str, instance: CallableGenDependency = Depends()
+):
+    return next(instance(value))
+
+
+@app.get("/async-callable-dependency-class")
+async def get_async_callable_dependency_class(
+    value: str, instance: AsyncCallableDependency = Depends()
+):
+    return await instance(value)
+
+
+@app.get("/async-callable-gen-dependency-class")
+async def get_async_callable_gen_dependency_class(
+    value: str, instance: AsyncCallableGenDependency = Depends()
+):
+    return await instance(value).__anext__()
+
+
 @app.get("/callable-dependency")
 async def get_callable_dependency(value: str = Depends(callable_dependency)):
     return value
@@ -114,6 +142,10 @@ client = TestClient(app)
         ("/synchronous-method-gen-dependency", "synchronous-method-gen-dependency"),
         ("/asynchronous-method-dependency", "asynchronous-method-dependency"),
         ("/asynchronous-method-gen-dependency", "asynchronous-method-gen-dependency"),
+        ("/callable-dependency-class", "callable-dependency-class"),
+        ("/callable-gen-dependency-class", "callable-gen-dependency-class"),
+        ("/async-callable-dependency-class", "async-callable-dependency-class"),
+        ("/async-callable-gen-dependency-class", "async-callable-gen-dependency-class"),
     ],
 )
 def test_class_dependency(route, value):


### PR DESCRIPTION
As reported in https://github.com/fastapi/fastapi/discussions/14452, FastAPI 0.123.6 introduced a regression - if we use class (not instance) as dependency and this class has `__call__` method that is coroutine or generator, it is mistakenly treated as coroutine\generator (actually class is not coroutine\generator, instance of this class is).


So, to fix this we need to check if the callable is class before inspecting its `dunder_call` in `is_coroutine_callable`, `is_async_gen_callable`, and `is_gen_callable`.