### PR TITLE
🌐 Update `llm-prompt.md` for Korean language

### DIFF
--- a/docs/ko/llm-prompt.md
+++ b/docs/ko/llm-prompt.md
@@ -33,6 +33,8 @@ Use the following preferred translations when they apply in documentation prose:
 - response (HTTP): 응답
 - path operation: 경로 처리
 - path operation function: 경로 처리 함수
+- app: 애플리케이션
+- command: 명령어
 - burger: 햄버거 (NOT 버거)
 
 ### `///` admonitions

--- a/docs/ko/llm-prompt.md
+++ b/docs/ko/llm-prompt.md
@@ -33,6 +33,7 @@ Use the following preferred translations when they apply in documentation prose:
 - response (HTTP): 응답
 - path operation: 경로 처리
 - path operation function: 경로 처리 함수
+- burger: 햄버거
 
 ### `///` admonitions
 

--- a/docs/ko/llm-prompt.md
+++ b/docs/ko/llm-prompt.md
@@ -33,7 +33,7 @@ Use the following preferred translations when they apply in documentation prose:
 - response (HTTP): 응답
 - path operation: 경로 처리
 - path operation function: 경로 처리 함수
-- burger: 햄버거
+- burger: 햄버거 (NOT 버거)
 
 ### `///` admonitions
 


### PR DESCRIPTION
Hi! I've updated the Korean translation for the "Concurrency and Burgers" section.

In Korea, "햄버거" (Hamburger) is much more natural and commonly used than just "버거" (Burger). I updated the glossary in docs/ko/llm-prompt.md to ensure consistency in future automated translations.

This change will help Korean readers understand the concurrency analogy more intuitively. Thanks!