### PR TITLE
🔧 Configure `test` workflow to run tests with `inline-snapshot=review`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   UV_NO_SYNC: true
+  INLINE_SNAPSHOT_DEFAULT_FLAGS: review
 
 jobs:
   changes:

--- a/tests/test_request_params/test_path/test_required_str.py
+++ b/tests/test_request_params/test_path/test_required_str.py
@@ -59,7 +59,7 @@ def test_schema(path: str, expected_name: str, expected_title: str):
             {
                 "required": True,
                 "schema": {"title": Is(expected_title), "type": "string"},
-                "name": expected_name,
+                "name": Is(expected_name),
                 "in": "path",
             }
         ]

--- a/tests/test_request_params/test_path/test_required_str.py
+++ b/tests/test_request_params/test_path/test_required_str.py
@@ -59,7 +59,7 @@ def test_schema(path: str, expected_name: str, expected_title: str):
             {
                 "required": True,
                 "schema": {"title": Is(expected_title), "type": "string"},
-                "name": Is(expected_name),
+                "name": expected_name,
                 "in": "path",
             }
         ]


### PR DESCRIPTION
This is to prevent adding new mistakes with inline snapshots in parameterized tests.
See: https://github.com/fastapi/fastapi/pull/14875

By-default inline-snapshot is run with `inline-snapshot=disable` in CI environment and we can miss errors that we will only notice when run tests locally.