### PR TITLE
refactor - replaced deprecated on_event with lifespan in SQL tutorials

### DIFF
--- a/docs_src/sql_databases/tutorial001_an_py310.py
+++ b/docs_src/sql_databases/tutorial001_an_py310.py
@@ -1,5 +1,6 @@
-from typing import Annotated
 from contextlib import asynccontextmanager
+from typing import Annotated
+
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 
@@ -32,6 +33,7 @@ async def lifespan(app: FastAPI):
     create_db_and_tables()
     yield
     # will leave this as is for now
+
 
 SessionDep = Annotated[Session, Depends(get_session)]
 

--- a/docs_src/sql_databases/tutorial001_an_py310.py
+++ b/docs_src/sql_databases/tutorial001_an_py310.py
@@ -1,5 +1,5 @@
 from typing import Annotated
-
+from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 
@@ -27,14 +27,15 @@ def get_session():
         yield session
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    create_db_and_tables()
+    yield
+    # will leave this as is for now
+
 SessionDep = Annotated[Session, Depends(get_session)]
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
-    create_db_and_tables()
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_an_py39.py
+++ b/docs_src/sql_databases/tutorial001_an_py39.py
@@ -1,5 +1,6 @@
-from typing import Annotated, Union
 from contextlib import asynccontextmanager
+from typing import Annotated, Union
+
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 

--- a/docs_src/sql_databases/tutorial001_an_py39.py
+++ b/docs_src/sql_databases/tutorial001_an_py39.py
@@ -1,5 +1,5 @@
 from typing import Annotated, Union
-
+from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 
@@ -27,14 +27,16 @@ def get_session():
         yield session
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    create_db_and_tables()
+    yield
+    # will leave this as is for now
+
+
 SessionDep = Annotated[Session, Depends(get_session)]
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
-    create_db_and_tables()
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_py310.py
+++ b/docs_src/sql_databases/tutorial001_py310.py
@@ -1,6 +1,7 @@
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
-from contextlib import asynccontextmanager
 
 
 class Hero(SQLModel, table=True):

--- a/docs_src/sql_databases/tutorial001_py310.py
+++ b/docs_src/sql_databases/tutorial001_py310.py
@@ -1,5 +1,6 @@
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
+from contextlib import asynccontextmanager
 
 
 class Hero(SQLModel, table=True):
@@ -25,12 +26,14 @@ def get_session():
         yield session
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+    # will leave this as is for now
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_py39.py
+++ b/docs_src/sql_databases/tutorial001_py39.py
@@ -1,5 +1,6 @@
-from typing import Union
 from contextlib import asynccontextmanager
+from typing import Union
+
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 
@@ -26,6 +27,7 @@ def get_session():
     with Session(engine) as session:
         yield session
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     create_db_and_tables()
@@ -34,7 +36,6 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
-
 
 
 @app.post("/heroes/")

--- a/docs_src/sql_databases/tutorial001_py39.py
+++ b/docs_src/sql_databases/tutorial001_py39.py
@@ -1,5 +1,5 @@
 from typing import Union
-
+from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlmodel import Field, Session, SQLModel, create_engine, select
 
@@ -26,13 +26,15 @@ def get_session():
     with Session(engine) as session:
         yield session
 
-
-app = FastAPI()
-
-
-@app.on_event("startup")
-def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     create_db_and_tables()
+    yield
+    # will leave this as is for now
+
+
+app = FastAPI(lifespan=lifespan)
+
 
 
 @app.post("/heroes/")

--- a/tests/test_tutorial/test_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial001.py
@@ -30,8 +30,7 @@ def clear_sqlmodel():
 )
 def get_client(request: pytest.FixtureRequest):
     clear_sqlmodel()
-    # TODO: remove when updating SQL tutorial to use new lifespan API
-    with warnings.catch_warnings(record=True):
+    with warnings.catch_warnings():
         warnings.simplefilter("always")
         mod = importlib.import_module(f"docs_src.sql_databases.{request.param}")
         clear_sqlmodel()
@@ -50,7 +49,7 @@ def get_client(request: pytest.FixtureRequest):
 def test_crud_app(client: TestClient):
     # TODO: this warns that SQLModel.from_orm is deprecated in Pydantic v1, refactor
     # this if using obj.model_validate becomes independent of Pydantic v2
-    with warnings.catch_warnings(record=True):
+    with warnings.catch_warnings():
         warnings.simplefilter("always")
         # No heroes before creating
         response = client.get("heroes/")


### PR DESCRIPTION
This pull request updates the SQL database tutorial example `tutorial001` to use the FastAPI `lifespan` parameter for application initialization, replacing the deprecated `@app.on_event("startup")` decorator. The tutorial now reflects the current and recommended lifecycle pattern in FastAPI instead of relying on behavior that is already deprecated.

The accompanying test update removes a TODO and the `warnings.catch_warnings`  block was adjusted by `removing record = True` argument in tests/test_tutorial/`test_sql_databases/test_tutorial001.py`  that was previously suppressing the deprecation warning. The underlying cause is fixed by migrating to lifespan events.

As a result, the test suite runs without emitting `DeprecationWarning` for `tutorial001`.
