### PR TITLE
✅ Add regression test for `ForwardRef` in annotated dependency

### DIFF
--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -8,6 +8,9 @@ from fastapi import Depends, FastAPI
 from fastapi.concurrency import iterate_in_threadpool, run_in_threadpool
 from fastapi.testclient import TestClient
 
+from typing import Annotated, ForwardRef
+
+
 if sys.version_info >= (3, 13):  # pragma: no cover
     from inspect import iscoroutinefunction
 else:  # pragma: no cover
@@ -447,3 +450,21 @@ def test_class_dependency(route):
     response = client.get(route)
     assert response.status_code == 200, response.text
     assert response.json() is True
+
+def test_annotated_forwardref_dependency():
+    app = FastAPI()
+
+    User = ForwardRef("User")
+
+    def get_user() -> "User":
+        return {"name": "amulya"}
+
+    @app.get("/")
+    def read_user(user: Annotated[User, Depends(get_user)]):
+        return user
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {"name": "amulya"}

--- a/tests/test_dependency_wrapped.py
+++ b/tests/test_dependency_wrapped.py
@@ -2,14 +2,12 @@ import inspect
 import sys
 from collections.abc import AsyncGenerator, Generator
 from functools import wraps
+from typing import Annotated, ForwardRef
 
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.concurrency import iterate_in_threadpool, run_in_threadpool
 from fastapi.testclient import TestClient
-
-from typing import Annotated, ForwardRef
-
 
 if sys.version_info >= (3, 13):  # pragma: no cover
     from inspect import iscoroutinefunction
@@ -450,6 +448,7 @@ def test_class_dependency(route):
     response = client.get(route)
     assert response.status_code == 200, response.text
     assert response.json() is True
+
 
 def test_annotated_forwardref_dependency():
     app = FastAPI()

--- a/tests/test_forwardref_in_annotation.py
+++ b/tests/test_forwardref_in_annotation.py
@@ -1,0 +1,23 @@
+from typing import Annotated, ForwardRef
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_annotated_forwardref_dependency():
+    app = FastAPI()
+
+    User = ForwardRef("User")
+
+    def get_user() -> "User":
+        return {"name": "amulya"}
+
+    @app.get("/")
+    def read_user(user: Annotated[User, Depends(get_user)]):
+        return user
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {"name": "amulya"}


### PR DESCRIPTION
### 🧪 Regression Test

This PR adds a regression test covering the use of `Annotated` parameters
with `ForwardRef` in dependency injection.

### 🔍 Context
While investigating an existing issue, I verified that this behavior
works correctly on the current default branch with Python 3.12.
This test documents the expected behavior and guards against regressions.

### 📎 Related Issue
Refs #14808

