### PR TITLE
refactor: Improve type annotations and use python 3.10+ syntax

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -381,19 +381,12 @@ def analyze_param(
         fastapi_annotations = [
             arg
             for arg in annotated_args[1:]
-            if isinstance(arg, (FieldInfo, params.Depends))
+            if isinstance(arg, FieldInfo | params.Depends)
         ]
         fastapi_specific_annotations = [
             arg
             for arg in fastapi_annotations
-            if isinstance(
-                arg,
-                (
-                    params.Param,
-                    params.Body,
-                    params.Depends,
-                ),
-            )
+            if isinstance(arg, params.Param | params.Body | params.Depends)
         ]
         if fastapi_specific_annotations:
             fastapi_annotation: FieldInfo | params.Depends | None = (
@@ -724,7 +717,7 @@ def _get_multidict_value(
     if (
         (not _is_json_field(field))
         and field_annotation_is_sequence(field.field_info.annotation)
-        and isinstance(values, (ImmutableMultiDict, Headers))
+        and isinstance(values, ImmutableMultiDict | Headers)
     ):
         value = values.getlist(alias)
     else:
@@ -833,7 +826,7 @@ def request_params_to_args(
     return values, errors
 
 
-def is_union_of_base_models(field_type: Any) -> bool:
+def is_union_of_base_models(field_type: type | None) -> bool:
     """Check if field type is a Union where all members are BaseModel subclasses."""
     from fastapi.types import UnionType
 

--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -16,7 +16,7 @@ class APIKeyBase(SecurityBase):
         description: str | None,
         scheme_name: str | None,
         auto_error: bool,
-    ):
+    ) -> None:
         self.auto_error = auto_error
 
         self.model: APIKey = APIKey(
@@ -128,7 +128,7 @@ class APIKeyQuery(APIKeyBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         super().__init__(
             location=APIKeyIn.query,
             name=name,
@@ -216,7 +216,7 @@ class APIKeyHeader(APIKeyBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         super().__init__(
             location=APIKeyIn.header,
             name=name,
@@ -304,7 +304,7 @@ class APIKeyCookie(APIKeyBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         super().__init__(
             location=APIKeyIn.cookie,
             name=name,

--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -74,7 +74,7 @@ class HTTPBase(SecurityBase):
         scheme_name: str | None = None,
         description: str | None = None,
         auto_error: bool = True,
-    ):
+    ) -> None:
         self.model: HTTPBaseModel = HTTPBaseModel(
             scheme=scheme, description=description
         )
@@ -188,7 +188,7 @@ class HTTPBasic(HTTPBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         self.model = HTTPBaseModel(scheme="basic", description=description)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.realm = realm
@@ -295,7 +295,7 @@ class HTTPBearer(HTTPBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         self.model = HTTPBearerModel(bearerFormat=bearerFormat, description=description)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
@@ -396,7 +396,7 @@ class HTTPDigest(HTTPBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         self.model = HTTPBaseModel(scheme="digest", description=description)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -150,7 +150,7 @@ class OAuth2PasswordRequestForm:
                 """
             ),
         ] = None,
-    ):
+    ) -> None:
         self.grant_type = grant_type
         self.username = username
         self.password = password
@@ -316,7 +316,7 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
                 """
             ),
         ] = None,
-    ):
+    ) -> None:
         super().__init__(
             grant_type=grant_type,
             username=username,
@@ -391,7 +391,7 @@ class OAuth2(SecurityBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         self.model = OAuth2Model(
             flows=cast(OAuthFlowsModel, flows), description=description
         )
@@ -513,7 +513,7 @@ class OAuth2PasswordBearer(OAuth2):
                 """
             ),
         ] = None,
-    ):
+    ) -> None:
         if not scopes:
             scopes = {}
         flows = OAuthFlowsModel(
@@ -618,7 +618,7 @@ class OAuth2AuthorizationCodeBearer(OAuth2):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         if not scopes:
             scopes = {}
         flows = OAuthFlowsModel(
@@ -673,7 +673,7 @@ class SecurityScopes:
                 """
             ),
         ] = None,
-    ):
+    ) -> None:
         self.scopes: Annotated[
             list[str],
             Doc(

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -70,7 +70,7 @@ class OpenIdConnect(SecurityBase):
                 """
             ),
         ] = True,
-    ):
+    ) -> None:
         self.model = OpenIdConnectModel(
             openIdConnectUrl=openIdConnectUrl, description=description
         )


### PR DESCRIPTION
- **ANN204**: add missing return type annotations in fastapi/security/
- **UP038**:  use `X | Y` syntax for isinstance calls