### PR TITLE
🐛 Fix OAuth2 scopes in OpenAPI in extra corner cases, parent dependency with scopes, sub-dependency security scheme without scopes

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -55,10 +55,9 @@ from fastapi.concurrency import (
     asynccontextmanager,
     contextmanager_in_threadpool,
 )
-from fastapi.dependencies.models import Dependant, SecurityRequirement
+from fastapi.dependencies.models import Dependant
 from fastapi.exceptions import DependencyScopeError
 from fastapi.logger import logger
-from fastapi.security.base import SecurityBase
 from fastapi.security.oauth2 import SecurityScopes
 from fastapi.types import DependencyCacheKey
 from fastapi.utils import create_model_field, get_path_param_names
@@ -142,10 +141,14 @@ def get_flat_dependant(
     *,
     skip_repeats: bool = False,
     visited: Optional[List[DependencyCacheKey]] = None,
+    parent_oauth_scopes: Optional[List[str]] = None,
 ) -> Dependant:
     if visited is None:
         visited = []
     visited.append(dependant.cache_key)
+    use_parent_oauth_scopes = (parent_oauth_scopes or []) + (
+        dependant.oauth_scopes or []
+    )
 
     flat_dependant = Dependant(
         path_params=dependant.path_params.copy(),
@@ -153,22 +156,37 @@ def get_flat_dependant(
         header_params=dependant.header_params.copy(),
         cookie_params=dependant.cookie_params.copy(),
         body_params=dependant.body_params.copy(),
-        security_requirements=dependant.security_requirements.copy(),
+        name=dependant.name,
+        call=dependant.call,
+        request_param_name=dependant.request_param_name,
+        websocket_param_name=dependant.websocket_param_name,
+        http_connection_param_name=dependant.http_connection_param_name,
+        response_param_name=dependant.response_param_name,
+        background_tasks_param_name=dependant.background_tasks_param_name,
+        security_scopes_param_name=dependant.security_scopes_param_name,
+        own_oauth_scopes=dependant.own_oauth_scopes,
+        parent_oauth_scopes=use_parent_oauth_scopes,
         use_cache=dependant.use_cache,
         path=dependant.path,
+        scope=dependant.scope,
     )
     for sub_dependant in dependant.dependencies:
         if skip_repeats and sub_dependant.cache_key in visited:
             continue
         flat_sub = get_flat_dependant(
-            sub_dependant, skip_repeats=skip_repeats, visited=visited
+            sub_dependant,
+            skip_repeats=skip_repeats,
+            visited=visited,
+            parent_oauth_scopes=flat_dependant.oauth_scopes,
         )
+        flat_dependant.dependencies.append(flat_sub)
         flat_dependant.path_params.extend(flat_sub.path_params)
         flat_dependant.query_params.extend(flat_sub.query_params)
         flat_dependant.header_params.extend(flat_sub.header_params)
         flat_dependant.cookie_params.extend(flat_sub.cookie_params)
         flat_dependant.body_params.extend(flat_sub.body_params)
-        flat_dependant.security_requirements.extend(flat_sub.security_requirements)
+        flat_dependant.dependencies.extend(flat_sub.dependencies)
+
     return flat_dependant
 
 
@@ -258,11 +276,6 @@ def get_dependant(
     path_param_names = get_path_param_names(path)
     endpoint_signature = get_typed_signature(call)
     signature_params = endpoint_signature.parameters
-    if isinstance(call, SecurityBase):
-        security_requirement = SecurityRequirement(
-            security_scheme=call, scopes=current_scopes
-        )
-        dependant.security_requirements.append(security_requirement)
     for param_name, param in signature_params.items():
         is_path_param = param_name in path_param_names
         param_details = analyze_param(

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -81,18 +81,18 @@ def get_openapi_security_definitions(
     security_definitions = {}
     # Use a dict to merge scopes for same security scheme
     operation_security_dict: Dict[str, List[str]] = {}
-    for security_requirement in flat_dependant.security_requirements:
+    for security_dependency in flat_dependant._security_dependencies:
         security_definition = jsonable_encoder(
-            security_requirement.security_scheme.model,
+            security_dependency._security_scheme.model,
             by_alias=True,
             exclude_none=True,
         )
-        security_name = security_requirement.security_scheme.scheme_name
+        security_name = security_dependency._security_scheme.scheme_name
         security_definitions[security_name] = security_definition
         # Merge scopes for the same security scheme
         if security_name not in operation_security_dict:
             operation_security_dict[security_name] = []
-        for scope in security_requirement.scopes or []:
+        for scope in security_dependency.oauth_scopes or []:
             if scope not in operation_security_dict[security_name]:
                 operation_security_dict[security_name].append(scope)
     operation_security = [

--- a/tests/test_security_oauth2_authorization_code_bearer_scopes_openapi.py
+++ b/tests/test_security_oauth2_authorization_code_bearer_scopes_openapi.py
@@ -69,6 +69,22 @@ def test_root():
     assert response.json() == {"message": "Hello World"}
 
 
+def test_read_with_oauth2_scheme():
+    response = client.get(
+        "/with-oauth2-scheme", headers={"Authorization": "Bearer testtoken"}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "Admin Access"}
+
+
+def test_read_with_get_token():
+    response = client.get(
+        "/with-get-token", headers={"Authorization": "Bearer testtoken"}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "Admin Access"}
+
+
 def test_read_token():
     response = client.get("/items/", headers={"Authorization": "Bearer testtoken"})
     assert response.status_code == 200, response.text

--- a/tests/test_security_oauth2_authorization_code_bearer_scopes_openapi_simple.py
+++ b/tests/test_security_oauth2_authorization_code_bearer_scopes_openapi_simple.py
@@ -28,6 +28,12 @@ async def read_admin():
 client = TestClient(app)
 
 
+def test_read_admin():
+    response = client.get("/admin", headers={"Authorization": "Bearer faketoken"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "Admin Access"}
+
+
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text

--- a/tests/test_security_oauth2_authorization_code_bearer_scopes_openapi_simple.py
+++ b/tests/test_security_oauth2_authorization_code_bearer_scopes_openapi_simple.py
@@ -1,0 +1,98 @@
+# Ref: https://github.com/fastapi/fastapi/issues/14454
+
+from fastapi import APIRouter, Depends, FastAPI, Security
+from fastapi.security import OAuth2AuthorizationCodeBearer, SecurityScopes
+from fastapi.testclient import TestClient
+from inline_snapshot import snapshot
+from typing_extensions import Annotated
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2AuthorizationCodeBearer(
+    authorizationUrl="api/oauth/authorize",
+    tokenUrl="/api/oauth/token",
+    refreshUrl="/api/oauth/token",
+    auto_error=False,
+    scopes={"read": "Read access", "write": "Write access"},
+)
+
+
+async def get_token(token: Annotated[str, Depends(oauth2_scheme)]) -> str:
+    return token
+
+
+AccessToken = Annotated[str, Depends(get_token)]
+
+
+async def require_oauth_scopes(
+    security_scopes: SecurityScopes, token: AccessToken
+) -> None:
+    pass
+
+
+async def check_limit(token: AccessToken) -> None:
+    pass
+
+
+router = APIRouter(prefix="/v1", dependencies=[Depends(check_limit)])
+
+channels_router = APIRouter(prefix="/channels", tags=["Channels"])
+
+
+@channels_router.get(
+    "/", dependencies=[Security(require_oauth_scopes, scopes=["read"])]
+)
+def read_items():
+    return {"msg": "You have READ access"}
+
+
+router.include_router(channels_router)
+
+app.include_router(router)
+
+client = TestClient(app)
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == snapshot(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/v1/channels/": {
+                    "get": {
+                        "tags": ["Channels"],
+                        "summary": "Read Items",
+                        "operationId": "read_items_v1_channels__get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            }
+                        },
+                        "security": [{"OAuth2AuthorizationCodeBearer": ["read"]}],
+                    }
+                }
+            },
+            "components": {
+                "securitySchemes": {
+                    "OAuth2AuthorizationCodeBearer": {
+                        "type": "oauth2",
+                        "flows": {
+                            "authorizationCode": {
+                                "refreshUrl": "/api/oauth/token",
+                                "scopes": {
+                                    "read": "Read access",
+                                    "write": "Write access",
+                                },
+                                "authorizationUrl": "api/oauth/authorize",
+                                "tokenUrl": "/api/oauth/token",
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    )


### PR DESCRIPTION
🐛 Fix OAuth2 scopes in OpenAPI in extra corner cases, parent dependency with scopes, sub-dependency security scheme without scopes, and the same security scheme used as another sub-dependency without scopes in a different path operation.

The dependency without scopes would be cached for OpenAPI and for the one with scopes, it would render without scopes.

This also refactors the internals of how dependencies are handled, and how scopes and security schemes are passed through the code, removing duplication and simplifying parts, making them more robust and less error-prone. :muscle: 

This should fix https://github.com/fastapi/fastapi/issues/14454 (strike 2 :baseball:)