### PR TITLE
Use sorted() rather than list() for consistent operation_id naming

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -124,7 +124,7 @@ def generate_unique_id(route: "APIRoute") -> str:
     operation_id = f"{route.name}{route.path_format}"
     operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    operation_id = f"{operation_id}_{sorted(route.methods)[0].lower()}"
     return operation_id
 
 


### PR DESCRIPTION
The current code does list(methods)[0] where methods is a set and so picks one based on hash order (unreliable). The fix uses sorted(methods)[0] to consistently pick the first lexicographically.