### PR TITLE
Add docstrings to default exception handler functions

### DIFF
--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -9,6 +9,12 @@ from starlette.status import WS_1008_POLICY_VIOLATION
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
+    """Default handler for `HTTPException`.
+
+    Returns a plain `Response` (no body) when the status code disallows a
+    response body (e.g. 204, 304), otherwise returns a JSON response with
+    the exception's `detail` field.
+    """
     headers = getattr(exc, "headers", None)
     if not is_body_allowed_for_status_code(exc.status_code):
         return Response(status_code=exc.status_code, headers=headers)
@@ -20,6 +26,11 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
+    """Default handler for `RequestValidationError`.
+
+    Returns a 422 JSON response whose body contains the list of validation
+    errors produced by Pydantic.
+    """
     return JSONResponse(
         status_code=422,
         content={"detail": jsonable_encoder(exc.errors())},
@@ -29,6 +40,11 @@ async def request_validation_exception_handler(
 async def websocket_request_validation_exception_handler(
     websocket: WebSocket, exc: WebSocketRequestValidationError
 ) -> None:
+    """Default handler for `WebSocketRequestValidationError`.
+
+    Closes the WebSocket connection with policy-violation code 1008 and
+    includes the validation errors in the close reason.
+    """
     await websocket.close(
         code=WS_1008_POLICY_VIOLATION, reason=jsonable_encoder(exc.errors())
     )


### PR DESCRIPTION
## Summary
- Added docstrings to the three public exception handler functions in `fastapi/exception_handlers.py`
- `http_exception_handler` - documents the body/no-body behavior based on status code
- `request_validation_exception_handler` - documents the 422 response format
- `websocket_request_validation_exception_handler` - documents the WebSocket close behavior

## Test plan
- [x] No functional changes, docstrings only
- [x] Verified file still imports correctly