### PR TITLE
♻️ Refactor logic to handle OpenAPI and Swagger UI escaping data

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1101,16 +1101,18 @@ class FastAPI(Starlette):
 
     def setup(self) -> None:
         if self.openapi_url:
-            urls = (server_data.get("url") for server_data in self.servers)
-            server_urls = {url for url in urls if url}
 
             async def openapi(req: Request) -> JSONResponse:
                 root_path = req.scope.get("root_path", "").rstrip("/")
-                if root_path not in server_urls:
-                    if root_path and self.root_path_in_servers:
-                        self.servers.insert(0, {"url": root_path})
-                        server_urls.add(root_path)
-                return JSONResponse(self.openapi())
+                schema = self.openapi()
+                if root_path and self.root_path_in_servers:
+                    server_urls = {s.get("url") for s in schema.get("servers", [])}
+                    if root_path not in server_urls:
+                        schema = dict(schema)
+                        schema["servers"] = [{"url": root_path}] + schema.get(
+                            "servers", []
+                        )
+                return JSONResponse(schema)
 
             self.add_route(self.openapi_url, openapi, include_in_schema=False)
         if self.openapi_url and self.docs_url:

--- a/tests/test_openapi_cache_root_path.py
+++ b/tests/test_openapi_cache_root_path.py
@@ -1,0 +1,91 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+def _make_root_path_middleware(root_path: str):
+    """Return middleware that injects root_path into every request scope."""
+
+    class _Middleware:
+        def __init__(self, app: ASGIApp):
+            self.app = app
+
+        async def __call__(self, scope: Scope, receive: Receive, send: Send):
+            if scope["type"] == "http":
+                scope["root_path"] = root_path
+            await self.app(scope, receive, send)
+
+    return _Middleware
+
+
+def test_root_path_does_not_persist_across_requests():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    # Attacker request with a spoofed root_path
+    attacker_client = TestClient(app, root_path="/evil-api")
+    response1 = attacker_client.get("/openapi.json")
+    data1 = response1.json()
+    assert any(s.get("url") == "/evil-api" for s in data1.get("servers", []))
+
+    # Subsequent legitimate request with no root_path
+    clean_client = TestClient(app)
+    response2 = clean_client.get("/openapi.json")
+    data2 = response2.json()
+    servers = [s.get("url") for s in data2.get("servers", [])]
+    assert "/evil-api" not in servers
+
+
+def test_multiple_different_root_paths_do_not_accumulate():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    for prefix in ["/path-a", "/path-b", "/path-c"]:
+        c = TestClient(app, root_path=prefix)
+        c.get("/openapi.json")
+
+    # A clean request should not have any of them
+    clean_client = TestClient(app)
+    response = clean_client.get("/openapi.json")
+    data = response.json()
+    servers = [s.get("url") for s in data.get("servers", [])]
+    for prefix in ["/path-a", "/path-b", "/path-c"]:
+        assert prefix not in servers, (
+            f"root_path '{prefix}' leaked into clean request: {servers}"
+        )
+
+
+def test_legitimate_root_path_still_appears():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    client = TestClient(app, root_path="/api/v1")
+    response = client.get("/openapi.json")
+    data = response.json()
+    servers = [s.get("url") for s in data.get("servers", [])]
+    assert "/api/v1" in servers
+
+
+def test_configured_servers_not_mutated():
+    configured_servers = [{"url": "https://prod.example.com"}]
+    app = FastAPI(servers=configured_servers)
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    # Request with a rogue root_path
+    attacker_client = TestClient(app, root_path="/evil")
+    attacker_client.get("/openapi.json")
+
+    # The original servers list must be untouched
+    assert configured_servers == [{"url": "https://prod.example.com"}]

--- a/tests/test_openapi_cache_root_path.py
+++ b/tests/test_openapi_cache_root_path.py
@@ -1,28 +1,12 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from starlette.types import ASGIApp, Receive, Scope, Send
-
-
-def _make_root_path_middleware(root_path: str):
-    """Return middleware that injects root_path into every request scope."""
-
-    class _Middleware:
-        def __init__(self, app: ASGIApp):
-            self.app = app
-
-        async def __call__(self, scope: Scope, receive: Receive, send: Send):
-            if scope["type"] == "http":
-                scope["root_path"] = root_path
-            await self.app(scope, receive, send)
-
-    return _Middleware
 
 
 def test_root_path_does_not_persist_across_requests():
     app = FastAPI()
 
     @app.get("/")
-    def read_root():
+    def read_root():  # pragma: no cover
         return {"ok": True}
 
     # Attacker request with a spoofed root_path
@@ -43,7 +27,7 @@ def test_multiple_different_root_paths_do_not_accumulate():
     app = FastAPI()
 
     @app.get("/")
-    def read_root():
+    def read_root():  # pragma: no cover
         return {"ok": True}
 
     for prefix in ["/path-a", "/path-b", "/path-c"]:
@@ -65,7 +49,7 @@ def test_legitimate_root_path_still_appears():
     app = FastAPI()
 
     @app.get("/")
-    def read_root():
+    def read_root():  # pragma: no cover
         return {"ok": True}
 
     client = TestClient(app, root_path="/api/v1")
@@ -80,7 +64,7 @@ def test_configured_servers_not_mutated():
     app = FastAPI(servers=configured_servers)
 
     @app.get("/")
-    def read_root():
+    def read_root():  # pragma: no cover
         return {"ok": True}
 
     # Request with a rogue root_path

--- a/tests/test_swagger_ui_escape.py
+++ b/tests/test_swagger_ui_escape.py
@@ -1,0 +1,37 @@
+from fastapi.openapi.docs import get_swagger_ui_html
+
+
+def test_init_oauth_html_chars_are_escaped():
+    xss_payload = "Evil</script><script>alert(1)</script>"
+    html = get_swagger_ui_html(
+        openapi_url="/openapi.json",
+        title="Test",
+        init_oauth={"appName": xss_payload},
+    )
+    body = html.body.decode()
+
+    assert "</script><script>" not in body
+    assert "\\u003c/script\\u003e\\u003cscript\\u003e" in body
+
+
+def test_swagger_ui_parameters_html_chars_are_escaped():
+    html = get_swagger_ui_html(
+        openapi_url="/openapi.json",
+        title="Test",
+        swagger_ui_parameters={"customKey": "<img src=x onerror=alert(1)>"},
+    )
+    body = html.body.decode()
+    assert "<img src=x onerror=alert(1)>" not in body
+    assert "\\u003cimg" in body
+
+
+def test_normal_init_oauth_still_works():
+    html = get_swagger_ui_html(
+        openapi_url="/openapi.json",
+        title="Test",
+        init_oauth={"clientId": "my-client", "appName": "My App"},
+    )
+    body = html.body.decode()
+    assert '"clientId": "my-client"' in body
+    assert '"appName": "My App"' in body
+    assert "ui.initOAuth" in body


### PR DESCRIPTION
♻️ Refactor logic to handle OpenAPI and Swagger UI escaping data

OpenAPI, do not store `root_path` in servers: the only way this could be a problem is if there was a misconfigured proxy that somehow allowed an attacker client to set `x-forwarded-*` headers and passed them along. For a proxy (or server) to do this, it normally has to be intentionally/explicitly misconfigured. But again, doesn't hurt to have it there.

Escape Swagger UI configs: I wouldn't consider this really important, the Swagger UI logic takes only data from the same developer building the app, I don't see a feasible scenario where this could be a problem, but probably also doesn't hurt much to have it there.

---

I received several "security reports" with this, I suspect some automated scanning tool that checks any JSON inside of HTML or similar. I don't consider these security issues, but also think it's probably fine to have these changes.