### PR TITLE
✨ Support Starlette 0.52.0+ generic `Request`

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -350,6 +350,7 @@ def get_dependant(
 def add_non_field_param_to_dependency(
     *, param_name: str, type_annotation: Any, dependant: Dependant
 ) -> bool | None:
+    type_annotation = get_origin(type_annotation) or type_annotation
     if lenient_issubclass(type_annotation, Request):
         dependant.request_param_name = param_name
         return True
@@ -474,7 +475,7 @@ def analyze_param(
     # Only apply special handling when there's no explicit Depends - if there's a Depends,
     # the dependency will be called and its return value used instead of the special injection
     if depends is None and lenient_issubclass(
-        type_annotation,
+        get_origin(type_annotation) or type_annotation,
         (
             Request,
             WebSocket,


### PR DESCRIPTION
[Starlette 0.52.0](https://github.com/Kludex/starlette/releases/tag/0.52.0) introduced dictionary-style syntax for improve type safety when accessing `State`. This PR adds support for this pattern when using FastAPI.

More context is given in this discussion: https://github.com/fastapi/fastapi/pull/14695#issuecomment-3850260807

Related:
https://github.com/fastapi/fastapi/pull/13965 - it seems like this draft PR was made prior to Starlette adding this functionality natively. Is there anything from this PR which should be brought into here?