### PR TITLE
🐛 Update `ValidationError` schema to include `input` and `ctx`

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -49,6 +49,8 @@ validation_error_definition = {
         },
         "msg": {"title": "Message", "type": "string"},
         "type": {"title": "Error Type", "type": "string"},
+        "input": {"title": "Input"},
+        "ctx": {"title": "Context", "type": "object"},
     },
     "required": ["loc", "msg", "type"],
 }

--- a/tests/test_additional_properties.py
+++ b/tests/test_additional_properties.py
@@ -89,8 +89,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_additional_properties.py
+++ b/tests/test_additional_properties.py
@@ -89,6 +89,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_additional_properties_bool.py
+++ b/tests/test_additional_properties_bool.py
@@ -101,6 +101,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_additional_responses_custom_model_in_callback.py
+++ b/tests/test_additional_responses_custom_model_in_callback.py
@@ -128,6 +128,8 @@ def test_openapi_schema():
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_additional_responses_default_validationerror.py
+++ b/tests/test_additional_responses_default_validationerror.py
@@ -66,6 +66,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -284,6 +284,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -284,8 +284,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1260,8 +1260,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1260,6 +1260,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_dependency_duplicates.py
+++ b/tests/test_dependency_duplicates.py
@@ -223,8 +223,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_dependency_duplicates.py
+++ b/tests/test_dependency_duplicates.py
@@ -223,6 +223,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_enforce_once_required_parameter.py
+++ b/tests/test_enforce_once_required_parameter.py
@@ -42,6 +42,8 @@ expected_schema = {
             },
             "ValidationError": {
                 "properties": {
+                    "ctx": {"title": "Context", "type": "object"},
+                    "input": {"title": "Input"},
                     "loc": {
                         "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                         "title": "Location",

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -347,8 +347,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_extra_routes.py
+++ b/tests/test_extra_routes.py
@@ -347,6 +347,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_filter_pydantic_sub_model_pv2.py
+++ b/tests/test_filter_pydantic_sub_model_pv2.py
@@ -165,6 +165,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_forms_single_param.py
+++ b/tests/test_forms_single_param.py
@@ -81,6 +81,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_generate_unique_id_function.py
+++ b/tests/test_generate_unique_id_function.py
@@ -213,6 +213,8 @@ def test_top_level_generate_unique_id():
                     "required": ["loc", "msg", "type"],
                     "type": "object",
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "title": "Location",
                             "type": "array",
@@ -414,6 +416,8 @@ def test_router_overrides_generate_unique_id():
                     "required": ["loc", "msg", "type"],
                     "type": "object",
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "title": "Location",
                             "type": "array",
@@ -615,6 +619,8 @@ def test_router_include_overrides_generate_unique_id():
                     "required": ["loc", "msg", "type"],
                     "type": "object",
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "title": "Location",
                             "type": "array",
@@ -889,6 +895,8 @@ def test_subrouter_top_level_include_overrides_generate_unique_id():
                     "required": ["loc", "msg", "type"],
                     "type": "object",
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "title": "Location",
                             "type": "array",
@@ -1093,6 +1101,8 @@ def test_router_path_operation_overrides_generate_unique_id():
                     "required": ["loc", "msg", "type"],
                     "type": "object",
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "title": "Location",
                             "type": "array",
@@ -1301,6 +1311,8 @@ def test_app_path_operation_overrides_generate_unique_id():
                     "required": ["loc", "msg", "type"],
                     "type": "object",
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "title": "Location",
                             "type": "array",
@@ -1587,6 +1599,8 @@ def test_callback_override_generate_unique_id():
                     "required": ["loc", "msg", "type"],
                     "type": "object",
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "title": "Location",
                             "type": "array",

--- a/tests/test_get_model_definitions_formfeed_escape.py
+++ b/tests/test_get_model_definitions_formfeed_escape.py
@@ -98,6 +98,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_get_request_body.py
+++ b/tests/test_get_request_body.py
@@ -100,6 +100,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_get_request_body.py
+++ b/tests/test_get_request_body.py
@@ -100,8 +100,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_include_router_defaults_overrides.py
+++ b/tests/test_include_router_defaults_overrides.py
@@ -7290,8 +7290,8 @@ def test_openapi():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_include_router_defaults_overrides.py
+++ b/tests/test_include_router_defaults_overrides.py
@@ -7290,6 +7290,8 @@ def test_openapi():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -325,6 +325,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_infer_param_optionality.py
+++ b/tests/test_infer_param_optionality.py
@@ -325,8 +325,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_modules_same_name_body/test_main.py
+++ b/tests/test_modules_same_name_body/test_main.py
@@ -131,6 +131,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_modules_same_name_body/test_main.py
+++ b/tests/test_modules_same_name_body/test_main.py
@@ -131,8 +131,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -167,6 +167,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_multi_body_errors.py
+++ b/tests/test_multi_body_errors.py
@@ -167,8 +167,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_multi_query_errors.py
+++ b/tests/test_multi_query_errors.py
@@ -97,8 +97,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_multi_query_errors.py
+++ b/tests/test_multi_query_errors.py
@@ -97,6 +97,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_no_schema_split.py
+++ b/tests/test_no_schema_split.py
@@ -154,8 +154,8 @@ def test_openapi_schema():
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_no_schema_split.py
+++ b/tests/test_no_schema_split.py
@@ -154,6 +154,8 @@ def test_openapi_schema():
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_openapi_examples.py
+++ b/tests/test_openapi_examples.py
@@ -398,6 +398,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_openapi_query_parameter_extension.py
+++ b/tests/test_openapi_query_parameter_extension.py
@@ -119,8 +119,8 @@ def test_openapi():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_openapi_query_parameter_extension.py
+++ b/tests/test_openapi_query_parameter_extension.py
@@ -119,6 +119,8 @@ def test_openapi():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_openapi_separate_input_output_schemas.py
+++ b/tests/test_openapi_separate_input_output_schemas.py
@@ -418,6 +418,8 @@ def test_openapi_schema():
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]
@@ -649,6 +651,8 @@ def test_openapi_schema_no_separate():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_openapi_separate_input_output_schemas.py
+++ b/tests/test_openapi_separate_input_output_schemas.py
@@ -418,8 +418,8 @@ def test_openapi_schema():
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_param_in_path_and_dependency.py
+++ b/tests/test_param_in_path_and_dependency.py
@@ -86,6 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_param_in_path_and_dependency.py
+++ b/tests/test_param_in_path_and_dependency.py
@@ -86,8 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_param_include_in_schema.py
+++ b/tests/test_param_include_in_schema.py
@@ -151,6 +151,8 @@ openapi_schema = {
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
+                "input": {"title": "Input"},
+                "ctx": {"title": "Context", "type": "object"},
                 },
             },
         }

--- a/tests/test_param_include_in_schema.py
+++ b/tests/test_param_include_in_schema.py
@@ -151,8 +151,8 @@ openapi_schema = {
                     },
                     "msg": {"title": "Message", "type": "string"},
                     "type": {"title": "Error Type", "type": "string"},
-                "input": {"title": "Input"},
-                "ctx": {"title": "Context", "type": "object"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                 },
             },
         }

--- a/tests/test_put_no_body.py
+++ b/tests/test_put_no_body.py
@@ -78,8 +78,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_put_no_body.py
+++ b/tests/test_put_no_body.py
@@ -78,6 +78,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_regex_deprecated_body.py
+++ b/tests/test_regex_deprecated_body.py
@@ -132,6 +132,8 @@ def test_openapi_schema():
                     },
                     "ValidationError": {
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_regex_deprecated_params.py
+++ b/tests/test_regex_deprecated_params.py
@@ -121,6 +121,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_repeated_dependency_schema.py
+++ b/tests/test_repeated_dependency_schema.py
@@ -35,6 +35,8 @@ schema = {
             },
             "ValidationError": {
                 "properties": {
+                    "ctx": {"title": "Context", "type": "object"},
+                    "input": {"title": "Input"},
                     "loc": {
                         "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
                         "title": "Location",

--- a/tests/test_repeated_parameter_alias.py
+++ b/tests/test_repeated_parameter_alias.py
@@ -41,6 +41,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_reponse_set_reponse_code_empty.py
+++ b/tests/test_reponse_set_reponse_code_empty.py
@@ -90,6 +90,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_reponse_set_reponse_code_empty.py
+++ b/tests/test_reponse_set_reponse_code_empty.py
@@ -90,8 +90,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_request_body_parameters_media_type.py
+++ b/tests/test_request_body_parameters_media_type.py
@@ -168,8 +168,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_request_body_parameters_media_type.py
+++ b/tests/test_request_body_parameters_media_type.py
@@ -168,6 +168,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -845,6 +845,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_schema_extra_examples.py
+++ b/tests/test_schema_extra_examples.py
@@ -845,8 +845,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -237,6 +237,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -237,8 +237,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -240,6 +240,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_security_oauth2_optional.py
+++ b/tests/test_security_oauth2_optional.py
@@ -240,8 +240,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_security_oauth2_optional_description.py
+++ b/tests/test_security_oauth2_optional_description.py
@@ -241,6 +241,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_security_oauth2_optional_description.py
+++ b/tests/test_security_oauth2_optional_description.py
@@ -241,8 +241,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_starlette_exception.py
+++ b/tests/test_starlette_exception.py
@@ -184,8 +184,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_starlette_exception.py
+++ b/tests/test_starlette_exception.py
@@ -184,6 +184,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_sub_callbacks.py
+++ b/tests/test_sub_callbacks.py
@@ -277,6 +277,8 @@ def test_openapi_schema():
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tuples.py
+++ b/tests/test_tuples.py
@@ -262,8 +262,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tuples.py
+++ b/tests/test_tuples.py
@@ -262,6 +262,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_additional_responses/test_tutorial001.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial001.py
@@ -98,6 +98,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial001.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial001.py
@@ -98,8 +98,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial002.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial002.py
@@ -115,6 +115,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial002.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial002.py
@@ -115,8 +115,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial003.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial003.py
@@ -102,8 +102,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial003.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial003.py
@@ -102,6 +102,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial004.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial004.py
@@ -118,6 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_additional_responses/test_tutorial004.py
+++ b/tests/test_tutorial/test_additional_responses/test_tutorial004.py
@@ -118,8 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_bigger_applications/test_main.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main.py
@@ -593,6 +593,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_bigger_applications/test_main.py
+++ b/tests/test_tutorial/test_bigger_applications/test_main.py
@@ -593,8 +593,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -328,6 +328,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body/test_tutorial001.py
+++ b/tests/test_tutorial/test_body/test_tutorial001.py
@@ -328,8 +328,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body/test_tutorial002.py
+++ b/tests/test_tutorial/test_body/test_tutorial002.py
@@ -143,8 +143,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body/test_tutorial002.py
+++ b/tests/test_tutorial/test_body/test_tutorial002.py
@@ -143,6 +143,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body/test_tutorial003.py
+++ b/tests/test_tutorial/test_body/test_tutorial003.py
@@ -153,8 +153,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body/test_tutorial003.py
+++ b/tests/test_tutorial/test_body/test_tutorial003.py
@@ -153,6 +153,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body/test_tutorial004.py
+++ b/tests/test_tutorial/test_body/test_tutorial004.py
@@ -164,8 +164,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body/test_tutorial004.py
+++ b/tests/test_tutorial/test_body/test_tutorial004.py
@@ -164,6 +164,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_fields/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001.py
@@ -166,8 +166,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_fields/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_fields/test_tutorial001.py
@@ -166,6 +166,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
@@ -162,8 +162,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial001.py
@@ -162,6 +162,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial002.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial002.py
@@ -325,6 +325,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -202,8 +202,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial003.py
@@ -202,6 +202,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial004.py
@@ -272,6 +272,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial004.py
@@ -272,8 +272,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_multiple_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_body_multiple_params/test_tutorial005.py
@@ -236,6 +236,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial001_tutorial002_tutorial003.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial001_tutorial002_tutorial003.py
@@ -233,8 +233,8 @@ def test_openapi_schema(client: TestClient, mod_name: str):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial001_tutorial002_tutorial003.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial001_tutorial002_tutorial003.py
@@ -233,6 +233,8 @@ def test_openapi_schema(client: TestClient, mod_name: str):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial004.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial004.py
@@ -257,6 +257,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial004.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial004.py
@@ -257,8 +257,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial005.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial005.py
@@ -283,8 +283,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial005.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial005.py
@@ -283,6 +283,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial006.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial006.py
@@ -251,8 +251,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial006.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial006.py
@@ -251,6 +251,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial007.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial007.py
@@ -326,6 +326,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial007.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial007.py
@@ -326,8 +326,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial008.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial008.py
@@ -139,6 +139,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial008.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial008.py
@@ -139,8 +139,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
@@ -98,8 +98,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial009.py
@@ -98,6 +98,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_updates/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001.py
@@ -168,6 +168,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_updates/test_tutorial001.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial001.py
@@ -168,8 +168,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_updates/test_tutorial002.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial002.py
@@ -189,8 +189,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_body_updates/test_tutorial002.py
+++ b/tests/test_tutorial/test_body_updates/test_tutorial002.py
@@ -189,6 +189,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_cookie_param_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_param_models/test_tutorial001.py
@@ -151,8 +151,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_cookie_param_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_param_models/test_tutorial001.py
@@ -151,6 +151,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_cookie_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_cookie_param_models/test_tutorial002.py
@@ -161,6 +161,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_cookie_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_cookie_param_models/test_tutorial002.py
@@ -161,8 +161,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001.py
@@ -101,6 +101,8 @@ def test_openapi_schema(mod: ModuleType):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_cookie_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_cookie_params/test_tutorial001.py
@@ -101,8 +101,8 @@ def test_openapi_schema(mod: ModuleType):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dataclasses/test_tutorial001.py
+++ b/tests/test_tutorial/test_dataclasses/test_tutorial001.py
@@ -129,8 +129,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_dataclasses/test_tutorial001.py
+++ b/tests/test_tutorial/test_dataclasses/test_tutorial001.py
@@ -129,6 +129,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_dataclasses/test_tutorial003.py
+++ b/tests/test_tutorial/test_dataclasses/test_tutorial003.py
@@ -195,8 +195,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_dataclasses/test_tutorial003.py
+++ b/tests/test_tutorial/test_dataclasses/test_tutorial003.py
@@ -195,6 +195,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_dependencies/test_tutorial001_tutorial001_02.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001_tutorial001_02.py
@@ -170,8 +170,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial001_tutorial001_02.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial001_tutorial001_02.py
@@ -170,6 +170,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial002_tutorial003_tutorial004.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial002_tutorial003_tutorial004.py
@@ -161,6 +161,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial002_tutorial003_tutorial004.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial002_tutorial003_tutorial004.py
@@ -161,8 +161,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial005.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial005.py
@@ -121,8 +121,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial005.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial005.py
@@ -121,6 +121,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial006.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006.py
@@ -125,6 +125,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial006.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial006.py
@@ -125,8 +125,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial011.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial011.py
@@ -102,8 +102,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial011.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial011.py
@@ -102,6 +102,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_dependencies/test_tutorial012.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012.py
@@ -219,8 +219,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_dependencies/test_tutorial012.py
+++ b/tests/test_tutorial/test_dependencies/test_tutorial012.py
@@ -219,6 +219,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_encoder/test_tutorial001.py
+++ b/tests/test_tutorial/test_encoder/test_tutorial001.py
@@ -172,6 +172,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_events/test_tutorial001.py
+++ b/tests/test_tutorial/test_events/test_tutorial001.py
@@ -63,6 +63,8 @@ def test_openapi_schema(app: FastAPI):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_events/test_tutorial003.py
+++ b/tests/test_tutorial/test_events/test_tutorial003.py
@@ -76,6 +76,8 @@ def test_openapi_schema():
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
@@ -133,6 +133,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_extra_models/test_tutorial001_tutorial002.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial001_tutorial002.py
@@ -138,8 +138,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_extra_models/test_tutorial001_tutorial002.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial001_tutorial002.py
@@ -138,6 +138,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_extra_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_extra_models/test_tutorial003.py
@@ -127,6 +127,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_generate_clients/test_tutorial001.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial001.py
@@ -135,8 +135,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_generate_clients/test_tutorial001.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial001.py
@@ -135,6 +135,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_generate_clients/test_tutorial002.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial002.py
@@ -180,6 +180,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_generate_clients/test_tutorial002.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial002.py
@@ -180,8 +180,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_generate_clients/test_tutorial003.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial003.py
@@ -180,6 +180,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_generate_clients/test_tutorial003.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial003.py
@@ -180,8 +180,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_generate_clients/test_tutorial004.py
+++ b/tests/test_tutorial/test_generate_clients/test_tutorial004.py
@@ -82,6 +82,8 @@ def test_remove_tags(tmp_path: pathlib.Path):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_handling_errors/test_tutorial001.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial001.py
@@ -72,8 +72,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial001.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial001.py
@@ -72,6 +72,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial002.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial002.py
@@ -72,8 +72,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial002.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial002.py
@@ -72,6 +72,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial003.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial003.py
@@ -73,8 +73,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial003.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial003.py
@@ -73,6 +73,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial004.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial004.py
@@ -78,8 +78,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial004.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial004.py
@@ -78,6 +78,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial005.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial005.py
@@ -102,6 +102,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial005.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial005.py
@@ -102,8 +102,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_handling_errors/test_tutorial006.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial006.py
@@ -86,8 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_handling_errors/test_tutorial006.py
+++ b/tests/test_tutorial/test_handling_errors/test_tutorial006.py
@@ -86,6 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_header_param_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial001.py
@@ -187,6 +187,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_header_param_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial001.py
@@ -187,8 +187,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_header_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial002.py
@@ -184,8 +184,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_header_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial002.py
@@ -184,6 +184,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_header_param_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial003.py
@@ -224,8 +224,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_header_param_models/test_tutorial003.py
+++ b/tests/test_tutorial/test_header_param_models/test_tutorial003.py
@@ -224,6 +224,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_header_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001.py
@@ -93,8 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_header_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial001.py
@@ -93,6 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_header_params/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial002.py
@@ -104,8 +104,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_header_params/test_tutorial002.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial002.py
@@ -104,6 +104,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_header_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial003.py
@@ -112,6 +112,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_header_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_header_params/test_tutorial003.py
@@ -112,8 +112,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
+++ b/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
@@ -195,8 +195,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
+++ b/tests/test_tutorial/test_openapi_callbacks/test_tutorial001.py
@@ -195,6 +195,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_openapi_webhooks/test_tutorial001.py
+++ b/tests/test_tutorial/test_openapi_webhooks/test_tutorial001.py
@@ -98,6 +98,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
@@ -118,6 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_operation_advanced_configurations/test_tutorial004.py
@@ -118,8 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial001.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial001.py
@@ -150,6 +150,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial002.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial002.py
@@ -187,6 +187,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial003_tutorial004.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial003_tutorial004.py
@@ -172,6 +172,8 @@ def test_openapi_schema(client: TestClient, mod_name: str):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
@@ -117,8 +117,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial005.py
@@ -117,6 +117,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_path_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial001.py
@@ -80,6 +80,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_params/test_tutorial002.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial002.py
@@ -88,6 +88,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial003.py
@@ -97,6 +97,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial004.py
@@ -73,8 +73,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_path_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial004.py
@@ -73,6 +73,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -110,8 +110,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_path_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params/test_tutorial005.py
@@ -110,6 +110,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial001.py
+++ b/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial001.py
@@ -128,6 +128,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial002_tutorial003.py
+++ b/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial002_tutorial003.py
@@ -134,6 +134,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial004.py
+++ b/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial004.py
@@ -149,6 +149,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial005.py
+++ b/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial005.py
@@ -166,6 +166,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial006.py
+++ b/tests/test_tutorial/test_path_params_numeric_validations/test_tutorial006.py
@@ -185,6 +185,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_query_param_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_param_models/test_tutorial001.py
@@ -207,6 +207,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_query_param_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_query_param_models/test_tutorial002.py
@@ -213,6 +213,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_query_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial001.py
@@ -108,6 +108,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial001.py
@@ -108,8 +108,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial002.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial002.py
@@ -109,8 +109,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial002.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial002.py
@@ -109,6 +109,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial003.py
@@ -130,8 +130,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial003.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial003.py
@@ -130,6 +130,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial004.py
@@ -138,8 +138,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial004.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial004.py
@@ -138,6 +138,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial005.py
@@ -86,8 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial005.py
@@ -86,6 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006.py
@@ -137,6 +137,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params/test_tutorial006.py
@@ -137,8 +137,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
@@ -103,6 +103,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial001.py
@@ -103,8 +103,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial002.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial002.py
@@ -124,6 +124,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial002.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial002.py
@@ -124,8 +124,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial003.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial003.py
@@ -135,8 +135,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial003.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial003.py
@@ -135,6 +135,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial004.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial004.py
@@ -129,6 +129,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial004.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial004.py
@@ -129,8 +129,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial005.py
@@ -113,6 +113,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial005.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial005.py
@@ -113,8 +113,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial006.py
@@ -118,6 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial006.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial006.py
@@ -118,8 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
@@ -130,8 +130,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
@@ -130,6 +130,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial007.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial007.py
@@ -118,6 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial007.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial007.py
@@ -118,8 +118,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial008.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial008.py
@@ -120,6 +120,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial008.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial008.py
@@ -120,8 +120,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial009.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial009.py
@@ -105,8 +105,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial009.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial009.py
@@ -105,6 +105,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
@@ -136,8 +136,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
@@ -136,6 +136,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
@@ -98,8 +98,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial011.py
@@ -98,6 +98,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
@@ -93,8 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial012.py
@@ -93,6 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
@@ -93,8 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial013.py
@@ -93,6 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial014.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial014.py
@@ -93,6 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial014.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial014.py
@@ -93,8 +93,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial015.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial015.py
@@ -122,6 +122,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -183,8 +183,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001.py
@@ -183,6 +183,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_files/test_tutorial001_02.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_02.py
@@ -173,6 +173,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_request_files/test_tutorial001_03.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_03.py
@@ -163,8 +163,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_request_files/test_tutorial001_03.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial001_03.py
@@ -163,6 +163,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_request_files/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002.py
@@ -223,6 +223,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_files/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial002.py
@@ -223,8 +223,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_files/test_tutorial003.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial003.py
@@ -206,8 +206,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_request_files/test_tutorial003.py
+++ b/tests/test_tutorial/test_request_files/test_tutorial003.py
@@ -206,6 +206,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_request_form_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_form_models/test_tutorial001.py
@@ -159,8 +159,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_form_models/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_form_models/test_tutorial001.py
@@ -159,6 +159,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_form_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_form_models/test_tutorial002.py
@@ -177,8 +177,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_form_models/test_tutorial002.py
+++ b/tests/test_tutorial/test_request_form_models/test_tutorial002.py
@@ -177,6 +177,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -161,6 +161,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_forms/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms/test_tutorial001.py
@@ -161,8 +161,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -216,8 +216,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
+++ b/tests/test_tutorial/test_request_forms_and_files/test_tutorial001.py
@@ -216,6 +216,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_response_directly/test_tutorial001.py
+++ b/tests/test_tutorial/test_response_directly/test_tutorial001.py
@@ -130,6 +130,8 @@ def test_openapi_schema_pv2(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_tutorial/test_response_model/test_tutorial001_tutorial001_01.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial001_tutorial001_01.py
@@ -175,8 +175,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_response_model/test_tutorial001_tutorial001_01.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial001_tutorial001_01.py
@@ -175,6 +175,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_response_model/test_tutorial002.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial002.py
@@ -111,6 +111,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_response_model/test_tutorial002.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial002.py
@@ -111,8 +111,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_response_model/test_tutorial003.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003.py
@@ -126,6 +126,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_response_model/test_tutorial003_01.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_01.py
@@ -139,6 +139,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_response_model/test_tutorial003_02.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_02.py
@@ -86,6 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_02.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_02.py
@@ -86,8 +86,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_05.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_05.py
@@ -101,8 +101,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_response_model/test_tutorial003_05.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial003_05.py
@@ -101,6 +101,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_response_model/test_tutorial004.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial004.py
@@ -117,6 +117,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_response_model/test_tutorial005.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial005.py
@@ -135,6 +135,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_response_model/test_tutorial006.py
+++ b/tests/test_tutorial/test_response_model/test_tutorial006.py
@@ -135,6 +135,8 @@ def test_openapi_schema(client: TestClient):
                         "required": ["loc", "msg", "type"],
                         "type": "object",
                         "properties": {
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "title": "Location",
                                 "type": "array",

--- a/tests/test_tutorial/test_response_status_code/test_tutorial001_tutorial002.py
+++ b/tests/test_tutorial/test_response_status_code/test_tutorial001_tutorial002.py
@@ -78,8 +78,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_response_status_code/test_tutorial001_tutorial002.py
+++ b/tests/test_tutorial/test_response_status_code/test_tutorial001_tutorial002.py
@@ -78,6 +78,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial001.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial001.py
@@ -120,6 +120,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial002.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial002.py
@@ -122,6 +122,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial003.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial003.py
@@ -124,6 +124,8 @@ def test_openapi_schema(client: TestClient):
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial004.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial004.py
@@ -140,8 +140,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial004.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial004.py
@@ -140,6 +140,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial005.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial005.py
@@ -149,8 +149,8 @@ def test_openapi_schema(client: TestClient) -> None:
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_schema_extra_example/test_tutorial005.py
+++ b/tests/test_tutorial/test_schema_extra_example/test_tutorial005.py
@@ -149,6 +149,8 @@ def test_openapi_schema(client: TestClient) -> None:
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
             }

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -182,8 +182,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_security/test_tutorial003.py
+++ b/tests/test_tutorial/test_security/test_tutorial003.py
@@ -182,6 +182,8 @@ def test_openapi_schema(client: TestClient):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_security/test_tutorial004.py
+++ b/tests/test_tutorial/test_security/test_tutorial004.py
@@ -334,6 +334,8 @@ def test_openapi_schema(mod: ModuleType):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_security/test_tutorial004.py
+++ b/tests/test_tutorial/test_security/test_tutorial004.py
@@ -334,8 +334,8 @@ def test_openapi_schema(mod: ModuleType):
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -379,6 +379,8 @@ def test_openapi_schema(mod: ModuleType):
                             },
                             "msg": {"title": "Message", "type": "string"},
                             "type": {"title": "Error Type", "type": "string"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                         },
                     },
                     "HTTPValidationError": {

--- a/tests/test_tutorial/test_security/test_tutorial005.py
+++ b/tests/test_tutorial/test_security/test_tutorial005.py
@@ -379,8 +379,8 @@ def test_openapi_schema(mod: ModuleType):
                             },
                             "msg": {"title": "Message", "type": "string"},
                             "type": {"title": "Error Type", "type": "string"},
-                        "input": {"title": "Input"},
-                        "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
                         },
                     },
                     "HTTPValidationError": {

--- a/tests/test_tutorial/test_separate_openapi_schemas/test_tutorial001.py
+++ b/tests/test_tutorial/test_separate_openapi_schemas/test_tutorial001.py
@@ -121,6 +121,8 @@ def test_openapi_schema(client: TestClient) -> None:
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_separate_openapi_schemas/test_tutorial002.py
+++ b/tests/test_tutorial/test_separate_openapi_schemas/test_tutorial002.py
@@ -121,6 +121,8 @@ def test_openapi_schema(client: TestClient) -> None:
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial001.py
@@ -335,8 +335,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_sql_databases/test_tutorial001.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial001.py
@@ -335,6 +335,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_sql_databases/test_tutorial002.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial002.py
@@ -416,6 +416,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_sql_databases/test_tutorial002.py
+++ b/tests/test_tutorial/test_sql_databases/test_tutorial002.py
@@ -416,8 +416,8 @@ def test_openapi_schema(client: TestClient):
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_tutorial/test_using_request_directly/test_tutorial001.py
+++ b/tests/test_tutorial/test_using_request_directly/test_tutorial001.py
@@ -76,6 +76,8 @@ def test_openapi():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [

--- a/tests/test_union_body.py
+++ b/tests/test_union_body.py
@@ -111,6 +111,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_union_body.py
+++ b/tests/test_union_body.py
@@ -111,8 +111,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_union_body_discriminator.py
+++ b/tests/test_union_body_discriminator.py
@@ -154,6 +154,8 @@ def test_discriminator_pydantic_v2() -> None:
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_union_body_discriminator.py
+++ b/tests/test_union_body_discriminator.py
@@ -154,8 +154,8 @@ def test_discriminator_pydantic_v2() -> None:
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_union_body_discriminator_annotated.py
+++ b/tests/test_union_body_discriminator_annotated.py
@@ -181,8 +181,8 @@ def test_openapi_schema(client: TestClient) -> None:
                     },
                     "ValidationError": {
                         "properties": {
-                        "ctx": {"title": "Context", "type": "object"},
-                        "input": {"title": "Input"},
+                            "ctx": {"title": "Context", "type": "object"},
+                            "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_union_body_discriminator_annotated.py
+++ b/tests/test_union_body_discriminator_annotated.py
@@ -181,6 +181,8 @@ def test_openapi_schema(client: TestClient) -> None:
                     },
                     "ValidationError": {
                         "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                             "loc": {
                                 "items": {
                                     "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_union_forms.py
+++ b/tests/test_union_forms.py
@@ -136,6 +136,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]

--- a/tests/test_union_inherited_body.py
+++ b/tests/test_union_inherited_body.py
@@ -117,8 +117,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
-                    "input": {"title": "Input"},
-                    "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
+                        "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_union_inherited_body.py
+++ b/tests/test_union_inherited_body.py
@@ -117,6 +117,8 @@ def test_openapi_schema():
                         },
                         "msg": {"title": "Message", "type": "string"},
                         "type": {"title": "Error Type", "type": "string"},
+                    "input": {"title": "Input"},
+                    "ctx": {"title": "Context", "type": "object"},
                     },
                 },
                 "HTTPValidationError": {

--- a/tests/test_webhooks_security.py
+++ b/tests/test_webhooks_security.py
@@ -106,6 +106,8 @@ def test_openapi_schema():
                 },
                 "ValidationError": {
                     "properties": {
+                        "ctx": {"title": "Context", "type": "object"},
+                        "input": {"title": "Input"},
                         "loc": {
                             "items": {
                                 "anyOf": [{"type": "string"}, {"type": "integer"}]


### PR DESCRIPTION
## Summary

Related to #10787

The OpenAPI `ValidationError` schema was outdated and didn't reflect the actual error format returned by Pydantic V2.

## Changes
Updated `validation_error_definition` in `fastapi/openapi/utils.py` to include:
- `input`: The actual input value that caused the validation error  
- `ctx`: Optional context dictionary with additional error information

## Testing
All existing tests pass with the updated schema. The test snapshots have been updated to reflect the new schema structure.