### PR TITLE
♻️ Update build setup for `fastapi-slim`, deprecate it, and make it only depend on `fastapi`

### DIFF
--- a/.github/workflows/test-redistribute.yml
+++ b/.github/workflows/test-redistribute.yml
@@ -12,11 +12,6 @@ on:
 jobs:
   test-redistribute:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package:
-          - fastapi
-          - fastapi-slim
     steps:
       - name: Dump GitHub context
         env:
@@ -30,8 +25,6 @@ jobs:
       - name: Install build dependencies
         run: pip install build
       - name: Build source distribution
-        env:
-          TIANGOLO_BUILD_PACKAGE: ${{ matrix.package }}
         run: python -m build --sdist
       - name: Decompress source distribution
         run: |
@@ -41,8 +34,6 @@ jobs:
         run: |
           cd dist/fastapi*/
           pip install --group tests --editable .[all]
-        env:
-          TIANGOLO_BUILD_PACKAGE: ${{ matrix.package }}
       - name: Run source distribution tests
         run: |
           cd dist/fastapi*/

--- a/fastapi-slim/README.md
+++ b/fastapi-slim/README.md
@@ -1,0 +1,54 @@
+<p align="center">
+  <a href="https://fastapi.tiangolo.com"><img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" alt="FastAPI"></a>
+</p>
+<p align="center">
+    <em>FastAPI framework, high performance, easy to learn, fast to code, ready for production</em>
+</p>
+<p align="center">
+<a href="https://github.com/fastapi/fastapi/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster" target="_blank">
+    <img src="https://github.com/fastapi/fastapi/actions/workflows/test.yml/badge.svg?event=push&branch=master" alt="Test">
+</a>
+<a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi" target="_blank">
+    <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/fastapi.svg" alt="Coverage">
+</a>
+<a href="https://pypi.org/project/fastapi" target="_blank">
+    <img src="https://img.shields.io/pypi/v/fastapi?color=%2334D058&label=pypi%20package" alt="Package version">
+</a>
+<a href="https://pypi.org/project/fastapi" target="_blank">
+    <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
+</a>
+</p>
+
+---
+
+**Documentation**: <a href="https://fastapi.tiangolo.com" target="_blank">https://fastapi.tiangolo.com</a>
+
+**Source Code**: <a href="https://github.com/fastapi/fastapi" target="_blank">https://github.com/fastapi/fastapi</a>
+
+---
+
+FastAPI is a modern, fast (high-performance), web framework for building APIs with Python based on standard Python type hints.
+
+## `fastapi-slim`
+
+⚠️ Do not install this package. ⚠️
+
+This package, `fastapi-slim`, does nothing other than depend on `fastapi`.
+
+All the functionality has been integrated into `fastapi`.
+
+The only reason this package exists is as a migration path for old projects that used to depend on `fastapi-slim`, so that they can get the latest version of `fastapi`.
+
+You **should not** install this package.
+
+Install instead:
+
+```bash
+pip install fastapi
+```
+
+This package is deprecated and will stop receiving any updates and published versions.
+
+## License
+
+This project is licensed under the terms of the MIT license.

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -3,18 +3,38 @@ from typing import Any
 
 from pdm.backend.hooks import Context
 
-TIANGOLO_BUILD_PACKAGE = os.getenv("TIANGOLO_BUILD_PACKAGE", "fastapi")
+TIANGOLO_BUILD_PACKAGE = os.getenv("TIANGOLO_BUILD_PACKAGE", "typer")
 
 
 def pdm_build_initialize(context: Context) -> None:
     metadata = context.config.metadata
+    # Get main version
+    version = metadata["version"]
     # Get custom config for the current package, from the env var
-    config: dict[str, Any] = context.config.data["tool"]["tiangolo"][
+    all_configs_config: dict[str, Any] = context.config.data["tool"]["tiangolo"][
         "_internal-slim-build"
-    ]["packages"].get(TIANGOLO_BUILD_PACKAGE)
-    if not config:
+    ]["packages"]
+
+    if TIANGOLO_BUILD_PACKAGE not in all_configs_config:
         return
+
+    config = all_configs_config[TIANGOLO_BUILD_PACKAGE]
     project_config: dict[str, Any] = config["project"]
     # Override main [project] configs with custom configs for this package
     for key, value in project_config.items():
         metadata[key] = value
+    # Get custom build config for the current package
+    build_config: dict[str, Any] = (
+        config.get("tool", {}).get("pdm", {}).get("build", {})
+    )
+    # Override PDM build config with custom build config for this package
+    for key, value in build_config.items():
+        context.config.build_config[key] = value
+    # Get main dependencies
+    dependencies: list[str] = metadata.get("dependencies", [])
+    # Sync versions in dependencies
+    new_dependencies = []
+    for dep in dependencies:
+        new_dep = f"{dep}>={version}"
+        new_dependencies.append(new_dep)
+    metadata["dependencies"] = new_dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,29 @@ source-includes = [
 
 [tool.tiangolo._internal-slim-build.packages.fastapi-slim.project]
 name = "fastapi-slim"
+readme = "fastapi-slim/README.md"
+dependencies = [
+    "fastapi",
+]
+optional-dependencies = {}
+scripts = {}
+
+[tool.tiangolo._internal-slim-build.packages.fastapi-slim.tool.pdm.build]
+# excludes needs to explicitly exclude the top level python packages,
+# otherwise PDM includes them by default
+# A "*" glob pattern can't be used here because in PDM internals, the patterns are put
+# in a set (unordered, order varies) and each excluded file is assigned one of the
+# glob patterns that matches, as the set is unordered, the matched pattern could be "*"
+# independent of the order here. And then the internal code would give it a lower score
+# than the one for a default included file.
+# By not using "*" and explicitly excluding the top level packages, they get a higher
+# score than the default inclusion
+excludes = ["fastapi", "tests", "pdm_build.py"]
+# source-includes needs to explicitly define some value because PDM will check the
+# truthy value of the list, and if empty, will include some defaults, including "tests",
+# an empty string doesn't match anything, but makes the list truthy, so that PDM
+# doesn't override it during the build.
+source-includes = [""]
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]


### PR DESCRIPTION
♻️ Update build setup for `fastapi-slim`, deprecate it, and make it only depend on `fastapi`