### PR TITLE
Fix HTTPBasic to always include realm in WWW-Authenticate

### DIFF
--- a/docs_src/security/tutorial007_an_py39.py
+++ b/docs_src/security/tutorial007_an_py39.py
@@ -26,7 +26,7 @@ def get_current_username(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Basic"},
+            headers=security.make_authenticate_headers(),
         )
     return credentials.username
 

--- a/docs_src/security/tutorial007_py39.py
+++ b/docs_src/security/tutorial007_py39.py
@@ -23,7 +23,7 @@ def get_current_username(credentials: HTTPBasicCredentials = Depends(security)):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Basic"},
+            headers=security.make_authenticate_headers(),
         )
     return credentials.username
 

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -197,9 +197,8 @@ class HTTPBasic(HTTPBase):
         self.auto_error = auto_error
 
     def make_authenticate_headers(self) -> dict[str, str]:
-        if self.realm:
-            return {"WWW-Authenticate": f'Basic realm="{self.realm}"'}
-        return {"WWW-Authenticate": "Basic"}
+        realm = self.realm or "FastAPI"
+        return {"WWW-Authenticate": f'Basic realm="{realm}"'}
 
     async def __call__(  # type: ignore
         self, request: Request

--- a/tests/test_security_http_basic_default_realm.py
+++ b/tests/test_security_http_basic_default_realm.py
@@ -5,11 +5,14 @@ from fastapi.testclient import TestClient
 app = FastAPI()
 security = HTTPBasic()
 
+
 @app.get("/users/me")
 def read_current_user(credentials: HTTPBasicCredentials = Depends(security)):
     return {"username": credentials.username, "password": credentials.password}
 
+
 client = TestClient(app)
+
 
 def test_security_http_basic_default_realm():
     # 401 branch: should include default realm

--- a/tests/test_security_http_basic_default_realm.py
+++ b/tests/test_security_http_basic_default_realm.py
@@ -1,0 +1,20 @@
+from fastapi import Depends, FastAPI
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from starlette.testclient import TestClient
+
+
+def test_http_basic_includes_realm_by_default():
+    app = FastAPI()
+    security = HTTPBasic()  # no realm provided
+
+    @app.get("/protected")
+    def protected(credentials: HTTPBasicCredentials = Depends(security)):
+        return {"username": credentials.username}
+
+    client = TestClient(app)
+    resp = client.get("/protected")
+
+    assert resp.status_code == 401
+    www_auth = resp.headers.get("www-authenticate")
+    assert www_auth is not None
+    assert www_auth.startswith('Basic realm="')

--- a/tests/test_security_http_basic_optional.py
+++ b/tests/test_security_http_basic_optional.py
@@ -36,8 +36,10 @@ def test_security_http_basic_invalid_credentials():
     response = client.get(
         "/users/me", headers={"Authorization": "Basic notabase64token"}
     )
+    www_auth = response.headers["WWW-Authenticate"]
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.json() == {"detail": "Not authenticated"}
 
 
@@ -45,8 +47,11 @@ def test_security_http_basic_non_basic_credentials():
     payload = b64encode(b"johnsecret").decode("ascii")
     auth_header = f"Basic {payload}"
     response = client.get("/users/me", headers={"Authorization": auth_header})
+    www_auth = response.headers["WWW-Authenticate"]
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
+
     assert response.json() == {"detail": "Not authenticated"}
 
 

--- a/tests/test_tutorial/test_security/test_tutorial006.py
+++ b/tests/test_tutorial/test_security/test_tutorial006.py
@@ -27,17 +27,22 @@ def test_security_http_basic(client: TestClient):
 
 def test_security_http_basic_no_credentials(client: TestClient):
     response = client.get("/users/me")
+    www_auth = response.headers["WWW-Authenticate"]
     assert response.json() == {"detail": "Not authenticated"}
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
+
 
 
 def test_security_http_basic_invalid_credentials(client: TestClient):
     response = client.get(
         "/users/me", headers={"Authorization": "Basic notabase64token"}
     )
+    www_auth = response.headers["WWW-Authenticate"]
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.json() == {"detail": "Not authenticated"}
 
 
@@ -45,8 +50,10 @@ def test_security_http_basic_non_basic_credentials(client: TestClient):
     payload = b64encode(b"johnsecret").decode("ascii")
     auth_header = f"Basic {payload}"
     response = client.get("/users/me", headers={"Authorization": auth_header})
+    www_auth = response.headers["WWW-Authenticate"]
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.json() == {"detail": "Not authenticated"}
 
 

--- a/tests/test_tutorial/test_security/test_tutorial006.py
+++ b/tests/test_tutorial/test_security/test_tutorial006.py
@@ -34,7 +34,6 @@ def test_security_http_basic_no_credentials(client: TestClient):
     assert 'realm="' in www_auth.lower()
 
 
-
 def test_security_http_basic_invalid_credentials(client: TestClient):
     response = client.get(
         "/users/me", headers={"Authorization": "Basic notabase64token"}

--- a/tests/test_tutorial/test_security/test_tutorial007.py
+++ b/tests/test_tutorial/test_security/test_tutorial007.py
@@ -25,17 +25,21 @@ def test_security_http_basic(client: TestClient):
 
 def test_security_http_basic_no_credentials(client: TestClient):
     response = client.get("/users/me")
+    www_auth = response.headers["WWW-Authenticate"]
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.json() == {"detail": "Not authenticated"}
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
 
 
 def test_security_http_basic_invalid_credentials(client: TestClient):
     response = client.get(
         "/users/me", headers={"Authorization": "Basic notabase64token"}
     )
+    www_auth = response.headers["WWW-Authenticate"]
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
     assert response.json() == {"detail": "Not authenticated"}
 
 
@@ -43,23 +47,29 @@ def test_security_http_basic_non_basic_credentials(client: TestClient):
     payload = b64encode(b"johnsecret").decode("ascii")
     auth_header = f"Basic {payload}"
     response = client.get("/users/me", headers={"Authorization": auth_header})
+    www_auth = response.headers["WWW-Authenticate"]
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.status_code == 401, response.text
-    assert response.headers["WWW-Authenticate"] == "Basic"
     assert response.json() == {"detail": "Not authenticated"}
 
 
 def test_security_http_basic_invalid_username(client: TestClient):
     response = client.get("/users/me", auth=("alice", "swordfish"))
+    www_auth = response.headers["WWW-Authenticate"]
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Incorrect username or password"}
-    assert response.headers["WWW-Authenticate"] == "Basic"
 
 
 def test_security_http_basic_invalid_password(client: TestClient):
     response = client.get("/users/me", auth=("stanleyjobson", "wrongpassword"))
+    www_auth = response.headers["WWW-Authenticate"]
+    assert www_auth.lower().startswith("basic")
+    assert 'realm="' in www_auth.lower()
     assert response.status_code == 401, response.text
     assert response.json() == {"detail": "Incorrect username or password"}
-    assert response.headers["WWW-Authenticate"] == "Basic"
 
 
 def test_openapi_schema(client: TestClient):


### PR DESCRIPTION
Fixes fastapi/fastapi#13471

FastAPI previously returned `WWW-Authenticate: Basic` when HTTPBasic was used
without an explicit realm. Some clients expect a realm per RFC 7617 and may
fail without it.

This change ensures HTTPBasic always includes a realm (defaulting to "FastAPI")
and adds a regression test. Existing tests were updated accordingly.

Tests:
python -m pytest -q tests/test_security_http_basic_default_realm.py tests/test_security_http_basic_realm.py tests/test_security_http_basic_optional.py
