### PR TITLE
docs: Add streaming inference example using StreamingResponse

### DIFF
--- a/docs_src/streaming/streaming_inference.py
+++ b/docs_src/streaming/streaming_inference.py
@@ -7,7 +7,7 @@ latency and user experience.
 """
 
 import time
-from typing import Generator
+from collections.abc import Generator
 
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse

--- a/docs_src/streaming/streaming_inference.py
+++ b/docs_src/streaming/streaming_inference.py
@@ -1,0 +1,47 @@
+"""
+Streaming inference example using StreamingResponse.
+
+This pattern is useful for long-running workloads such as machine learning
+or large language model inference, where returning partial results improves
+latency and user experience.
+"""
+
+import time
+from typing import Generator
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+app = FastAPI()
+
+
+def fake_model_inference(prompt: str) -> Generator[str, None, None]:
+    """
+    Simulates token-by-token inference.
+
+    In a real application, this could wrap a machine learning model that
+    yields partial outputs as they are generated.
+    """
+    try:
+        for i in range(10):
+            # Simulate computation time (e.g. model forward pass)
+            time.sleep(0.2)
+            yield f"token_{i} for prompt='{prompt}'\n"
+    except GeneratorExit:
+        # This is triggered when the client disconnects early.
+        # Cleanup logic for model inference can be placed here.
+        print("Client disconnected, stopping inference")
+
+
+@app.get("/stream")
+def stream(prompt: str) -> StreamingResponse:
+    """
+    Stream inference results incrementally to the client.
+
+    This endpoint returns partial results as they become available instead
+    of waiting for the full inference to complete, making the user experience better.
+    """
+    return StreamingResponse(
+        fake_model_inference(prompt),
+        media_type="text/plain",
+    )


### PR DESCRIPTION
## What does this PR do?

Adds a documentation example demonstrating how to use `StreamingResponse`
for long-running inference workloads, such as machine learning or
token-based generation, where returning partial results improves latency
and user experience.

The example shows a simple generator-based pattern that can be adapted
to real-world ML or LLM inference pipelines.

## Why is this useful?

FastAPI is commonly used to serve ML and LLM-backed APIs, but there is
currently no dedicated documentation example focused on streaming
inference results incrementally.

This PR provides a minimal, dependency-free example that users can
copy and adapt for production inference use cases.

## Scope of the change

- Documentation/example only
- No changes to FastAPI core behavior
- No new dependencies introduced

## Testing

- Ran the example locally using Uvicorn
- Verified incremental streaming behavior via browser request
