### PR TITLE
Fix HTTP Basic realm handling (RFC 7617)

### DIFF
--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -152,14 +152,7 @@ class HTTPBasic(HTTPBase):
                 """
             ),
         ] = None,
-        realm: Annotated[
-            Optional[str],
-            Doc(
-                """
-                HTTP Basic authentication realm.
-                """
-            ),
-        ] = None,
+        realm: Annotated[str, Doc("HTTP Basic authentication realm.")] = "fastapi",
         description: Annotated[
             Optional[str],
             Doc(
@@ -197,9 +190,7 @@ class HTTPBasic(HTTPBase):
         self.auto_error = auto_error
 
     def make_authenticate_headers(self) -> dict[str, str]:
-        if self.realm:
-            return {"WWW-Authenticate": f'Basic realm="{self.realm}"'}
-        return {"WWW-Authenticate": "Basic"}
+        return {"WWW-Authenticate": f'Basic realm="{self.realm}"'}
 
     async def __call__(  # type: ignore
         self, request: Request

--- a/tests/test_security_http_base.py
+++ b/tests/test_security_http_base.py
@@ -1,7 +1,7 @@
-from fastapi import FastAPI, Security, Depends
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import HTTPBasic
 from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBase
 from fastapi.testclient import TestClient
-from fastapi.security import HTTPBasic
 
 app = FastAPI()
 
@@ -55,6 +55,7 @@ def test_openapi_schema():
         },
     }
 
+
 def test_http_basic_includes_realm():
     app = FastAPI()
     security = HTTPBasic(realm="MyRealm")
@@ -68,4 +69,3 @@ def test_http_basic_includes_realm():
 
     assert response.status_code == 401
     assert response.headers["WWW-Authenticate"] == 'Basic realm="MyRealm"'
-    


### PR DESCRIPTION
Per RFC 7617, the realm parameter is required for HTTP Basic authentication.
This PR makes realm mandatory and ensures the WWW-Authenticate header
always includes it.

Fixes #13471
