### PR TITLE
👷 Do not include benchmark tests in coverage to speed up coverage processing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,9 +149,12 @@ jobs:
         run: uv sync --no-dev --group tests --extra all
       - name: CodSpeed benchmarks
         uses: CodSpeedHQ/action@v4
+        env:
+            COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py3.13
+            CONTEXT: ${{ runner.os }}-py3.13
         with:
           mode: simulation
-          run: uv run --no-sync pytest tests/benchmarks --codspeed
+          run: uv run --no-sync coverage run -m pytest tests/ --codspeed
 
   coverage-combine:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,10 +68,8 @@ jobs:
             python-version: "3.13"
             coverage: coverage
             uv-resolution: highest
-            # Ubuntu with 3.13 needs coverage for CodSpeed benchmarks
           - os: ubuntu-latest
             python-version: "3.13"
-            coverage: coverage
             uv-resolution: highest
             codspeed: codspeed
           - os: ubuntu-latest
@@ -109,20 +107,10 @@ jobs:
         run: uv pip install "git+https://github.com/Kludex/starlette@main"
       - run: mkdir coverage
       - name: Test
-        if: matrix.codspeed != 'codspeed'
         run: uv run --no-sync bash scripts/test.sh
         env:
           COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
           CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}
-      - name: CodSpeed benchmarks
-        if: matrix.codspeed == 'codspeed'
-        uses: CodSpeedHQ/action@v4
-        env:
-            COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
-            CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}
-        with:
-          mode: simulation
-          run: uv run --no-sync coverage run -m pytest tests/ --codspeed
       # Do not store coverage for all possible combinations to avoid file size max errors in Smokeshow
       - name: Store coverage files
         if: matrix.coverage == 'coverage'
@@ -131,6 +119,39 @@ jobs:
           name: coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/coverage/.coverage.*') }}
           path: coverage
           include-hidden-files: true
+
+  benchmark:
+    needs:
+      - changes
+    if: needs.changes.outputs.src == 'true' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.13"
+      UV_RESOLUTION: highest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+      - name: Install Dependencies
+        run: uv sync --no-dev --group tests --extra all
+      - name: CodSpeed benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: simulation
+          run: uv run --no-sync pytest tests/benchmarks --codspeed
 
   coverage-combine:
     needs:
@@ -176,6 +197,7 @@ jobs:
     if: always()
     needs:
       - coverage-combine
+      - benchmark
     runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,7 @@ relative_files = true
 context = '${CONTEXT}'
 dynamic_context = "test_function"
 omit = [
+    "tests/benchmarks/*",
     "docs_src/response_model/tutorial003_04_py39.py",
     "docs_src/response_model/tutorial003_04_py310.py",
     "docs_src/dependencies/tutorial013_an_py310.py",  # temporary code example?


### PR DESCRIPTION
👷 Do not include benchmark tests in coverage to speed up coverage processing