### PR TITLE
📝 Clarify when to use async def vs def

### DIFF
--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -351,7 +351,8 @@ async def read_burgers():
 
 **Clarification on `async def` usage**
 
-Using `async def` is beneficial only when the function performs asynchronous I/O operations, such as awaiting database calls, HTTP requests, or other non-blocking tasks. If a path operation function contains only blocking or CPU-bound code, defining it with `async def` does not provide performance benefits and may add unnecessary complexity. In those cases, using a regular `def` function is recommended.
+Using `async def` is beneficial primarily when the function performs I/O-bound work, such as awaiting network or disk operations (e.g. database calls, HTTP requests, or other non-blocking tasks). If a path operation function contains only blocking or CPU-bound code, defining it with `async def` does not provide performance benefits and may add unnecessary complexity. In such cases, using a regular `def` function is often simpler and clearer.
+
 
 ### More technical details { #more-technical-details }
 

--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -349,6 +349,10 @@ async def read_burgers():
     return burgers
 ```
 
+**Clarification on `async def` usage**
+
+Using `async def` is beneficial only when the function performs asynchronous I/O operations, such as awaiting database calls, HTTP requests, or other non-blocking tasks. If a path operation function contains only blocking or CPU-bound code, defining it with `async def` does not provide performance benefits and may add unnecessary complexity. In those cases, using a regular `def` function is recommended.
+
 ### More technical details { #more-technical-details }
 
 You might have noticed that `await` can only be used inside of functions defined with `async def`.


### PR DESCRIPTION
This PR adds a small clarification to the documentation explaining when `async def` provides benefits and when a regular `def` function is more appropriate.

No behavior changes. Documentation-only improvement intended to reduce confusion for new users.
