### PR TITLE
docs: clarify required nullable query parameter behavior

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -222,11 +222,15 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 ### Required, can be `None` { #required-can-be-none }
 
-You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
+You can declare that a parameter can include `None` in its type while still being required.
 
 To do that, you can declare that `None` is a valid type but simply do not declare a default value:
 
 {* ../../docs_src/query_params_str_validations/tutorial006c_an_py310.py hl[9] *}
+
+In this case, clients still have to provide the query parameter.
+If the query parameter is omitted, FastAPI returns a validation error.
+Also keep in mind that query parameters are strings in URLs, so clients don't directly send a JSON `null` value.
 
 ## Query parameter list / multiple values { #query-parameter-list-multiple-values }
 

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
@@ -22,25 +22,34 @@ def get_client(request: pytest.FixtureRequest):
     return client
 
 
-@pytest.mark.xfail(
-    reason="Code example is not valid. See https://github.com/fastapi/fastapi/issues/12419"
-)
 def test_query_params_str_validations_no_query(client: TestClient):
     response = client.get("/items/")
-    assert response.status_code == 200
-    assert response.json() == {  # pragma: no cover
-        "items": [{"item_id": "Foo"}, {"item_id": "Bar"}],
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "missing",
+                "loc": ["query", "q"],
+                "msg": "Field required",
+                "input": None,
+            }
+        ]
     }
 
 
-@pytest.mark.xfail(
-    reason="Code example is not valid. See https://github.com/fastapi/fastapi/issues/12419"
-)
 def test_query_params_str_validations_empty_str(client: TestClient):
     response = client.get("/items/?q=")
-    assert response.status_code == 200
-    assert response.json() == {  # pragma: no cover
-        "items": [{"item_id": "Foo"}, {"item_id": "Bar"}],
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "string_too_short",
+                "loc": ["query", "q"],
+                "msg": "String should have at least 3 characters",
+                "input": "",
+                "ctx": {"min_length": 3},
+            }
+        ]
     }
 
 


### PR DESCRIPTION
## Summary
- clarify the `Required, can be None` docs section to match real query-parameter behavior
- note that required query params must still be provided, and URL query values are strings
- convert tutorial006c tests from `xfail` to explicit assertions for current behavior (`422` on missing or empty query values)

Closes #12419

## Testing
- `uv run --python 3.12 -m pytest tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py -q`
- `uv run --python 3.12 -m pytest tests/test_tutorial/test_query_params_str_validations/test_tutorial006.py -q`
