### PR TITLE
✅ Fix all tests are skipped on Windows

### DIFF
--- a/scripts/tests/test_translation_fixer/conftest.py
+++ b/scripts/tests/test_translation_fixer/conftest.py
@@ -10,9 +10,17 @@ skip_on_windows = pytest.mark.skipif(
 )
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+THIS_DIR = Path(__file__).parent.resolve()
+
+
+def pytest_collection_modifyitems(config, items: list[pytest.Item]) -> None:
+    if sys.platform != "win32":
+        return
+
     for item in items:
-        item.add_marker(skip_on_windows)
+        item_path = Path(item.fspath).resolve()
+        if item_path.is_relative_to(THIS_DIR):
+            item.add_marker(skip_on_windows)
 
 
 @pytest.fixture(name="runner")


### PR DESCRIPTION
`pytest_collection_modifyitems` hook from `scripts/tests/test_translation_fixer/conftest.py` doesn't check that item is placed inside the `scripts/tests/test_translation_fixer/`. That leads to skipping all tests on Windows.

```
=========================== 3094 skipped in 21.42s ============================
```

See: https://github.com/fastapi/fastapi/actions/runs/22365255134/job/64729413552#step:9:620