### PR TITLE
🔧 Ensure that an edit to `uv.lock` gets the `internal` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,6 +31,7 @@ internal:
         - .pre-commit-config.yaml
         - pdm_build.py
         - requirements*.txt
+        - uv.lock
         - docs/en/data/sponsors.yml
         - docs/en/overrides/main.html
       - all-globs-to-all-files:


### PR DESCRIPTION
When `dependabot` pushes a sync to `uv.lock`, we want the `internal` label just like we had before when (only) `requirements*.txt` files were being edited. We need the `internal` label for the CI to pass.