### PR TITLE
Add example for API Key header configuration

### DIFF
--- a/docs/api_key_header_example.md
+++ b/docs/api_key_header_example.md
@@ -1,0 +1,14 @@
+from fastapi import FastAPI, Header, HTTPException, Depends
+
+app = FastAPI()
+
+API_KEY = "mysecretapikey"
+
+def get_api_key(x_api_key: str = Header(...)):
+    if x_api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid API Key")
+    return x_api_key
+
+@app.get("/secure-data")
+def read_secure_data(api_key: str = Depends(get_api_key)):
+    return {"message": "This is secure data"}


### PR DESCRIPTION
Title:
Add example for API Key header configuration

Description:
This PR adds a simple example showing how to configure and verify an API Key using FastAPI.

Demonstrates using Header and Depends to secure an endpoint with a custom API key.

Returns 401 Unauthorized if the API key is invalid.

Includes a sample /secure-data endpoint to test the functionality.

This addition is meant to help users understand how to implement basic API key authentication in their FastAPI projects.