### PR TITLE
Add database session management to tutorial007

### DIFF
--- a/docs_src/dependencies/tutorial007_py310.py
+++ b/docs_src/dependencies/tutorial007_py310.py
@@ -1,3 +1,4 @@
+from .database import DBSession
 async def get_db():
     db = DBSession()
     try:

--- a/docs_src/dependencies/tutorial007_py310.py
+++ b/docs_src/dependencies/tutorial007_py310.py
@@ -1,4 +1,6 @@
 from .database import DBSession
+
+
 async def get_db():
     db = DBSession()
     try:


### PR DESCRIPTION
## Summary
Added missing DBSession import in get_db example.

## Why This Is Important
Current example fails when copied; prevents errors for developers following tutorial.

## Changes Made
- Added `from .database import DBSession` at top
