### PR TITLE
🌐 Sync German docs

### DIFF
--- a/docs/de/docs/_llm-test.md
+++ b/docs/de/docs/_llm-test.md
@@ -15,7 +15,7 @@ So verwenden:
 
 Die Tests:
 
-## Codeschnipsel { #code-snippets}
+## Codeschnipsel { #code-snippets }
 
 //// tab | Test
 
@@ -53,7 +53,7 @@ Siehe zum Beispiel den Abschnitt `### Quotes` in `docs/de/llm-prompt.md`.
 
 ////
 
-## Anführungszeichen in Codeschnipseln { #quotes-in-code-snippets}
+## Anführungszeichen in Codeschnipseln { #quotes-in-code-snippets }
 
 //// tab | Test
 

--- a/docs/de/docs/index.md
+++ b/docs/de/docs/index.md
@@ -52,13 +52,13 @@ Seine Schlüssel-Merkmale sind:
 
 <!-- sponsors -->
 
-### Keystone-Sponsor
+### Keystone-Sponsor { #keystone-sponsor }
 
 {% for sponsor in sponsors.keystone -%}
 <a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
 {% endfor -%}
 
-### Gold- und Silber-Sponsoren
+### Gold- und Silber-Sponsoren { #gold-and-silver-sponsors }
 
 {% for sponsor in sponsors.gold -%}
 <a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>


### PR DESCRIPTION
This was inspired by #14505. I searched for those patterns using VS Code.

Always:

    files to exclude: README.md, SECURITY.md, llm-prompt.md

The following search & replace cleans up the hash parts everywhere under `docs/`. It only finds the four occurrences in the two `_llm-test.md`s under `docs/de/` and `docs/pt/`

    files to include: docs/**
        Search regex: \{[^\S\n]*#([^\S\n]*[a-z0-9]+(?:-[a-z0-9]+)*)[^\S\n]*\}
        Replace with: { #$1 }

The following search (only under `docs/de/` and `docs/pt/`) finds headings without hash parts. Amongst a few code comments it finds two headings in `docs\de\docs\index.md` (those which #14505 fixed) and all headings in `docs\pt\docs\tutorial\security\index.md`, which I also fixed on the way, as that document seems to be in sync. `docs\pt\docs\index.md` is not in sync, so I didn't touch it.

    files to include: docs/de/**, docs/pt/**
        Search regex: ^(#+)[^\S\n]*([^{}#\s]+(?:[^\S\n]+[^{}\s]+)*)[^\S\n]*(?=\n)
        (added the missing hash parts)