### PR TITLE
Prevent IncEx reexport from being stripped from stubs.

### DIFF
--- a/fastapi/types.py
+++ b/fastapi/types.py
@@ -1,12 +1,13 @@
 import types
 from collections.abc import Callable
 from enum import Enum
-from typing import Any, TypeVar, Union
+from typing import Any, TypeAlias, TypeVar, Union
 
 from pydantic import BaseModel
-from pydantic.main import IncEx as IncEx
+from pydantic.main import IncEx as _IncEx
 
 DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
 UnionType = getattr(types, "UnionType", Union)
 ModelNameMap = dict[type[BaseModel] | type[Enum], str]
 DependencyCacheKey = tuple[Callable[..., Any] | None, tuple[str, ...], str]
+IncEx: TypeAlias = _IncEx


### PR DESCRIPTION
`pyright --createstub` strips out IncEx reexport line added by #14641, because it comes from module that it thinks is private.

This patch makes public at fastapi level.

Context: I use stubs because I deploy my fastapi server on an embedded devices and some of the dependencies are not installable on my workstation.
