### PR TITLE
Fix: Preserve model_fields_set for Form models (issue #13399)

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -754,6 +754,11 @@ def _get_multidict_value(
         if field.required:
             return
         else:
+            # For FormData, return None to let Pydantic handle defaults
+            # This preserves model_fields_set metadata correctly
+            if isinstance(values, FormData):
+                return
+            # For non-FormData (Query, Header, Cookie), keep existing behavior
             return deepcopy(field.default)
     return value
 

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -6,7 +6,7 @@ This test validates that Form models correctly track which fields were
 explicitly provided vs. which fields use defaults.
 """
 
-from typing_extensions import Annotated
+from typing import Annotated
 
 from fastapi import FastAPI, Form, Header, Query
 from fastapi._compat import PYDANTIC_V2
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 
-class FormModelFieldsSet(BaseModel) -> None:
+class FormModelFieldsSet(BaseModel):
     """Model for testing fields_set metadata preservation."""
 
     field_1: bool = True
@@ -26,7 +26,9 @@ app = FastAPI()
 
 
 @app.post("/form-fields-set")
-async def form_fields_set_endpoint(model: Annotated[FormModelFieldsSet, Form()]) -> None:
+async def form_fields_set_endpoint(
+    model: Annotated[FormModelFieldsSet, Form()],
+) -> None:
     # Use correct attribute name for each Pydantic version
     if PYDANTIC_V2:
         fields_set = list(model.model_fields_set)

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -32,7 +32,9 @@ async def form_fields_set_endpoint(
 ) -> None:
     # Works for both Pydantic v1 (__fields_set__) and v2 (model_fields_set)
     fields_set = list(
-        model.model_fields_set if hasattr(model, "model_fields_set") else model.__fields_set__  # type: ignore[attr-defined]
+        model.model_fields_set
+        if hasattr(model, "model_fields_set")
+        else model.__fields_set__  # type: ignore[attr-defined]
     )
     return {
         "fields_set": fields_set,
@@ -44,7 +46,9 @@ async def form_fields_set_endpoint(
 async def body_fields_set_endpoint(model: FormModelFieldsSet) -> None:
     # Works for both Pydantic v1 (__fields_set__) and v2 (model_fields_set)
     fields_set = list(
-        model.model_fields_set if hasattr(model, "model_fields_set") else model.__fields_set__  # type: ignore[attr-defined]
+        model.model_fields_set
+        if hasattr(model, "model_fields_set")
+        else model.__fields_set__  # type: ignore[attr-defined]
     )
     return {"fields_set": fields_set}
 

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -6,12 +6,11 @@ This test validates that Form models correctly track which fields were
 explicitly provided vs. which fields use defaults.
 """
 
-from typing import Annotated
-
 import pydantic
 from fastapi import FastAPI, Form, Header, Query
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
+from typing_extensions import Annotated  # noqa: UP035
 
 PYDANTIC_V2 = int(pydantic.VERSION.split(".")[0]) >= 2
 

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -5,6 +5,22 @@ Related to issue #13399: https://github.com/fastapi/fastapi/issues/13399
 
 from typing import Annotated
 
+import pytest
+
+# Skip this entire module if Pydantic v1 is installed
+# field_validator is a Pydantic v2-only API
+try:
+    from pydantic import __version__ as pydantic_version
+
+    pydantic_major = int(pydantic_version.split(".")[0])
+    if pydantic_major < 2:
+        pytest.skip(
+            "This test module requires Pydantic v2 (uses field_validator)",
+            allow_module_level=True,
+        )
+except Exception:
+    pass
+
 from fastapi import FastAPI, Form
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, field_validator

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -1,0 +1,163 @@
+"""
+Tests for Form fields preserving model_fields_set metadata.
+Related to issue #13399: https://github.com/fastapi/fastapi/issues/13399
+"""
+
+from typing import Annotated
+
+from fastapi import FastAPI, Form
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, field_validator
+
+
+class ExampleModel(BaseModel):
+    field_1: bool = True
+    field_2: str = "default"
+    field_3: int = 42
+
+
+class ExampleModelWithValidator(BaseModel):
+    field_1: bool = True
+    field_2: str = 0  # Intentionally wrong type to test validation
+
+    @field_validator("field_2")
+    @classmethod
+    def validate_field_2(cls, v):
+        # This validator should only run if field_2 is explicitly provided
+        if isinstance(v, int):
+            raise ValueError("field_2 must be a string")
+        return v
+
+
+app = FastAPI()
+
+
+@app.post("/body")
+async def body_endpoint(model: ExampleModel):
+    return {"fields_set": list(model.model_fields_set)}
+
+
+@app.post("/form")
+async def form_endpoint(model: Annotated[ExampleModel, Form()]):
+    return {"fields_set": list(model.model_fields_set)}
+
+
+@app.post("/form-validator")
+async def form_validator_endpoint(model: Annotated[ExampleModelWithValidator, Form()]):
+    return {"fields_set": list(model.model_fields_set)}
+
+
+client = TestClient(app)
+
+
+def test_body_empty_fields_set():
+    """JSON body with no data should have empty fields_set."""
+    resp = client.post("/body", json={})
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert fields_set == []
+
+
+def test_form_empty_fields_set():
+    """Form with no data should have empty fields_set (matching JSON behavior)."""
+    resp = client.post("/form", data={})
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert fields_set == []
+
+
+def test_body_partial_fields_set():
+    """JSON body with partial data should only show provided fields in fields_set."""
+    resp = client.post("/body", json={"field_1": False})
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert fields_set == ["field_1"]
+
+
+def test_form_partial_fields_set():
+    """Form with partial data should only show provided fields in fields_set."""
+    resp = client.post("/form", data={"field_1": "False"})
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert fields_set == ["field_1"]
+
+
+def test_body_all_fields_set():
+    """JSON body with all fields should show all fields in fields_set."""
+    resp = client.post(
+        "/body", json={"field_1": False, "field_2": "test", "field_3": 100}
+    )
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert set(fields_set) == {"field_1", "field_2", "field_3"}
+
+
+def test_form_all_fields_set():
+    """Form with all fields should show all fields in fields_set."""
+    resp = client.post(
+        "/form", data={"field_1": "False", "field_2": "test", "field_3": "100"}
+    )
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert set(fields_set) == {"field_1", "field_2", "field_3"}
+
+
+def test_body_field_with_same_value_as_default():
+    """JSON body field explicitly set to default value should appear in fields_set."""
+    resp = client.post("/body", json={"field_1": True})  # Same as default
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert fields_set == ["field_1"]
+
+
+def test_form_field_with_same_value_as_default():
+    """Form field explicitly set to default value should appear in fields_set."""
+    resp = client.post("/form", data={"field_1": "True"})  # Same as default
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert fields_set == ["field_1"]
+
+
+def test_form_default_not_validated_when_not_provided():
+    """
+    Form default values should NOT be validated when not provided.
+    This test ensures validation is only run on explicitly provided fields.
+    """
+    resp = client.post("/form-validator", data={})
+    # Should succeed because field_2 default (0) should NOT be validated
+    assert resp.status_code == 200, resp.text
+    fields_set = resp.json()["fields_set"]
+    assert fields_set == []
+
+
+def test_form_default_validated_when_provided():
+    """
+    Form fields should be validated when explicitly provided, even if invalid.
+    """
+    resp = client.post("/form-validator", data={"field_2": "0"})
+    # Should fail validation because we're providing an integer-like string
+    # But actually field_2 expects a string, so this should pass
+    # Let's provide an actual int type by modifying the test
+    assert resp.status_code == 200, resp.text
+
+
+def test_body_form_consistency():
+    """
+    Verify that body and form behave consistently regarding fields_set.
+    """
+    # Empty data
+    body_resp = client.post("/body", json={})
+    form_resp = client.post("/form", data={})
+    assert body_resp.json()["fields_set"] == form_resp.json()["fields_set"] == []
+
+    # Partial data
+    body_resp = client.post("/body", json={"field_1": False, "field_3": 99})
+    form_resp = client.post("/form", data={"field_1": "False", "field_3": "99"})
+    assert (
+        set(body_resp.json()["fields_set"])
+        == set(form_resp.json()["fields_set"])
+        == {
+            "field_1",
+            "field_3",
+        }
+    )

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -6,7 +6,7 @@ This test validates that Form models correctly track which fields were
 explicitly provided vs. which fields use defaults.
 """
 
-from typing import Annotated
+from typing_extensions import Annotated
 
 from fastapi import FastAPI, Form, Header, Query
 from fastapi._compat import PYDANTIC_V2
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 
-class FormModelFieldsSet(BaseModel):
+class FormModelFieldsSet(BaseModel) -> None:
     """Model for testing fields_set metadata preservation."""
 
     field_1: bool = True
@@ -26,7 +26,7 @@ app = FastAPI()
 
 
 @app.post("/form-fields-set")
-async def form_fields_set_endpoint(model: Annotated[FormModelFieldsSet, Form()]):
+async def form_fields_set_endpoint(model: Annotated[FormModelFieldsSet, Form()]) -> None:
     # Use correct attribute name for each Pydantic version
     if PYDANTIC_V2:
         fields_set = list(model.model_fields_set)
@@ -39,7 +39,7 @@ async def form_fields_set_endpoint(model: Annotated[FormModelFieldsSet, Form()])
 
 
 @app.post("/body-fields-set")
-async def body_fields_set_endpoint(model: FormModelFieldsSet):
+async def body_fields_set_endpoint(model: FormModelFieldsSet) -> None:
     # Use correct attribute name for each Pydantic version
     if PYDANTIC_V2:
         fields_set = list(model.model_fields_set)
@@ -52,14 +52,14 @@ async def body_fields_set_endpoint(model: FormModelFieldsSet):
 def query_model(
     name: Annotated[str, Query()] = "query_default",
     age: Annotated[int, Query()] = 10,
-):
+) -> None:
     return {"name": name, "age": age}
 
 
 @app.get("/header/default")
 def header_model(
     x_token: Annotated[str, Header()] = "header_default",
-):
+) -> None:
     return {"x_token": x_token}
 
 
@@ -69,35 +69,35 @@ client = TestClient(app)
 class TestFormFieldsSetMetadata:
     """Test that Form models correctly preserve fields_set metadata."""
 
-    def test_form_empty_data_has_empty_fields_set(self):
+    def test_form_empty_data_has_empty_fields_set(self) -> None:
         """Form with no data should have empty fields_set (matching JSON behavior)."""
         resp = client.post("/form-fields-set", data={})
         assert resp.status_code == 200, resp.text
         fields_set = resp.json()["fields_set"]
         assert fields_set == []
 
-    def test_body_empty_data_has_empty_fields_set(self):
+    def test_body_empty_data_has_empty_fields_set(self) -> None:
         """JSON body with no data should have empty fields_set."""
         resp = client.post("/body-fields-set", json={})
         assert resp.status_code == 200, resp.text
         fields_set = resp.json()["fields_set"]
         assert fields_set == []
 
-    def test_form_partial_data_tracks_provided_fields(self):
+    def test_form_partial_data_tracks_provided_fields(self) -> None:
         """Form with partial data should only show provided fields in fields_set."""
         resp = client.post("/form-fields-set", data={"field_1": "False"})
         assert resp.status_code == 200, resp.text
         fields_set = resp.json()["fields_set"]
         assert fields_set == ["field_1"]
 
-    def test_body_partial_data_tracks_provided_fields(self):
+    def test_body_partial_data_tracks_provided_fields(self) -> None:
         """JSON body with partial data should only show provided fields."""
         resp = client.post("/body-fields-set", json={"field_1": False})
         assert resp.status_code == 200, resp.text
         fields_set = resp.json()["fields_set"]
         assert fields_set == ["field_1"]
 
-    def test_form_all_fields_provided(self):
+    def test_form_all_fields_provided(self) -> None:
         """Form with all fields should show all fields in fields_set."""
         resp = client.post(
             "/form-fields-set",
@@ -107,7 +107,7 @@ class TestFormFieldsSetMetadata:
         fields_set = resp.json()["fields_set"]
         assert set(fields_set) == {"field_1", "field_2", "field_3"}
 
-    def test_body_all_fields_provided(self):
+    def test_body_all_fields_provided(self) -> None:
         """JSON body with all fields should show all fields in fields_set."""
         resp = client.post(
             "/body-fields-set",
@@ -117,7 +117,7 @@ class TestFormFieldsSetMetadata:
         fields_set = resp.json()["fields_set"]
         assert set(fields_set) == {"field_1", "field_2", "field_3"}
 
-    def test_form_field_set_to_default_value_is_tracked(self):
+    def test_form_field_set_to_default_value_is_tracked(self) -> None:
         """Form field explicitly set to default value should appear in fields_set."""
         # Same as default=True, but explicitly provided
         resp = client.post("/form-fields-set", data={"field_1": "True"})
@@ -125,14 +125,14 @@ class TestFormFieldsSetMetadata:
         fields_set = resp.json()["fields_set"]
         assert fields_set == ["field_1"]
 
-    def test_body_field_set_to_default_value_is_tracked(self):
+    def test_body_field_set_to_default_value_is_tracked(self) -> None:
         """JSON body field explicitly set to default value should appear in fields_set."""
         resp = client.post("/body-fields-set", json={"field_1": True})
         assert resp.status_code == 200, resp.text
         fields_set = resp.json()["fields_set"]
         assert fields_set == ["field_1"]
 
-    def test_form_body_consistency(self):
+    def test_form_body_consistency(self) -> None:
         """
         Verify that body and form behave consistently.
         Form fields_set should match JSON body fields_set for equivalent data.
@@ -160,21 +160,21 @@ class TestNonFormCoverage:
     This ensures line 762 of utils.py is covered and legacy behavior is preserved.
     """
 
-    def test_query_params_missing_uses_defaults(self):
+    def test_query_params_missing_uses_defaults(self) -> None:
         """Test Query input where fields are missing -> returns default."""
         response = client.get("/query/default")
         assert response.status_code == 200
         data = response.json()
         assert data == {"name": "query_default", "age": 10}
 
-    def test_header_params_missing_uses_defaults(self):
+    def test_header_params_missing_uses_defaults(self) -> None:
         """Test Header input where fields are missing -> returns default."""
         response = client.get("/header/default")
         assert response.status_code == 200
         data = response.json()
         assert data == {"x_token": "header_default"}
 
-    def test_query_params_provided(self):
+    def test_query_params_provided(self) -> None:
         """Test Query input where fields are provided -> returns value."""
         response = client.get("/query/default?name=overridden&age=99")
         assert response.status_code == 200

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -1,179 +1,139 @@
 """
 Tests for Form fields preserving model_fields_set metadata.
 Related to issue #13399: https://github.com/fastapi/fastapi/issues/13399
+
+This test validates that Form models correctly track which fields were
+explicitly provided vs. which fields use defaults.
 """
 
 from typing import Annotated
 
-import pytest
-
-# Skip this entire module if Pydantic v1 is installed
-# field_validator is a Pydantic v2-only API
-try:
-    from pydantic import __version__ as pydantic_version
-
-    pydantic_major = int(pydantic_version.split(".")[0])
-    if pydantic_major < 2:
-        pytest.skip(
-            "This test module requires Pydantic v2 (uses field_validator)",
-            allow_module_level=True,
-        )
-except Exception:
-    pass
-
 from fastapi import FastAPI, Form
+from fastapi._compat import PYDANTIC_V2
 from fastapi.testclient import TestClient
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 
 
-class ExampleModel(BaseModel):
+class FormModelFieldsSet(BaseModel):
+    """Model for testing fields_set metadata preservation."""
+
     field_1: bool = True
     field_2: str = "default"
     field_3: int = 42
 
 
-class ExampleModelWithValidator(BaseModel):
-    field_1: bool = True
-    field_2: str = 0  # Intentionally wrong type to test validation
-
-    @field_validator("field_2")
-    @classmethod
-    def validate_field_2(cls, v):
-        # This validator should only run if field_2 is explicitly provided
-        if isinstance(v, int):
-            raise ValueError("field_2 must be a string")
-        return v
-
-
 app = FastAPI()
 
 
-@app.post("/body")
-async def body_endpoint(model: ExampleModel):
-    return {"fields_set": list(model.model_fields_set)}
+@app.post("/form-fields-set")
+async def form_fields_set_endpoint(model: Annotated[FormModelFieldsSet, Form()]):
+    # Use correct attribute name for each Pydantic version
+    if PYDANTIC_V2:
+        fields_set = list(model.model_fields_set)
+    else:
+        fields_set = list(model.__fields_set__)
+    return {
+        "fields_set": fields_set,
+        "data": model.dict() if not PYDANTIC_V2 else model.model_dump(),
+    }
 
 
-@app.post("/form")
-async def form_endpoint(model: Annotated[ExampleModel, Form()]):
-    return {"fields_set": list(model.model_fields_set)}
-
-
-@app.post("/form-validator")
-async def form_validator_endpoint(model: Annotated[ExampleModelWithValidator, Form()]):
-    return {"fields_set": list(model.model_fields_set)}
+@app.post("/body-fields-set")
+async def body_fields_set_endpoint(model: FormModelFieldsSet):
+    # Use correct attribute name for each Pydantic version
+    if PYDANTIC_V2:
+        fields_set = list(model.model_fields_set)
+    else:
+        fields_set = list(model.__fields_set__)
+    return {"fields_set": fields_set}
 
 
 client = TestClient(app)
 
 
-def test_body_empty_fields_set():
-    """JSON body with no data should have empty fields_set."""
-    resp = client.post("/body", json={})
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert fields_set == []
+class TestFormFieldsSetMetadata:
+    """Test that Form models correctly preserve fields_set metadata."""
 
+    def test_form_empty_data_has_empty_fields_set(self):
+        """Form with no data should have empty fields_set (matching JSON behavior)."""
+        resp = client.post("/form-fields-set", data={})
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert fields_set == []
 
-def test_form_empty_fields_set():
-    """Form with no data should have empty fields_set (matching JSON behavior)."""
-    resp = client.post("/form", data={})
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert fields_set == []
+    def test_body_empty_data_has_empty_fields_set(self):
+        """JSON body with no data should have empty fields_set."""
+        resp = client.post("/body-fields-set", json={})
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert fields_set == []
 
+    def test_form_partial_data_tracks_provided_fields(self):
+        """Form with partial data should only show provided fields in fields_set."""
+        resp = client.post("/form-fields-set", data={"field_1": "False"})
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert fields_set == ["field_1"]
 
-def test_body_partial_fields_set():
-    """JSON body with partial data should only show provided fields in fields_set."""
-    resp = client.post("/body", json={"field_1": False})
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert fields_set == ["field_1"]
+    def test_body_partial_data_tracks_provided_fields(self):
+        """JSON body with partial data should only show provided fields."""
+        resp = client.post("/body-fields-set", json={"field_1": False})
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert fields_set == ["field_1"]
 
+    def test_form_all_fields_provided(self):
+        """Form with all fields should show all fields in fields_set."""
+        resp = client.post(
+            "/form-fields-set",
+            data={"field_1": "False", "field_2": "test", "field_3": "100"},
+        )
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert set(fields_set) == {"field_1", "field_2", "field_3"}
 
-def test_form_partial_fields_set():
-    """Form with partial data should only show provided fields in fields_set."""
-    resp = client.post("/form", data={"field_1": "False"})
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert fields_set == ["field_1"]
+    def test_body_all_fields_provided(self):
+        """JSON body with all fields should show all fields in fields_set."""
+        resp = client.post(
+            "/body-fields-set",
+            json={"field_1": False, "field_2": "test", "field_3": 100},
+        )
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert set(fields_set) == {"field_1", "field_2", "field_3"}
 
+    def test_form_field_set_to_default_value_is_tracked(self):
+        """Form field explicitly set to default value should appear in fields_set."""
+        # Same as default=True, but explicitly provided
+        resp = client.post("/form-fields-set", data={"field_1": "True"})
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert fields_set == ["field_1"]
 
-def test_body_all_fields_set():
-    """JSON body with all fields should show all fields in fields_set."""
-    resp = client.post(
-        "/body", json={"field_1": False, "field_2": "test", "field_3": 100}
-    )
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert set(fields_set) == {"field_1", "field_2", "field_3"}
+    def test_body_field_set_to_default_value_is_tracked(self):
+        """JSON body field explicitly set to default value should appear in fields_set."""
+        resp = client.post("/body-fields-set", json={"field_1": True})
+        assert resp.status_code == 200, resp.text
+        fields_set = resp.json()["fields_set"]
+        assert fields_set == ["field_1"]
 
+    def test_form_body_consistency(self):
+        """
+        Verify that body and form behave consistently.
+        Form fields_set should match JSON body fields_set for equivalent data.
+        """
+        # Empty data - both should have empty fields_set
+        body_resp = client.post("/body-fields-set", json={})
+        form_resp = client.post("/form-fields-set", data={})
+        assert body_resp.json()["fields_set"] == []
+        assert form_resp.json()["fields_set"] == []
 
-def test_form_all_fields_set():
-    """Form with all fields should show all fields in fields_set."""
-    resp = client.post(
-        "/form", data={"field_1": "False", "field_2": "test", "field_3": "100"}
-    )
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert set(fields_set) == {"field_1", "field_2", "field_3"}
-
-
-def test_body_field_with_same_value_as_default():
-    """JSON body field explicitly set to default value should appear in fields_set."""
-    resp = client.post("/body", json={"field_1": True})  # Same as default
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert fields_set == ["field_1"]
-
-
-def test_form_field_with_same_value_as_default():
-    """Form field explicitly set to default value should appear in fields_set."""
-    resp = client.post("/form", data={"field_1": "True"})  # Same as default
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert fields_set == ["field_1"]
-
-
-def test_form_default_not_validated_when_not_provided():
-    """
-    Form default values should NOT be validated when not provided.
-    This test ensures validation is only run on explicitly provided fields.
-    """
-    resp = client.post("/form-validator", data={})
-    # Should succeed because field_2 default (0) should NOT be validated
-    assert resp.status_code == 200, resp.text
-    fields_set = resp.json()["fields_set"]
-    assert fields_set == []
-
-
-def test_form_default_validated_when_provided():
-    """
-    Form fields should be validated when explicitly provided, even if invalid.
-    """
-    resp = client.post("/form-validator", data={"field_2": "0"})
-    # Should fail validation because we're providing an integer-like string
-    # But actually field_2 expects a string, so this should pass
-    # Let's provide an actual int type by modifying the test
-    assert resp.status_code == 200, resp.text
-
-
-def test_body_form_consistency():
-    """
-    Verify that body and form behave consistently regarding fields_set.
-    """
-    # Empty data
-    body_resp = client.post("/body", json={})
-    form_resp = client.post("/form", data={})
-    assert body_resp.json()["fields_set"] == form_resp.json()["fields_set"] == []
-
-    # Partial data
-    body_resp = client.post("/body", json={"field_1": False, "field_3": 99})
-    form_resp = client.post("/form", data={"field_1": "False", "field_3": "99"})
-    assert (
-        set(body_resp.json()["fields_set"])
-        == set(form_resp.json()["fields_set"])
-        == {
-            "field_1",
-            "field_3",
-        }
-    )
+        # Partial data - both should track same fields
+        body_resp = client.post(
+            "/body-fields-set", json={"field_1": False, "field_3": 99}
+        )
+        form_resp = client.post(
+            "/form-fields-set", data={"field_1": "False", "field_3": "99"}
+        )
+        assert set(body_resp.json()["fields_set"]) == {"field_1", "field_3"}
+        assert set(form_resp.json()["fields_set"]) == {"field_1", "field_3"}

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -30,24 +30,22 @@ app = FastAPI()
 async def form_fields_set_endpoint(
     model: Annotated[FormModelFieldsSet, Form()],
 ) -> None:
-    # Use correct attribute name for each Pydantic version
-    if PYDANTIC_V2:
-        fields_set = list(model.model_fields_set)
-    else:
-        fields_set = list(model.__fields_set__)
+    # Works for both Pydantic v1 (__fields_set__) and v2 (model_fields_set)
+    fields_set = list(
+        model.model_fields_set if hasattr(model, "model_fields_set") else model.__fields_set__  # type: ignore[attr-defined]
+    )
     return {
         "fields_set": fields_set,
-        "data": model.dict() if not PYDANTIC_V2 else model.model_dump(),
+        "data": model.model_dump() if PYDANTIC_V2 else model.dict(),
     }
 
 
 @app.post("/body-fields-set")
 async def body_fields_set_endpoint(model: FormModelFieldsSet) -> None:
-    # Use correct attribute name for each Pydantic version
-    if PYDANTIC_V2:
-        fields_set = list(model.model_fields_set)
-    else:
-        fields_set = list(model.__fields_set__)
+    # Works for both Pydantic v1 (__fields_set__) and v2 (model_fields_set)
+    fields_set = list(
+        model.model_fields_set if hasattr(model, "model_fields_set") else model.__fields_set__  # type: ignore[attr-defined]
+    )
     return {"fields_set": fields_set}
 
 

--- a/tests/test_forms_fields_set.py
+++ b/tests/test_forms_fields_set.py
@@ -8,10 +8,12 @@ explicitly provided vs. which fields use defaults.
 
 from typing import Annotated
 
+import pydantic
 from fastapi import FastAPI, Form, Header, Query
-from fastapi._compat import PYDANTIC_V2
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
+
+PYDANTIC_V2 = int(pydantic.VERSION.split(".")[0]) >= 2
 
 
 class FormModelFieldsSet(BaseModel):

--- a/tests/test_forms_single_model.py
+++ b/tests/test_forms_single_model.py
@@ -99,13 +99,13 @@ def test_no_data():
                 "type": "missing",
                 "loc": ["body", "username"],
                 "msg": "Field required",
-                "input": {"tags": ["foo", "bar"], "with": "nothing"},
+                "input": {},
             },
             {
                 "type": "missing",
                 "loc": ["body", "lastname"],
                 "msg": "Field required",
-                "input": {"tags": ["foo", "bar"], "with": "nothing"},
+                "input": {},
             },
         ]
     }


### PR DESCRIPTION
When using Form() with Pydantic models, FastAPI was preloading default values and passing them to Pydantic, causing all fields to appear in model_fields_set even when not provided. This also caused validation to be enforced on unprovided defaults.

Changes:
- Modified _get_multidict_value() to check if values is FormData
- For FormData, return None for unprovided fields instead of defaults
- This lets Pydantic handle defaults properly and preserve fields_set
- Updated test expectation in test_forms_single_model.py
- Added comprehensive test suite in test_forms_fields_set.py

The fix ensures Form models behave consistently with JSON body models regarding field tracking and validation.

Closes #13399