### PR TITLE
docs: Basic auth `realm` is REQUIRED but handled as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,3 +560,8 @@ Additional optional FastAPI dependencies:
 ## License
 
 This project is licensed under the terms of the MIT license.
+
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
## Description

According to https://datatracker.ietf.org/doc/html/rfc7617#autoid-3 , specification of the `realm` parameter is REQUIRED, so making `realm` optional here

https://github.com/fastapi/fastapi/blob/643d2

## Changes Made

- docs: Added contributing section

Fixes #13471
