### PR TITLE
🔧 Update test workflow config, remove commented code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,10 +73,11 @@ jobs:
             python-version: "3.13"
             pydantic-version: "pydantic>=2.0.2,<3.0.0"
             coverage: coverage
-          # - os: ubuntu-latest
-          #   python-version: "3.13"
-          #   pydantic-version: "pydantic>=2.0.2,<2.7.0"
-          #   coverage: coverage
+          # Run one test with Pydantic < 2.7 to test changes across versions
+          - os: ubuntu-latest
+            python-version: "3.13"
+            pydantic-version: "pydantic>=2.0.2,<2.7.0"
+            coverage: coverage
           - os: ubuntu-latest
             python-version: "3.14"
             pydantic-version: "pydantic>=2.0.2,<3.0.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
             coverage: coverage
           # Run one test with Pydantic < 2.7 to test changes across versions
           - os: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.12"
             pydantic-version: "pydantic>=2.0.2,<2.7.0"
             coverage: coverage
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,17 +66,17 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.12"
             pydantic-version: "pydantic>=2.0.2,<3.0.0"
+          # Run one test with Pydantic < 2.7 to test changes across versions
+          - os: ubuntu-latest
+            python-version: "3.12"
+            pydantic-version: "pydantic>=2.0.2,<2.7.0"
+            coverage: coverage
           - os: macos-latest
             python-version: "3.13"
             pydantic-version: "pydantic>=1.10.0,<2.0.0"
           - os: windows-latest
             python-version: "3.13"
             pydantic-version: "pydantic>=2.0.2,<3.0.0"
-            coverage: coverage
-          # Run one test with Pydantic < 2.7 to test changes across versions
-          - os: ubuntu-latest
-            python-version: "3.12"
-            pydantic-version: "pydantic>=2.0.2,<2.7.0"
             coverage: coverage
           - os: ubuntu-latest
             python-version: "3.14"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,6 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.12"
             pydantic-version: "pydantic>=2.0.2,<3.0.0"
-          # Run one test with Pydantic < 2.7 to test changes across versions
-          - os: ubuntu-latest
-            python-version: "3.12"
-            pydantic-version: "pydantic>=2.0.2,<2.7.0"
-            coverage: coverage
           - os: macos-latest
             python-version: "3.13"
             pydantic-version: "pydantic>=1.10.0,<2.0.0"


### PR DESCRIPTION
🔧 Update test workflow config, remove commented code

---

The original intention of this PR was to make tests run in Pydantic 2.6, which is currently failing, but that version is almost 2 years old, and I'll drop support for Pydantic v1 in the next days/weeks. So, then I'll bump the minimum version to Pydantic 2.7 or so.