### PR TITLE
✨ Add `viewport` meta tag to improve Swagger UI on mobile devices

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -118,6 +118,7 @@ def get_swagger_ui_html(
     <!DOCTYPE html>
     <html>
     <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link type="text/css" rel="stylesheet" href="{swagger_css_url}">
     <link rel="shortcut icon" href="{swagger_favicon_url}">
     <title>{title}</title>


### PR DESCRIPTION
Adds a standard `<meta name="viewport">` tag to the Swagger UI HTML.
This improves basic behavior on mobile browsers.

## Compatibility

Desktop browsers are unaffected.
Mobile browsers benefit from correct scaling behavior.