### PR TITLE
Improve error message for missing dependency type annotation

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -109,9 +109,7 @@ def ensure_multipart_is_installed() -> None:
             raise RuntimeError(multipart_not_installed_error) from None
 
 
-def get_parameterless_sub_dependant(
-    *, depends: params.Depends, path: str
-) -> Dependant:
+def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> Dependant:
     assert callable(depends.dependency), (
         "A parameter-less dependency must have a callable dependency"
     )
@@ -299,7 +297,7 @@ def get_dependant(
             ):
                 raise FastAPIError(
                     f'Dependency parameter "{param_name}" must have a type annotation. '
-                    f'For example: `{param_name}: SomeType = Depends(...)`'
+                    f"For example: `{param_name}: SomeType = Depends(...)`"
                 )
             if (
                 (dependant.is_gen_callable or dependant.is_async_gen_callable)
@@ -339,7 +337,7 @@ def get_dependant(
         if enforce_annotation and param_details.field is None:
             raise FastAPIError(
                 f'Dependency parameter "{param_name}" must have a type annotation. '
-                f'For example: `{param_name}: SomeType = Depends(...)`'
+                f"For example: `{param_name}: SomeType = Depends(...)`"
             )
         if isinstance(param_details.field.field_info, params.Body):
             dependant.body_params.append(param_details.field)

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -456,7 +456,10 @@ class APIWebSocketRoute(routing.WebSocketRoute):
         self.dependencies = list(dependencies or [])
         self.path_regex, self.path_format, self.param_convertors = compile_path(path)
         self.dependant = get_dependant(
-            path=self.path_format, call=self.endpoint, scope="function"
+            path=self.path_format,
+            call=self.endpoint,
+            scope="function",
+            enforce_annotation=False,
         )
         for depends in self.dependencies[::-1]:
             self.dependant.dependencies.insert(

--- a/tests/test_dependency_overrides.py
+++ b/tests/test_dependency_overrides.py
@@ -399,9 +399,11 @@ def test_missing_type_annotation_dependency():
         return "db"
 
     with pytest.raises(FastAPIError) as exc:
+
         @local_app.get("/bad")
         def bad(dep=Depends(get_db)):
             return dep
+
         TestClient(local_app)
 
     msg = str(exc.value)


### PR DESCRIPTION
This PR improves the error raised when a dependency parameter is missing a type annotation.

Previously, FastAPI would raise a generic AssertionError during dependency resolution, which made it difficult to understand what went wrong and how to fix it.

Changes in this PR:
- Replace the assertion with a FastAPIError that includes:
  - the dependency parameter name
  - a clear explanation of the issue
  - an example of the correct annotation syntax
- Ensure the error is only enforced in appropriate contexts to avoid breaking
  parameter-less dependencies, dependency overrides, and WebSocket sub-dependencies
- Add a test covering the missing type annotation case

All existing tests pass.
