### PR TITLE
Add tests for form data validation and optional fields

### DIFF
--- a/tests/test_forms_single_model.py
+++ b/tests/test_forms_single_model.py
@@ -139,8 +139,8 @@ def test_extra_param_list():
         "param": "123",
         "extra_params": ["456", "789"],
     }
-   
-    
+
+
     def test_list_field_single_value():
     response = client.post(
         "/form/",

--- a/tests/test_forms_single_model.py
+++ b/tests/test_forms_single_model.py
@@ -139,3 +139,40 @@ def test_extra_param_list():
         "param": "123",
         "extra_params": ["456", "789"],
     }
+   
+    
+    def test_list_field_single_value():
+    response = client.post(
+        "/form/",
+        data={
+            "username": "Rick",
+            "lastname": "Sanchez",
+            "tags": "single",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["tags"] == ["single"]
+
+
+    def test_alias_field_name_not_accepted():
+    response = client.post(
+        "/form/",
+        data={
+            "username": "Rick",
+            "lastname": "Sanchez",
+            "alias_with": "something",
+        },
+    )
+    assert response.status_code == 422
+
+  def test_optional_int_empty_string():
+    response = client.post(
+        "/form/",
+        data={
+            "username": "Rick",
+            "lastname": "Sanchez",
+            "age": "",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["age"] is None


### PR DESCRIPTION
This PR adds unit tests for form data handling in the application:

1. `test_list_field_single_value`: Ensures that a single value in a list field is correctly wrapped as a list.
2. `test_alias_field_name_not_accepted`: Ensures that fields with unrecognized aliases return a 422 validation error.
3. `test_optional_int_empty_string`: Ensures that empty strings for optional integer fields are correctly converted to None.

These tests improve coverage for form input validation and ensure consistent API behavior.