### PR TITLE
Add docstring to SolvedDependency dataclass

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -555,6 +555,12 @@ async def _solve_generator(
 
 @dataclass
 class SolvedDependency:
+    """Result of resolving all dependencies for a request.
+
+    Returned by :func:`solve_dependencies` and consumed by the request
+    handler wrapper in :mod:`fastapi.routing`.
+    """
+
     values: dict[str, Any]
     errors: list[Any]
     background_tasks: StarletteBackgroundTasks | None


### PR DESCRIPTION
## Summary
- Added a concise docstring to the `SolvedDependency` dataclass in `fastapi/dependencies/utils.py`
- This dataclass is returned by `solve_dependencies()` and used in `fastapi.routing`, but had no documentation

## Test plan
- [x] No functional changes, documentation only