### PR TITLE
Add upload file size limit

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -18,11 +18,15 @@ from fastapi import routing
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.exception_handlers import (
     http_exception_handler,
+    request_entity_too_large_exception_handler,
     request_validation_exception_handler,
     websocket_request_validation_exception_handler,
-    request_entity_too_large_exception_handler,
 )
-from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError, RequestEntityTooLarge
+from fastapi.exceptions import (
+    RequestEntityTooLarge,
+    RequestValidationError,
+    WebSocketRequestValidationError,
+)
 from fastapi.logger import logger
 from fastapi.middleware.asyncexitstack import AsyncExitStackMiddleware
 from fastapi.openapi.docs import (
@@ -994,10 +998,9 @@ class FastAPI(Starlette):
             websocket_request_validation_exception_handler,  # type: ignore
         )
         self.exception_handlers.setdefault(
-                RequestEntityTooLarge,
-                request_entity_too_large_exception_handler,
-                )
-
+            RequestEntityTooLarge,
+            request_entity_too_large_exception_handler,
+        )
 
         self.user_middleware: List[Middleware] = (
             [] if middleware is None else list(middleware)

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -20,8 +20,9 @@ from fastapi.exception_handlers import (
     http_exception_handler,
     request_validation_exception_handler,
     websocket_request_validation_exception_handler,
+    request_entity_too_large_exception_handler,
 )
-from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
+from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError, RequestEntityTooLarge
 from fastapi.logger import logger
 from fastapi.middleware.asyncexitstack import AsyncExitStackMiddleware
 from fastapi.openapi.docs import (
@@ -992,6 +993,11 @@ class FastAPI(Starlette):
             # Starlette still has incorrect type specification for the handlers
             websocket_request_validation_exception_handler,  # type: ignore
         )
+        self.exception_handlers.setdefault(
+                RequestEntityTooLarge,
+                request_entity_too_large_exception_handler,
+                )
+
 
         self.user_middleware: List[Middleware] = (
             [] if middleware is None else list(middleware)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -36,7 +36,6 @@ from fastapi._compat import (
     get_annotation_from_field_info,
     get_cached_model_fields,
     get_missing_field_error,
-    is_bytes_field,
     is_bytes_sequence_field,
     is_scalar_field,
     is_scalar_sequence_field,
@@ -883,6 +882,7 @@ def _should_embed_body_fields(fields: List[ModelField]) -> bool:
 
 from fastapi.exceptions import RequestEntityTooLarge
 
+
 async def _extract_form_body(
     body_fields: List[ModelField],
     received_body: FormData,
@@ -892,11 +892,10 @@ async def _extract_form_body(
     for field in body_fields:
         value = _get_multidict_value(field, received_body)
         field_info = field.field_info
-        if (
-            isinstance(field_info, (params.File, temp_pydantic_v1_params.File))
-            and isinstance(value, UploadFile)
-        ):
-            #If a file size limit is defined through max_size
+        if isinstance(
+            field_info, (params.File, temp_pydantic_v1_params.File)
+        ) and isinstance(value, UploadFile):
+            # If a file size limit is defined through max_size
             max_size = getattr(field_info, "max_size", None)
             if max_size is not None:
                 CHUNK = 8192
@@ -910,8 +909,8 @@ async def _extract_form_body(
                     total += len(chunk)
                     if total > max_size:
                         raise RequestEntityTooLarge(
-                                f"Uploaded file '{field.alias}' exceeded max size={max_size} bytes"
-                                )
+                            f"Uploaded file '{field.alias}' exceeded max size={max_size} bytes"
+                        )
                         content.extend(chunk)
                     value = bytes(content)
                 else:

--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -1,5 +1,8 @@
 from fastapi.encoders import jsonable_encoder
-from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError, RequestEntityTooLarge
+from fastapi.exceptions import (
+    RequestValidationError,
+    WebSocketRequestValidationError,
+)
 from fastapi.utils import is_body_allowed_for_status_code
 from fastapi.websockets import WebSocket
 from starlette.exceptions import HTTPException
@@ -13,6 +16,7 @@ async def request_entity_too_large_exception_handler(request, exc: Exception):
         status_code=413,
         content={"detail": str(exc) or "Uploaded file too large"},
     )
+
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
     headers = getattr(exc, "headers", None)

--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -1,5 +1,5 @@
 from fastapi.encoders import jsonable_encoder
-from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
+from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError, RequestEntityTooLarge
 from fastapi.utils import is_body_allowed_for_status_code
 from fastapi.websockets import WebSocket
 from starlette.exceptions import HTTPException
@@ -7,6 +7,12 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
 
+
+async def request_entity_too_large_exception_handler(request, exc: Exception):
+    return JSONResponse(
+        status_code=413,
+        content={"detail": str(exc) or "Uploaded file too large"},
+    )
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
     headers = getattr(exc, "headers", None)

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -182,3 +182,8 @@ class ResponseValidationError(ValidationException):
         for err in self._errors:
             message += f"  {err}\n"
         return message
+
+class RequestEntityTooLarge(Exception):
+    """Raised when uploaded content exceeds the configured max_size."""
+    pass
+

--- a/fastapi/exceptions.py
+++ b/fastapi/exceptions.py
@@ -183,7 +183,8 @@ class ResponseValidationError(ValidationException):
             message += f"  {err}\n"
         return message
 
+
 class RequestEntityTooLarge(Exception):
     """Raised when uploaded content exceeds the configured max_size."""
-    pass
 
+    pass

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -725,6 +725,7 @@ class File(Form):  # type: ignore[misc]
         deprecated: Union[deprecated, str, bool, None] = None,
         include_in_schema: bool = True,
         json_schema_extra: Union[Dict[str, Any], None] = None,
+        max_size: Optional[int] = None,
         **extra: Any,
     ):
         super().__init__(
@@ -760,6 +761,7 @@ class File(Form):  # type: ignore[misc]
             json_schema_extra=json_schema_extra,
             **extra,
         )
+        self.max_size = max_size
 
 
 @dataclass(frozen=True)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,15 @@
 from typing import Union
 
 from fastapi import FastAPI
+from pydantic import BaseModel
 
 app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+    is_offer: Union[bool, None] = None
 
 
 @app.get("/")
@@ -13,3 +20,8 @@ def read_root():
 @app.get("/items/{item_id}")
 def read_item(item_id: int, q: Union[str, None] = None):
     return {"item_id": item_id, "q": q}
+
+
+@app.put("/items/{item_id}")
+def update_item(item_id: int, item: Item):
+    return {"item_name": item.name, "item_id": item_id}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,15 @@
+from typing import Union
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int, q: Union[str, None] = None):
+    return {"item_id": item_id, "q": q}

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI, File, UploadFile
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -30,7 +30,7 @@ def update_item(item_id: int, item: Item):
 @app.post("/upload")
 async def upload_file(file: UploadFile = File(max_size=500)):
     total_bytes = 0
-    
+
     # Safest: process in chunks instead of reading whole file
     while True:
         chunk = await file.read(1024 * 1024)  # 1MB
@@ -39,5 +39,3 @@ async def upload_file(file: UploadFile = File(max_size=500)):
         total_bytes += len(chunk)
 
     return {"filename": file.filename, "size": total_bytes}
-
-

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from fastapi import FastAPI
+from fastapi import FastAPI, UploadFile, File
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -25,3 +25,19 @@ def read_item(item_id: int, q: Union[str, None] = None):
 @app.put("/items/{item_id}")
 def update_item(item_id: int, item: Item):
     return {"item_name": item.name, "item_id": item_id}
+
+
+@app.post("/upload")
+async def upload_file(file: UploadFile = File(max_size=500)):
+    total_bytes = 0
+    
+    # Safest: process in chunks instead of reading whole file
+    while True:
+        chunk = await file.read(1024 * 1024)  # 1MB
+        if not chunk:
+            break
+        total_bytes += len(chunk)
+
+    return {"filename": file.filename, "size": total_bytes}
+
+


### PR DESCRIPTION
Background: 
For my computer security course project, we were asked to scan vulnerabilities for an open source project and try to fix them. I used Bandit for SAST and ZAP for DAST on a Linux VM. One possible vulnerability I found was FastAPI has no upload file size limitations, large multipart file uploads are allowed without limits, referencing OWASP API4 - https://owasp.org/www-project-api-security/ Well, it greatly depends on the isolated resource I separate out for the test environment, and the smaller I assign it, the easier it could break. I guess in production, you could also trust the ASGI server (Uvicorn) and reverse proxies (Nginx) to handle limits. But it would be good to add a limit check to the FastAPI framework.
Changes:
Add a new optional parameter max_size to File() and enforce file upload size limits during request parsing. This resolves the unbounded file upload DoS vector identified during DAST.
It is optional, I’ve tested without setting the parameter – keep File(…) as None will work the same way it did before; after setting the parameter, I’ve tested uploading a file that exceeds the limit and got the 413 Request Entity Too Large Error I was looking for.