### PR TITLE
✏️ Fix typo in `docs/en/docs/_llm-test.md`

### DIFF
--- a/docs/en/docs/_llm-test.md
+++ b/docs/en/docs/_llm-test.md
@@ -166,7 +166,7 @@ See sections `### Special blocks` and `### Tab blocks` in the general prompt in 
 
 //// tab | Test
 
-The link text should get translated, the link address should remain unchaged:
+The link text should get translated, the link address should remain unchanged:
 
 * [Link to heading above](#code-snippets)
 * [Internal link](index.md#installation){.internal-link target=_blank}


### PR DESCRIPTION
Fixes one typo in docs/en/docs/_llm-test.md (`unchaged` -> `unchanged`).