### PR TITLE
📝 Fix duplicated variable in `docs_src/python_types/tutorial005_py39.py`

### DIFF
--- a/docs_src/python_types/tutorial005_py39.py
+++ b/docs_src/python_types/tutorial005_py39.py
@@ -1,2 +1,2 @@
 def get_items(item_a: str, item_b: int, item_c: float, item_d: bool, item_e: bytes):
-    return item_a, item_b, item_c, item_d, item_d, item_e
+    return item_a, item_b, item_c, item_d, item_e


### PR DESCRIPTION
This PR fixes a small bug in the Python Types “Simple types” example used in the docs.​

The return statement currently duplicates ```item_d``` and includes six values: 
```python
def get_items(item_a: str, item_b: int, item_c: float, item_d: bool, item_e: bytes):
    return item_a, item_b, item_c, item_d, item_d, item_e
```
This change updates it to return each parameter once:
```python
def get_items(item_a: str, item_b: int, item_c: float, item_d: bool, item_e: bytes):
    return item_a, item_b, item_c, item_d, item_e

```

No existing issue was found for this; opening a direct docs/example fix PR.