### PR TITLE
Also dump v2 models in `_prepare_response_content`

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -29,6 +29,7 @@ from fastapi._compat import (
     _model_dump,
     _normalize_errors,
     lenient_issubclass,
+    may_v1,
 )
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
@@ -152,7 +153,7 @@ def _prepare_response_content(
     exclude_defaults: bool = False,
     exclude_none: bool = False,
 ) -> Any:
-    if isinstance(res, BaseModel):
+    if isinstance(res, (may_v1.BaseModel, BaseModel)):
         read_with_orm_mode = getattr(_get_model_config(res), "read_with_orm_mode", None)
         if read_with_orm_mode:
             # Let from_orm extract the data from this model instead of converting

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -29,7 +29,6 @@ from fastapi._compat import (
     _model_dump,
     _normalize_errors,
     lenient_issubclass,
-    may_v1,
 )
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
@@ -58,6 +57,7 @@ from fastapi.utils import (
     get_value_or_default,
     is_body_allowed_for_status_code,
 )
+from pydantic import BaseModel
 from starlette import routing
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import is_async_callable
@@ -152,7 +152,7 @@ def _prepare_response_content(
     exclude_defaults: bool = False,
     exclude_none: bool = False,
 ) -> Any:
-    if isinstance(res, may_v1.BaseModel):
+    if isinstance(res, BaseModel):
         read_with_orm_mode = getattr(_get_model_config(res), "read_with_orm_mode", None)  # type: ignore[arg-type]
         if read_with_orm_mode:
             # Let from_orm extract the data from this model instead of converting

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -154,7 +154,7 @@ def _prepare_response_content(
     exclude_none: bool = False,
 ) -> Any:
     if isinstance(res, (may_v1.BaseModel, BaseModel)):
-        read_with_orm_mode = getattr(_get_model_config(res), "read_with_orm_mode", None)
+        read_with_orm_mode = getattr(_get_model_config(res), "read_with_orm_mode", None)  # type: ignore[arg-type]
         if read_with_orm_mode:
             # Let from_orm extract the data from this model instead of converting
             # it now to a dict.
@@ -162,7 +162,7 @@ def _prepare_response_content(
             # access instead of dict iteration, e.g. lazy relationships.
             return res
         return _model_dump(
-            res,
+            res,  # type: ignore[arg-type]
             by_alias=True,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -153,7 +153,7 @@ def _prepare_response_content(
     exclude_none: bool = False,
 ) -> Any:
     if isinstance(res, BaseModel):
-        read_with_orm_mode = getattr(_get_model_config(res), "read_with_orm_mode", None)  # type: ignore[arg-type]
+        read_with_orm_mode = getattr(_get_model_config(res), "read_with_orm_mode", None)
         if read_with_orm_mode:
             # Let from_orm extract the data from this model instead of converting
             # it now to a dict.
@@ -161,7 +161,7 @@ def _prepare_response_content(
             # access instead of dict iteration, e.g. lazy relationships.
             return res
         return _model_dump(
-            res,  # type: ignore[arg-type]
+            res,
             by_alias=True,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,


### PR DESCRIPTION
Corrects #14575 to also dump Pydantic v2 models in `_prepare_response_content`, fixing the regression.