### PR TITLE
fix: remove deprecated Pydantic v1 JSON schema methods

### DIFF
--- a/fastapi/datastructures.py
+++ b/fastapi/datastructures.py
@@ -2,7 +2,6 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
-    Dict,
     Iterable,
     Optional,
     Type,
@@ -13,8 +12,6 @@ from typing import (
 from annotated_doc import Doc
 from fastapi._compat import (
     CoreSchema,
-    GetJsonSchemaHandler,
-    JsonSchemaValue,
 )
 from starlette.datastructures import URL as URL  # noqa: F401
 from starlette.datastructures import Address as Address  # noqa: F401

--- a/fastapi/datastructures.py
+++ b/fastapi/datastructures.py
@@ -153,17 +153,6 @@ class UploadFile(StarletteUploadFile):
             raise ValueError(f"Expected UploadFile, received: {type(__input_value)}")
         return cast(UploadFile, __input_value)
 
-    # TODO: remove when deprecating Pydantic v1
-    @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
-        field_schema.update({"type": "string", "format": "binary"})
-
-    @classmethod
-    def __get_pydantic_json_schema__(
-        cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
-    ) -> JsonSchemaValue:
-        return {"type": "string", "format": "binary"}
-
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source: Type[Any], handler: Callable[[Any], CoreSchema]


### PR DESCRIPTION
Remove deprecated Pydantic v1 JSON schema methods from `UploadFile` in `fastapi/datastructures.py`.

- Deleted `__modify_schema__` (marked with TODO for v1 deprecation)
- Deleted static `__get_pydantic_json_schema__` that always returned `{"type": "string", "format": "binary"}`

These methods are no longer needed in Pydantic v2 and were actively preventing metadata (title, description, examples) from `Annotated[UploadFile, File(...)]` from appearing in the generated OpenAPI schema and docs.

With only `__get_pydantic_core_schema__` defined, Pydantic v2 now correctly generates the file schema and preserves all user-provided metadata.
