### PR TITLE
Docs: clarify handling of extra fields in request body

### DIFF
--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -57,7 +57,7 @@ For example, this model above declares a JSON "`object`" (or Python `dict`) like
 
 /// note
 
-By default, if the client sends extra fields in the request body that are not defined in the Pydantic model, they are ignored (not included in the model instance or in the response). This behavior comes from Pydantic's default `extra = "ignore"` configuration.
+By default, if the client sends extra fields in the request body that are not defined in the Pydantic model, they are ignored (not included in the model instance or in the response). This behavior comes from Pydantic's default handling of extra fields.
 
 ///
 

--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -55,6 +55,12 @@ For example, this model above declares a JSON "`object`" (or Python `dict`) like
 }
 ```
 
+/// note
+
+By default, if the client sends extra fields in the request body that are not defined in the Pydantic model, they are ignored (not included in the model instance or in the response). This behavior comes from Pydantic's default `extra = "ignore"` configuration.
+
+///
+
 ## Declare it as a parameter { #declare-it-as-a-parameter }
 
 To add it to your *path operation*, declare it the same way you declared path and query parameters:


### PR DESCRIPTION
This PR adds a short note to the Request Body tutorial clarifying that extra fields in the request body are ignored by default when using Pydantic models.

This behavior surprised me while following the tutorial, so I made it explicit to help readers understand what to expect.