### PR TITLE
Add __all__ to security module for explicit public API

### DIFF
--- a/fastapi/security/__init__.py
+++ b/fastapi/security/__init__.py
@@ -13,3 +13,21 @@ from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect
+
+__all__ = [
+    "APIKeyCookie",
+    "APIKeyHeader",
+    "APIKeyQuery",
+    "HTTPAuthorizationCredentials",
+    "HTTPBasic",
+    "HTTPBasicCredentials",
+    "HTTPBearer",
+    "HTTPDigest",
+    "OAuth2",
+    "OAuth2AuthorizationCodeBearer",
+    "OAuth2PasswordBearer",
+    "OAuth2PasswordRequestForm",
+    "OAuth2PasswordRequestFormStrict",
+    "OpenIdConnect",
+    "SecurityScopes",
+]


### PR DESCRIPTION
## Summary
- Adds an `__all__` list to `fastapi/security/__init__.py` to make the module's public API explicit
- Lists all 15 security classes in alphabetical order
- Improves IDE autocompletion, documentation tools, and `from fastapi.security import *` support

## Test plan
- [ ] Verify existing security imports still work
- [ ] Verify `from fastapi.security import *` exports only listed names

🤖 Generated with [Claude Code](https://claude.com/claude-code)