### PR TITLE
🐛 Fix copy button in custom.js

### DIFF
--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -81,6 +81,8 @@ function setupTermynal() {
                     }
                 }
                 saveBuffer();
+                const inputCommands = useLines.filter(line => line.type === "input").map(line => line.value).join("\n");
+                node.textContent = inputCommands;
                 const div = document.createElement("div");
                 node.style.display = "none";
                 node.after(div);

--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -82,7 +82,8 @@ function setupTermynal() {
                 }
                 saveBuffer();
                 const div = document.createElement("div");
-                node.replaceWith(div);
+                node.style.display = "none";
+                node.after(div);
                 const termynal = new Termynal(div, {
                     lineData: useLines,
                     noInit: true,

--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -81,7 +81,10 @@ function setupTermynal() {
                     }
                 }
                 saveBuffer();
-                const inputCommands = useLines.filter(line => line.type === "input").map(line => line.value).join("\n");
+                const inputCommands = useLines
+                    .filter(line => line.type === "input")
+                    .map(line => line.value)
+                    .join("\n");
                 node.textContent = inputCommands;
                 const div = document.createElement("div");
                 node.style.display = "none";


### PR DESCRIPTION
I saw this bug in this discussion: https://github.com/fastapi/fastapi/discussions/14002
And I'm happy to contribute, even if it's a very small start

**Issue**: clicking the copy button was not working (error message in console)

**Fix**: the copy button is looking for a code tag, which doesn't exist, because it's replaced by a div in custom.js. I modified custom.js to put the div after the code tag, not in place

**Testing**: Tested locally on the fastAPI docs page.
