### PR TITLE
Replace deprecated pydantic.color with pydantic-extra-types

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -21,7 +21,7 @@ from annotated_doc import Doc
 from fastapi.exceptions import PydanticV1NotSupportedError
 from fastapi.types import IncEx
 from pydantic import BaseModel
-from pydantic.color import Color
+from pydantic_extra_types.color import Color
 from pydantic.networks import AnyUrl, NameEmail
 from pydantic.types import SecretBytes, SecretStr
 from pydantic_core import PydanticUndefinedType

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -21,10 +21,10 @@ from annotated_doc import Doc
 from fastapi.exceptions import PydanticV1NotSupportedError
 from fastapi.types import IncEx
 from pydantic import BaseModel
-from pydantic_extra_types.color import Color
 from pydantic.networks import AnyUrl, NameEmail
 from pydantic.types import SecretBytes, SecretStr
 from pydantic_core import PydanticUndefinedType
+from pydantic_extra_types.color import Color
 
 from ._compat import (
     Url,


### PR DESCRIPTION
Replaced pydantic.color to pydantic_extra_types.color since pydantic.color is deprecated.

Source: https://github.com/pydantic/pydantic/blob/main/pydantic/color.py