### PR TITLE
📝 Fix dependency installation command in `docs/en/docs/contributing.md`

### DIFF
--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -13,7 +13,7 @@ Create a virtual environment and install the required packages with <a href="htt
 <div class="termy">
 
 ```console
-$ uv sync
+$ uv sync --extra all
 
 ---> 100%
 ```
@@ -32,9 +32,9 @@ That way, you don't have to "install" your local version to be able to test ever
 
 /// note | Technical Details
 
-This only happens when you install using `uv sync` instead of running `pip install fastapi` directly.
+This only happens when you install using `uv sync --extra all` instead of running `pip install fastapi` directly.
 
-That is because `uv sync` will install the local version of FastAPI in "editable" mode by default.
+That is because `uv sync --extra all` will install the local version of FastAPI in "editable" mode by default.
 
 ///
 


### PR DESCRIPTION
Just `uv sync` will not install optional dependencies, but some dependencies from `all` option are required for tests:

```
E   ModuleNotFoundError: No module named 'orjson'
```

Discussed this with @DoctorJohn, this solution was actually proposed by him.

Alternatively we can duplicate required dependencies in `tests` group:

```
    "orjson >=3.2.1",
    "fastapi-cli[standard] >=0.0.8",
    "email-validator >=2.0.0",
    "ujson >=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0",
```
