### PR TITLE
👷 Always run tests on push to `master` branch and when run by scheduler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,7 @@ jobs:
   test:
     needs:
       - changes
-    if: |
-      needs.changes.outputs.src == 'true' ||
-      github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: needs.changes.outputs.src == 'true' || github.ref == 'refs/heads/master'
     strategy:
       matrix:
         os: [ windows-latest, macos-latest ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,10 @@ jobs:
   test:
     needs:
       - changes
-    if: needs.changes.outputs.src == 'true'
+    if: |
+      needs.changes.outputs.src == 'true' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/master')
     strategy:
       matrix:
         os: [ windows-latest, macos-latest ]


### PR DESCRIPTION
Currently we skip tests if there are no code changes.
But then in some cases smokeshow workflow fails on `master` branch with `Artifact not found for name: coverage-html`.


It results in:

<img width="656" height="97" alt="image" src="https://github.com/user-attachments/assets/79508153-6816-4f4f-8131-15e3610a3f72" />

or 

<img width="645" height="95" alt="image" src="https://github.com/user-attachments/assets/816b3263-2ff1-4e8e-979a-4984247f1c92" />

---

To fix this we need to always run tests on push to `master` and when `test` workflow is run by scheduler