### PR TITLE
🔒 Escape HTML in Swagger and ReDoc titles and URLs

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -1,3 +1,4 @@
+import html as html_escape
 import json
 from typing import Any, Dict, Optional
 
@@ -121,7 +122,7 @@ def get_swagger_ui_html(
     <head>
     <link type="text/css" rel="stylesheet" href="{swagger_css_url}">
     <link rel="shortcut icon" href="{swagger_favicon_url}">
-    <title>{title}</title>
+    <title>{html_escape.escape(title)}</title>
     </head>
     <body>
     <div id="swagger-ui">
@@ -130,7 +131,7 @@ def get_swagger_ui_html(
     <!-- `SwaggerUIBundle` is now available on the page -->
     <script>
     const ui = SwaggerUIBundle({{
-        url: '{openapi_url}',
+        url: '{html_escape.escape(openapi_url)}',
     """
 
     for key, value in current_swagger_ui_parameters.items():
@@ -221,7 +222,7 @@ def get_redoc_html(
     <!DOCTYPE html>
     <html>
     <head>
-    <title>{title}</title>
+    <title>{html_escape.escape(title)}</title>
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -246,7 +247,7 @@ def get_redoc_html(
     <noscript>
         ReDoc requires Javascript to function. Please enable it to browse the documentation.
     </noscript>
-    <redoc spec-url="{openapi_url}"></redoc>
+    <redoc spec-url="{html_escape.escape(openapi_url)}"></redoc>
     <script src="{redoc_js_url}"> </script>
     </body>
     </html>


### PR DESCRIPTION
## Summary
Fix potential XSS vulnerability in Swagger UI and ReDoc documentation pages by escaping `title` and `openapi_url` parameters.

## Details
- Added `html.escape()` to `title` in both `get_swagger_ui_html()` and `get_redoc_html()`
- Added `html.escape()` to `openapi_url` in both functions

Related discussion: #14406