### PR TITLE
docs: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       # pin to actions/checkout@v5 for compatibility with latest-changes
       # Ref: https://github.com/actions/checkout/issues/2313
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # To allow latest-changes to commit to the main branch
           token: ${{ secrets.FASTAPI_LATEST_CHANGES }}


### PR DESCRIPTION
This PR updates an outdated GitHub Action version.

- Updated `actions/checkout` from `v5` to `v6` in `tmp/pr/fastapi_fastapi/.github/workflows/latest-changes.yml`
