### PR TITLE
Fix: propagate Mount routes in include_router

### DIFF
--- a/docs/pt/docs/tutorial/sql-databases.md
+++ b/docs/pt/docs/tutorial/sql-databases.md
@@ -96,7 +96,7 @@ Vamos criar uma **dependência** do FastAPI com `yield` que fornecerá uma nova 
 
 Então, criamos uma dependência `Annotated` chamada `SessionDep` para simplificar o restante do código que usará essa dependência.
 
-{* ../../docs_src/sql_databases/tutorial001_an_py310.py ln[25:30] hl[25:27,30] *}
+{* ../../docs_src/sql_databases/tutorial001_an_py310.py ln[25:30]  hl[25:27,30] *}
 
 ### Criar Tabelas de Banco de Dados na Inicialização { #create-database-tables-on-startup }
 

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1420,7 +1420,8 @@ class APIRouter(routing.Router):
         Include another `APIRouter` in the same current `APIRouter`.
 
         Read more about it in the
-        [FastAPI docs for Bigger Applications](https://fastapi.tiangolo.com/tutorial/bigger-applications/).
+        [FastAPI docs for Bigger Applications]
+        (https://fastapi.tiangolo.com/tutorial/bigger-applications/).
 
         ## Example
 

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1550,8 +1550,8 @@ class APIRouter(routing.Router):
                     prefix + route.path, route.endpoint, name=route.name
                 )
             elif isinstance(route, routing.Mount):
-                self.mount(prefix + route.path, route.app, route.name)
-
+                self.mount(prefix + router.prefix + route.path, route.app, name=route.name)
+                    
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1548,6 +1548,9 @@ class APIRouter(routing.Router):
                 self.add_websocket_route(
                     prefix + route.path, route.endpoint, name=route.name
                 )
+            elif isinstance(route, routing.Mount):
+                self.mount(prefix + route.path, route.app, route.name)
+
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1550,8 +1550,10 @@ class APIRouter(routing.Router):
                     prefix + route.path, route.endpoint, name=route.name
                 )
             elif isinstance(route, routing.Mount):
-                self.mount(prefix + router.prefix + route.path, route.app, name=route.name)
-                    
+                self.mount(
+                    prefix + router.prefix + route.path, route.app, name=route.name
+                )
+
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,19 +1,25 @@
-from fastapi import APIRouter, FastAPI
+from fastapi import FastAPI, APIRouter
+from fastapi.testclient import TestClient
 
-app = FastAPI()
-api_router = APIRouter(prefix="/api")
+
+def test_mount_on_router():
+    app = FastAPI()
+    api_router = APIRouter(prefix="/api")
 
     @api_router.get("/app")
     def read_main():
         return {"message": "Hello World from main app"}
 
-subapi = FastAPI()
+    subapi = FastAPI()
 
     @subapi.get("/sub")
     def read_sub():
         return {"message": "Hello World from sub API"}
 
-api_router.mount("/subapi", subapi)  # ← moved up
-app.include_router(api_router)       # ← now after
+    api_router.mount("/subapi", subapi)
+    app.include_router(api_router)
 
-print("All tests passed.")
+    client = TestClient(app)
+
+    assert client.get("/api/app").status_code == 200
+    assert client.get("/api/subapi/sub").status_code == 200

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, APIRouter
+from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, FastAPI
+from fastapi import FastAPI, APIRouter
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,20 +1,23 @@
-from fastapi import FastAPI, APIRouter
-from fastapi.testclient import TestClient
+from fastapi import APIRouter, FastAPI
 
 app = FastAPI()
 api_router = APIRouter(prefix="/api")
+
 
 @api_router.get("/app")
 def read_main():
     return {"message": "Hello World from main app"}
 
+
 subapi = FastAPI()
+
 
 @subapi.get("/sub")
 def read_sub():
     return {"message": "Hello World from sub API"}
 
+
 api_router.mount("/subapi", subapi)  # ← moved up
-app.include_router(api_router)       # ← now after
+app.include_router(api_router)  # ← now after
 
 print("All tests passed.")

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,20 +1,25 @@
 from fastapi import FastAPI, APIRouter
 from fastapi.testclient import TestClient
 
-app = FastAPI()
-api_router = APIRouter(prefix="/api")
 
-@api_router.get("/app")
-def read_main():
-    return {"message": "Hello World from main app"}
+def test_mount_on_router():
+    app = FastAPI()
+    api_router = APIRouter(prefix="/api")
 
-subapi = FastAPI()
+    @api_router.get("/app")
+    def read_main():
+        return {"message": "Hello World from main app"}
 
-@subapi.get("/sub")
-def read_sub():
-    return {"message": "Hello World from sub API"}
+    subapi = FastAPI()
 
-api_router.mount("/subapi", subapi)  # ← moved up
-app.include_router(api_router)       # ← now after
+    @subapi.get("/sub")
+    def read_sub():
+        return {"message": "Hello World from sub API"}
 
-print("All tests passed.")
+    api_router.mount("/subapi", subapi)
+    app.include_router(api_router)
+
+    client = TestClient(app)
+
+    assert client.get("/api/app").status_code == 200
+    assert client.get("/api/subapi/sub").status_code == 200

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI, APIRouter
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+api_router = APIRouter(prefix="/api")
+
+@api_router.get("/app")
+def read_main():
+    return {"message": "Hello World from main app"}
+
+subapi = FastAPI()
+
+@subapi.get("/sub")
+def read_sub():
+    return {"message": "Hello World from sub API"}
+
+api_router.mount("/subapi", subapi)  # ← moved up
+app.include_router(api_router)       # ← now after
+
+print("All tests passed.")


### PR DESCRIPTION
##Overview

Fixes #10180 

APIRouter.include_router was silently ignoring any routing. 
Mount entries when copying routes to the router application parent. 
Added an elif isinstance(route, routing.Mount) branch to handle them.
Then tested to confirm a sub-app mounted on an APIRouter is reachable through the parents FastAPI app. 

## Notes
Can provide test file, but was not sure where to place it so didn't add to commit. 

Fix added before include_router is called (ordering requirement to prevent the mentioned bug).

##Need BUG label for Checks