### PR TITLE
📝 Fix doctrings for `max_digits` and `decimal_places`

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -211,7 +211,7 @@ def Path(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of allow digits for strings.
+            Maximum number of digits allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -219,7 +219,7 @@ def Path(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of decimal places allowed for numbers.
+            Maximum number of decimal places allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -570,7 +570,7 @@ def Query(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of allow digits for strings.
+            Maximum number of digits allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -578,7 +578,7 @@ def Query(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of decimal places allowed for numbers.
+            Maximum number of decimal places allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -892,7 +892,7 @@ def Header(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of allow digits for strings.
+            Maximum number of digits allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -900,7 +900,7 @@ def Header(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of decimal places allowed for numbers.
+            Maximum number of decimal places allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -1198,7 +1198,7 @@ def Cookie(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of allow digits for strings.
+            Maximum number of digits allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -1206,7 +1206,7 @@ def Cookie(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of decimal places allowed for numbers.
+            Maximum number of decimal places allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -1526,7 +1526,7 @@ def Body(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of allow digits for strings.
+            Maximum number of digits allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -1534,7 +1534,7 @@ def Body(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of decimal places allowed for numbers.
+            Maximum number of decimal places allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -1842,7 +1842,7 @@ def Form(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of allow digits for strings.
+            Maximum number of digits allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -1850,7 +1850,7 @@ def Form(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of decimal places allowed for numbers.
+            Maximum number of decimal places allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -2157,7 +2157,7 @@ def File(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of allow digits for strings.
+            Maximum number of digits allowed for decimal values.
             """
         ),
     ] = _Unset,
@@ -2165,7 +2165,7 @@ def File(  # noqa: N802
         int | None,
         Doc(
             """
-            Maximum number of decimal places allowed for numbers.
+            Maximum number of decimal places allowed for decimal values.
             """
         ),
     ] = _Unset,


### PR DESCRIPTION
They are only applicable for `Decimal` type: https://github.com/pydantic/pydantic/blob/8be4a57eb36760c85fa97a3bdea78a1f283489d0/pydantic/_internal/_known_annotated_metadata.py#L44