### PR TITLE
 Fix Duplicate OperationId When Using Multiple Methods on Same Route

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -243,6 +243,10 @@ def get_openapi_operation_metadata(
     if route.description:
         operation["description"] = route.description
     operation_id = route.operation_id or route.unique_id
+    # When a route has multiple methods and uses auto-generated unique_id,
+    # append the method to make the operation_id unique for each method
+    if not route.operation_id and len(route.methods) > 1:
+        operation_id = f"{operation_id}_{method.lower()}"
     if operation_id in operation_ids:
         message = (
             f"Duplicate Operation ID {operation_id} for function "


### PR DESCRIPTION
## Description

Fixes #13175

When a route is added with multiple HTTP methods using `router.add_api_route("/path", handler, methods=["POST", "DELETE"])`, all methods were getting the same auto-generated `operationId` (based only on the first method), causing `UserWarning: Duplicate Operation ID` warnings.

## Changes

### Code Fix (`fastapi/openapi/utils.py`)

Modified `get_openapi_operation_metadata()` to append the method name to the `operationId` when:
1. No explicit `operation_id` is provided (uses auto-generated `unique_id`)
2. The route has multiple methods

```python
operation_id = route.operation_id or route.unique_id
# When a route has multiple methods and uses auto-generated unique_id,
# append the method to make the operation_id unique for each method
if not route.operation_id and len(route.methods) > 1:
    operation_id = f"{operation_id}_{method.lower()}"
```

### Test Cases (`tests/test_generate_unique_id_function.py`)

Added 4 new test cases:
- `test_multiple_methods_unique_operation_id` - Verifies POST and DELETE get unique IDs
- `test_three_methods_unique_operation_id` - Verifies 3 methods all get unique IDs
- `test_explicit_operation_id_multiple_methods` - Verifies explicit operation_id still triggers warning (expected behavior)
- `test_single_method_no_extra_suffix` - Verifies single method routes remain unchanged

## Behavior Changes

### Before (Bug)
```python
router.add_api_route("/clear", clear_endpoint, methods=["POST", "DELETE"])
```
Generated OpenAPI:
```json
{
  "/clear": {
    "post": {"operationId": "clear_endpoint_clear_post"},
    "delete": {"operationId": "clear_endpoint_clear_post"}  // ❌ Same!
  }
}
```
Warning: `UserWarning: Duplicate Operation ID clear_endpoint_clear_post`

### After (Fixed)
```python
router.add_api_route("/clear", clear_endpoint, methods=["POST", "DELETE"])
```
Generated OpenAPI:
```json
{
  "/clear": {
    "post": {"operationId": "clear_endpoint_clear_post_post"},      // ✅ Unique
    "delete": {"operationId": "clear_endpoint_clear_post_delete"}   // ✅ Unique
  }
}
```
No warnings.

## Backward Compatibility

✅ **Single method routes**: Unchanged (no extra suffix added)  
✅ **Explicit `operation_id`**: Respected as-is (user's intentional choice)  
⚠️ **Multiple methods**: Will now get unique operationIds (fixes the bug)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/fastapi/fastapi/blob/master/CONTRIBUTING.md)
- [x] The code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Related Issue

Closes #13175
