### PR TITLE
Merge injected BackgroundTasks with Response background tasks

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -61,9 +61,9 @@ from fastapi.utils import (
     is_body_allowed_for_status_code,
 )
 from starlette import routing
-from starlette.background import BackgroundTasks as StarletteBackgroundTasks
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import is_async_callable
+from starlette.background import BackgroundTasks as StarletteBackgroundTasks
 from starlette.concurrency import run_in_threadpool
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
@@ -446,9 +446,7 @@ def get_request_handler(
                         merged.tasks.extend(existing.tasks)
                     else:
                         merged.tasks.append(existing)
-                    merged.tasks.extend(
-                        solved_result.background_tasks.tasks
-                    )
+                    merged.tasks.extend(solved_result.background_tasks.tasks)
                     raw_response.background = merged
                 response = raw_response
             else:

--- a/tests/test_background_tasks_merge.py
+++ b/tests/test_background_tasks_merge.py
@@ -3,7 +3,6 @@ from fastapi.testclient import TestClient
 from starlette.background import BackgroundTask
 from starlette.responses import JSONResponse
 
-
 results: list[str] = []
 
 

--- a/tests/test_background_tasks_merge.py
+++ b/tests/test_background_tasks_merge.py
@@ -1,0 +1,71 @@
+from fastapi import BackgroundTasks, FastAPI
+from fastapi.testclient import TestClient
+from starlette.background import BackgroundTask
+from starlette.responses import JSONResponse
+
+
+results: list[str] = []
+
+
+def task_from_injection():
+    results.append("injected")
+
+
+def task_from_response():
+    results.append("response")
+
+
+def test_merge_injected_and_response_background_tasks():
+    """Both injected BackgroundTasks and Response background tasks should run."""
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(background_tasks: BackgroundTasks):
+        background_tasks.add_task(task_from_injection)
+        return JSONResponse(
+            {"status": "ok"},
+            background=BackgroundTask(task_from_response),
+        )
+
+    results.clear()
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "injected" in results
+    assert "response" in results
+
+
+def test_only_injected_background_tasks():
+    """When Response has no background, injected tasks still run."""
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(background_tasks: BackgroundTasks):
+        background_tasks.add_task(task_from_injection)
+        return JSONResponse({"status": "ok"})
+
+    results.clear()
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "injected" in results
+    assert "response" not in results
+
+
+def test_only_response_background_task():
+    """When no BackgroundTasks are injected, response background task runs."""
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint():
+        return JSONResponse(
+            {"status": "ok"},
+            background=BackgroundTask(task_from_response),
+        )
+
+    results.clear()
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "response" in results
+    assert "injected" not in results


### PR DESCRIPTION
## Summary
- When an endpoint injects `BackgroundTasks` and adds tasks to it, but also returns a `Response` with its own `background` task, the injected tasks were silently discarded.
- Now both sets of background tasks are merged into a single `BackgroundTasks` instance so all tasks execute after the response is sent.
- The response's own background tasks run first, followed by the injected tasks.

Closes #11215

## Test plan
- [x] New test `test_merge_injected_and_response_background_tasks` - both task sources run
- [x] New test `test_only_injected_background_tasks` - no regression for inject-only case
- [x] New test `test_only_response_background_task` - no regression for response-only case
- [x] Existing `test_tutorial/test_background_tasks` tests pass