### PR TITLE
👷 Do not run translations on cron while finishing updating existing languages

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,8 +1,8 @@
 name: Translate
 
 on:
-  schedule:
-    - cron: "0 5 15 * *"  # Run at 05:00 on the 15 of every month
+  # schedule:
+  #   - cron: "0 5 15 * *"  # Run at 05:00 on the 15 of every month
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
👷 Do not run translations on cron while finishing updating existing languages