### PR TITLE
Fix: Require realm in HTTPBasic to comply with RFC 7617

### DIFF
--- a/docs_src/security/tutorial006_an_py39.py
+++ b/docs_src/security/tutorial006_an_py39.py
@@ -5,7 +5,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 app = FastAPI()
 
-security = HTTPBasic()
+security = HTTPBasic(realm="simple")
 
 
 @app.get("/users/me")

--- a/docs_src/security/tutorial006_py39.py
+++ b/docs_src/security/tutorial006_py39.py
@@ -3,7 +3,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 app = FastAPI()
 
-security = HTTPBasic()
+security = HTTPBasic(realm="simple")
 
 
 @app.get("/users/me")

--- a/docs_src/security/tutorial007_an_py39.py
+++ b/docs_src/security/tutorial007_an_py39.py
@@ -6,7 +6,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 app = FastAPI()
 
-security = HTTPBasic()
+security = HTTPBasic(realm="simple")
 
 
 def get_current_username(
@@ -26,7 +26,7 @@ def get_current_username(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Basic"},
+            headers={"WWW-Authenticate": 'Basic realm="simple"'},
         )
     return credentials.username
 

--- a/docs_src/security/tutorial007_py39.py
+++ b/docs_src/security/tutorial007_py39.py
@@ -5,7 +5,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 app = FastAPI()
 
-security = HTTPBasic()
+security = HTTPBasic(realm="simple")
 
 
 def get_current_username(credentials: HTTPBasicCredentials = Depends(security)):
@@ -23,7 +23,7 @@ def get_current_username(credentials: HTTPBasicCredentials = Depends(security)):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Basic"},
+            headers={"WWW-Authenticate": 'Basic realm="simple"'},
         )
     return credentials.username
 

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -153,13 +153,13 @@ class HTTPBasic(HTTPBase):
             ),
         ] = None,
         realm: Annotated[
-            Optional[str],
+            str,
             Doc(
                 """
                 HTTP Basic authentication realm.
                 """
             ),
-        ] = None,
+        ],
         description: Annotated[
             Optional[str],
             Doc(
@@ -197,9 +197,7 @@ class HTTPBasic(HTTPBase):
         self.auto_error = auto_error
 
     def make_authenticate_headers(self) -> dict[str, str]:
-        if self.realm:
-            return {"WWW-Authenticate": f'Basic realm="{self.realm}"'}
-        return {"WWW-Authenticate": "Basic"}
+        return {"WWW-Authenticate": f'Basic realm="{self.realm}"'}
 
     async def __call__(  # type: ignore
         self, request: Request

--- a/tests/test_security_http_basic_optional.py
+++ b/tests/test_security_http_basic_optional.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 app = FastAPI()
 
-security = HTTPBasic(auto_error=False)
+security = HTTPBasic(realm="simple", auto_error=False)
 
 
 @app.get("/users/me")
@@ -37,7 +37,7 @@ def test_security_http_basic_invalid_credentials():
         "/users/me", headers={"Authorization": "Basic notabase64token"}
     )
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="simple"'
     assert response.json() == {"detail": "Not authenticated"}
 
 
@@ -46,7 +46,7 @@ def test_security_http_basic_non_basic_credentials():
     auth_header = f"Basic {payload}"
     response = client.get("/users/me", headers={"Authorization": auth_header})
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="simple"'
     assert response.json() == {"detail": "Not authenticated"}
 
 

--- a/tests/test_tutorial/test_security/test_tutorial006.py
+++ b/tests/test_tutorial/test_security/test_tutorial006.py
@@ -29,7 +29,7 @@ def test_security_http_basic_no_credentials(client: TestClient):
     response = client.get("/users/me")
     assert response.json() == {"detail": "Not authenticated"}
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="simple"'
 
 
 def test_security_http_basic_invalid_credentials(client: TestClient):
@@ -37,7 +37,7 @@ def test_security_http_basic_invalid_credentials(client: TestClient):
         "/users/me", headers={"Authorization": "Basic notabase64token"}
     )
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="simple"'
     assert response.json() == {"detail": "Not authenticated"}
 
 
@@ -46,7 +46,7 @@ def test_security_http_basic_non_basic_credentials(client: TestClient):
     auth_header = f"Basic {payload}"
     response = client.get("/users/me", headers={"Authorization": auth_header})
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert response.headers["WWW-Authenticate"] == 'Basic realm="simple"'
     assert response.json() == {"detail": "Not authenticated"}
 
 


### PR DESCRIPTION
### Description

This PR fixes issue #13471 where `HTTPBasic` authentication allowed instantiation without a `realm` parameter. According to [RFC 7617 Section 2](https://datatracker.ietf.org/doc/html/rfc7617#section-2), the `realm` parameter is **REQUIRED** for Basic authentication.

This change:
1.  Modifies `HTTPBasic.__init__` to make `realm` a required argument (removing the default `None`).
2.  Updates `make_authenticate_headers` to always include the `realm` in the `WWW-Authenticate` header.

### Breaking Change :warning:

This is a **BREAKING CHANGE**.
Existing code dealing with security like:
```python
security = HTTPBasic()
```
will now raise a `TypeError`. Users must update their code to provide a realm:
```python
security = HTTPBasic(realm='my-realm')
```

### Verification

- Created a reproduction script (`reproduce_issue_13471.py`, not included in PR) confirming failure before fix and success after.
- Updated existing tutorials (`docs_src/security/tutorial00[67]*.py`) to use `realm='simple'`.
- Updated existing tests (`tests/test_tutorial/test_security/test_tutorial006.py`, `tests/test_security_http_basic_optional.py`) to match the new behavior.
- Ran specific security tests (`tests/test_security_http_basic_realm.py`, `tests/test_security_http_basic_optional.py`) and tutorials tests.
- Ran `ruff format` and `ruff check`.
