### PR TITLE
📝 Fix StreamingResponse doc example to actually stream

### DIFF
--- a/docs_src/custom_response/tutorial007_py39.py
+++ b/docs_src/custom_response/tutorial007_py39.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 
@@ -6,6 +8,7 @@ app = FastAPI()
 
 async def fake_video_streamer():
     for i in range(10):
+        await asyncio.sleep(1)
         yield b"some fake video bytes"
 
 


### PR DESCRIPTION
## Summary

Fix the `StreamingResponse` async generator doc example so it actually demonstrates streaming behavior.

## Problem

The current example in `docs_src/custom_response/tutorial007_py39.py` uses an async generator that yields all chunks synchronously without ever awaiting, so the event loop never gets a chance to send intermediate chunks — the response is buffered and returned all at once.

As discussed in [encode/starlette#1776](https://github.com/Kludex/starlette/discussions/1776#discussioncomment-3207518), async generators need an `await` point to actually stream.

## Fix

Added `await asyncio.sleep(1)` inside the async generator loop so it yields control back to the event loop between chunks, making the streaming behavior observable.

Closes #14680