### PR TITLE
👷 Allow skipping `benchmark` job in `test` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,4 +208,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: coverage-combine,test
+          allowed-skips: coverage-combine,test,benchmark


### PR DESCRIPTION
The `benchmark` job is skipped for docs-only PRs, but it's still required in `check` job. This causes `test` wokflow to fail for PRs that only modify docs