### PR TITLE
📝 Use return type annotation instead of `response_model` when possible

### DIFF
--- a/docs/en/docs/tutorial/path-operation-configuration.md
+++ b/docs/en/docs/tutorial/path-operation-configuration.md
@@ -70,7 +70,7 @@ It will be used in the interactive docs:
 
 You can specify the response description with the parameter `response_description`:
 
-{* ../../docs_src/path_operation_configuration/tutorial005_py310.py hl[19] *}
+{* ../../docs_src/path_operation_configuration/tutorial005_py310.py hl[18] *}
 
 /// info
 

--- a/docs/en/docs/tutorial/path-operation-configuration.md
+++ b/docs/en/docs/tutorial/path-operation-configuration.md
@@ -52,7 +52,7 @@ In these cases, it could make sense to store the tags in an `Enum`.
 
 You can add a `summary` and `description`:
 
-{* ../../docs_src/path_operation_configuration/tutorial003_py310.py hl[18:19] *}
+{* ../../docs_src/path_operation_configuration/tutorial003_py310.py hl[17:18] *}
 
 ## Description from docstring { #description-from-docstring }
 

--- a/docs_src/app_testing/app_b_an_py310/main.py
+++ b/docs_src/app_testing/app_b_an_py310/main.py
@@ -28,8 +28,8 @@ async def read_main(item_id: str, x_token: Annotated[str, Header()]):
     return fake_db[item_id]
 
 
-@app.post("/items/", response_model=Item)
-async def create_item(item: Item, x_token: Annotated[str, Header()]):
+@app.post("/items/")
+async def create_item(item: Item, x_token: Annotated[str, Header()]) -> Item:
     if x_token != fake_secret_token:
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:

--- a/docs_src/app_testing/app_b_an_py39/main.py
+++ b/docs_src/app_testing/app_b_an_py39/main.py
@@ -28,8 +28,8 @@ async def read_main(item_id: str, x_token: Annotated[str, Header()]):
     return fake_db[item_id]
 
 
-@app.post("/items/", response_model=Item)
-async def create_item(item: Item, x_token: Annotated[str, Header()]):
+@app.post("/items/")
+async def create_item(item: Item, x_token: Annotated[str, Header()]) -> Item:
     if x_token != fake_secret_token:
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:

--- a/docs_src/app_testing/app_b_py310/main.py
+++ b/docs_src/app_testing/app_b_py310/main.py
@@ -26,8 +26,8 @@ async def read_main(item_id: str, x_token: str = Header()):
     return fake_db[item_id]
 
 
-@app.post("/items/", response_model=Item)
-async def create_item(item: Item, x_token: str = Header()):
+@app.post("/items/")
+async def create_item(item: Item, x_token: str = Header()) -> Item:
     if x_token != fake_secret_token:
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:

--- a/docs_src/app_testing/app_b_py39/main.py
+++ b/docs_src/app_testing/app_b_py39/main.py
@@ -28,8 +28,8 @@ async def read_main(item_id: str, x_token: str = Header()):
     return fake_db[item_id]
 
 
-@app.post("/items/", response_model=Item)
-async def create_item(item: Item, x_token: str = Header()):
+@app.post("/items/")
+async def create_item(item: Item, x_token: str = Header()) -> Item:
     if x_token != fake_secret_token:
         raise HTTPException(status_code=400, detail="Invalid X-Token header")
     if item.id in fake_db:

--- a/docs_src/body_updates/tutorial002_py310.py
+++ b/docs_src/body_updates/tutorial002_py310.py
@@ -25,8 +25,8 @@ async def read_item(item_id: str):
     return items[item_id]
 
 
-@app.patch("/items/{item_id}", response_model=Item)
-async def update_item(item_id: str, item: Item):
+@app.patch("/items/{item_id}")
+async def update_item(item_id: str, item: Item) -> Item:
     stored_item_data = items[item_id]
     stored_item_model = Item(**stored_item_data)
     update_data = item.model_dump(exclude_unset=True)

--- a/docs_src/body_updates/tutorial002_py39.py
+++ b/docs_src/body_updates/tutorial002_py39.py
@@ -27,8 +27,8 @@ async def read_item(item_id: str):
     return items[item_id]
 
 
-@app.patch("/items/{item_id}", response_model=Item)
-async def update_item(item_id: str, item: Item):
+@app.patch("/items/{item_id}")
+async def update_item(item_id: str, item: Item) -> Item:
     stored_item_data = items[item_id]
     stored_item_model = Item(**stored_item_data)
     update_data = item.model_dump(exclude_unset=True)

--- a/docs_src/path_operation_advanced_configuration/tutorial004_py310.py
+++ b/docs_src/path_operation_advanced_configuration/tutorial004_py310.py
@@ -12,8 +12,8 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, summary="Create an item")
-async def create_item(item: Item):
+@app.post("/items/", summary="Create an item")
+async def create_item(item: Item) -> Item:
     """
     Create an item with all the information:
 

--- a/docs_src/path_operation_advanced_configuration/tutorial004_py39.py
+++ b/docs_src/path_operation_advanced_configuration/tutorial004_py39.py
@@ -14,8 +14,8 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, summary="Create an item")
-async def create_item(item: Item):
+@app.post("/items/", summary="Create an item")
+async def create_item(item: Item) -> Item:
     """
     Create an item with all the information:
 

--- a/docs_src/path_operation_configuration/tutorial001_py310.py
+++ b/docs_src/path_operation_configuration/tutorial001_py310.py
@@ -12,6 +12,6 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, status_code=status.HTTP_201_CREATED)
-async def create_item(item: Item):
+@app.post("/items/", status_code=status.HTTP_201_CREATED)
+async def create_item(item: Item) -> Item:
     return item

--- a/docs_src/path_operation_configuration/tutorial001_py39.py
+++ b/docs_src/path_operation_configuration/tutorial001_py39.py
@@ -14,6 +14,6 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, status_code=status.HTTP_201_CREATED)
-async def create_item(item: Item):
+@app.post("/items/", status_code=status.HTTP_201_CREATED)
+async def create_item(item: Item) -> Item:
     return item

--- a/docs_src/path_operation_configuration/tutorial002_py310.py
+++ b/docs_src/path_operation_configuration/tutorial002_py310.py
@@ -12,8 +12,8 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, tags=["items"])
-async def create_item(item: Item):
+@app.post("/items/", tags=["items"])
+async def create_item(item: Item) -> Item:
     return item
 
 

--- a/docs_src/path_operation_configuration/tutorial002_py39.py
+++ b/docs_src/path_operation_configuration/tutorial002_py39.py
@@ -14,8 +14,8 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, tags=["items"])
-async def create_item(item: Item):
+@app.post("/items/", tags=["items"])
+async def create_item(item: Item) -> Item:
     return item
 
 

--- a/docs_src/path_operation_configuration/tutorial003_py310.py
+++ b/docs_src/path_operation_configuration/tutorial003_py310.py
@@ -14,9 +14,8 @@ class Item(BaseModel):
 
 @app.post(
     "/items/",
-    response_model=Item,
     summary="Create an item",
     description="Create an item with all the information, name, description, price, tax and a set of unique tags",
 )
-async def create_item(item: Item):
+async def create_item(item: Item) -> Item:
     return item

--- a/docs_src/path_operation_configuration/tutorial003_py39.py
+++ b/docs_src/path_operation_configuration/tutorial003_py39.py
@@ -16,9 +16,8 @@ class Item(BaseModel):
 
 @app.post(
     "/items/",
-    response_model=Item,
     summary="Create an item",
     description="Create an item with all the information, name, description, price, tax and a set of unique tags",
 )
-async def create_item(item: Item):
+async def create_item(item: Item) -> Item:
     return item

--- a/docs_src/path_operation_configuration/tutorial004_py310.py
+++ b/docs_src/path_operation_configuration/tutorial004_py310.py
@@ -12,8 +12,8 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, summary="Create an item")
-async def create_item(item: Item):
+@app.post("/items/", summary="Create an item")
+async def create_item(item: Item) -> Item:
     """
     Create an item with all the information:
 

--- a/docs_src/path_operation_configuration/tutorial004_py39.py
+++ b/docs_src/path_operation_configuration/tutorial004_py39.py
@@ -14,8 +14,8 @@ class Item(BaseModel):
     tags: set[str] = set()
 
 
-@app.post("/items/", response_model=Item, summary="Create an item")
-async def create_item(item: Item):
+@app.post("/items/", summary="Create an item")
+async def create_item(item: Item) -> Item:
     """
     Create an item with all the information:
 

--- a/docs_src/path_operation_configuration/tutorial005_py310.py
+++ b/docs_src/path_operation_configuration/tutorial005_py310.py
@@ -14,11 +14,10 @@ class Item(BaseModel):
 
 @app.post(
     "/items/",
-    response_model=Item,
     summary="Create an item",
     response_description="The created item",
 )
-async def create_item(item: Item):
+async def create_item(item: Item) -> Item:
     """
     Create an item with all the information:
 

--- a/docs_src/path_operation_configuration/tutorial005_py39.py
+++ b/docs_src/path_operation_configuration/tutorial005_py39.py
@@ -16,11 +16,10 @@ class Item(BaseModel):
 
 @app.post(
     "/items/",
-    response_model=Item,
     summary="Create an item",
     response_description="The created item",
 )
-async def create_item(item: Item):
+async def create_item(item: Item) -> Item:
     """
     Create an item with all the information:
 

--- a/docs_src/security/tutorial004_an_py310.py
+++ b/docs_src/security/tutorial004_an_py310.py
@@ -133,10 +133,10 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
+@app.get("/users/me/")
 async def read_users_me(
     current_user: Annotated[User, Depends(get_current_active_user)],
-):
+) -> User:
     return current_user
 
 

--- a/docs_src/security/tutorial004_an_py39.py
+++ b/docs_src/security/tutorial004_an_py39.py
@@ -133,10 +133,10 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
+@app.get("/users/me/")
 async def read_users_me(
     current_user: Annotated[User, Depends(get_current_active_user)],
-):
+) -> User:
     return current_user
 
 

--- a/docs_src/security/tutorial004_py310.py
+++ b/docs_src/security/tutorial004_py310.py
@@ -130,8 +130,8 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
-async def read_users_me(current_user: User = Depends(get_current_active_user)):
+@app.get("/users/me/")
+async def read_users_me(current_user: User = Depends(get_current_active_user)) -> User:
     return current_user
 
 

--- a/docs_src/security/tutorial004_py39.py
+++ b/docs_src/security/tutorial004_py39.py
@@ -131,8 +131,8 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
-async def read_users_me(current_user: User = Depends(get_current_active_user)):
+@app.get("/users/me/")
+async def read_users_me(current_user: User = Depends(get_current_active_user)) -> User:
     return current_user
 
 

--- a/docs_src/security/tutorial005_an_py310.py
+++ b/docs_src/security/tutorial005_an_py310.py
@@ -160,10 +160,10 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
+@app.get("/users/me/")
 async def read_users_me(
     current_user: Annotated[User, Depends(get_current_active_user)],
-):
+) -> User:
     return current_user
 
 

--- a/docs_src/security/tutorial005_an_py39.py
+++ b/docs_src/security/tutorial005_an_py39.py
@@ -160,10 +160,10 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
+@app.get("/users/me/")
 async def read_users_me(
     current_user: Annotated[User, Depends(get_current_active_user)],
-):
+) -> User:
     return current_user
 
 

--- a/docs_src/security/tutorial005_py310.py
+++ b/docs_src/security/tutorial005_py310.py
@@ -159,8 +159,8 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
-async def read_users_me(current_user: User = Depends(get_current_active_user)):
+@app.get("/users/me/")
+async def read_users_me(current_user: User = Depends(get_current_active_user)) -> User:
     return current_user
 
 

--- a/docs_src/security/tutorial005_py39.py
+++ b/docs_src/security/tutorial005_py39.py
@@ -160,8 +160,8 @@ async def login_for_access_token(
     return Token(access_token=access_token, token_type="bearer")
 
 
-@app.get("/users/me/", response_model=User)
-async def read_users_me(current_user: User = Depends(get_current_active_user)):
+@app.get("/users/me/")
+async def read_users_me(current_user: User = Depends(get_current_active_user)) -> User:
     return current_user
 
 


### PR DESCRIPTION
Specifying the return type annotation should be a default way to specify response model.
This PR updates code examples to specify response model as return type annotation where it's possible.

I checked that surrounding text doesn't refer to `response_model` and highlights didn't get broken