### PR TITLE
Fix #13175: Generate unique operation IDs for routes with multiple methods

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -244,6 +244,19 @@ def get_openapi_operation_metadata(
     if route.description:
         operation["description"] = route.description
     operation_id = route.operation_id or route.unique_id
+    # If the route has multiple methods and operation_id was not explicitly set,
+    # append the method to make each operation ID unique
+    if (
+        not route.operation_id
+        and route.methods
+        and len(route.methods) > 1
+    ):
+        # unique_id already includes a method suffix, so we need to replace it
+        # with the actual method being processed
+        # unique_id format: "{name}_{path}_{first_method}"
+        # We need to replace the last method suffix with the current method
+        base_id = operation_id.rsplit("_", 1)[0]
+        operation_id = f"{base_id}_{method.lower()}"
     if operation_id in operation_ids:
         message = (
             f"Duplicate Operation ID {operation_id} for function "

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -246,11 +246,7 @@ def get_openapi_operation_metadata(
     operation_id = route.operation_id or route.unique_id
     # If the route has multiple methods and operation_id was not explicitly set,
     # append the method to make each operation ID unique
-    if (
-        not route.operation_id
-        and route.methods
-        and len(route.methods) > 1
-    ):
+    if not route.operation_id and route.methods and len(route.methods) > 1:
         # unique_id already includes a method suffix, so we need to replace it
         # with the actual method being processed
         # unique_id format: "{name}_{path}_{first_method}"

--- a/tests/test_duplicate_operation_id.py
+++ b/tests/test_duplicate_operation_id.py
@@ -1,0 +1,122 @@
+"""
+Test that routes with multiple methods get unique operation IDs.
+Related to issue #13175
+"""
+import warnings
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_multiple_methods_unique_operation_ids():
+    """Test that a route with multiple methods generates unique operation IDs"""
+    app = FastAPI()
+
+    @app.api_route("/clear", methods=["POST", "DELETE"])
+    def clear():
+        return {"message": "cleared"}
+
+    # Capture warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        # Get OpenAPI schema which triggers operation ID generation
+        openapi_schema = app.openapi()
+
+        # Check that no duplicate operation ID warning was raised
+        duplicate_warnings = [
+            warning for warning in w
+            if "Duplicate Operation ID" in str(warning.message)
+        ]
+        assert len(duplicate_warnings) == 0, (
+            f"Found {len(duplicate_warnings)} duplicate operation ID warnings: "
+            f"{[str(w.message) for w in duplicate_warnings]}"
+        )
+
+    # Verify both methods are in the schema with different operation IDs
+    assert "/clear" in openapi_schema["paths"]
+    clear_path = openapi_schema["paths"]["/clear"]
+
+    # Both POST and DELETE should be present
+    assert "post" in clear_path
+    assert "delete" in clear_path
+
+    # Operation IDs should be different
+    post_op_id = clear_path["post"]["operationId"]
+    delete_op_id = clear_path["delete"]["operationId"]
+
+    assert post_op_id != delete_op_id, (
+        f"Operation IDs should be different: "
+        f"POST={post_op_id}, DELETE={delete_op_id}"
+    )
+
+
+def test_multiple_routes_with_multiple_methods():
+    """Test multiple routes each with multiple methods"""
+    app = FastAPI()
+
+    @app.api_route("/clear", methods=["POST", "DELETE"])
+    def clear():
+        return {"message": "cleared"}
+
+    @app.api_route("/reset", methods=["POST", "PUT"])
+    def reset():
+        return {"message": "reset"}
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        openapi_schema = app.openapi()
+
+        duplicate_warnings = [
+            warning for warning in w
+            if "Duplicate Operation ID" in str(warning.message)
+        ]
+        assert len(duplicate_warnings) == 0
+
+    # Verify all operation IDs are unique
+    operation_ids = set()
+    for path_data in openapi_schema["paths"].values():
+        for method_data in path_data.values():
+            if isinstance(method_data, dict) and "operationId" in method_data:
+                op_id = method_data["operationId"]
+                assert op_id not in operation_ids, f"Duplicate operation ID: {op_id}"
+                operation_ids.add(op_id)
+
+
+def test_single_method_route_unchanged():
+    """Test that routes with single methods still work as before"""
+    app = FastAPI()
+
+    @app.get("/items")
+    def get_items():
+        return {"items": []}
+
+    openapi_schema = app.openapi()
+
+    # Should have the expected structure
+    assert "/items" in openapi_schema["paths"]
+    assert "get" in openapi_schema["paths"]["/items"]
+    assert "operationId" in openapi_schema["paths"]["/items"]["get"]
+
+
+def test_add_api_route_with_multiple_methods():
+    """Test using add_api_route directly with multiple methods"""
+    app = FastAPI()
+
+    def clear_handler():
+        return {"message": "cleared"}
+
+    app.add_api_route("/clear", clear_handler, methods=["POST", "DELETE"])
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        openapi_schema = app.openapi()
+
+        duplicate_warnings = [
+            warning for warning in w
+            if "Duplicate Operation ID" in str(warning.message)
+        ]
+        assert len(duplicate_warnings) == 0
+
+    clear_path = openapi_schema["paths"]["/clear"]
+    assert clear_path["post"]["operationId"] != clear_path["delete"]["operationId"]

--- a/tests/test_duplicate_operation_id.py
+++ b/tests/test_duplicate_operation_id.py
@@ -135,8 +135,7 @@ def test_explicit_operation_id_with_multiple_methods():
         # If user provides explicit operation_id with multiple methods,
         # they'll get a duplicate warning - this is intentional
         duplicate_warnings = [
-            warning for warning in w
-            if "Duplicate Operation ID" in str(warning.message)
+            warning for warning in w if "Duplicate Operation ID" in str(warning.message)
         ]
         # We expect a duplicate warning because the user explicitly set the same
         # operation_id for multiple methods

--- a/tests/test_duplicate_operation_id.py
+++ b/tests/test_duplicate_operation_id.py
@@ -2,10 +2,10 @@
 Test that routes with multiple methods get unique operation IDs.
 Related to issue #13175
 """
+
 import warnings
 
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
 
 def test_multiple_methods_unique_operation_ids():
@@ -25,8 +25,7 @@ def test_multiple_methods_unique_operation_ids():
 
         # Check that no duplicate operation ID warning was raised
         duplicate_warnings = [
-            warning for warning in w
-            if "Duplicate Operation ID" in str(warning.message)
+            warning for warning in w if "Duplicate Operation ID" in str(warning.message)
         ]
         assert len(duplicate_warnings) == 0, (
             f"Found {len(duplicate_warnings)} duplicate operation ID warnings: "
@@ -46,8 +45,7 @@ def test_multiple_methods_unique_operation_ids():
     delete_op_id = clear_path["delete"]["operationId"]
 
     assert post_op_id != delete_op_id, (
-        f"Operation IDs should be different: "
-        f"POST={post_op_id}, DELETE={delete_op_id}"
+        f"Operation IDs should be different: POST={post_op_id}, DELETE={delete_op_id}"
     )
 
 
@@ -68,8 +66,7 @@ def test_multiple_routes_with_multiple_methods():
         openapi_schema = app.openapi()
 
         duplicate_warnings = [
-            warning for warning in w
-            if "Duplicate Operation ID" in str(warning.message)
+            warning for warning in w if "Duplicate Operation ID" in str(warning.message)
         ]
         assert len(duplicate_warnings) == 0
 
@@ -113,8 +110,7 @@ def test_add_api_route_with_multiple_methods():
         openapi_schema = app.openapi()
 
         duplicate_warnings = [
-            warning for warning in w
-            if "Duplicate Operation ID" in str(warning.message)
+            warning for warning in w if "Duplicate Operation ID" in str(warning.message)
         ]
         assert len(duplicate_warnings) == 0
 


### PR DESCRIPTION
## Summary
Fixes #13175 by ensuring routes with multiple HTTP methods generate unique operation IDs for each method in the OpenAPI schema.

## Problem
When using `add_api_route()` or `@api_route()` with multiple methods (e.g., `methods=["POST", "DELETE"]`), all methods shared the same operation ID, causing "Duplicate Operation ID" warnings.

Example that triggered the warning:
```python
router.add_api_route("/clear", clear, methods=["POST", "DELETE"])
# Warning: Duplicate Operation ID clear_clear_post
```

## Solution
Modified `get_openapi_operation_metadata()` in `fastapi/openapi/utils.py`:
- When a route has multiple methods and no explicit `operation_id`
- Append the actual HTTP method to the base operation ID
- Ensures each method gets a unique operation ID: `clear_clear_post`, `clear_clear_delete`
- Maintains backward compatibility for single-method routes and explicit operation IDs

## Test Plan
Added comprehensive test suite in `tests/test_duplicate_operation_id.py`:
- ✅ No duplicate warnings for multi-method routes
- ✅ Operation IDs are unique for each method
- ✅ Multiple routes with multiple methods all get unique IDs
- ✅ Single-method routes unchanged (backward compatibility)
- ✅ Direct `add_api_route()` usage works correctly

All tests pass:
- New tests: 4/4 passed
- Existing OpenAPI tests: all passed
- Application tests: all passed

Generated with [Claude Code](https://claude.com/claude-code)