### PR TITLE
🔧 Temporarily disable translations still in progress, being migrated to the new LLM setup

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -317,24 +317,10 @@ extra:
     name: de - Deutsch
   - link: /es/
     name: es - español
-  - link: /fr/
-    name: fr - français
-  - link: /ja/
-    name: ja - 日本語
-  - link: /ko/
-    name: ko - 한국어
   - link: /pt/
     name: pt - português
   - link: /ru/
     name: ru - русский язык
-  - link: /tr/
-    name: tr - Türkçe
-  - link: /uk/
-    name: uk - українська мова
-  - link: /zh/
-    name: zh - 简体中文
-  - link: /zh-hant/
-    name: zh-hant - 繁體中文
 extra_css:
 - css/termynal.css
 - css/custom.css

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -428,7 +428,7 @@ def verify_docs():
 def langs_json():
     langs = []
     for lang_path in get_lang_paths():
-        if lang_path.is_dir():
+        if lang_path.is_dir() and lang_path.name in SUPPORTED_LANGS:
             langs.append(lang_path.name)
     print(json.dumps(langs))
 

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -19,6 +19,9 @@ from slugify import slugify as py_slugify
 
 logging.basicConfig(level=logging.INFO)
 
+SUPPORTED_LANGS = {"en", "de", "es", "pt", "ru"}
+
+
 app = typer.Typer()
 
 mkdocs_name = "mkdocs.yml"
@@ -260,7 +263,7 @@ def build_all() -> None:
     """
     update_languages()
     shutil.rmtree(site_path, ignore_errors=True)
-    langs = [lang.name for lang in get_lang_paths() if lang.is_dir()]
+    langs = [lang.name for lang in get_lang_paths() if (lang.is_dir() and lang.name in SUPPORTED_LANGS)]
     cpu_count = os.cpu_count() or 1
     process_pool_size = cpu_count * 4
     typer.echo(f"Using process pool size: {process_pool_size}")
@@ -340,7 +343,7 @@ def get_updated_config_content() -> Dict[str, Any]:
     for lang_path in get_lang_paths():
         if lang_path.name in {"en", "em"} or not lang_path.is_dir():
             continue
-        if lang_path.name not in ("de", "es", "pt", "ru"):
+        if lang_path.name not in SUPPORTED_LANGS:
             # Skip languages that are not yet ready
             continue
         code = lang_path.name

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -340,6 +340,9 @@ def get_updated_config_content() -> Dict[str, Any]:
     for lang_path in get_lang_paths():
         if lang_path.name in {"en", "em"} or not lang_path.is_dir():
             continue
+        if lang_path.name not in ("de", "es", "pt", "ru"):
+            # Skip languages that are not yet ready
+            continue
         code = lang_path.name
         languages.append({code: f"/{code}/"})
     for lang_dict in languages:

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -263,7 +263,11 @@ def build_all() -> None:
     """
     update_languages()
     shutil.rmtree(site_path, ignore_errors=True)
-    langs = [lang.name for lang in get_lang_paths() if (lang.is_dir() and lang.name in SUPPORTED_LANGS)]
+    langs = [
+        lang.name
+        for lang in get_lang_paths()
+        if (lang.is_dir() and lang.name in SUPPORTED_LANGS)
+    ]
     cpu_count = os.cpu_count() or 1
     process_pool_size = cpu_count * 4
     typer.echo(f"Using process pool size: {process_pool_size}")


### PR DESCRIPTION
This is to prevent building docs from failing while we are updating code includes.
We will enable these translations later when update them with LLM