### PR TITLE
refactor: Make the logic more explicit in validation error insertion in get_openapi_path

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -417,10 +417,11 @@ def get_openapi_path(
                     openapi_response["description"] = description
             http422 = "422"
             all_route_params = get_flat_params(route.dependant)
-            if (all_route_params or route.body_field) and not any(
-                status in operation["responses"]
-                for status in [http422, "4XX", "default"]
-            ):
+            requires_validation_error = bool(all_route_params or route.body_field)
+            has_validation_response = any(
+                status in operation["responses"] for status in ("422", "4XX", "default")
+            )
+            if requires_validation_error and not has_validation_response:
                 operation["responses"][http422] = {
                     "description": "Validation Error",
                     "content": {

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -417,11 +417,13 @@ def get_openapi_path(
                     openapi_response["description"] = description
             http422 = "422"
             all_route_params = get_flat_params(route.dependant)
-            requires_validation_error = bool(all_route_params or route.body_field)
-            has_validation_response = any(
-                status in operation["responses"] for status in ("422", "4XX", "default")
-            )
-            if requires_validation_error and not has_validation_response:
+            if (
+                (all_route_params or route.body_field)  # May raise validation error
+                and not any(  # Doesn't have a defined validation error response already
+                    status in operation["responses"]
+                    for status in [http422, "4XX", "default"]
+                )
+            ):
                 operation["responses"][http422] = {
                     "description": "Validation Error",
                     "content": {

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -419,8 +419,7 @@ def get_openapi_path(
             all_route_params = get_flat_params(route.dependant)
             requires_validation_error = bool(all_route_params or route.body_field)
             has_validation_response = any(
-                status in operation["responses"] 
-                for status in ("422", "4XX", "default")
+                status in operation["responses"] for status in ("422", "4XX", "default")
             )
             if requires_validation_error and not has_validation_response:
                 operation["responses"][http422] = {

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -417,10 +417,12 @@ def get_openapi_path(
                     openapi_response["description"] = description
             http422 = "422"
             all_route_params = get_flat_params(route.dependant)
-            if (all_route_params or route.body_field) and not any(
-                status in operation["responses"]
-                for status in [http422, "4XX", "default"]
-            ):
+            requires_validation_error = bool(all_route_params or route.body_field)
+            has_validation_response = any(
+                status in operation["responses"] 
+                for status in ("422", "4XX", "default")
+            )
+            if requires_validation_error and not has_validation_response:
                 operation["responses"][http422] = {
                     "description": "Validation Error",
                     "content": {


### PR DESCRIPTION
This PR simplifies and clarifies the logic that determines when a 422 Validation Error response should be added to an operation's OpenAPI schema.

Why is this an improvement?

**Improved readability:** The conditions are easier to understand at a glance, reducing cognitive load during maintenance.

**Less error-prone:** Explicit naming makes it clear why validation errors are added and avoids misinterpreting the previous inline logic.

**Behavior preserved:** No functional change- only a clarity/refactor improvement.