### PR TITLE
fix: replace assert with raise FastAPIError in routing.py

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -347,9 +347,7 @@ def get_request_handler(
         response: Response | None = None
         file_stack = request.scope.get("fastapi_middleware_astack")
         if not isinstance(file_stack, AsyncExitStack):
-            raise FastAPIError(
-                "fastapi_middleware_astack not found in request scope"
-            )
+            raise FastAPIError("fastapi_middleware_astack not found in request scope")
 
         # Extract endpoint context for error messages
         endpoint_ctx = (
@@ -417,9 +415,7 @@ def get_request_handler(
         errors: list[Any] = []
         async_exit_stack = request.scope.get("fastapi_inner_astack")
         if not isinstance(async_exit_stack, AsyncExitStack):
-            raise FastAPIError(
-                "fastapi_inner_astack not found in request scope"
-            )
+            raise FastAPIError("fastapi_inner_astack not found in request scope")
         solved_result = await solve_dependencies(
             request=request,
             dependant=dependant,
@@ -514,9 +510,7 @@ def get_websocket_app(
             endpoint_ctx["path"] = f"WS {mount_path}{dependant.path}"
         async_exit_stack = websocket.scope.get("fastapi_inner_astack")
         if not isinstance(async_exit_stack, AsyncExitStack):
-            raise FastAPIError(
-                "fastapi_inner_astack not found in request scope"
-            )
+            raise FastAPIError("fastapi_inner_astack not found in request scope")
         solved_result = await solve_dependencies(
             request=websocket,
             dependant=dependant,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -346,9 +346,10 @@ def get_request_handler(
     async def app(request: Request) -> Response:
         response: Response | None = None
         file_stack = request.scope.get("fastapi_middleware_astack")
-        assert isinstance(file_stack, AsyncExitStack), (
-            "fastapi_middleware_astack not found in request scope"
-        )
+        if not isinstance(file_stack, AsyncExitStack):
+            raise FastAPIError(
+                "fastapi_middleware_astack not found in request scope"
+            )
 
         # Extract endpoint context for error messages
         endpoint_ctx = (
@@ -415,9 +416,10 @@ def get_request_handler(
         # Solve dependencies and run path operation function, auto-closing dependencies
         errors: list[Any] = []
         async_exit_stack = request.scope.get("fastapi_inner_astack")
-        assert isinstance(async_exit_stack, AsyncExitStack), (
-            "fastapi_inner_astack not found in request scope"
-        )
+        if not isinstance(async_exit_stack, AsyncExitStack):
+            raise FastAPIError(
+                "fastapi_inner_astack not found in request scope"
+            )
         solved_result = await solve_dependencies(
             request=request,
             dependant=dependant,
@@ -511,9 +513,10 @@ def get_websocket_app(
             mount_path = websocket.scope.get("root_path", "").rstrip("/")
             endpoint_ctx["path"] = f"WS {mount_path}{dependant.path}"
         async_exit_stack = websocket.scope.get("fastapi_inner_astack")
-        assert isinstance(async_exit_stack, AsyncExitStack), (
-            "fastapi_inner_astack not found in request scope"
-        )
+        if not isinstance(async_exit_stack, AsyncExitStack):
+            raise FastAPIError(
+                "fastapi_inner_astack not found in request scope"
+            )
         solved_result = await solve_dependencies(
             request=websocket,
             dependant=dependant,


### PR DESCRIPTION
## Summary

Three `assert isinstance(...)` guards in `routing.py` check for required ASGI scope keys (`fastapi_middleware_astack`, `fastapi_inner_astack`). These are runtime guards, not development-time invariants.

Under `python -O` (optimized mode), **all `assert` statements are stripped**. This converts these diagnostic guards into bare `AttributeError` exceptions with no context message, making production debugging significantly harder.

**Fix:** Replace with explicit `if not isinstance(...): raise FastAPIError(...)`. Same error messages, same behavior — except now they survive `python -O`.

## Changes

- `routing.py:349` — HTTP middleware stack check (`fastapi_middleware_astack`)
- `routing.py:418` — HTTP dependency stack check (`fastapi_inner_astack`)  
- `routing.py:514` — WebSocket dependency stack check (`fastapi_inner_astack`)

## Before/After

```python
# Before (stripped by python -O)
assert isinstance(file_stack, AsyncExitStack), (
    "fastapi_middleware_astack not found in request scope"
)

# After (survives python -O)
if not isinstance(file_stack, AsyncExitStack):
    raise FastAPIError(
        "fastapi_middleware_astack not found in request scope"
    )
```

`FastAPIError` is already imported in `routing.py` and used for other runtime checks in the same file.

## Test plan

- [x] Verified `FastAPIError` is already imported and used in `routing.py`
- [x] No behavioral change under normal execution (same check, same message)
- [ ] Existing test suite should pass unchanged