### PR TITLE
✨ Allow including additional scripts to Swagger UI page and adding presets

### DIFF
--- a/docs/en/docs/how-to/configure-swagger-ui.md
+++ b/docs/en/docs/how-to/configure-swagger-ui.md
@@ -60,8 +60,7 @@ FastAPI also includes these JavaScript-only `presets` settings:
 
 ```JavaScript
 presets: [
-    SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
+    SwaggerUIBundle.presets.apis
 ]
 ```
 

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -141,7 +141,6 @@ def get_swagger_ui_html(
     html += """
     presets: [
         SwaggerUIBundle.presets.apis,
-        SwaggerUIBundle.SwaggerUIStandalonePreset
         ],
     })"""
 

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -133,7 +133,9 @@ def get_swagger_ui_html(
     js_urls = [swagger_js_url]
     if swagger_extra_js_urls:
         js_urls.extend(swagger_extra_js_urls)
-    scripts_str = "\n    ".join(f'<script src="{js_url}"></script>' for js_url in js_urls)
+    scripts_str = "\n    ".join(
+        f'<script src="{js_url}"></script>' for js_url in js_urls
+    )
 
     html = f"""
     <!DOCTYPE html>

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -54,6 +54,14 @@ def get_swagger_ui_html(
             """
         ),
     ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+    swagger_extra_js_urls: Annotated[
+        Optional[list[str]],
+        Doc(
+            """
+            The URLs of additional JavaScript files to include.
+            """
+        ),
+    ] = None,
     swagger_css_url: Annotated[
         str,
         Doc(
@@ -114,6 +122,11 @@ def get_swagger_ui_html(
     if swagger_ui_parameters:
         current_swagger_ui_parameters.update(swagger_ui_parameters)
 
+    js_urls = [swagger_js_url]
+    if swagger_extra_js_urls:
+        js_urls.extend(swagger_extra_js_urls)
+    scripts_str = "\n    ".join(f'<script src="{js_url}"></script>' for js_url in js_urls)
+
     html = f"""
     <!DOCTYPE html>
     <html>
@@ -125,7 +138,7 @@ def get_swagger_ui_html(
     <body>
     <div id="swagger-ui">
     </div>
-    <script src="{swagger_js_url}"></script>
+    {scripts_str}
     <!-- `SwaggerUIBundle` is now available on the page -->
     <script>
     const ui = SwaggerUIBundle({{

--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -106,6 +106,14 @@ def get_swagger_ui_html(
             """
         ),
     ] = None,
+    swagger_extra_presets: Annotated[
+        Optional[list[str]],
+        Doc(
+            """
+            Extra presets to add to Swagger UI.
+            """
+        ),
+    ] = None,
 ) -> HTMLResponse:
     """
     Generate and return the HTML  that loads Swagger UI for the interactive
@@ -151,11 +159,18 @@ def get_swagger_ui_html(
     if oauth2_redirect_url:
         html += f"oauth2RedirectUrl: window.location.origin + '{oauth2_redirect_url}',"
 
-    html += """
+    presets = ["SwaggerUIBundle.presets.apis"]
+    if swagger_extra_presets:
+        presets.extend(swagger_extra_presets)
+    presets_str = ",\n        ".join(presets)
+
+    html += f"""
     presets: [
-        SwaggerUIBundle.presets.apis,
+        {presets_str},
         ],
-    })"""
+    """
+
+    html += "    })"
 
     if init_oauth:
         html += f"""

--- a/tests/test_tutorial/test_configure_swagger_ui/test_tutorial001.py
+++ b/tests/test_tutorial/test_configure_swagger_ui/test_tutorial001.py
@@ -18,9 +18,6 @@ def test_swagger_ui():
     assert "SwaggerUIBundle.presets.apis," in response.text, (
         "default configs should be preserved"
     )
-    assert "SwaggerUIBundle.SwaggerUIStandalonePreset" in response.text, (
-        "default configs should be preserved"
-    )
     assert '"layout": "BaseLayout",' in response.text, (
         "default configs should be preserved"
     )

--- a/tests/test_tutorial/test_configure_swagger_ui/test_tutorial002.py
+++ b/tests/test_tutorial/test_configure_swagger_ui/test_tutorial002.py
@@ -21,9 +21,6 @@ def test_swagger_ui():
     assert "SwaggerUIBundle.presets.apis," in response.text, (
         "default configs should be preserved"
     )
-    assert "SwaggerUIBundle.SwaggerUIStandalonePreset" in response.text, (
-        "default configs should be preserved"
-    )
     assert '"layout": "BaseLayout",' in response.text, (
         "default configs should be preserved"
     )

--- a/tests/test_tutorial/test_configure_swagger_ui/test_tutorial003.py
+++ b/tests/test_tutorial/test_configure_swagger_ui/test_tutorial003.py
@@ -24,9 +24,6 @@ def test_swagger_ui():
     assert "SwaggerUIBundle.presets.apis," in response.text, (
         "default configs should be preserved"
     )
-    assert "SwaggerUIBundle.SwaggerUIStandalonePreset" in response.text, (
-        "default configs should be preserved"
-    )
     assert '"layout": "BaseLayout",' in response.text, (
         "default configs should be preserved"
     )


### PR DESCRIPTION
For now there is no easy way to enable `StandaloneLayout` and dark mode that comes with it.

To do this you need to:
* include additional JS script (https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js)
* add `SwaggerUIStandalonePreset` to presets
* change the default `layout` swagger parameter to `StandaloneLayout` (this is possible now, but will give `No layout defined for "StandaloneLayout"` without first two steps)

With changes from this PR we will be able to enable `StandaloneLayout` the following way:

```diff
from fastapi import FastAPI
from fastapi.openapi.docs import (
    get_swagger_ui_html,
    get_swagger_ui_oauth2_redirect_html,
)

app = FastAPI(docs_url=None, redoc_url=None)


@app.get("/docs", include_in_schema=False)
async def custom_swagger_ui_html():
    return get_swagger_ui_html(
        openapi_url=app.openapi_url,
        title=app.title + " - Swagger UI",
        oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
+       swagger_extra_js_urls=["https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"],
+       swagger_extra_presets=["SwaggerUIStandalonePreset"],
+       swagger_ui_parameters={"layout": "StandaloneLayout"},
    )


@app.get(app.swagger_ui_oauth2_redirect_url, include_in_schema=False)
async def swagger_ui_redirect():
    return get_swagger_ui_oauth2_redirect_html()


@app.get("/users/{username}")
async def read_user(username: str):
    return {"message": f"Hello {username}"}

```

<img width="1261" height="547" alt="image" src="https://github.com/user-attachments/assets/e6a25aab-7ca9-40c7-9ca9-23d27e63dd6c" />
