### PR TITLE
fix: use await asyncio.sleep() in StreamingResponse async generator example

### DIFF
--- a/docs_src/custom_response/tutorial007_py39.py
+++ b/docs_src/custom_response/tutorial007_py39.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 
@@ -6,6 +8,7 @@ app = FastAPI()
 
 async def fake_video_streamer():
     for i in range(10):
+        await asyncio.sleep(0)
         yield b"some fake video bytes"
 
 


### PR DESCRIPTION
## Summary

The async generator in the StreamingResponse docs example (`docs_src/custom_response/tutorial007_py39.py`) did not `await` anything, causing all chunks to be buffered and returned at once instead of streaming incrementally.

## Fix

- Added `import asyncio`
- Added `await asyncio.sleep(0)` inside the async generator loop so the event loop yields between chunks, enabling proper streaming behavior

Closes #14680