### PR TITLE
⬆️ Upgrade Starlette supported version range to `starlette>=0.40.0,<1.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.40.0,<0.51.0",
+    "starlette>=0.40.0",
     "pydantic>=2.7.0",
     "typing-extensions>=4.8.0",
     "typing-inspection>=0.4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.40.0",
+    "starlette>=0.40.0,<1.0.0",
     "pydantic>=2.7.0",
     "typing-extensions>=4.8.0",
     "typing-inspection>=0.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1198,7 +1198,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'standard'", specifier = ">=0.0.18" },
     { name = "python-multipart", marker = "extra == 'standard-no-fastapi-cloud-cli'", specifier = ">=0.0.18" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=5.3.1" },
-    { name = "starlette", specifier = ">=0.40.0,<0.51.0" },
+    { name = "starlette", specifier = ">=0.40.0" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
     { name = "typing-inspection", specifier = ">=0.4.2" },
     { name = "ujson", marker = "extra == 'all'", specifier = ">=5.8.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1198,7 +1198,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'standard'", specifier = ">=0.0.18" },
     { name = "python-multipart", marker = "extra == 'standard-no-fastapi-cloud-cli'", specifier = ">=0.0.18" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=5.3.1" },
-    { name = "starlette", specifier = ">=0.40.0" },
+    { name = "starlette", specifier = ">=0.40.0,<1.0.0" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
     { name = "typing-inspection", specifier = ">=0.4.2" },
     { name = "ujson", marker = "extra == 'all'", specifier = ">=5.8.0" },


### PR DESCRIPTION
⬆️ Upgrade Starlette supported version range to `starlette>=0.40.0,<1.0.0`

As now CI tests run also against Starlette on the main branch in git, we'll hopefully notice if there are breaking changes, so I think we can relax this pin a bit, to `<1.0.0` (any future version prior 1.0.0).

After 1.0.0 is released, we can adjust again.