### PR TITLE
ci: add explicit least-privilege permissions to project workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,6 +7,8 @@ on:
       - opened
       - reopened
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add to project

--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -16,6 +16,10 @@ on:
         required: false
         default: 'false'
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   latest-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-redistribute.yml
+++ b/.github/workflows/test-redistribute.yml
@@ -9,6 +9,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   test-redistribute:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary\n- add explicit workflow permissions to workflows that currently rely on implicit defaults\n- set `permissions: {}` for `add-to-project` (uses dedicated PAT input instead of `GITHUB_TOKEN`)\n- set `contents: write` and `pull-requests: read` for `latest-changes`\n- set `contents: read` for `test-redistribute`\n\n## Why\nDeclaring explicit token permissions improves security posture and documents intent, especially for `pull_request_target` workflows and CI jobs that only need read access.\n\n## Changed files\n- `.github/workflows/add-to-project.yml`\n- `.github/workflows/latest-changes.yml`\n- `.github/workflows/test-redistribute.yml`\n\n## Notes\n- configuration-only updates; no runtime/test logic changed\n