### PR TITLE
Add test coverage for strict_content_type with charset parameters

### DIFF
--- a/tests/test_strict_content_type_charset.py
+++ b/tests/test_strict_content_type_charset.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+
+@app.post("/items/")
+async def create_item(data: dict):
+    return data
+
+
+client = TestClient(app)
+
+
+def test_json_content_type_with_charset_utf8():
+    """Content-Type: application/json; charset=utf-8 should be accepted."""
+    response = client.post(
+        "/items/",
+        content='{"key": "value"}',
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"key": "value"}
+
+
+def test_vendor_json_content_type_with_charset_utf8():
+    """Content-Type: application/vnd.api+json; charset=utf-8 should be accepted."""
+    response = client.post(
+        "/items/",
+        content='{"key": "value"}',
+        headers={"Content-Type": "application/vnd.api+json; charset=utf-8"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"key": "value"}
+
+
+def test_json_content_type_with_charset_iso_8859_1():
+    """Content-Type: application/json; charset=iso-8859-1 should be accepted."""
+    response = client.post(
+        "/items/",
+        content='{"key": "value"}',
+        headers={"Content-Type": "application/json; charset=iso-8859-1"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"key": "value"}
+
+
+def test_text_plain_content_type_is_rejected():
+    """Content-Type: text/plain should be rejected with 422."""
+    response = client.post(
+        "/items/",
+        content='{"key": "value"}',
+        headers={"Content-Type": "text/plain"},
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Add tests verifying that `Content-Type` headers containing charset parameters (e.g., `application/json; charset=utf-8`) are correctly accepted by the `strict_content_type` parsing logic
- Cover vendor JSON media types with charset (`application/vnd.api+json; charset=utf-8`) and non-UTF-8 charsets (`charset=iso-8859-1`)
- Confirm that non-JSON content types like `text/plain` continue to be rejected with 422

## Test plan
- [x] `test_json_content_type_with_charset_utf8` — accepts `application/json; charset=utf-8`
- [x] `test_vendor_json_content_type_with_charset_utf8` — accepts `application/vnd.api+json; charset=utf-8`
- [x] `test_json_content_type_with_charset_iso_8859_1` — accepts `application/json; charset=iso-8859-1`
- [x] `test_text_plain_content_type_is_rejected` — rejects `text/plain` with 422
- [x] All 4 tests pass with `python3 -m pytest tests/test_strict_content_type_charset.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)