### PR TITLE
⬆ Bump `markdown-include-variants` from 0.0.7 to 0.0.8

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -17,5 +17,5 @@ griffe-warnings-deprecated==1.1.0
 # For griffe, it formats with black
 black==25.1.0
 mkdocs-macros-plugin==1.4.1
-markdown-include-variants==0.0.7
+markdown-include-variants==0.0.8
 python-slugify==8.0.4


### PR DESCRIPTION
⬆ Bump `markdown-include-variants` from 0.0.7 to 0.0.8