### PR TITLE
Minor clarification suggestion for the “Parallel Burgers” analogy in …

### DIFF
--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -219,6 +219,13 @@ The fast food store has 8 processors (cashiers/cooks). While the concurrent burg
 
 But still, the final experience is not the best. 😞
 
+/// note
+
+This example focuses on an <abbr title="Input and Output">I/O</abbr>-bound scenario with significant waiting. Parallelism shines instead for <abbr title="Central Processing Unit">CPU</abbr>-bound work, where multiple workers actively perform computation at the same time.
+
+///
+
+
 ---
 
 This would be the parallel equivalent story for burgers. 🍔


### PR DESCRIPTION
…concurrency docs

Hi 👋
The burgers analogy is one of the clearest explanations of async/concurrency I’ve seen.

I wanted to raise a small pedagogical point regarding the “Parallel Burgers” section.

While the analogy does highlight why parallelism is not ideal for I/O-bound workloads, it may unintentionally give readers the impression that parallelism itself is inefficient or inherently worse than concurrency, rather than simply better suited for CPU-bound work.

In particular, the example emphasises waiting and idle time, whereas true parallelism is most beneficial when multiple workers are actively doing computation simultaneously.

A small clarification (or an alternative example where multiple cooks actively work on different parts of the task at the same time) might help reinforce that distinction.

This is a minor point, but I thought it could help avoid confusion for readers learning these concepts for the first time.

Thanks again for the great docs!