### PR TITLE
Docs/add dutch translations

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -319,6 +319,8 @@ extra:
     name: es - español
   - link: /ko/
     name: ko - 한국어
+  - link: /nl/
+    name: nl - Nederlands
   - link: /pt/
     name: pt - português
   - link: /ru/

--- a/docs/nl/docs/_llm-test.md
+++ b/docs/nl/docs/_llm-test.md
@@ -1,0 +1,503 @@
+# LLM Testbestand { #llm-test-file }
+
+Dit document test of de <abbr title="Large Language Model - Groot taalmodel">LLM</abbr>, die de documentatie vertaalt, de `general_prompt` in `scripts/translate.py` en de taalspecifieke prompt in `docs/{language code}/llm-prompt.md` begrijpt. De taalspecifieke prompt wordt toegevoegd aan het einde van `general_prompt`.
+
+De tests die hier worden toegevoegd zullen worden gezien door alle mensen die taalspecifieke prompts ontwerpen.
+
+Gebruik het als volgt:
+
+* Heb een taalspecifieke prompt - `docs/{language code}/llm-prompt.md`.
+* Maak een nieuwe vertaling van dit document naar je doeltaal (zie bijvoorbeeld het `translate-page` commando van `translate.py`). Dit zal de vertaling aanmaken in `docs/{language code}/docs/_llm-test.md`.
+* Controleer of de dingen goed zijn in de vertaling.
+* Indien nodig, verbeter je taalspecifieke prompt, de algemene prompt, of het Engelse document.
+* Corrigeer vervolgens handmatig de resterende problemen in de vertaling zodat het een goede vertaling is.
+* Vertaal opnieuw, met de goede vertaling op zijn plaats. Het ideale resultaat zou zijn dat de LLM geen wijzigingen meer aanbrengt in de vertaling. Dat betekent dat de algemene prompt en je taalspecifieke prompt zo goed zijn als ze kunnen zijn (Soms zal het enkele schijnbaar willekeurige wijzigingen maken; de reden is dat <a href="https://doublespeak.chat/#/handbook#deterministic-output" class="external-link" target="_blank">LLM's geen deterministische algoritmes zijn</a>).
+
+De tests:
+
+## Code snippets { #code-snippets }
+
+//// tab | Test
+
+Dit is een code snippet: `foo`. En dit is een ander code snippet: `bar`. En nog een: `baz quux`.
+
+////
+
+//// tab | Info
+
+De inhoud van code snippets moet onveranderd worden gelaten.
+
+Zie de sectie `### Content of code snippets` in de algemene prompt in `scripts/translate.py`.
+
+////
+
+## Aanhalingstekens { #quotes }
+
+//// tab | Test
+
+Gisteren schreef mijn vriend: "Als je 'incorrectly' correct schrijft, heb je het incorrect geschreven". Waarop ik antwoordde: "Correct, maar 'incorrectly' is incorrect, niet '"incorrectly"'".
+
+/// note | Opmerking
+
+De LLM zal dit waarschijnlijk verkeerd vertalen. Wat interessant is, is of het de gecorrigeerde vertaling behoudt bij het opnieuw vertalen.
+
+///
+
+////
+
+//// tab | Info
+
+De persoon die de prompt ontwerpt kan kiezen of hij neutrale aanhalingstekens wil omzetten naar typografische aanhalingstekens. Het is ook prima om ze te laten zoals ze zijn.
+
+Zie bijvoorbeeld de sectie `### Quotes` in `docs/de/llm-prompt.md`.
+
+////
+
+## Aanhalingstekens in code snippets { #quotes-in-code-snippets }
+
+//// tab | Test
+
+`pip install "foo[bar]"`
+
+Voorbeelden van string literals in code snippets: `"this"`, `'that'`.
+
+Een moeilijk voorbeeld van string literals in code snippets: `f"I like {'oranges' if orange else "apples"}"`
+
+Hardcore: `Yesterday, my friend wrote: "If you spell incorrectly correctly, you have spelled it incorrectly". To which I answered: "Correct, but 'incorrectly' is incorrectly not '"incorrectly"'"`
+
+////
+
+//// tab | Info
+
+... Echter, aanhalingstekens binnen code snippets moeten onveranderd blijven.
+
+////
+
+## Codeblokken { #code-blocks }
+
+//// tab | Test
+
+Een voorbeeld van Bash code...
+
+```bash
+# Print een groet naar het universum
+echo "Hello universe"
+```
+
+...en een voorbeeld van console code...
+
+```console
+$ <font color="#4E9A06">fastapi</font> run <u style="text-decoration-style:solid">main.py</u>
+<span style="background-color:#009485"><font color="#D3D7CF"> FastAPI </font></span>  Starting server
+        Searching for package file structure
+```
+
+...en nog een voorbeeld van console code...
+
+```console
+// Maak een "Code" directory
+$ mkdir code
+// Ga naar die directory
+$ cd code
+```
+
+...en een voorbeeld van Python code...
+
+```Python
+wont_work()  # Dit gaat niet werken 😱
+works(foo="bar")  # Dit werkt 🎉
+```
+
+...en dat is alles.
+
+////
+
+//// tab | Info
+
+De code in codeblokken mag niet worden gewijzigd, met uitzondering van commentaar.
+
+Zie de sectie `### Content of code blocks` in de algemene prompt in `scripts/translate.py`.
+
+////
+
+## Tabs en gekleurde vakken { #tabs-and-colored-boxes }
+
+//// tab | Test
+
+/// info | Informatie
+Wat tekst
+///
+
+/// note | Opmerking
+Wat tekst
+///
+
+/// note | Technische details
+Wat tekst
+///
+
+/// check | Controleer
+Wat tekst
+///
+
+/// tip | Tip
+Wat tekst
+///
+
+/// warning | Waarschuwing
+Wat tekst
+///
+
+/// danger | Gevaar
+Wat tekst
+///
+
+////
+
+//// tab | Info
+
+Tabs en `Info`/`Note`/`Warning`/etc. blokken moeten de vertaling van hun titel toegevoegd krijgen na een verticale streep (`|`).
+
+Zie de secties `### Special blocks` en `### Tab blocks` in de algemene prompt in `scripts/translate.py`.
+
+////
+
+## Web en interne links { #web-and-internal-links }
+
+//// tab | Test
+
+De linktekst moet worden vertaald, het linkadres moet onveranderd blijven:
+
+* [Link naar de kop hierboven](#code-snippets)
+* [Interne link](index.md#installation){.internal-link target=_blank}
+* <a href="https://sqlmodel.tiangolo.com/" class="external-link" target="_blank">Externe link</a>
+* <a href="https://fastapi.tiangolo.com/css/styles.css" class="external-link" target="_blank">Link naar een stylesheet</a>
+* <a href="https://fastapi.tiangolo.com/js/logic.js" class="external-link" target="_blank">Link naar een script</a>
+* <a href="https://fastapi.tiangolo.com/img/foo.jpg" class="external-link" target="_blank">Link naar een afbeelding</a>
+
+De linktekst moet worden vertaald, het linkadres moet naar de vertaling wijzen:
+
+* <a href="https://fastapi.tiangolo.com/nl/" class="external-link" target="_blank">Link naar FastAPI</a>
+
+////
+
+//// tab | Info
+
+Links moeten worden vertaald, maar hun adres moet onveranderd blijven. Een uitzondering zijn absolute links naar FastAPI documentatiepagina's. In dat geval moeten ze linken naar de vertaling.
+
+Zie de sectie `### Links` in de algemene prompt in `scripts/translate.py`.
+
+////
+
+## HTML "abbr" elementen { #html-abbr-elements }
+
+//// tab | Test
+
+Hier zijn enkele dingen verpakt in HTML "abbr" elementen (sommige zijn verzonnen):
+
+### De abbr geeft een volledige frase { #the-abbr-gives-a-full-phrase }
+
+* <abbr title="Getting Things Done - Dingen voor elkaar krijgen">GTD</abbr>
+* <abbr title="less than - kleiner dan"><code>lt</code></abbr>
+* <abbr title="XML Web Token - XML web token">XWT</abbr>
+* <abbr title="Parallel Server Gateway Interface - Parallelle server gateway interface">PSGI</abbr>
+
+### De abbr geeft een uitleg { #the-abbr-gives-an-explanation }
+
+* <abbr title="Een groep machines geconfigureerd om verbonden te zijn en op een of andere manier samen te werken.">cluster</abbr>
+* <abbr title="Een machine learning methode die gebruik maakt van kunstmatige neurale netwerken met talrijke verborgen lagen tussen de invoer- en uitvoerlagen, en zo een complexe interne structuur ontwikkelt">Deep Learning</abbr>
+
+### De abbr geeft een volledige frase en een uitleg { #the-abbr-gives-a-full-phrase-and-an-explanation }
+
+* <abbr title="Mozilla Developer Network - Mozilla Ontwikkelaar Netwerk: documentatie voor ontwikkelaars, geschreven door de mensen van Firefox">MDN</abbr>
+* <abbr title="Input/Output - Invoer/Uitvoer: lezen of schrijven naar schijf, netwerkcommunicatie.">I/O</abbr>.
+
+////
+
+//// tab | Info
+
+De "title" attributen van "abbr" elementen worden vertaald volgens specifieke instructies.
+
+Vertalingen kunnen hun eigen "abbr" elementen toevoegen die de LLM niet moet verwijderen. Bijv. om Engelse woorden uit te leggen.
+
+Zie de sectie `### HTML abbr elements` in de algemene prompt in `scripts/translate.py`.
+
+////
+
+## Koppen { #headings }
+
+//// tab | Test
+
+### Ontwikkel een webapp - een tutorial { #develop-a-webapp-a-tutorial }
+
+Hallo.
+
+### Type hints en -annotaties { #type-hints-and-annotations }
+
+Hallo weer.
+
+### Superclasses en subclasses { #super-and-subclasses }
+
+Hallo weer.
+
+////
+
+//// tab | Info
+
+De enige strikte regel voor koppen is dat de LLM het hash-gedeelte binnen accolades onveranderd laat, wat ervoor zorgt dat links niet breken.
+
+Zie de sectie `### Headings` in de algemene prompt in `scripts/translate.py`.
+
+Voor taalspecifieke instructies, zie bijv. de sectie `### Headings` in `docs/de/llm-prompt.md`.
+
+////
+
+## Termen gebruikt in de documentatie { #terms-used-in-the-docs }
+
+//// tab | Test
+
+* jij
+* jouw
+
+* bijv.
+* enz.
+
+* `foo` als een `int`
+* `bar` als een `str`
+* `baz` als een `list`
+
+* de Tutorial - Gebruikershandleiding
+* de Geavanceerde Gebruikershandleiding
+* de SQLModel documentatie
+* de API documentatie
+* de automatische documentatie
+
+* Data Science
+* Deep Learning
+* Machine Learning
+* Dependency Injection
+* HTTP Basic authenticatie
+* HTTP Digest
+* ISO formaat
+* de JSON Schema standaard
+* het JSON Schema
+* de schema definitie
+* Password Flow
+* Mobiel
+
+* verouderd
+* ontworpen
+* ongeldig
+* on the fly
+* standaard
+* standaard waarde
+* hoofdlettergevoelig
+* niet hoofdlettergevoelig
+
+* de applicatie serveren
+* de pagina serveren
+
+* de app
+* de applicatie
+
+* de request
+* de response
+* de error response
+
+* de path operation
+* de path operation decorator
+* de path operation functie
+
+* de body
+* de request body
+* de response body
+* de JSON body
+* de form body
+* de file body
+* het functie body
+
+* de parameter
+* de body parameter
+* de path parameter
+* de query parameter
+* de cookie parameter
+* de header parameter
+* de form parameter
+* de functie parameter
+
+* de event
+* de startup event
+* de server startup
+* de shutdown event
+* de lifespan event
+
+* de handler
+* de event handler
+* de exception handler
+* handelen
+
+* het model
+* het Pydantic model
+* het data model
+* het database model
+* het form model
+* het model object
+
+* de class
+* de base class
+* de parent class
+* de subclass
+* de child class
+* de sibling class
+* de class method
+
+* de header
+* de headers
+* de authorization header
+* de `Authorization` header
+* de forwarded header
+
+* het dependency injection systeem
+* de dependency
+* de dependable
+* de dependent
+
+* I/O gebonden
+* CPU gebonden
+* concurrency
+* parallelisme
+* multiprocessing
+
+* de env var
+* de environment variable
+* de `PATH`
+* de `PATH` variable
+
+* de authenticatie
+* de authenticatie provider
+* de autorisatie
+* het autorisatie formulier
+* de autorisatie provider
+* de gebruiker authenticeert
+* het systeem authenticeert de gebruiker
+
+* de CLI
+* de command-line interface
+
+* de server
+* de client
+
+* de cloud provider
+* de cloud service
+
+* de ontwikkeling
+* de ontwikkelfases
+
+* de dict
+* het dictionary
+* de enumeratie
+* de enum
+* het enum member
+
+* de encoder
+* de decoder
+* encoderen
+* decoderen
+
+* de exception
+* gooien
+
+* de expressie
+* het statement
+
+* de frontend
+* de backend
+
+* de GitHub discussie
+* de GitHub issue
+
+* de performance
+* de performance optimalisatie
+
+* het return type
+* de return waarde
+
+* de beveiliging
+* het beveiligingsschema
+
+* de taak
+* de achtergrondtaak
+* de taak functie
+
+* de template
+* de template engine
+
+* de type annotatie
+* de type annotaties
+
+* de server worker
+* de Uvicorn worker
+* de Gunicorn Worker
+* het worker process
+* de worker class
+* de workload
+
+* de deployment
+* deployen
+
+* de SDK
+* de software development kit
+
+* de `APIRouter`
+* de `requirements.txt`
+* de Bearer Token
+* de breaking change
+* de bug
+* de button
+* de callable
+* de code
+* de commit
+* de context manager
+* de coroutine
+* de database sessie
+* de disk
+* het domein
+* de engine
+* de nepX
+* de HTTP GET methode
+* het item
+* het package
+* de lifespan
+* de lock
+* de middleware
+* de mobiele app
+* de module
+* de mount
+* het netwerk
+* de origin
+* de override
+* de payload
+* de processor
+* de property
+* de proxy
+* de pull request
+* de query
+* de RAM
+* de remote machine
+* de status code
+* de string
+* de tag
+* het web framework
+* de wildcard
+* retourneren
+* valideren
+
+////
+
+//// tab | Info
+
+Dit is een niet-complete en niet-normatieve lijst van (meestal) technische termen die in de documentatie voorkomen. Het kan de persoon die de prompt ontwerpt helpen om te identificeren voor welke termen de LLM een handje nodig heeft. Bijvoorbeeld wanneer het steeds een goede vertaling blijft terugdraaien naar een suboptimale vertaling. Of wanneer het problemen heeft met het vervoegen/verbuigen van een term in jouw taal.
+
+Zie bijv. de sectie `### List of English terms and their preferred German translations` in `docs/de/llm-prompt.md`.
+
+////

--- a/docs/nl/docs/index.md
+++ b/docs/nl/docs/index.md
@@ -5,7 +5,7 @@
 </style>
 
 <p align="center">
-  <a href="https://fastapi.tiangolo.com"><img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" alt="FastAPI"></a>
+  <a href="https://fastapi.tiangolo.com/nl"><img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" alt="FastAPI"></a>
 </p>
 <p align="center">
     <em>Het FastAPI-framework, hoge prestaties, makkelijk te leren, snel te coderen, klaar voor productie</em>
@@ -27,7 +27,7 @@
 
 ---
 
-**Documentatie**: <a href="https://fastapi.tiangolo.com" target="_blank">https://fastapi.tiangolo.com</a>
+**Documentatie**: <a href="https://fastapi.tiangolo.com/nl" target="_blank">https://fastapi.tiangolo.com</a>
 
 **Broncode**: <a href="https://github.com/fastapi/fastapi" target="_blank">https://github.com/fastapi/fastapi</a>
 
@@ -69,7 +69,7 @@ De belangrijkste kenmerken zijn:
 
 <!-- /sponsors -->
 
-<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" class="external-link" target="_blank">Andere sponsors</a>
+<a href="https://fastapi.tiangolo.com/nl/fastapi-people/#sponsors" class="external-link" target="_blank">Andere sponsors</a>
 
 ## Meningen { #opinions }
 
@@ -140,7 +140,7 @@ FastAPI staat op de schouders van reuzen:
 
 ## Installatie { #installation }
 
-Maak en activeer een <a href="https://fastapi.tiangolo.com/virtual-environments/" class="external-link" target="_blank">virtuele omgeving</a> en installeer vervolgens FastAPI:
+Maak en activeer een <a href="https://fastapi.tiangolo.com/nl/virtual-environments/" class="external-link" target="_blank">virtuele omgeving</a> en installeer vervolgens FastAPI:
 
 <div class="termy">
 
@@ -203,7 +203,7 @@ async def read_item(item_id: int, q: Union[str, None] = None):
 
 **Opmerking**:
 
-Als je het niet weet, bekijk de _"Haast?"_ sectie over <a href="https://fastapi.tiangolo.com/async/#in-a-hurry" target="_blank">`async` en `await` in de docs</a>.
+Als je het niet weet, bekijk de _"Haast?"_ sectie over <a href="https://fastapi.tiangolo.com/nl/async/#in-a-hurry" target="_blank">`async` en `await` in de docs</a>.
 
 </details>
 
@@ -245,7 +245,7 @@ Het commando `fastapi dev` leest je `main.py` bestand, detecteert de **FastAPI**
 
 Standaard zal `fastapi dev` starten met auto-reload ingeschakeld voor lokale ontwikkeling.
 
-Je kunt er meer over lezen in de <a href="https://fastapi.tiangolo.com/fastapi-cli/" target="_blank">FastAPI CLI docs</a>.
+Je kunt er meer over lezen in de <a href="https://fastapi.tiangolo.com/nl/fastapi-cli/" target="_blank">FastAPI CLI docs</a>.
 
 </details>
 
@@ -439,7 +439,7 @@ Probeer de regel te veranderen met:
 
 ![editor support](https://fastapi.tiangolo.com/img/vscode-completion.png)
 
-Voor een completer voorbeeld inclusief meer functies, zie de <a href="https://fastapi.tiangolo.com/tutorial/">Tutorial - User Guide</a>.
+Voor een completer voorbeeld inclusief meer functies, zie de <a href="https://fastapi.tiangolo.com/nl/tutorial/">Tutorial - User Guide</a>.
 
 **Spoiler alert**: de tutorial - user guide bevat:
 
@@ -512,7 +512,7 @@ Volg de gidsen van je cloudprovider om FastAPI-apps met hen te deployen. 🤓
 
 Onafhankelijke TechEmpower benchmarks tonen **FastAPI**-applicaties draaiend onder Uvicorn als <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" class="external-link" target="_blank">een van de snelste Python-frameworks beschikbaar</a>, alleen onder Starlette en Uvicorn zelf (intern gebruikt door FastAPI). (*)
 
-Voor meer informatie hierover, zie de sectie <a href="https://fastapi.tiangolo.com/benchmarks/" class="internal-link" target="_blank">Benchmarks</a>.
+Voor meer informatie hierover, zie de sectie <a href="https://fastapi.tiangolo.com/nl/benchmarks/" class="internal-link" target="_blank">Benchmarks</a>.
 
 ## Afhankelijkheden { #dependencies }
 

--- a/docs/nl/docs/index.md
+++ b/docs/nl/docs/index.md
@@ -8,7 +8,7 @@
   <a href="https://fastapi.tiangolo.com"><img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" alt="FastAPI"></a>
 </p>
 <p align="center">
-    <em>FastAPI framework, hoge prestaties, makkelijk te leren, snel te coderen, klaar voor productie</em>
+    <em>Het FastAPI-framework, hoge prestaties, makkelijk te leren, snel te coderen, klaar voor productie</em>
 </p>
 <p align="center">
 <a href="https://github.com/fastapi/fastapi/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster" target="_blank">
@@ -37,13 +37,13 @@ FastAPI is een modern, snel (high-performance) webframework voor het bouwen van 
 
 De belangrijkste kenmerken zijn:
 
-* **Snel**: Zeer hoge prestaties, vergelijkbaar met **NodeJS** en **Go** (dankzij Starlette en Pydantic). [Een van de snelste Python frameworks beschikbaar](#performance).
-* **Snel te coderen**: Verhoog de snelheid om functies te ontwikkelen met ongeveer 200% tot 300%. *
-* **Minder bugs**: Verminder ongeveer 40% van de door mensen (ontwikkelaars) veroorzaakte fouten. *
-* **Intuïtief**: Geweldige editor-ondersteuning. <abbr title="ook bekend als auto-complete, autocompletion, IntelliSense">Completion</abbr> overal. Minder tijd debuggen.
+* **Snel**: Zeer hoge prestaties, vergelijkbaar met **NodeJS** en **Go** (dankzij Starlette en Pydantic). [Een van de snelste Python-frameworks beschikbaar](#performance).
+* **Snel te coderen**: Verhoogt de ontwikkelsnelheid met ongeveer 200% tot 300%. *
+* **Minder bugs**: Vermindert ongeveer 40% van de door mensen (ontwikkelaars) veroorzaakte fouten. *
+* **Intuïtief**: Geweldige editorondersteuning. <abbr title="ook bekend als auto-complete, autocompletion, IntelliSense">Completion</abbr> overal. Minder tijd kwijt aan debuggen.
 * **Gemakkelijk**: Ontworpen om gemakkelijk te gebruiken en te leren. Minder tijd documentatie lezen.
-* **Kort**: Minimaliseer code duplicatie. Meerdere functies per parameter declaratie. Minder bugs.
-* **Robuust**: Krijg productie-klare code. Met automatische interactieve documentatie.
+* **Kort**: Minimaliseer codeduplicatie. Meerdere functies per parameter declaratie. Minder bugs.
+* **Robuust**: Krijg productieklare code. Met automatische interactieve documentatie.
 * **Gebaseerd op standaarden**: Gebaseerd op (en volledig compatibel met) de open standaarden voor API's: <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> (voorheen bekend als Swagger) en <a href="https://json-schema.org/" class="external-link" target="_blank">JSON Schema</a>.
 
 <small>* schatting gebaseerd op tests uitgevoerd door een intern ontwikkelteam, die productie applicaties bouwden.</small>
@@ -73,7 +73,7 @@ De belangrijkste kenmerken zijn:
 
 ## Meningen { #opinions }
 
-"_[...] Ik gebruik **FastAPI** tegenwoordig enorm veel. [...] Ik ben eigenlijk van plan om het te gebruiken voor alle **ML services van mijn team bij Microsoft**. Sommige daarvan worden geïntegreerd in het core **Windows** product en sommige **Office** producten._"
+"_[...] Ik gebruik **FastAPI** tegenwoordig enorm veel. [...] Ik ben eigenlijk van plan om het te gebruiken voor alle **ML-services van mijn team bij Microsoft**. Sommige daarvan worden geïntegreerd in het core **Windows-product** en sommige **Office-producten**._"
 
 <div style="text-align: right; margin-right: 10%;">Kabir Khan - <strong>Microsoft</strong> <a href="https://github.com/fastapi/fastapi/pull/26" target="_blank"><small>(ref)</small></a></div>
 
@@ -85,7 +85,7 @@ De belangrijkste kenmerken zijn:
 
 ---
 
-"_**Netflix** is verheugd om de open-source release aan te kondigen van ons **crisis management** orkestratie framework: **Dispatch**! [gebouwd met **FastAPI**]_"
+"_**Netflix** is verheugd om de open-sourcerelease aan te kondigen van ons **crisismanagement**-orkestratie framework: **Dispatch**! [gebouwd met **FastAPI**]_"
 
 <div style="text-align: right; margin-right: 10%;">Kevin Glisson, Marc Vilanova, Forest Monsen - <strong>Netflix</strong> <a href="https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072" target="_blank"><small>(ref)</small></a></div>
 
@@ -111,7 +111,7 @@ De belangrijkste kenmerken zijn:
 
 ---
 
-"_Als iemand op zoek is om een productie Python API te bouwen, zou ik **FastAPI** sterk aanbevelen. Het is **prachtig ontworpen**, **eenvoudig te gebruiken** en **zeer schaalbaar**, het is een **sleutelcomponent** geworden in onze API-first ontwikkelingsstrategie en drijft veel automatiseringen en services aan zoals onze Virtual TAC Engineer._"
+"_Als iemand een productie Python API wil bouwen, zou ik **FastAPI** sterk aanbevelen. Het is **prachtig ontworpen**, **eenvoudig te gebruiken** en **zeer schaalbaar**, het is een **sleutelcomponent** geworden in onze API-first ontwikkelingsstrategie en drijft veel automatiseringen en services aan zoals onze Virtual TAC Engineer._"
 
 <div style="text-align: right; margin-right: 10%;">Deon Pillsbury - <strong>Cisco</strong> <a href="https://www.linkedin.com/posts/deonpillsbury_cisco-cx-python-activity-6963242628536487936-trAp/" target="_blank"><small>(ref)</small></a></div>
 
@@ -119,7 +119,7 @@ De belangrijkste kenmerken zijn:
 
 ## FastAPI mini documentaire { #fastapi-mini-documentary }
 
-Er is een <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" class="external-link" target="_blank">FastAPI mini documentaire</a> uitgebracht eind 2025, je kunt hem online bekijken:
+Er is een <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" class="external-link" target="_blank">FastAPI mini documentaire</a> uitgebracht eind 2025; je kunt hem online bekijken:
 
 <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
 
@@ -135,8 +135,8 @@ Als je een <abbr title="Command Line Interface">CLI</abbr> app bouwt voor gebrui
 
 FastAPI staat op de schouders van reuzen:
 
-* <a href="https://www.starlette.dev/" class="external-link" target="_blank">Starlette</a> voor de web onderdelen.
-* <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> voor de data onderdelen.
+* <a href="https://www.starlette.dev/" class="external-link" target="_blank">Starlette</a> voor de webonderdelen.
+* <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> voor de data-onderdelen.
 
 ## Installatie { #installation }
 
@@ -261,22 +261,22 @@ Je zult de JSON response zien als:
 
 Je hebt al een API gemaakt die:
 
-* HTTP verzoeken ontvangt in de _paths_ `/` en `/items/{item_id}`.
-* Beide _paths_ nemen `GET` <em>operations</em> (ook bekend als HTTP _methods_).
-* De _path_ `/items/{item_id}` heeft een _path parameter_ `item_id` die een `int` moet zijn.
-* De _path_ `/items/{item_id}` heeft een optionele `str` _query parameter_ `q`.
+* HTTP-verzoeken ontvangt in de _paths_ `/` en `/items/{item_id}`.
+* Beide _paths_ hebben `GET`-<em>operaties</em> (ook bekend als HTTP-_methods_).
+* De _path_ `/items/{item_id}` heeft een _path-parameter_ `item_id` die een `int` moet zijn.
+* De _path_ `/items/{item_id}` heeft een optionele `str` _query-parameter_ `q`.
 
-### Interactieve API docs { #interactive-api-docs }
+### Interactieve API-docs { #interactive-api-docs }
 
 Ga nu naar <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
 
-Je zult de automatische interactieve API documentatie zien (geleverd door <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+Je zult de automatische interactieve API-documentatie zien (geleverd door <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
-### Alternatieve API docs { #alternative-api-docs }
+### Alternatieve API-docs { #alternative-api-docs }
 
-En nu, ga naar <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+Ga nu naar <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
 
 Je zult de alternatieve automatische documentatie zien (geleverd door <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
 
@@ -320,11 +320,11 @@ def update_item(item_id: int, item: Item):
 
 De `fastapi dev` server zou automatisch moeten herladen.
 
-### Interactieve API docs upgrade { #interactive-api-docs-upgrade }
+### Interactieve API-docs upgrade { #interactive-api-docs-upgrade }
 
 Ga nu naar <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
 
-* De interactieve API documentatie zal automatisch worden bijgewerkt, inclusief de nieuwe body:
+* De interactieve API-documentatie zal automatisch worden bijgewerkt, inclusief de nieuwe body:
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-03-swagger-02.png)
 
@@ -336,11 +336,11 @@ Ga nu naar <a href="http://127.0.0.1:8000/docs" class="external-link" target="_b
 
 ![Swagger UI interaction](https://fastapi.tiangolo.com/img/index/index-05-swagger-04.png)
 
-### Alternatieve API docs upgrade { #alternative-api-docs-upgrade }
+### Alternatieve API-docs upgrade { #alternative-api-docs-upgrade }
 
-En nu, ga naar <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+Ga nu naar <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
 
-* De alternatieve documentatie zal ook de nieuwe query parameter en body weerspiegelen:
+* De alternatieve documentatie zal ook de nieuwe query-parameter en body weerspiegelen:
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-06-redoc-02.png)
 
@@ -368,16 +368,16 @@ item: Item
 
 ...en met die enkele declaratie krijg je:
 
-* Editor ondersteuning, inclusief:
+* Editorondersteuning, inclusief:
     * Completion.
     * Type checks.
 * Validatie van data:
     * Automatische en duidelijke fouten wanneer de data ongeldig is.
-    * Validatie zelfs voor diep geneste JSON objecten.
+    * Validatie zelfs voor diep geneste JSON-objecten.
 * <abbr title="ook bekend als: serialization, parsing, marshalling">Conversie</abbr> van input data: afkomstig van het netwerk naar Python data en types. Lezen van:
     * JSON.
-    * Path parameters.
-    * Query parameters.
+    * Path-parameters.
+    * Query-parameters.
     * Cookies.
     * Headers.
     * Forms.
@@ -388,25 +388,25 @@ item: Item
     * `UUID` objecten.
     * Database modellen.
     * ...en nog veel meer.
-* Automatische interactieve API documentatie, inclusief 2 alternatieve gebruikersinterfaces:
+* Automatische interactieve API-documentatie, inclusief 2 alternatieve gebruikersinterfaces:
     * Swagger UI.
     * ReDoc.
 
 ---
 
-Terug komend op het vorige code voorbeeld, **FastAPI** zal:
+Terugkomend naar het vorige codevoorbeeld, **FastAPI** zal:
 
-* Valideren dat er een `item_id` in het path is voor `GET` en `PUT` verzoeken.
-* Valideren dat de `item_id` van het type `int` is voor `GET` en `PUT` verzoeken.
+* Valideren dat er een `item_id` in het path is voor `GET`- en `PUT`-verzoeken.
+* Valideren dat de `item_id` van het type `int` is voor `GET`- en `PUT`-verzoeken.
     * Als dat niet zo is, zal de client een nuttige, duidelijke fout zien.
-* Controleren of er een optionele query parameter genaamd `q` is (zoals in `http://127.0.0.1:8000/items/foo?q=somequery`) voor `GET` verzoeken.
+* Controleren of er een optionele query-parameter genaamd `q` is (zoals in `http://127.0.0.1:8000/items/foo?q=somequery`) voor `GET`-verzoeken.
     * Omdat de `q` parameter is gedeclareerd met `= None`, is het optioneel.
     * Zonder de `None` zou het verplicht zijn (zoals de body in het geval met `PUT`).
-* Voor `PUT` verzoeken naar `/items/{item_id}`, lees de body als JSON:
+* Voor `PUT`-verzoeken naar `/items/{item_id}`, lees de body als JSON:
     * Controleer dat het een verplicht attribuut `name` heeft dat een `str` moet zijn.
     * Controleer dat het een verplicht attribuut `price` heeft dat een `float` moet zijn.
     * Controleer dat het een optioneel attribuut `is_offer` heeft, dat een `bool` moet zijn, indien aanwezig.
-    * Dit zou ook werken voor diep geneste JSON objecten.
+    * Dit zou ook werken voor diep geneste JSON-objecten.
 * Automatisch converteren van en naar JSON.
 * Documenteer alles met OpenAPI, dat kan worden gebruikt door:
     * Interactieve documentatie systemen.
@@ -443,11 +443,11 @@ Voor een completer voorbeeld inclusief meer functies, zie de <a href="https://fa
 
 **Spoiler alert**: de tutorial - user guide bevat:
 
-* Declaratie van **parameters** van andere verschillende plaatsen als: **headers**, **cookies**, **form fields** en **files**.
+* Declaratie van **parameters** van verschillende andere plaatsen zoals: **headers**, **cookies**, **form fields** en **files**.
 * Hoe **validatie beperkingen** in te stellen als `maximum_length` of `regex`.
 * Een zeer krachtig en gemakkelijk te gebruiken **<abbr title="ook bekend als components, resources, providers, services, injectables">Dependency Injection</abbr>** systeem.
 * Beveiliging en authenticatie, inclusief ondersteuning voor **OAuth2** met **JWT tokens** en **HTTP Basic** auth.
-* Meer geavanceerde (maar even gemakkelijke) technieken voor het declareren van **diep geneste JSON modellen** (dankzij Pydantic).
+* Meer geavanceerde (maar even gemakkelijke) technieken voor het declareren van **diep geneste JSON-modellen** (dankzij Pydantic).
 * **GraphQL** integratie met <a href="https://strawberry.rocks" class="external-link" target="_blank">Strawberry</a> en andere bibliotheken.
 * Veel extra functies (dankzij Starlette) zoals:
     * **WebSockets**
@@ -456,13 +456,13 @@ Voor een completer voorbeeld inclusief meer functies, zie de <a href="https://fa
     * **Cookie Sessions**
     * ...en meer.
 
-### Implementeer je app (optioneel) { #deploy-your-app-optional }
+### Deploy je app (optioneel) { #deploy-your-app-optional }
 
-Je kunt optioneel je FastAPI app implementeren naar <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>, ga en meld je aan voor de wachtlijst als je dat nog niet hebt gedaan. 🚀
+Je kunt optioneel je FastAPI-app deployen naar <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>, meld je aan voor de wachtlijst als je dat nog niet hebt gedaan. 🚀
 
-Als je al een **FastAPI Cloud** account hebt (we hebben je uitgenodigd vanaf de wachtlijst 😉), kun je je applicatie implementeren met één commando.
+Als je al een **FastAPI Cloud**-account hebt (we hebben je uitgenodigd vanaf de wachtlijst 😉), kun je je applicatie deployen met één commando.
 
-Voordat je implementeert, zorg ervoor dat je bent ingelogd:
+Voordat je deployed, zorg ervoor dat je bent ingelogd:
 
 <div class="termy">
 
@@ -474,7 +474,7 @@ You are logged in to FastAPI Cloud 🚀
 
 </div>
 
-Implementeer vervolgens je app:
+Deploy vervolgens je app:
 
 <div class="termy">
 
@@ -496,23 +496,23 @@ Dat is het! Nu kun je je app op die URL bereiken. ✨
 
 **<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** is gebouwd door dezelfde auteur en team achter **FastAPI**.
 
-Het stroomlijnt het proces van het **bouwen**, **implementeren** en **toegang krijgen tot** een API met minimale inspanning.
+Het stroomlijnt het proces van het **bouwen**, **deployen** en **toegang krijgen tot** een API met minimale inspanning.
 
-Het brengt dezelfde **ontwikkelaarservaring** van het bouwen van apps met FastAPI naar het **implementeren** ervan naar de cloud. 🎉
+Het brengt dezelfde **ontwikkelaarservaring** van het bouwen van apps met FastAPI naar het **deployen** ervan naar de cloud. 🎉
 
 FastAPI Cloud is de primaire sponsor en financieringsverstrekker voor de *FastAPI en friends* open source projecten. ✨
 
-#### Implementeer naar andere cloud providers { #deploy-to-other-cloud-providers }
+#### Deployen naar andere cloudproviders { #deploy-to-other-cloud-providers }
 
-FastAPI is open source en gebaseerd op standaarden. Je kunt FastAPI apps implementeren naar elke cloud provider die je kiest.
+FastAPI is open source en gebaseerd op standaarden. Je kunt FastAPI-apps deployen naar elke cloudprovider die je kiest.
 
-Volg de gidsen van je cloud provider om FastAPI apps met hen te implementeren. 🤓
+Volg de gidsen van je cloudprovider om FastAPI-apps met hen te deployen. 🤓
 
 ## Prestaties { #performance }
 
-Onafhankelijke TechEmpower benchmarks tonen **FastAPI** applicaties draaiend onder Uvicorn als <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" class="external-link" target="_blank">een van de snelste Python frameworks beschikbaar</a>, alleen onder Starlette en Uvicorn zelf (intern gebruikt door FastAPI). (*)
+Onafhankelijke TechEmpower benchmarks tonen **FastAPI**-applicaties draaiend onder Uvicorn als <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" class="external-link" target="_blank">een van de snelste Python-frameworks beschikbaar</a>, alleen onder Starlette en Uvicorn zelf (intern gebruikt door FastAPI). (*)
 
-Om meer te begrijpen hierover, zie de sectie <a href="https://fastapi.tiangolo.com/benchmarks/" class="internal-link" target="_blank">Benchmarks</a>.
+Voor meer informatie hierover, zie de sectie <a href="https://fastapi.tiangolo.com/benchmarks/" class="internal-link" target="_blank">Benchmarks</a>.
 
 ## Afhankelijkheden { #dependencies }
 
@@ -536,7 +536,7 @@ Gebruikt door FastAPI:
 
 * <a href="https://www.uvicorn.dev" target="_blank"><code>uvicorn</code></a> - voor de server die je applicatie laadt en serveert. Dit bevat `uvicorn[standard]`, wat enkele afhankelijkheden bevat (bijv. `uvloop`) die nodig zijn voor high performance serving.
 * `fastapi-cli[standard]` - om het `fastapi` commando te bieden.
-    * Dit bevat `fastapi-cloud-cli`, waarmee je je FastAPI applicatie kunt implementeren naar <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>.
+    * Dit bevat `fastapi-cloud-cli`, waarmee je je FastAPI-applicatie kunt deployen naar <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>.
 
 ### Zonder `standard` Afhankelijkheden { #without-standard-dependencies }
 

--- a/docs/nl/docs/index.md
+++ b/docs/nl/docs/index.md
@@ -1,0 +1,565 @@
+# FastAPI { #fastapi }
+
+<style>
+.md-content .md-typeset h1 { display: none; }
+</style>
+
+<p align="center">
+  <a href="https://fastapi.tiangolo.com"><img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" alt="FastAPI"></a>
+</p>
+<p align="center">
+    <em>FastAPI framework, hoge prestaties, makkelijk te leren, snel te coderen, klaar voor productie</em>
+</p>
+<p align="center">
+<a href="https://github.com/fastapi/fastapi/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster" target="_blank">
+    <img src="https://github.com/fastapi/fastapi/actions/workflows/test.yml/badge.svg?event=push&branch=master" alt="Test">
+</a>
+<a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi" target="_blank">
+    <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/fastapi.svg" alt="Coverage">
+</a>
+<a href="https://pypi.org/project/fastapi" target="_blank">
+    <img src="https://img.shields.io/pypi/v/fastapi?color=%2334D058&label=pypi%20package" alt="Package version">
+</a>
+<a href="https://pypi.org/project/fastapi" target="_blank">
+    <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
+</a>
+</p>
+
+---
+
+**Documentatie**: <a href="https://fastapi.tiangolo.com" target="_blank">https://fastapi.tiangolo.com</a>
+
+**Broncode**: <a href="https://github.com/fastapi/fastapi" target="_blank">https://github.com/fastapi/fastapi</a>
+
+---
+
+FastAPI is een modern, snel (high-performance) webframework voor het bouwen van API's met Python, gebaseerd op standaard Python type hints.
+
+De belangrijkste kenmerken zijn:
+
+* **Snel**: Zeer hoge prestaties, vergelijkbaar met **NodeJS** en **Go** (dankzij Starlette en Pydantic). [Een van de snelste Python frameworks beschikbaar](#performance).
+* **Snel te coderen**: Verhoog de snelheid om functies te ontwikkelen met ongeveer 200% tot 300%. *
+* **Minder bugs**: Verminder ongeveer 40% van de door mensen (ontwikkelaars) veroorzaakte fouten. *
+* **Intuïtief**: Geweldige editor-ondersteuning. <abbr title="ook bekend als auto-complete, autocompletion, IntelliSense">Completion</abbr> overal. Minder tijd debuggen.
+* **Gemakkelijk**: Ontworpen om gemakkelijk te gebruiken en te leren. Minder tijd documentatie lezen.
+* **Kort**: Minimaliseer code duplicatie. Meerdere functies per parameter declaratie. Minder bugs.
+* **Robuust**: Krijg productie-klare code. Met automatische interactieve documentatie.
+* **Gebaseerd op standaarden**: Gebaseerd op (en volledig compatibel met) de open standaarden voor API's: <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> (voorheen bekend als Swagger) en <a href="https://json-schema.org/" class="external-link" target="_blank">JSON Schema</a>.
+
+<small>* schatting gebaseerd op tests uitgevoerd door een intern ontwikkelteam, die productie applicaties bouwden.</small>
+
+## Sponsors { #sponsors }
+
+<!-- sponsors -->
+
+### Keystone Sponsor { #keystone-sponsor }
+
+{% for sponsor in sponsors.keystone -%}
+<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+{% endfor -%}
+
+### Gouden en Zilveren Sponsors { #gold-and-silver-sponsors }
+
+{% for sponsor in sponsors.gold -%}
+<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+{% endfor -%}
+{%- for sponsor in sponsors.silver -%}
+<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+{% endfor %}
+
+<!-- /sponsors -->
+
+<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" class="external-link" target="_blank">Andere sponsors</a>
+
+## Meningen { #opinions }
+
+"_[...] Ik gebruik **FastAPI** tegenwoordig enorm veel. [...] Ik ben eigenlijk van plan om het te gebruiken voor alle **ML services van mijn team bij Microsoft**. Sommige daarvan worden geïntegreerd in het core **Windows** product en sommige **Office** producten._"
+
+<div style="text-align: right; margin-right: 10%;">Kabir Khan - <strong>Microsoft</strong> <a href="https://github.com/fastapi/fastapi/pull/26" target="_blank"><small>(ref)</small></a></div>
+
+---
+
+"_We hebben de **FastAPI** bibliotheek gebruikt om een **REST** server op te zetten die bevraagd kan worden om **voorspellingen** te verkrijgen. [voor Ludwig]_"
+
+<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, en Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/" target="_blank"><small>(ref)</small></a></div>
+
+---
+
+"_**Netflix** is verheugd om de open-source release aan te kondigen van ons **crisis management** orkestratie framework: **Dispatch**! [gebouwd met **FastAPI**]_"
+
+<div style="text-align: right; margin-right: 10%;">Kevin Glisson, Marc Vilanova, Forest Monsen - <strong>Netflix</strong> <a href="https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072" target="_blank"><small>(ref)</small></a></div>
+
+---
+
+"_Ik ben dolenthousiast over **FastAPI**. Het is zo leuk!_"
+
+<div style="text-align: right; margin-right: 10%;">Brian Okken - <strong><a href="https://pythonbytes.fm/episodes/show/123/time-to-right-the-py-wrongs?time_in_sec=855" target="_blank">Python Bytes</a> podcast host</strong> <a href="https://x.com/brianokken/status/1112220079972728832" target="_blank"><small>(ref)</small></a></div>
+
+---
+
+"_Eerlijk gezegd, wat je hebt gebouwd ziet er super solide en gepolijst uit. In veel opzichten is het wat ik wilde dat **Hug** zou zijn - het is echt inspirerend om te zien dat iemand dat bouwt._"
+
+<div style="text-align: right; margin-right: 10%;">Timothy Crosley - <strong><a href="https://github.com/hugapi/hug" target="_blank">Hug</a> creator</strong> <a href="https://news.ycombinator.com/item?id=19455465" target="_blank"><small>(ref)</small></a></div>
+
+---
+
+"_Als je op zoek bent naar één **modern framework** om REST API's te bouwen, bekijk dan **FastAPI** [...] Het is snel, makkelijk te gebruiken en makkelijk te leren [...]_"
+
+"_We zijn overgestapt naar **FastAPI** voor onze **API's** [...] Ik denk dat je het leuk zult vinden [...]_"
+
+<div style="text-align: right; margin-right: 10%;">Ines Montani - Matthew Honnibal - <strong><a href="https://explosion.ai" target="_blank">Explosion AI</a> oprichters - <a href="https://spacy.io" target="_blank">spaCy</a> creators</strong> <a href="https://x.com/_inesmontani/status/1144173225322143744" target="_blank"><small>(ref)</small></a> - <a href="https://x.com/honnibal/status/1144031421859655680" target="_blank"><small>(ref)</small></a></div>
+
+---
+
+"_Als iemand op zoek is om een productie Python API te bouwen, zou ik **FastAPI** sterk aanbevelen. Het is **prachtig ontworpen**, **eenvoudig te gebruiken** en **zeer schaalbaar**, het is een **sleutelcomponent** geworden in onze API-first ontwikkelingsstrategie en drijft veel automatiseringen en services aan zoals onze Virtual TAC Engineer._"
+
+<div style="text-align: right; margin-right: 10%;">Deon Pillsbury - <strong>Cisco</strong> <a href="https://www.linkedin.com/posts/deonpillsbury_cisco-cx-python-activity-6963242628536487936-trAp/" target="_blank"><small>(ref)</small></a></div>
+
+---
+
+## FastAPI mini documentaire { #fastapi-mini-documentary }
+
+Er is een <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" class="external-link" target="_blank">FastAPI mini documentaire</a> uitgebracht eind 2025, je kunt hem online bekijken:
+
+<a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
+
+## **Typer**, de FastAPI van CLI's { #typer-the-fastapi-of-clis }
+
+<a href="https://typer.tiangolo.com" target="_blank"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" style="width: 20%;"></a>
+
+Als je een <abbr title="Command Line Interface">CLI</abbr> app bouwt voor gebruik in de terminal in plaats van een web API, bekijk dan <a href="https://typer.tiangolo.com/" class="external-link" target="_blank">**Typer**</a>.
+
+**Typer** is FastAPI's kleine broertje. En het is bedoeld om de **FastAPI van CLI's** te zijn. ⌨️ 🚀
+
+## Vereisten { #requirements }
+
+FastAPI staat op de schouders van reuzen:
+
+* <a href="https://www.starlette.dev/" class="external-link" target="_blank">Starlette</a> voor de web onderdelen.
+* <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> voor de data onderdelen.
+
+## Installatie { #installation }
+
+Maak en activeer een <a href="https://fastapi.tiangolo.com/virtual-environments/" class="external-link" target="_blank">virtuele omgeving</a> en installeer vervolgens FastAPI:
+
+<div class="termy">
+
+```console
+$ pip install "fastapi[standard]"
+
+---> 100%
+```
+
+</div>
+
+**Opmerking**: Zorg ervoor dat je `"fastapi[standard]"` tussen aanhalingstekens zet om ervoor te zorgen dat het in alle terminals werkt.
+
+## Voorbeeld { #example }
+
+### Maak het aan { #create-it }
+
+Maak een bestand `main.py` met:
+
+```Python
+from typing import Union
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int, q: Union[str, None] = None):
+    return {"item_id": item_id, "q": q}
+```
+
+<details markdown="1">
+<summary>Of gebruik <code>async def</code>...</summary>
+
+Als je code `async` / `await` gebruikt, gebruik dan `async def`:
+
+```Python hl_lines="9  14"
+from typing import Union
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    return {"Hello": "World"}
+
+
+@app.get("/items/{item_id}")
+async def read_item(item_id: int, q: Union[str, None] = None):
+    return {"item_id": item_id, "q": q}
+```
+
+**Opmerking**:
+
+Als je het niet weet, bekijk de _"Haast?"_ sectie over <a href="https://fastapi.tiangolo.com/async/#in-a-hurry" target="_blank">`async` en `await` in de docs</a>.
+
+</details>
+
+### Voer het uit { #run-it }
+
+Start de server met:
+
+<div class="termy">
+
+```console
+$ fastapi dev main.py
+
+ ╭────────── FastAPI CLI - Development mode ───────────╮
+ │                                                     │
+ │  Serving at: http://127.0.0.1:8000                  │
+ │                                                     │
+ │  API docs: http://127.0.0.1:8000/docs               │
+ │                                                     │
+ │  Running in development mode, for production use:   │
+ │                                                     │
+ │  fastapi run                                        │
+ │                                                     │
+ ╰─────────────────────────────────────────────────────╯
+
+INFO:     Will watch for changes in these directories: ['/home/user/code/awesomeapp']
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process [2248755] using WatchFiles
+INFO:     Started server process [2248757]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+</div>
+
+<details markdown="1">
+<summary>Over het commando <code>fastapi dev main.py</code>...</summary>
+
+Het commando `fastapi dev` leest je `main.py` bestand, detecteert de **FastAPI** app erin, en start een server met <a href="https://www.uvicorn.dev" class="external-link" target="_blank">Uvicorn</a>.
+
+Standaard zal `fastapi dev` starten met auto-reload ingeschakeld voor lokale ontwikkeling.
+
+Je kunt er meer over lezen in de <a href="https://fastapi.tiangolo.com/fastapi-cli/" target="_blank">FastAPI CLI docs</a>.
+
+</details>
+
+### Controleer het { #check-it }
+
+Open je browser op <a href="http://127.0.0.1:8000/items/5?q=somequery" class="external-link" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.
+
+Je zult de JSON response zien als:
+
+```JSON
+{"item_id": 5, "q": "somequery"}
+```
+
+Je hebt al een API gemaakt die:
+
+* HTTP verzoeken ontvangt in de _paths_ `/` en `/items/{item_id}`.
+* Beide _paths_ nemen `GET` <em>operations</em> (ook bekend als HTTP _methods_).
+* De _path_ `/items/{item_id}` heeft een _path parameter_ `item_id` die een `int` moet zijn.
+* De _path_ `/items/{item_id}` heeft een optionele `str` _query parameter_ `q`.
+
+### Interactieve API docs { #interactive-api-docs }
+
+Ga nu naar <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+
+Je zult de automatische interactieve API documentatie zien (geleverd door <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+
+![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
+
+### Alternatieve API docs { #alternative-api-docs }
+
+En nu, ga naar <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+
+Je zult de alternatieve automatische documentatie zien (geleverd door <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
+
+![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
+
+## Voorbeeld upgrade { #example-upgrade }
+
+Wijzig nu het bestand `main.py` om een body te ontvangen van een `PUT` verzoek.
+
+Declareer de body met standaard Python types, dankzij Pydantic.
+
+```Python hl_lines="4  9-12  25-27"
+from typing import Union
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+    is_offer: Union[bool, None] = None
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int, q: Union[str, None] = None):
+    return {"item_id": item_id, "q": q}
+
+
+@app.put("/items/{item_id}")
+def update_item(item_id: int, item: Item):
+    return {"item_name": item.name, "item_id": item_id}
+```
+
+De `fastapi dev` server zou automatisch moeten herladen.
+
+### Interactieve API docs upgrade { #interactive-api-docs-upgrade }
+
+Ga nu naar <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+
+* De interactieve API documentatie zal automatisch worden bijgewerkt, inclusief de nieuwe body:
+
+![Swagger UI](https://fastapi.tiangolo.com/img/index/index-03-swagger-02.png)
+
+* Klik op de knop "Try it out", hiermee kun je de parameters invullen en direct interactie hebben met de API:
+
+![Swagger UI interaction](https://fastapi.tiangolo.com/img/index/index-04-swagger-03.png)
+
+* Klik vervolgens op de "Execute" knop, de gebruikersinterface zal communiceren met je API, de parameters verzenden, de resultaten krijgen en ze op het scherm tonen:
+
+![Swagger UI interaction](https://fastapi.tiangolo.com/img/index/index-05-swagger-04.png)
+
+### Alternatieve API docs upgrade { #alternative-api-docs-upgrade }
+
+En nu, ga naar <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+
+* De alternatieve documentatie zal ook de nieuwe query parameter en body weerspiegelen:
+
+![ReDoc](https://fastapi.tiangolo.com/img/index/index-06-redoc-02.png)
+
+### Samenvatting { #recap }
+
+Samenvattend, je declareert **één keer** de types van parameters, body, etc. als functie parameters.
+
+Je doet dat met standaard moderne Python types.
+
+Je hoeft geen nieuwe syntax te leren, de methoden of classes van een specifieke bibliotheek, etc.
+
+Gewoon standaard **Python**.
+
+Bijvoorbeeld, voor een `int`:
+
+```Python
+item_id: int
+```
+
+of voor een meer complex `Item` model:
+
+```Python
+item: Item
+```
+
+...en met die enkele declaratie krijg je:
+
+* Editor ondersteuning, inclusief:
+    * Completion.
+    * Type checks.
+* Validatie van data:
+    * Automatische en duidelijke fouten wanneer de data ongeldig is.
+    * Validatie zelfs voor diep geneste JSON objecten.
+* <abbr title="ook bekend als: serialization, parsing, marshalling">Conversie</abbr> van input data: afkomstig van het netwerk naar Python data en types. Lezen van:
+    * JSON.
+    * Path parameters.
+    * Query parameters.
+    * Cookies.
+    * Headers.
+    * Forms.
+    * Files.
+* <abbr title="ook bekend als: serialization, parsing, marshalling">Conversie</abbr> van output data: converteren van Python data en types naar netwerk data (als JSON):
+    * Converteer Python types (`str`, `int`, `float`, `bool`, `list`, etc).
+    * `datetime` objecten.
+    * `UUID` objecten.
+    * Database modellen.
+    * ...en nog veel meer.
+* Automatische interactieve API documentatie, inclusief 2 alternatieve gebruikersinterfaces:
+    * Swagger UI.
+    * ReDoc.
+
+---
+
+Terug komend op het vorige code voorbeeld, **FastAPI** zal:
+
+* Valideren dat er een `item_id` in het path is voor `GET` en `PUT` verzoeken.
+* Valideren dat de `item_id` van het type `int` is voor `GET` en `PUT` verzoeken.
+    * Als dat niet zo is, zal de client een nuttige, duidelijke fout zien.
+* Controleren of er een optionele query parameter genaamd `q` is (zoals in `http://127.0.0.1:8000/items/foo?q=somequery`) voor `GET` verzoeken.
+    * Omdat de `q` parameter is gedeclareerd met `= None`, is het optioneel.
+    * Zonder de `None` zou het verplicht zijn (zoals de body in het geval met `PUT`).
+* Voor `PUT` verzoeken naar `/items/{item_id}`, lees de body als JSON:
+    * Controleer dat het een verplicht attribuut `name` heeft dat een `str` moet zijn.
+    * Controleer dat het een verplicht attribuut `price` heeft dat een `float` moet zijn.
+    * Controleer dat het een optioneel attribuut `is_offer` heeft, dat een `bool` moet zijn, indien aanwezig.
+    * Dit zou ook werken voor diep geneste JSON objecten.
+* Automatisch converteren van en naar JSON.
+* Documenteer alles met OpenAPI, dat kan worden gebruikt door:
+    * Interactieve documentatie systemen.
+    * Automatische client code generatie systemen, voor veel talen.
+* Lever 2 interactieve documentatie web interfaces direct.
+
+---
+
+We hebben net aan de oppervlakte gekrabd, maar je begrijpt al het idee van hoe het allemaal werkt.
+
+Probeer de regel te veranderen met:
+
+```Python
+    return {"item_name": item.name, "item_id": item_id}
+```
+
+...van:
+
+```Python
+        ... "item_name": item.name ...
+```
+
+...naar:
+
+```Python
+        ... "item_price": item.price ...
+```
+
+...en zie hoe je editor de attributen zal auto-completen en hun types kent:
+
+![editor support](https://fastapi.tiangolo.com/img/vscode-completion.png)
+
+Voor een completer voorbeeld inclusief meer functies, zie de <a href="https://fastapi.tiangolo.com/tutorial/">Tutorial - User Guide</a>.
+
+**Spoiler alert**: de tutorial - user guide bevat:
+
+* Declaratie van **parameters** van andere verschillende plaatsen als: **headers**, **cookies**, **form fields** en **files**.
+* Hoe **validatie beperkingen** in te stellen als `maximum_length` of `regex`.
+* Een zeer krachtig en gemakkelijk te gebruiken **<abbr title="ook bekend als components, resources, providers, services, injectables">Dependency Injection</abbr>** systeem.
+* Beveiliging en authenticatie, inclusief ondersteuning voor **OAuth2** met **JWT tokens** en **HTTP Basic** auth.
+* Meer geavanceerde (maar even gemakkelijke) technieken voor het declareren van **diep geneste JSON modellen** (dankzij Pydantic).
+* **GraphQL** integratie met <a href="https://strawberry.rocks" class="external-link" target="_blank">Strawberry</a> en andere bibliotheken.
+* Veel extra functies (dankzij Starlette) zoals:
+    * **WebSockets**
+    * extreem gemakkelijke tests gebaseerd op HTTPX en `pytest`
+    * **CORS**
+    * **Cookie Sessions**
+    * ...en meer.
+
+### Implementeer je app (optioneel) { #deploy-your-app-optional }
+
+Je kunt optioneel je FastAPI app implementeren naar <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>, ga en meld je aan voor de wachtlijst als je dat nog niet hebt gedaan. 🚀
+
+Als je al een **FastAPI Cloud** account hebt (we hebben je uitgenodigd vanaf de wachtlijst 😉), kun je je applicatie implementeren met één commando.
+
+Voordat je implementeert, zorg ervoor dat je bent ingelogd:
+
+<div class="termy">
+
+```console
+$ fastapi login
+
+You are logged in to FastAPI Cloud 🚀
+```
+
+</div>
+
+Implementeer vervolgens je app:
+
+<div class="termy">
+
+```console
+$ fastapi deploy
+
+Deploying to FastAPI Cloud...
+
+✅ Deployment successful!
+
+🐔 Ready the chicken! Your app is ready at https://myapp.fastapicloud.dev
+```
+
+</div>
+
+Dat is het! Nu kun je je app op die URL bereiken. ✨
+
+#### Over FastAPI Cloud { #about-fastapi-cloud }
+
+**<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** is gebouwd door dezelfde auteur en team achter **FastAPI**.
+
+Het stroomlijnt het proces van het **bouwen**, **implementeren** en **toegang krijgen tot** een API met minimale inspanning.
+
+Het brengt dezelfde **ontwikkelaarservaring** van het bouwen van apps met FastAPI naar het **implementeren** ervan naar de cloud. 🎉
+
+FastAPI Cloud is de primaire sponsor en financieringsverstrekker voor de *FastAPI en friends* open source projecten. ✨
+
+#### Implementeer naar andere cloud providers { #deploy-to-other-cloud-providers }
+
+FastAPI is open source en gebaseerd op standaarden. Je kunt FastAPI apps implementeren naar elke cloud provider die je kiest.
+
+Volg de gidsen van je cloud provider om FastAPI apps met hen te implementeren. 🤓
+
+## Prestaties { #performance }
+
+Onafhankelijke TechEmpower benchmarks tonen **FastAPI** applicaties draaiend onder Uvicorn als <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" class="external-link" target="_blank">een van de snelste Python frameworks beschikbaar</a>, alleen onder Starlette en Uvicorn zelf (intern gebruikt door FastAPI). (*)
+
+Om meer te begrijpen hierover, zie de sectie <a href="https://fastapi.tiangolo.com/benchmarks/" class="internal-link" target="_blank">Benchmarks</a>.
+
+## Afhankelijkheden { #dependencies }
+
+FastAPI is afhankelijk van Pydantic en Starlette.
+
+### `standard` Afhankelijkheden { #standard-dependencies }
+
+Wanneer je FastAPI installeert met `pip install "fastapi[standard]"` komt het met de `standard` groep van optionele afhankelijkheden:
+
+Gebruikt door Pydantic:
+
+* <a href="https://github.com/JoshData/python-email-validator" target="_blank"><code>email-validator</code></a> - voor email validatie.
+
+Gebruikt door Starlette:
+
+* <a href="https://www.python-httpx.org" target="_blank"><code>httpx</code></a> - Vereist als je de `TestClient` wilt gebruiken.
+* <a href="https://jinja.palletsprojects.com" target="_blank"><code>jinja2</code></a> - Vereist als je de standaard template configuratie wilt gebruiken.
+* <a href="https://github.com/Kludex/python-multipart" target="_blank"><code>python-multipart</code></a> - Vereist als je form <abbr title="het converteren van de string die van een HTTP verzoek komt naar Python data">"parsing"</abbr> wilt ondersteunen, met `request.form()`.
+
+Gebruikt door FastAPI:
+
+* <a href="https://www.uvicorn.dev" target="_blank"><code>uvicorn</code></a> - voor de server die je applicatie laadt en serveert. Dit bevat `uvicorn[standard]`, wat enkele afhankelijkheden bevat (bijv. `uvloop`) die nodig zijn voor high performance serving.
+* `fastapi-cli[standard]` - om het `fastapi` commando te bieden.
+    * Dit bevat `fastapi-cloud-cli`, waarmee je je FastAPI applicatie kunt implementeren naar <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>.
+
+### Zonder `standard` Afhankelijkheden { #without-standard-dependencies }
+
+Als je de `standard` optionele afhankelijkheden niet wilt opnemen, kun je installeren met `pip install fastapi` in plaats van `pip install "fastapi[standard]"`.
+
+### Zonder `fastapi-cloud-cli` { #without-fastapi-cloud-cli }
+
+Als je FastAPI wilt installeren met de standaard afhankelijkheden maar zonder de `fastapi-cloud-cli`, kun je installeren met `pip install "fastapi[standard-no-fastapi-cloud-cli]"`.
+
+### Aanvullende Optionele Afhankelijkheden { #additional-optional-dependencies }
+
+Er zijn enkele extra afhankelijkheden die je misschien wilt installeren.
+
+Extra optionele Pydantic afhankelijkheden:
+
+* <a href="https://docs.pydantic.dev/latest/usage/pydantic_settings/" target="_blank"><code>pydantic-settings</code></a> - voor settings management.
+* <a href="https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/" target="_blank"><code>pydantic-extra-types</code></a> - voor extra types om te gebruiken met Pydantic.
+
+Extra optionele FastAPI afhankelijkheden:
+
+* <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Vereist als je `ORJSONResponse` wilt gebruiken.
+* <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Vereist als je `UJSONResponse` wilt gebruiken.
+
+## Licentie { #license }
+
+Dit project is gelicenseerd onder de voorwaarden van de MIT licentie.

--- a/docs/nl/llm-prompt.md
+++ b/docs/nl/llm-prompt.md
@@ -4,6 +4,11 @@ Gebruik de informele grammatica (gebruik "je" en "jij" in plaats van "u").
 
 Voor instructies of titels in de gebiedende wijs, houd ze in de gebiedende wijs, bijvoorbeeld "Edit it" naar "Bewerk het".
 
+## Belangrijke spelling en woordkeuze beslissingen:
+
+* Gebruik "types" (niet "typen") voor het meervoud van "type"
+* Gebruik "syntax" (niet "syntaxis")
+
 ---
 
 Voor de volgende termen, gebruik de volgende vertalingen:
@@ -105,3 +110,6 @@ Voor de volgende termen, gebruik de volgende vertalingen:
 * validation: validatie
 * decorator: decorator (niet vertalen)
 * payload: payload (niet vertalen naar "lading")
+* deploy (werkwoord): deployen (NIET vertalen naar "implementeren")
+* deployment (zelfstandig naamwoord): deployment (NIET vertalen naar "implementatie")
+* implement (als in software implementatie/put into practice): implementeren

--- a/docs/nl/llm-prompt.md
+++ b/docs/nl/llm-prompt.md
@@ -1,0 +1,107 @@
+Vertaal naar Nederlands.
+
+Gebruik de informele grammatica (gebruik "je" en "jij" in plaats van "u").
+
+Voor instructies of titels in de gebiedende wijs, houd ze in de gebiedende wijs, bijvoorbeeld "Edit it" naar "Bewerk het".
+
+---
+
+Voor de volgende termen, gebruik de volgende vertalingen:
+
+* framework: framework (niet vertalen naar "raamwerk")
+* performance: prestaties
+* program (werkwoord): programmeren
+* code (werkwoord): coderen
+* type hints: type hints (niet vertalen)
+* type annotations: type annotaties
+* autocomplete: autocompletion (niet vertalen)
+* completion (in de context van autocompletion): completion (niet vertalen)
+* feature: functie of functionaliteit
+* sponsor: sponsor
+* host (in een podcast): host
+* request (als in HTTP request): request (niet vertalen naar "verzoek")
+* response (als in HTTP response): response (niet vertalen naar "antwoord")
+* path operation function: path operation functie
+* path operation: path operation
+* path (als in URL path): path (niet vertalen naar "pad")
+* query (als in URL query): query (niet vertalen naar "zoekopdracht")
+* cookie (als in HTTP cookie): cookie
+* header (als in HTTP header): header (niet vertalen naar "kop")
+* form (als in HTML form): formulier
+* type checks: type checks
+* parse: parsen
+* parsing: parsing
+* marshall: marshall
+* library: bibliotheek
+* instance: instance (niet vertalen naar "instantie")
+* scratch the surface: aan de oppervlakte krabben
+* string: string (niet vertalen naar "tekenreeks")
+* bug: bug
+* docs: documentatie (niet vertalen naar "documenten")
+* cheat sheet: cheat sheet (niet vertalen)
+* key (als in key-value paar, dictionary key): key (niet vertalen naar "sleutel")
+* array (als in JSON array): array
+* API key: API key (niet vertalen naar "API sleutel")
+* 100% test coverage: 100% test coverage
+* back and forth: heen en weer
+* I/O (als in "input and output"): I/O (niet vertalen)
+* Machine Learning: Machine Learning (niet vertalen)
+* Deep Learning: Deep Learning (niet vertalen)
+* callback hell: callback hell (niet vertalen)
+* tip: Tip (niet vertalen)
+* check: Controleer
+* Cross-Origin Resource Sharing: Cross-Origin Resource Sharing (niet vertalen)
+* Release Notes: Release Notes (niet vertalen)
+* Semantic Versioning: Semantic Versioning (niet vertalen)
+* dependable: dependable (niet vertalen)
+* list (als in Python list): list (niet vertalen naar "lijst")
+* context manager: context manager (niet vertalen)
+* a little bit: een beetje
+* graph (data structuur, als in "dependency graph"): graph (niet vertalen naar "grafiek")
+* form data: form data (niet vertalen)
+* import (als in code import): import (niet vertalen)
+* JSON Schema: JSON Schema (niet vertalen)
+* embed: embedden (niet vertalen naar "inbedden")
+* request body: request body (niet vertalen)
+* response body: response body (niet vertalen)
+* cross domain: cross domain (niet vertalen)
+* cross origin: cross origin (niet vertalen)
+* plugin: plugin (niet vertalen naar "invoegtoepassing")
+* plug-in: plug-in (niet vertalen naar "invoegtoepassing")
+* plug-ins: plug-ins (niet vertalen naar "invoegtoepassingen")
+* full stack: full stack (niet vertalen)
+* full-stack: full-stack (niet vertalen)
+* stack: stack (niet vertalen)
+* loop (als in async loop): loop (niet vertalen naar "lus")
+* hard dependencies: harde afhankelijkheden
+* locking: locking (niet vertalen naar "vergrendeling")
+* testing (als in software testing): testen
+* code base: codebase
+* default: standaard
+* default values: standaard waarden
+* media type: media type (niet vertalen naar "mediatype")
+* instantiate: instantiëren
+* OAuth2 Scopes: OAuth2 Scopes (niet vertalen)
+* on the fly: on the fly (niet vertalen naar "ter plekke")
+* terminal: terminal
+* lifespan: lifespan (niet vertalen naar "levensduur")
+* unload: uit het geheugen verwijderen
+* mount (zelfstandig naamwoord): mount (niet vertalen)
+* mount (werkwoord): mounten
+* statement (als in code statement): statement (niet vertalen naar "verklaring")
+* worker process: worker process (niet vertalen)
+* worker processes: worker processes (niet vertalen)
+* worker: worker (niet vertalen)
+* load balancer: load balancer (niet vertalen)
+* load balance: load balance (niet vertalen)
+* self hosting: self hosting (niet vertalen)
+* timing attack: timing attack (niet vertalen)
+* endpoint: endpoint (niet vertalen naar "eindpunt")
+* routing: routing (niet vertalen naar "routering")
+* middleware: middleware (niet vertalen)
+* dependency injection: dependency injection (niet vertalen naar "afhankelijkheidsinjectie")
+* model: model
+* schema: schema
+* validation: validatie
+* decorator: decorator (niet vertalen)
+* payload: payload (niet vertalen naar "lading")

--- a/docs/nl/mkdocs.yml
+++ b/docs/nl/mkdocs.yml
@@ -1,0 +1,1 @@
+INHERIT: ../en/mkdocs.yml

--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -24,6 +24,7 @@ SUPPORTED_LANGS = {
     "de",
     "es",
     "ko",
+    "nl",
     "pt",
     "ru",
     "uk",


### PR DESCRIPTION
### Summary
  This PR adds complete Dutch (Nederlands) translation support for the FastAPI documentation.

  ### Changes Made

  #### New Files Created
  - `docs/nl/mkdocs.yml` - Configuration file for Dutch documentation
  - `docs/nl/docs/index.md` - Main documentation page translated to Dutch
  - `docs/nl/docs/_llm-test.md` - LLM translation testing file
  - `docs/nl/llm-prompt.md` - Dutch-specific translation guidelines for LLMs

  #### Modified Files
  - `docs/en/mkdocs.yml` - Added Dutch language to alternates list