### PR TITLE
🏷️ Re-export `IncEx` type from Pydantic instead of duplicating it

### DIFF
--- a/fastapi/types.py
+++ b/fastapi/types.py
@@ -3,9 +3,9 @@ from enum import Enum
 from typing import Any, Callable, Optional, TypeVar, Union
 
 from pydantic import BaseModel
+from pydantic.main import IncEx as IncEx
 
 DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
 UnionType = getattr(types, "UnionType", Union)
 ModelNameMap = dict[Union[type[BaseModel], type[Enum]], str]
-IncEx = Union[set[int], set[str], dict[int, Any], dict[str, Any]]
 DependencyCacheKey = tuple[Optional[Callable[..., Any]], tuple[str, ...], str]


### PR DESCRIPTION
Loosen IncEx type declaration and ensure it stays in sync with Pydantic.
Currently it's too strict and an old copy that is out of sync. By removing the copy, we remove the possibility of it going out of sync. FastAPI only uses this for typing variables that are not used and passed directly into Pydantic.

* https://github.com/fastapi/fastapi/discussions/14640