### PR TITLE
⬆️  Upgrade Starlette supported version range to >=0.40.0, <0.52.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.40.0,<0.51.0",
+    "starlette>=0.40.0,<0.52.0",
     "pydantic>=2.7.0",
     "typing-extensions>=4.8.0",
     "typing-inspection>=0.4.2",


### PR DESCRIPTION
## Summary

Bump Starlette upper bound from `<0.51.0` to `<0.52.0` to allow installing Starlette 0.51.0

 ## Motivation

 We have an API deployed on an internal/private network. Browsers (Chrome 104+ and Chromium-based)
 enforce the [Private Network Access](https://wicg.github.io/private-network-access/) specification,
 which requires servers to explicitly allow cross-origin requests from public networks to private
 networks via the `Access-Control-Allow-Private-Network` header. Without this header, preflight
 requests fail and the browser blocks the actual request with a CORS error.

 Starlette 0.51.0 introduced the `allow_private_network` parameter in `CORSMiddleware`
 ([encode/starlette#3065](https://github.com/encode/starlette/pull/3065)), which automatically
 handles the `Access-Control-Request-Private-Network` / `Access-Control-Allow-Private-Network`
 header exchange during CORS preflight. This is the standard, supported way to solve this problem
 rather than implementing custom middleware or manual header injection.

 ## Impact assessment - no breaking changes

 Starlette 0.51.0 contains only two minor changes:

 1. **Added** `allow_private_network` parameter to `CORSMiddleware` - additive, defaults to `False`,
    fully backward compatible
 2. **Changed** deprecation warning stacklevel for the WSGI module - no behavioral impact

 All Starlette APIs used by FastAPI were verified to be unchanged in 0.51.0:

 | API | Status |
 |-----|--------|
 | `starlette._exception_handler.wrap_app_handling_exceptions` | Unchanged |
 | `starlette._utils.is_async_callable` | Unchanged |
 | `CORSMiddleware` | Compatible (new param is additive with default) |
 | `WSGIMiddleware`, `GZipMiddleware`, other middleware re-exports | Unchanged |
 | Public classes (Request, Response, WebSocket, routing, etc.) | Unchanged |

 **Python 3.9 compatibility**: Starlette 0.50.0+ requires Python >= 3.10, but this does not
 affect FastAPI's `requires-python = ">=3.9"` constraint. Package resolvers (pip/uv) respect
 the `requires-python` metadata and will automatically install Starlette 0.49.x on Python 3.9.

 There is no risk of degradation to existing services.

 ## Usage after this bump

 ```python
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware

 app = FastAPI()

 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
     allow_private_network=True,  # requires Starlette >= 0.51.0
 )
```


### References

 - https://wicg.github.io/private-network-access/
 - https://github.com/encode/starlette/pull/3065
 - https://github.com/encode/starlette/releases/tag/0.51.0
 - https://github.com/fastapi/fastapi/pull/14282
 - https://developer.chrome.com/blog/private-network-access-preflight