### PR TITLE
Fix #12419: Clarify docs for required query params with None type

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -244,13 +244,25 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 {* ../../docs_src/query_params_str_validations/tutorial006_an_py39.py hl[9] *}
 
-### Required, can be `None` { #required-can-be-none }
+### Required with `None` type { #required-can-be-none }
 
-You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
-
-To do that, you can declare that `None` is a valid type but simply do not declare a default value:
+You can declare that a parameter has a type that includes `None` (like `str | None`) but without a default value, which makes it required:
 
 {* ../../docs_src/query_params_str_validations/tutorial006c_an_py310.py hl[9] *}
+
+/// note
+
+**Important**: Even though the type includes `None`, the parameter is still **required** because there's no default value. This means clients **must** provide the parameter.
+
+In practice, HTTP query parameters are sent as strings. While the type annotation `str | None` indicates the parameter could theoretically be `None`, there's no standard way to send a literal `None` value in HTTP query parameters - you can only send string values or omit the parameter entirely.
+
+**Omitting the parameter will result in a validation error** since it's required.
+
+This pattern is more commonly useful for **dependencies** (where you might pass `None` programmatically) rather than direct HTTP endpoints.
+
+For an optional query parameter that can be omitted, use: `q: Annotated[str | None, Query(min_length=3)] = None`
+
+///
 
 ## Query parameter list / multiple values { #query-parameter-list-multiple-values }
 

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -244,7 +244,7 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 {* ../../docs_src/query_params_str_validations/tutorial006_an_py39.py hl[9] *}
 
-### Required with `None` type { #required-can-be-none }
+### Required with `None` type { #required-with-none-type }
 
 You can declare that a parameter has a type that includes `None` (like `str | None`) but without a default value, which makes it required:
 


### PR DESCRIPTION
## Summary
Clarifies documentation for the confusing "Required, can be None" pattern, which doesn't work as described for HTTP query parameters.

## Problem
Issue #12419 reported confusion about the "Required, can be None" section. The documentation suggested you could force clients to send a `None` value, but:

1. HTTP query parameters cannot send literal `None` - they're either strings or omitted
2. The example has no default value, making the parameter required
3. Omitting the parameter causes a validation error (not shown in docs)
4. The tests for this example are marked as `xfail` with reference to this issue

## Changes
Updated `/docs/en/docs/tutorial/query-params-str-validations.md` to:

1. **Rename section**: "Required with None type" (more accurate)
2. **Add detailed note** explaining:
   - Parameter is required (no default value)
   - HTTP can't send literal None values  
   - Omitting parameter causes validation error
   - Pattern is more useful for dependencies than HTTP endpoints
   - How to make truly optional parameters

## Example
**Before (confusing):**
> "You can declare that a parameter can accept None, but that it's still required. This would force clients to send a value, even if the value is None."

**After (clear):**
> Explains that while the type includes `None`, the parameter is required and must be provided. Clarifies HTTP limitations and shows the correct pattern for optional parameters.

## Testing
- No code changes, only documentation
- Existing tests in `test_tutorial006c.py` are already marked as `xfail` for this issue
- Documentation now accurately describes the behavior

## Impact
- Reduces confusion for developers
- Explains when to use this pattern (dependencies) vs optional parameters (HTTP)
- Clarifies HTTP query parameter limitations

Closes #12419