### PR TITLE
Docs: clarify SQLite threading and pagination limit in SQL tutorial

### DIFF
--- a/docs_src/sql_databases/tutorial001_an_py310.py
+++ b/docs_src/sql_databases/tutorial001_an_py310.py
@@ -14,7 +14,7 @@ class Hero(SQLModel, table=True):
 sqlite_file_name = "database.db"
 sqlite_url = f"sqlite:///{sqlite_file_name}"
 
-connect_args = {"check_same_thread": False}
+connect_args = {"check_same_thread": False} # needed for SQLite when using the session across threads
 engine = create_engine(sqlite_url, connect_args=connect_args)
 
 
@@ -49,7 +49,7 @@ def create_hero(hero: Hero, session: SessionDep) -> Hero:
 def read_heroes(
     session: SessionDep,
     offset: int = 0,
-    limit: Annotated[int, Query(le=100)] = 100,
+    limit: Annotated[int, Query(le=100)] = 100, # safety cap to avoid returning too many rows
 ) -> list[Hero]:
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes

--- a/docs_src/sql_databases/tutorial001_an_py310.py
+++ b/docs_src/sql_databases/tutorial001_an_py310.py
@@ -14,7 +14,9 @@ class Hero(SQLModel, table=True):
 sqlite_file_name = "database.db"
 sqlite_url = f"sqlite:///{sqlite_file_name}"
 
-connect_args = {"check_same_thread": False} # needed for SQLite when using the session across threads
+connect_args = {
+    "check_same_thread": False
+}  # needed for SQLite when using the session across threads
 engine = create_engine(sqlite_url, connect_args=connect_args)
 
 
@@ -49,7 +51,9 @@ def create_hero(hero: Hero, session: SessionDep) -> Hero:
 def read_heroes(
     session: SessionDep,
     offset: int = 0,
-    limit: Annotated[int, Query(le=100)] = 100, # safety cap to avoid returning too many rows
+    limit: Annotated[
+        int, Query(le=100)
+    ] = 100,  # safety cap to avoid returning too many rows
 ) -> list[Hero]:
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes

--- a/docs_src/sql_databases/tutorial001_an_py39.py
+++ b/docs_src/sql_databases/tutorial001_an_py39.py
@@ -12,9 +12,11 @@ class Hero(SQLModel, table=True):
 
 
 sqlite_file_name = "database.db"
-sqlite_url = f"sqlite:///{sqlite_file_name}" 
+sqlite_url = f"sqlite:///{sqlite_file_name}"
 
-connect_args = {"check_same_thread": False}  # needed for SQLite when using the session across threads
+connect_args = {
+    "check_same_thread": False
+}  # needed for SQLite when using the session across threads
 engine = create_engine(sqlite_url, connect_args=connect_args)
 
 
@@ -49,7 +51,9 @@ def create_hero(hero: Hero, session: SessionDep) -> Hero:
 def read_heroes(
     session: SessionDep,
     offset: int = 0,
-    limit: Annotated[int, Query(le=100)] = 100,  # safety cap to avoid returning too many rows
+    limit: Annotated[
+        int, Query(le=100)
+    ] = 100,  # safety cap to avoid returning too many rows
 ) -> list[Hero]:
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes

--- a/docs_src/sql_databases/tutorial001_an_py39.py
+++ b/docs_src/sql_databases/tutorial001_an_py39.py
@@ -12,9 +12,9 @@ class Hero(SQLModel, table=True):
 
 
 sqlite_file_name = "database.db"
-sqlite_url = f"sqlite:///{sqlite_file_name}"
+sqlite_url = f"sqlite:///{sqlite_file_name}" 
 
-connect_args = {"check_same_thread": False}
+connect_args = {"check_same_thread": False}  # needed for SQLite when using the session across threads
 engine = create_engine(sqlite_url, connect_args=connect_args)
 
 
@@ -49,7 +49,7 @@ def create_hero(hero: Hero, session: SessionDep) -> Hero:
 def read_heroes(
     session: SessionDep,
     offset: int = 0,
-    limit: Annotated[int, Query(le=100)] = 100,
+    limit: Annotated[int, Query(le=100)] = 100,  # safety cap to avoid returning too many rows
 ) -> list[Hero]:
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes


### PR DESCRIPTION
Adds small clarifying comments to the SQL databases tutorial example:

- Explain why `check_same_thread=False` is required when using SQLite
- Clarify the purpose of the pagination limit cap

No behavior changes (comments only).
