### PR TITLE
🐛 Fix `on_startup` and `on_shutdown` parameters of `APIRouter`

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -952,16 +952,6 @@ class APIRouter(routing.Router):
             ),
         ] = Default(generate_unique_id),
     ) -> None:
-        # Handle on_startup/on_shutdown locally since Starlette removed support
-        # Ref: https://github.com/Kludex/starlette/pull/3117
-        # TODO: deprecate this once the lifespan (or alternative) interface is improved
-        self.on_startup: list[Callable[[], Any]] = (
-            [] if on_startup is None else list(on_startup)
-        )
-        self.on_shutdown: list[Callable[[], Any]] = (
-            [] if on_shutdown is None else list(on_shutdown)
-        )
-
         # Determine the lifespan context to use
         if lifespan is None:
             # Use the default lifespan that runs on_startup/on_shutdown handlers
@@ -985,6 +975,17 @@ class APIRouter(routing.Router):
             assert not prefix.endswith("/"), (
                 "A path prefix must not end with '/', as the routes will start with '/'"
             )
+
+        # Handle on_startup/on_shutdown locally since Starlette removed support
+        # Ref: https://github.com/Kludex/starlette/pull/3117
+        # TODO: deprecate this once the lifespan (or alternative) interface is improved
+        self.on_startup: list[Callable[[], Any]] = (
+            [] if on_startup is None else list(on_startup)
+        )
+        self.on_shutdown: list[Callable[[], Any]] = (
+            [] if on_shutdown is None else list(on_shutdown)
+        )
+
         self.prefix = prefix
         self.tags: list[Union[str, Enum]] = tags or []
         self.dependencies = list(dependencies or [])

--- a/tests/test_router_events.py
+++ b/tests/test_router_events.py
@@ -317,3 +317,65 @@ def test_router_async_generator_lifespan(state: State) -> None:
         assert response.json() == {"message": "Hello World"}
     assert state.app_startup is True
     assert state.app_shutdown is True
+
+
+def test_startup_shutdown_handlers_as_parameters(state: State) -> None:
+    """Test that startup/shutdown handlers passed as parameters to FastAPI are called correctly."""
+
+
+    def app_startup() -> None:
+        state.app_startup = True
+
+    def app_shutdown() -> None:
+        state.app_shutdown = True
+
+    app = FastAPI(on_startup=[app_startup], on_shutdown=[app_shutdown])
+
+    @app.get("/")
+    def main() -> dict[str, str]:
+        return {"message": "Hello World"}
+
+    def router_startup() -> None:
+        state.router_startup = True
+
+    def router_shutdown() -> None:
+        state.router_shutdown = True
+
+    router = APIRouter(on_startup=[router_startup], on_shutdown=[router_shutdown])
+
+
+    def sub_router_startup() -> None:
+        state.sub_router_startup = True
+
+    def sub_router_shutdown() -> None:
+        state.sub_router_shutdown = True
+
+
+    sub_router = APIRouter(on_startup=[sub_router_startup], on_shutdown=[sub_router_shutdown])
+
+
+    router.include_router(sub_router)
+    app.include_router(router)
+
+    assert state.app_startup is False
+    assert state.router_startup is False
+    assert state.sub_router_startup is False
+    assert state.app_shutdown is False
+    assert state.router_shutdown is False
+    assert state.sub_router_shutdown is False
+    with TestClient(app) as client:
+        assert state.app_startup is True
+        assert state.router_startup is True
+        assert state.sub_router_startup is True
+        assert state.app_shutdown is False
+        assert state.router_shutdown is False
+        assert state.sub_router_shutdown is False
+        response = client.get("/")
+        assert response.status_code == 200, response.text
+        assert response.json() == {"message": "Hello World"}
+    assert state.app_startup is True
+    assert state.router_startup is True
+    assert state.sub_router_startup is True
+    assert state.app_shutdown is True
+    assert state.router_shutdown is True
+    assert state.sub_router_shutdown is True

--- a/tests/test_router_events.py
+++ b/tests/test_router_events.py
@@ -322,7 +322,6 @@ def test_router_async_generator_lifespan(state: State) -> None:
 def test_startup_shutdown_handlers_as_parameters(state: State) -> None:
     """Test that startup/shutdown handlers passed as parameters to FastAPI are called correctly."""
 
-
     def app_startup() -> None:
         state.app_startup = True
 
@@ -343,16 +342,15 @@ def test_startup_shutdown_handlers_as_parameters(state: State) -> None:
 
     router = APIRouter(on_startup=[router_startup], on_shutdown=[router_shutdown])
 
-
     def sub_router_startup() -> None:
         state.sub_router_startup = True
 
     def sub_router_shutdown() -> None:
         state.sub_router_shutdown = True
 
-
-    sub_router = APIRouter(on_startup=[sub_router_startup], on_shutdown=[sub_router_shutdown])
-
+    sub_router = APIRouter(
+        on_startup=[sub_router_startup], on_shutdown=[sub_router_shutdown]
+    )
 
     router.include_router(sub_router)
     app.include_router(router)


### PR DESCRIPTION
This fixes the issue reported in this comment: https://github.com/fastapi/fastapi/pull/14851#issuecomment-3863896385

```py
from fastapi import FastAPI


def s_start():
    print("SYNC START", flush=True)


app = FastAPI(on_startup=[s_start])


@app.get("/health")
async def health():
    return {"ok": True}
```

Startup event is not called because `APIRouter.on_startup` is set in `APIRouter.__init__` before calling `super().__init__` and  is overridden by `router.__init__` (https://github.com/Kludex/starlette/blob/e5b8a5d200504a2608bed11fe6f66b1d20b9ae2c/starlette/routing.py#L597-L598)