### PR TITLE
✨ Add dataclasses-based route parameters

### DIFF
--- a/fastapi/datastructures.py
+++ b/fastapi/datastructures.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Mapping
 from typing import (
     Annotated,
@@ -152,6 +153,7 @@ class UploadFile(StarletteUploadFile):
         return with_info_plain_validator_function(cls._validate)
 
 
+@dataclasses.dataclass(frozen=True)
 class DefaultPlaceholder:
     """
     You shouldn't use this class directly.
@@ -160,8 +162,7 @@ class DefaultPlaceholder:
     if the overridden default value was truthy.
     """
 
-    def __init__(self, value: Any):
-        self.value = value
+    value: Any
 
     def __bool__(self) -> bool:
         return bool(self.value)


### PR DESCRIPTION
Proposal for discussion:

Adding a dataclass that represents the arguments to `api_route`
allows for custom route-building functions
without having to copy all the parameters supported in `api_route`.

For an example, see [classy_fastapi](https://gitlab.com/companionlabs-opensource/classy-fastapi/-/blob/5ae37f2395e7df5b1d3c9b570d1802f2e3fcdd1c/classy_fastapi/decorators.py#L43), or [this related code and discussion](https://stackoverflow.com/q/79873541/62821).
