### PR TITLE
Fix grammar in `docs/fr/docs`

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -11,6 +11,10 @@ hide:
 
 * ➖ Drop support for Python 3.9. PR [#14897](https://github.com/fastapi/fastapi/pull/14897) by [@tiangolo](https://github.com/tiangolo).
 
+### Refactors
+
+* 🎨 Update internal types for Python 3.10. PR [#14898](https://github.com/fastapi/fastapi/pull/14898) by [@tiangolo](https://github.com/tiangolo).
+
 ## 0.128.8
 
 ### Docs

--- a/docs/fr/docs/async.md
+++ b/docs/fr/docs/async.md
@@ -39,7 +39,7 @@ def results():
 
 ---
 
-Si votre application n'a pas à communiquer avec une bibliothèque externe et pas à attendre de réponse, utilisez `async def`.
+Si votre application n'a pas à communiquer avec une bibliothèque externe et n'a pas à attendre de réponse, utilisez `async def`.
 
 ---
 

--- a/docs/fr/docs/features.md
+++ b/docs/fr/docs/features.md
@@ -1,17 +1,17 @@
-# Fonctionnalités
+# Fonctionnalités { #features }
 
-## Fonctionnalités de FastAPI
+## Fonctionnalités de FastAPI { #fastapi-features }
 
-**FastAPI** vous offre ceci:
+**FastAPI** vous offre ceci :
 
-### Basé sur des standards ouverts
+### Basé sur des standards ouverts { #based-on-open-standards }
 
 * <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank"><strong>OpenAPI</strong></a> pour la création d'API, incluant la déclaration de <abbr title="en français: routes. Aussi connu sous le nom anglais endpoints ou routes">path</abbr> <abbr title="Aussi connu sous le nom de méthodes HTTP. À savoir POST, GET, PUT, DELETE">operations</abbr>, paramètres, corps de requêtes, sécurité, etc.
-* Documentation automatique des modèles de données avec <a href="http://json-schema.org/" class="external-link" target="_blank"><strong>JSON Schema</strong></a> (comme OpenAPI est aussi basée sur JSON Schema).
+* Documentation automatique des modèles de données avec <a href="https://json-schema.org/" class="external-link" target="_blank"><strong>JSON Schema</strong></a> (comme OpenAPI est aussi basée sur JSON Schema).
 * Conçue avec ces standards après une analyse méticuleuse. Plutôt qu'en rajoutant des surcouches après coup.
 * Cela permet d'utiliser de la **génération automatique de code client** dans beaucoup de langages.
 
-### Documentation automatique
+### Documentation automatique { #automatic-docs }
 
 Documentation d'API interactive et interface web d'exploration. Comme le framework est basé sur OpenAPI, de nombreuses options sont disponibles. Deux d'entre-elles sont incluses par défaut.
 
@@ -23,7 +23,7 @@ Documentation d'API interactive et interface web d'exploration. Comme le framewo
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-06-redoc-02.png)
 
-### Faite en python moderne
+### Écrit en python moderne { #just-modern-python }
 
 Tout est basé sur la déclaration de type standard de **Python 3.8** (grâce à Pydantic). Pas de nouvelles syntaxes à apprendre. Juste du Python standard et moderne.
 
@@ -48,7 +48,7 @@ class User(BaseModel):
     name: str
     joined: date
 ```
-Qui peuvent ensuite être utilisés comme cela:
+Cela peut ensuite être utilisés comme suit :
 
 ```Python
 my_user: User = User(id=3, name="John Doe", joined="2018-07-19")
@@ -70,7 +70,7 @@ Utilise les clés et valeurs du dictionnaire `second_user_data` directement comm
 
 ///
 
-### Support d'éditeurs
+### Support d'éditeurs { #editor-support }
 
 Tout le framework a été conçu pour être facile et intuitif d'utilisation, toutes les décisions de design ont été testées sur de nombreux éditeurs avant même de commencer le développement final afin d'assurer la meilleure expérience de développement possible.
 
@@ -94,13 +94,13 @@ Vous aurez des propositions de complétion que vous n'auriez jamais imaginées. 
 
 Plus jamais vous ne vous tromperez en tapant le nom d'une clé, vous ne ferez des aller-retour entre votre code et la documentation ou vous ne scrollerez de haut en bas afin d'enfin savoir si vous devez taper `username` ou `user_name`.
 
-### Court
+### Court { #short }
 
 Des **valeurs par défaut** sont définies pour tout, des configurations optionnelles sont présentent partout. Tous ces paramètres peuvent être ajustés afin de faire ce que vous voulez et définir l'API dont vous avez besoin.
 
 Mais, **tout fonctionne** par défaut.
 
-### Validation
+### Validation { #validation }
 
 * Validation pour la plupart (ou tous?) les **types de données** Python incluant:
     * objets JSON (`dict`).
@@ -116,7 +116,7 @@ Mais, **tout fonctionne** par défaut.
 
 Toutes les validations sont gérées par le bien établi et robuste **Pydantic**.
 
-### Sécurité et authentification
+### Sécurité et authentification { #security-and-authentication }
 
 La sécurité et l'authentification sont intégrées. Sans aucun compromis avec les bases de données ou les modèles de données.
 
@@ -133,30 +133,30 @@ Plus toutes les fonctionnalités de sécurités venant de Starlette (incluant le
 
 Le tout conçu en composant réutilisable facilement intégrable à vos systèmes, data stores, base de données relationnelle ou NoSQL, etc.
 
-### Injection de dépendances
+### Injection de dépendances { #dependency-injection }
 
 FastAPI contient un système simple mais extrêmement puissant d'<abbr title='aussi connus sous le nom de "composants", "ressources", "services", "providers"'><strong>Injection de Dépendances</strong></abbr>.
 
 * Même les dépendances peuvent avoir des dépendances, créant une hiérarchie ou un **"graph" de dépendances**
 * Tout est **automatiquement géré** par le framework
-* Toutes les dépendances peuvent exiger des données d'une requêtes et **Augmenter les contraintes d'un path operation** et de la documentation automatique.
+* Toutes les dépendances peuvent exiger des données d'une requêtes et **augmenter les contraintes d'un path operation** et de la documentation automatique.
 * **Validation automatique** même pour les paramètres de *path operation* définis dans les dépendances.
 * Supporte les systèmes d'authentification d'utilisateurs complexes, les **connexions de base de données**, etc.
 * **Aucun compromis** avec les bases de données, les frontends, etc. Mais une intégration facile avec n'importe lequel d'entre eux.
 
-### "Plug-ins" illimités
+### "Plug-ins" illimités { #unlimited-plug-ins }
 
 Ou, en d'autres termes, pas besoin d'eux, importez le code que vous voulez et utilisez le.
 
 Tout intégration est conçue pour être si simple à utiliser (avec des dépendances) que vous pouvez créer un "plug-in" pour votre application en deux lignes de code utilisant la même syntaxe que celle de vos *path operations*
 
-### Testé
+### Testé { #tested }
 
 * 100% <abbr title="La quantité de code qui est testé automatiquement">de couverture de test</abbr>.
 * 100% <abbr title="Annotation de types Python, avec cela votre éditeur et autres outils externes peuvent vous fournir un meilleur support">d'annotations de type</abbr> dans le code.
 * Utilisé dans des applications mises en production.
 
-## Fonctionnalités de Starlette
+## Fonctionnalités de Starlette { #starlette-features }
 
 **FastAPI** est complètement compatible (et basé sur) <a href="https://www.starlette.dev/" class="external-link" target="_blank"><strong>Starlette</strong></a>. Le code utilisant Starlette que vous ajouterez fonctionnera donc aussi.
 
@@ -164,7 +164,7 @@ En fait, `FastAPI` est un sous composant de `Starlette`. Donc, si vous savez dé
 
 Avec **FastAPI** vous aurez toutes les fonctionnalités de **Starlette** (FastAPI est juste Starlette sous stéroïdes):
 
-* Des performances vraiment impressionnantes. C'est l'<a href="https://github.com/encode/starlette#performance" class="external-link" target="_blank">un des framework Python les plus rapide, à égalité avec **NodeJS** et **GO**</a>.
+* Des performances vraiment impressionnantes. C'est l'<a href="https://github.com/encode/starlette#performance" class="external-link" target="_blank">un des frameworks Python les plus rapides, à égalité avec **NodeJS** et **GO**</a>.
 * Le support des **WebSockets**.
 * Le support de **GraphQL**.
 * Les <abbr title="En anglais: In-process background tasks">tâches d'arrière-plan.</abbr>
@@ -175,7 +175,7 @@ Avec **FastAPI** vous aurez toutes les fonctionnalités de **Starlette** (FastAP
 * Une couverture de test à 100 %.
 * 100 % de la base de code avec des annotations de type.
 
-## Fonctionnalités de Pydantic
+## Fonctionnalités de Pydantic { #pydantic-features }
 
 **FastAPI** est totalement compatible avec (et basé sur) <a href="https://docs.pydantic.dev/" class="external-link" target="_blank"><strong>Pydantic</strong></a>. Le code utilisant Pydantic que vous ajouterez fonctionnera donc aussi.
 


### PR DESCRIPTION
Just some minor grammar issues found in the French docs while skimming through it.