### PR TITLE
👷 Fix CI, do not attempt to publish `fastapi-slim`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package:
-          - fastapi
-          - fastapi-slim
     permissions:
       id-token: write
       contents: read
@@ -26,14 +21,9 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version-file: ".python-version"
-          # Issue ref: https://github.com/actions/setup-python/issues/436
-          # cache: "pip"
-          # cache-dependency-path: pyproject.toml
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Build distribution
         run: uv build
-        env:
-          TIANGOLO_BUILD_PACKAGE: ${{ matrix.package }}
       - name: Publish
         run: uv publish


### PR DESCRIPTION
👷 Fix CI, do not attempt to publish `fastapi-slim`