### PR TITLE
Add additional invalid container response_model test cases

### DIFF
--- a/tests/test_response_model_invalid.py
+++ b/tests/test_response_model_invalid.py
@@ -41,3 +41,23 @@ def test_invalid_response_model_sub_type_in_responses_raises():
         @app.get("/", responses={"500": {"model": list[NonPydanticModel]}})
         def read_root():
             pass  # pragma: nocover
+
+
+def test_invalid_response_model_optional_raises():
+
+    with pytest.raises(FastAPIError):
+        app = FastAPI()
+
+        @app.get("/", response_model=NonPydanticModel | None)
+        def read_root():
+            pass  # pragma: nocover
+
+
+def test_invalid_response_model_dict_raises():
+
+    with pytest.raises(FastAPIError):
+        app = FastAPI()
+
+        @app.get("/", response_model=dict[str, NonPydanticModel])
+        def read_root():
+            pass  # pragma: nocover


### PR DESCRIPTION
This PR adds additional edge-case test coverage for invalid response_model
definitions involving container and Optional types.

Added cases:
- Optional[NonPydanticModel]
- Dict[str, NonPydanticModel]

These ensure consistent FastAPI Error behavior for nested invalid models.
No framework logic modified.