### PR TITLE
🔨 Fix retry logic for server check in `scripts/playwright`

### DIFF
--- a/scripts/playwright/sql_databases/image02.py
+++ b/scripts/playwright/sql_databases/image02.py
@@ -25,12 +25,16 @@ process = subprocess.Popen(
     ["fastapi", "run", "docs_src/sql_databases/tutorial002.py"],
 )
 try:
-    for _ in range(3):
+    for _ in range(10):
         try:
-            response = httpx.get("http://localhost:8000/docs")
+            response = httpx.get("http://localhost:8000/docs", timeout=1)
+            if response.status_code == 200:
+                break
         except httpx.ConnectError:
             time.sleep(1)
-            break
+    else:
+        raise RuntimeError("Server did not start in time")
+            
     with sync_playwright() as playwright:
         run(playwright)
 finally:

--- a/scripts/playwright/sql_databases/image02.py
+++ b/scripts/playwright/sql_databases/image02.py
@@ -34,7 +34,7 @@ try:
             time.sleep(1)
     else:
         raise RuntimeError("Server did not start in time")
-            
+
     with sync_playwright() as playwright:
         run(playwright)
 finally:


### PR DESCRIPTION
Problems:
break inside except stops the loop immediately after the first failure → retries are useless.
No check for response.status_code.

solution I propose:
Increased the retry attempts for server connection and added a timeout to the HTTP request.
Improved the HTTP Request Loop Logic:
