### PR TITLE
📝 Fix grammar in `docs/en/docs/tutorial/first-steps.md`

### DIFF
--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -56,7 +56,6 @@ INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 
 That line shows the URL where your app is being served on your local machine.
 
-
 ### Check it { #check-it }
 
 Open your browser at <a href="http://127.0.0.1:8000" class="external-link" target="_blank">http://127.0.0.1:8000</a>.

--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -54,7 +54,8 @@ In the output, there's a line with something like:
 INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```
 
-That line shows the URL where your app is being served, in your local machine.
+That line shows the URL where your app is being served on your local machine.
+
 
 ### Check it { #check-it }
 


### PR DESCRIPTION
 Fixes a minor grammatical issue in the First Steps documentation.