### PR TITLE
📝 Fix grammar in `docs/en/docs/tutorial/body.md`

### DIFF
--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -132,7 +132,7 @@ Inside of the function, you can access all the attributes of the model object di
 
 You can declare path parameters and request body at the same time.
 
-**FastAPI** will recognize that the function parameters that match path parameters should be **taken from the path**, and that function parameters that are declared to be Pydantic models should be **taken from the request body**.
+**FastAPI** will recognize that the function parameters that match path parameters should be **taken from the path**, and those function parameters that are declared to be Pydantic models should be **taken from the request body**.
 
 {* ../../docs_src/body/tutorial003_py310.py hl[15:16] *}
 


### PR DESCRIPTION
## Description
Fixed grammar issue in the tutorial documentation.

## Changes
- Changed "and that function parameters that are declared" to "and those function parameters that are declared" for better grammar and readability.

## Location
File: `docs/en/docs/tutorial/body.md`
Section: "Request body + path parameters"