### PR TITLE
👷 Do not run codspeed with coverage as it's not tracked

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,12 +149,9 @@ jobs:
         run: uv sync --no-dev --group tests --extra all
       - name: CodSpeed benchmarks
         uses: CodSpeedHQ/action@v4
-        env:
-            COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py3.13
-            CONTEXT: ${{ runner.os }}-py3.13
         with:
           mode: simulation
-          run: uv run --no-sync coverage run -m pytest tests/ --codspeed
+          run: uv run --no-sync pytest tests/benchmarks --codspeed
 
   coverage-combine:
     needs:


### PR DESCRIPTION
👷 Do not run codspeed with coverage as it's not tracked

This is done as a PR independent from https://github.com/fastapi/fastapi/pull/14965 to clearly isolate the fake "performance improvement" reported in the comment below.

The speed up in this PR is just because it's not running everything through coverage but running it directly, so it doesn't really count.

Performance improvements in previous PRs do count, as the code before and after changes was run through coverage in both cases, so the coverage overhead was the same. In fact, previous performance improvements were probably much higher than estimated, as coverage would account for a lot of the overhead.

This PR is made isolated apart so that it's clear when it's the change in how performance is measured (with and without coverage).

Future improvements will be measured against this new baseline without coverage taking overhead.