### PR TITLE
 Make default operation IDs deterministic for multi-method routes

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -98,7 +98,8 @@ def generate_unique_id(route: "APIRoute") -> str:
     operation_id = f"{route.name}{route.path_format}"
     operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    method = sorted(route.methods)[0].lower()
+    operation_id = f"{operation_id}_{method}"
     return operation_id
 
 

--- a/tests/test_generate_unique_id_function.py
+++ b/tests/test_generate_unique_id_function.py
@@ -29,6 +29,14 @@ class Message(BaseModel):
     description: str
 
 
+def test_generate_unique_id_is_deterministic_with_multiple_methods():
+    def read_items():  # pragma: nocover - used for name only
+        return None
+
+    route = APIRoute("/items", read_items, methods=["POST", "GET"])
+    assert route.unique_id == "read_items_items_get"
+
+
 def test_top_level_generate_unique_id():
     app = FastAPI(generate_unique_id_function=custom_generate_unique_id)
     router = APIRouter()


### PR DESCRIPTION
 ## Summary
  This pull request addresses a determinism issue in the default `operationId` generation logic.
  When a route is defined with multiple HTTP methods, `generate_unique_id()` currently derives the method suffix by taking the first
  element from a `set`. Because `set` iteration order is not guaranteed, the resulting `operationId` can vary between runs. This leads to
  non‑reproducible OpenAPI output and can introduce unnecessary diffs for users who depend on stable specs or client generation.

  ## Changes Made
  1. **Deterministic method selection**
     - Updated `generate_unique_id()` in `fastapi/utils.py` to sort `route.methods` and select the first method in a stable order.
     - This ensures the suffix of the generated `operationId` is consistent across runs.

  2. **Regression test**
     - Added a targeted test in `tests/test_generate_unique_id_function.py` that constructs a route with multiple methods and asserts the
  generated `unique_id` is stable.
     - This protects against future regressions in the deterministic behavior.

  ## Rationale
  Stable `operationId`s are important for:
  - reproducible OpenAPI specifications
  - consistent client SDK generation
  - avoiding spurious changes in documentation or CI artifacts

  ## Testing
  - Added a focused unit test that validates deterministic behavior for multi‑method routes.

  ## Notes
  This change only affects the default `generate_unique_id()` implementation and does not alter behavior for users who supply a custom
  `generate_unique_id_function`.
