### PR TITLE
✅ Fix parameterized tests with snapshots

### DIFF
--- a/tests/test_request_params/test_path/test_required_str.py
+++ b/tests/test_request_params/test_path/test_required_str.py
@@ -3,7 +3,7 @@ from typing import Annotated
 import pytest
 from fastapi import FastAPI, Path
 from fastapi.testclient import TestClient
-from inline_snapshot import snapshot
+from inline_snapshot import Is, snapshot
 
 app = FastAPI()
 
@@ -58,8 +58,8 @@ def test_schema(path: str, expected_name: str, expected_title: str):
         [
             {
                 "required": True,
-                "schema": {"title": expected_title, "type": "string"},
-                "name": expected_name,
+                "schema": {"title": Is(expected_title), "type": "string"},
+                "name": Is(expected_name),
                 "in": "path",
             }
         ]

--- a/tests/test_tutorial/test_body_nested_models/test_tutorial001_tutorial002_tutorial003.py
+++ b/tests/test_tutorial/test_body_nested_models/test_tutorial001_tutorial002_tutorial003.py
@@ -3,7 +3,7 @@ import importlib
 import pytest
 from dirty_equals import IsList
 from fastapi.testclient import TestClient
-from inline_snapshot import snapshot
+from inline_snapshot import Is, snapshot
 
 from ...utils import needs_py310
 
@@ -212,7 +212,7 @@ def test_openapi_schema(client: TestClient, mod_name: str):
                                 "title": "Tax",
                                 "anyOf": [{"type": "number"}, {"type": "null"}],
                             },
-                            "tags": tags_schema,
+                            "tags": Is(tags_schema),
                         },
                         "required": [
                             "name",

--- a/tests/test_tutorial/test_custom_response/test_tutorial002_tutorial003_tutorial004.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial002_tutorial003_tutorial004.py
@@ -2,7 +2,7 @@ import importlib
 
 import pytest
 from fastapi.testclient import TestClient
-from inline_snapshot import snapshot
+from inline_snapshot import Is, snapshot
 
 
 @pytest.fixture(
@@ -59,7 +59,7 @@ def test_openapi_schema(client: TestClient, mod_name: str):
                         "responses": {
                             "200": {
                                 "description": "Successful Response",
-                                "content": response_content,
+                                "content": Is(response_content),
                             }
                         },
                         "summary": "Read Items",

--- a/tests/test_tutorial/test_path_operation_configurations/test_tutorial003_tutorial004.py
+++ b/tests/test_tutorial/test_path_operation_configurations/test_tutorial003_tutorial004.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import pytest
 from dirty_equals import IsList
 from fastapi.testclient import TestClient
-from inline_snapshot import snapshot
+from inline_snapshot import Is, snapshot
 
 from ...utils import needs_py310
 
@@ -75,7 +75,7 @@ def test_openapi_schema(client: TestClient, mod_name: str):
                 "/items/": {
                     "post": {
                         "summary": "Create an item",
-                        "description": DESCRIPTIONS[mod_name],
+                        "description": Is(DESCRIPTIONS[mod_name]),
                         "operationId": "create_item_items__post",
                         "requestBody": {
                             "content": {

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial010.py
@@ -3,7 +3,7 @@ import importlib
 import pytest
 from fastapi._compat import PYDANTIC_VERSION_MINOR_TUPLE
 from fastapi.testclient import TestClient
-from inline_snapshot import snapshot
+from inline_snapshot import Is, snapshot
 
 from ...utils import needs_py310
 
@@ -66,6 +66,23 @@ def test_query_params_str_validations_item_query_nonregexquery(client: TestClien
 def test_openapi_schema(client: TestClient):
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text
+
+    parameters_schema = {
+        "anyOf": [
+            {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 50,
+                "pattern": "^fixedquery$",
+            },
+            {"type": "null"},
+        ],
+        "title": "Query string",
+        "description": "Query string for the items to search in the database that have a good match",
+        # See https://github.com/pydantic/pydantic/blob/80353c29a824c55dea4667b328ba8f329879ac9f/tests/test_fastapi.sh#L25-L34.
+        **({"deprecated": True} if PYDANTIC_VERSION_MINOR_TUPLE >= (2, 10) else {}),
+    }
+
     assert response.json() == snapshot(
         {
             "openapi": "3.1.0",
@@ -96,25 +113,7 @@ def test_openapi_schema(client: TestClient):
                                 "description": "Query string for the items to search in the database that have a good match",
                                 "required": False,
                                 "deprecated": True,
-                                "schema": {
-                                    "anyOf": [
-                                        {
-                                            "type": "string",
-                                            "minLength": 3,
-                                            "maxLength": 50,
-                                            "pattern": "^fixedquery$",
-                                        },
-                                        {"type": "null"},
-                                    ],
-                                    "title": "Query string",
-                                    "description": "Query string for the items to search in the database that have a good match",
-                                    # See https://github.com/pydantic/pydantic/blob/80353c29a824c55dea4667b328ba8f329879ac9f/tests/test_fastapi.sh#L25-L34.
-                                    **(
-                                        {"deprecated": True}
-                                        if PYDANTIC_VERSION_MINOR_TUPLE >= (2, 10)
-                                        else {}
-                                    ),
-                                },
+                                "schema": Is(parameters_schema),
                                 "name": "item-query",
                                 "in": "query",
                             }


### PR DESCRIPTION
Currently tests fail if we try running them locally as reported in https://github.com/fastapi/fastapi/pull/14864#issuecomment-3871166659

In CI tests pass because `inline-snapshot` can detect CI environment and runs with `--inline-snapshot=disable`.
See: https://15r10nk.github.io/inline-snapshot/latest/pytest/#-inline-snapshotdisable

---

To prevent this from happening again, I think we should set the `INLINE_SNAPSHOT_DEFAULT_FLAGS=review` in CI.
See: [docs](https://15r10nk.github.io/inline-snapshot/latest/configuration/) and [sources](https://github.com/15r10nk/inline-snapshot/blob/8e3d926ada6ef411f8a3e747caa97ba9324bca54/src/inline_snapshot/_snapshot_session.py#L284-L295)
