### PR TITLE
Fix typos in contributing and migration docs

### DIFF
--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -92,7 +92,7 @@ That way, you can edit the documentation/source files and see the changes live.
 
 /// tip
 
-Alternatively, you can perform the same steps that scripts does manually.
+Alternatively, you can perform the same steps that the script does manually.
 
 Go into the language directory, for the main docs in English it's at `docs/en/`:
 

--- a/docs/en/docs/how-to/migrate-from-pydantic-v1-to-pydantic-v2.md
+++ b/docs/en/docs/how-to/migrate-from-pydantic-v1-to-pydantic-v2.md
@@ -130,6 +130,6 @@ First try with `bump-pydantic`, if your tests pass and that works, then you're d
 
 If `bump-pydantic` doesn't work for your use case, you can use the support for both Pydantic v1 and v2 models in the same app to do the migration to Pydantic v2 gradually.
 
-You could fist upgrade Pydantic to use the latest version 2, and change the imports to use `pydantic.v1` for all your models.
+You could first upgrade Pydantic to use the latest version 2, and change the imports to use `pydantic.v1` for all your models.
 
 Then, you can start migrating your models from Pydantic v1 to v2 in groups, in gradual steps. 🚶


### PR DESCRIPTION
Fix two small typos in the English documentation:

- `docs/en/docs/how-to/migrate-from-pydantic-v1-to-pydantic-v2.md`: "fist" -> "first"
- `docs/en/docs/contributing.md`: "that scripts does" -> "that the script does"