### PR TITLE
docs: update pytest output example in Testing page

### DIFF
--- a/docs/en/docs/tutorial/testing.md
+++ b/docs/en/docs/tutorial/testing.md
@@ -178,9 +178,8 @@ Run the tests with:
 $ pytest
 
 ================ test session starts ================
-platform linux -- Python 3.6.9, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
+platform linux -- Python 3.12.x, pytest-8.x.y, pluggy-1.x.y
 rootdir: /home/user/code/superawesome-cli/app
-plugins: forked-1.1.3, xdist-1.31.0, cov-2.8.1
 collected 6 items
 
 ---> 100%


### PR DESCRIPTION
The Testing tutorial page shows an example pytest session output using very old versions (Python 3.6, pytest 5, and the deprecated py dependency).

This updates the example output line to use modern placeholder versions (Python 3.12.x, pytest 8.x.y, pluggy 1.x.y) and removes the extra plugins line from the snippet to avoid suggesting users will see those third-party plugins installed by default.

Only the English docs were updated.