### PR TITLE
🔨 Update translation script to retry if LLM-response doesn't pass validation with Translation Fixer tool

### DIFF
--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -136,7 +136,9 @@ def translate_page(
             )
             break  # Exit loop if no errors
         except ValueError as e:
-            print(f"Translation check failed on attempt {attempt_no}/{MAX_ATTEMPTS}: {e}")
+            print(
+                f"Translation check failed on attempt {attempt_no}/{MAX_ATTEMPTS}: {e}"
+            )
             continue  # Retry if not reached max attempts
     else:  # Max retry attempts reached
         print(f"Translation failed for {out_path} after {MAX_ATTEMPTS} attempts")

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -10,6 +10,7 @@ from typing import Annotated
 import git
 import typer
 import yaml
+from doc_parsing_utils import check_translation
 from github import Github
 from pydantic_ai import Agent
 from rich import print
@@ -119,9 +120,28 @@ def translate_page(
         ]
     )
     prompt = "\n\n".join(prompt_segments)
-    print(f"Running agent for {out_path}")
-    result = agent.run_sync(prompt)
-    out_content = f"{result.output.strip()}\n"
+
+    MAX_ATTEMPTS = 3
+    for attempt_no in range(1, MAX_ATTEMPTS + 1):
+        print(f"Running agent for {out_path} (attempt {attempt_no}/{MAX_ATTEMPTS})")
+        result = agent.run_sync(prompt)
+        out_content = f"{result.output.strip()}\n"
+        try:
+            check_translation(
+                doc_lines=out_content.splitlines(),
+                en_doc_lines=original_content.splitlines(),
+                lang_code=language,
+                auto_fix=False,
+                path=str(out_path),
+            )
+            break  # Exit loop if no errors
+        except ValueError as e:
+            print(f"Translation check failed on attempt {attempt_no}/{MAX_ATTEMPTS}: {e}")
+            continue  # Retry if not reached max attempts
+    else:  # Max retry attempts reached
+        print(f"Translation failed for {out_path} after {MAX_ATTEMPTS} attempts")
+        raise typer.Exit(code=1)
+
     print(f"Saving translation to {out_path}")
     out_path.write_text(out_content, encoding="utf-8", newline="\n")
 


### PR DESCRIPTION
Sometimes LLM fails to generate translation correctly - introduces some mistakes that can be found by translation fixer tool, but can't be automatically fixed (e.g. wrong number of code blocks or code includes).

For example, in https://github.com/fastapi/fastapi/pull/14588 LLM preserved existing mistake in `virtual-environments.md` (the language of code block was specified after whitespace) and it caused pre-commit CI to fail.
Just running translation script second time on that file resolved the problem - https://github.com/fastapi/fastapi/pull/14588/commits/4eb0b839b992e8c03dd2e9e7c2eec028b3d5d5f9

This PR updates the translation script to check LLM response with translation fixer and retry if it has non-fixable mistakes