### PR TITLE
📝 Update links in docs to no longer use the classes external-link and internal-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The key features are:
 * **Easy**: Designed to be easy to use and learn. Less time reading docs.
 * **Short**: Minimize code duplication. Multiple features from each parameter declaration. Fewer bugs.
 * **Robust**: Get production-ready code. With automatic interactive documentation.
-* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> (previously known as Swagger) and <a href="https://json-schema.org/" class="external-link" target="_blank">JSON Schema</a>.
+* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: <a href="https://github.com/OAI/OpenAPI-Specification" target="_blank">OpenAPI</a> (previously known as Swagger) and <a href="https://json-schema.org/" target="_blank">JSON Schema</a>.
 
 <small>* estimation based on tests conducted by an internal development team, building production applications.</small>
 
@@ -72,7 +72,7 @@ The key features are:
 
 <!-- /sponsors -->
 
-<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" class="external-link" target="_blank">Other sponsors</a>
+<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" target="_blank">Other sponsors</a>
 
 ## Opinions
 
@@ -122,7 +122,7 @@ The key features are:
 
 ## FastAPI mini documentary
 
-There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" class="external-link" target="_blank">FastAPI mini documentary</a> released at the end of 2025, you can watch it online:
+There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank">FastAPI mini documentary</a> released at the end of 2025, you can watch it online:
 
 <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
 
@@ -130,7 +130,7 @@ There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" class="external-
 
 <a href="https://typer.tiangolo.com" target="_blank"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" style="width: 20%;"></a>
 
-If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out <a href="https://typer.tiangolo.com/" class="external-link" target="_blank">**Typer**</a>.
+If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out <a href="https://typer.tiangolo.com/" target="_blank">**Typer**</a>.
 
 **Typer** is FastAPI's little sibling. And it's intended to be the **FastAPI of CLIs**. ⌨️ 🚀
 
@@ -138,12 +138,12 @@ If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be 
 
 FastAPI stands on the shoulders of giants:
 
-* <a href="https://www.starlette.dev/" class="external-link" target="_blank">Starlette</a> for the web parts.
-* <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> for the data parts.
+* <a href="https://www.starlette.dev/" target="_blank">Starlette</a> for the web parts.
+* <a href="https://docs.pydantic.dev/" target="_blank">Pydantic</a> for the data parts.
 
 ## Installation
 
-Create and activate a <a href="https://fastapi.tiangolo.com/virtual-environments/" class="external-link" target="_blank">virtual environment</a> and then install FastAPI:
+Create and activate a <a href="https://fastapi.tiangolo.com/virtual-environments/" target="_blank">virtual environment</a> and then install FastAPI:
 
 <div class="termy">
 
@@ -240,7 +240,7 @@ INFO:     Application startup complete.
 <details markdown="1">
 <summary>About the command <code>fastapi dev main.py</code>...</summary>
 
-The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using <a href="https://www.uvicorn.dev" class="external-link" target="_blank">Uvicorn</a>.
+The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using <a href="https://www.uvicorn.dev" target="_blank">Uvicorn</a>.
 
 By default, `fastapi dev` will start with auto-reload enabled for local development.
 
@@ -250,7 +250,7 @@ You can read more about it in the <a href="https://fastapi.tiangolo.com/fastapi-
 
 ### Check it
 
-Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" class="external-link" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.
+Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.
 
 You will see the JSON response as:
 
@@ -267,17 +267,17 @@ You already created an API that:
 
 ### Interactive API docs
 
-Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
 
-You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" target="_blank">Swagger UI</a>):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ### Alternative API docs
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
 
-You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
+You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" target="_blank">ReDoc</a>):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -319,7 +319,7 @@ The `fastapi dev` server should reload automatically.
 
 ### Interactive API docs upgrade
 
-Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
 
 * The interactive API documentation will be automatically updated, including the new body:
 
@@ -335,7 +335,7 @@ Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_bl
 
 ### Alternative API docs upgrade
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
 
 * The alternative documentation will also reflect the new query parameter and body:
 
@@ -445,7 +445,7 @@ For a more complete example including more features, see the <a href="https://fa
 * A very powerful and easy to use **<dfn title="also known as components, resources, providers, services, injectables">Dependency Injection</dfn>** system.
 * Security and authentication, including support for **OAuth2** with **JWT tokens** and **HTTP Basic** auth.
 * More advanced (but equally easy) techniques for declaring **deeply nested JSON models** (thanks to Pydantic).
-* **GraphQL** integration with <a href="https://strawberry.rocks" class="external-link" target="_blank">Strawberry</a> and other libraries.
+* **GraphQL** integration with <a href="https://strawberry.rocks" target="_blank">Strawberry</a> and other libraries.
 * Many extra features (thanks to Starlette) as:
     * **WebSockets**
     * extremely easy tests based on HTTPX and `pytest`
@@ -455,7 +455,7 @@ For a more complete example including more features, see the <a href="https://fa
 
 ### Deploy your app (optional)
 
-You can optionally deploy your FastAPI app to <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>, go and join the waiting list if you haven't. 🚀
+You can optionally deploy your FastAPI app to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>, go and join the waiting list if you haven't. 🚀
 
 If you already have a **FastAPI Cloud** account (we invited you from the waiting list 😉), you can deploy your application with one command.
 
@@ -491,7 +491,7 @@ That's it! Now you can access your app at that URL. ✨
 
 #### About FastAPI Cloud
 
-**<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
+**<a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 
@@ -507,9 +507,9 @@ Follow your cloud provider's guides to deploy FastAPI apps with them. 🤓
 
 ## Performance
 
-Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" class="external-link" target="_blank">one of the fastest Python frameworks available</a>, only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
+Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" target="_blank">one of the fastest Python frameworks available</a>, only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
 
-To understand more about it, see the section <a href="https://fastapi.tiangolo.com/benchmarks/" class="internal-link" target="_blank">Benchmarks</a>.
+To understand more about it, see the section <a href="https://fastapi.tiangolo.com/benchmarks/" target="_blank">Benchmarks</a>.
 
 ## Dependencies
 
@@ -533,7 +533,7 @@ Used by FastAPI:
 
 * <a href="https://www.uvicorn.dev" target="_blank"><code>uvicorn</code></a> - for the server that loads and serves your application. This includes `uvicorn[standard]`, which includes some dependencies (e.g. `uvloop`) needed for high performance serving.
 * `fastapi-cli[standard]` - to provide the `fastapi` command.
-    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>.
+    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>.
 
 ### Without `standard` Dependencies
 

--- a/README.md
+++ b/README.md
@@ -5,25 +5,25 @@
     <em>FastAPI framework, high performance, easy to learn, fast to code, ready for production</em>
 </p>
 <p align="center">
-<a href="https://github.com/fastapi/fastapi/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster" target="_blank">
+<a href="https://github.com/fastapi/fastapi/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster">
     <img src="https://github.com/fastapi/fastapi/actions/workflows/test.yml/badge.svg?event=push&branch=master" alt="Test">
 </a>
-<a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi" target="_blank">
+<a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/fastapi.svg" alt="Coverage">
 </a>
-<a href="https://pypi.org/project/fastapi" target="_blank">
+<a href="https://pypi.org/project/fastapi">
     <img src="https://img.shields.io/pypi/v/fastapi?color=%2334D058&label=pypi%20package" alt="Package version">
 </a>
-<a href="https://pypi.org/project/fastapi" target="_blank">
+<a href="https://pypi.org/project/fastapi">
     <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
 </a>
 </p>
 
 ---
 
-**Documentation**: <a href="https://fastapi.tiangolo.com" target="_blank">https://fastapi.tiangolo.com</a>
+**Documentation**: [https://fastapi.tiangolo.com](https://fastapi.tiangolo.com)
 
-**Source Code**: <a href="https://github.com/fastapi/fastapi" target="_blank">https://github.com/fastapi/fastapi</a>
+**Source Code**: [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi)
 
 ---
 
@@ -38,7 +38,7 @@ The key features are:
 * **Easy**: Designed to be easy to use and learn. Less time reading docs.
 * **Short**: Minimize code duplication. Multiple features from each parameter declaration. Fewer bugs.
 * **Robust**: Get production-ready code. With automatic interactive documentation.
-* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: <a href="https://github.com/OAI/OpenAPI-Specification" target="_blank">OpenAPI</a> (previously known as Swagger) and <a href="https://json-schema.org/" target="_blank">JSON Schema</a>.
+* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: [OpenAPI](https://github.com/OAI/OpenAPI-Specification) (previously known as Swagger) and [JSON Schema](https://json-schema.org/).
 
 <small>* estimation based on tests conducted by an internal development team, building production applications.</small>
 
@@ -72,37 +72,37 @@ The key features are:
 
 <!-- /sponsors -->
 
-<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" target="_blank">Other sponsors</a>
+[Other sponsors](https://fastapi.tiangolo.com/fastapi-people/#sponsors)
 
 ## Opinions
 
 "_[...] I'm using **FastAPI** a ton these days. [...] I'm actually planning to use it for all of my team's **ML services at Microsoft**. Some of them are getting integrated into the core **Windows** product and some **Office** products._"
 
-<div style="text-align: right; margin-right: 10%;">Kabir Khan - <strong>Microsoft</strong> <a href="https://github.com/fastapi/fastapi/pull/26" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Kabir Khan - <strong>Microsoft</strong> <a href="https://github.com/fastapi/fastapi/pull/26"><small>(ref)</small></a></div>
 
 ---
 
 "_We adopted the **FastAPI** library to spawn a **REST** server that can be queried to obtain **predictions**. [for Ludwig]_"
 
-<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/"><small>(ref)</small></a></div>
 
 ---
 
 "_**Netflix** is pleased to announce the open-source release of our **crisis management** orchestration framework: **Dispatch**! [built with **FastAPI**]_"
 
-<div style="text-align: right; margin-right: 10%;">Kevin Glisson, Marc Vilanova, Forest Monsen - <strong>Netflix</strong> <a href="https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Kevin Glisson, Marc Vilanova, Forest Monsen - <strong>Netflix</strong> <a href="https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072"><small>(ref)</small></a></div>
 
 ---
 
 "_I’m over the moon excited about **FastAPI**. It’s so fun!_"
 
-<div style="text-align: right; margin-right: 10%;">Brian Okken - <strong><a href="https://pythonbytes.fm/episodes/show/123/time-to-right-the-py-wrongs?time_in_sec=855" target="_blank">Python Bytes</a> podcast host</strong> <a href="https://x.com/brianokken/status/1112220079972728832" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Brian Okken - <strong>[Python Bytes](https://pythonbytes.fm/episodes/show/123/time-to-right-the-py-wrongs?time_in_sec=855) podcast host</strong> <a href="https://x.com/brianokken/status/1112220079972728832"><small>(ref)</small></a></div>
 
 ---
 
 "_Honestly, what you've built looks super solid and polished. In many ways, it's what I wanted **Hug** to be - it's really inspiring to see someone build that._"
 
-<div style="text-align: right; margin-right: 10%;">Timothy Crosley - <strong><a href="https://github.com/hugapi/hug" target="_blank">Hug</a> creator</strong> <a href="https://news.ycombinator.com/item?id=19455465" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Timothy Crosley - <strong>[Hug](https://github.com/hugapi/hug) creator</strong> <a href="https://news.ycombinator.com/item?id=19455465"><small>(ref)</small></a></div>
 
 ---
 
@@ -110,27 +110,27 @@ The key features are:
 
 "_We've switched over to **FastAPI** for our **APIs** [...] I think you'll like it [...]_"
 
-<div style="text-align: right; margin-right: 10%;">Ines Montani - Matthew Honnibal - <strong><a href="https://explosion.ai" target="_blank">Explosion AI</a> founders - <a href="https://spacy.io" target="_blank">spaCy</a> creators</strong> <a href="https://x.com/_inesmontani/status/1144173225322143744" target="_blank"><small>(ref)</small></a> - <a href="https://x.com/honnibal/status/1144031421859655680" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Ines Montani - Matthew Honnibal - <strong>[Explosion AI](https://explosion.ai) founders - [spaCy](https://spacy.io) creators</strong> <a href="https://x.com/_inesmontani/status/1144173225322143744"><small>(ref)</small></a> - <a href="https://x.com/honnibal/status/1144031421859655680"><small>(ref)</small></a></div>
 
 ---
 
 "_If anyone is looking to build a production Python API, I would highly recommend **FastAPI**. It is **beautifully designed**, **simple to use** and **highly scalable**, it has become a **key component** in our API first development strategy and is driving many automations and services such as our Virtual TAC Engineer._"
 
-<div style="text-align: right; margin-right: 10%;">Deon Pillsbury - <strong>Cisco</strong> <a href="https://www.linkedin.com/posts/deonpillsbury_cisco-cx-python-activity-6963242628536487936-trAp/" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Deon Pillsbury - <strong>Cisco</strong> <a href="https://www.linkedin.com/posts/deonpillsbury_cisco-cx-python-activity-6963242628536487936-trAp/"><small>(ref)</small></a></div>
 
 ---
 
 ## FastAPI mini documentary
 
-There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank">FastAPI mini documentary</a> released at the end of 2025, you can watch it online:
+There's a [FastAPI mini documentary](https://www.youtube.com/watch?v=mpR8ngthqiE) released at the end of 2025, you can watch it online:
 
-<a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
+<a href="https://www.youtube.com/watch?v=mpR8ngthqiE"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
 
 ## **Typer**, the FastAPI of CLIs
 
-<a href="https://typer.tiangolo.com" target="_blank"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" style="width: 20%;"></a>
+<a href="https://typer.tiangolo.com"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" style="width: 20%;"></a>
 
-If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out <a href="https://typer.tiangolo.com/" target="_blank">**Typer**</a>.
+If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out [**Typer**](https://typer.tiangolo.com/).
 
 **Typer** is FastAPI's little sibling. And it's intended to be the **FastAPI of CLIs**. ⌨️ 🚀
 
@@ -138,12 +138,12 @@ If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be 
 
 FastAPI stands on the shoulders of giants:
 
-* <a href="https://www.starlette.dev/" target="_blank">Starlette</a> for the web parts.
-* <a href="https://docs.pydantic.dev/" target="_blank">Pydantic</a> for the data parts.
+* [Starlette](https://www.starlette.dev/) for the web parts.
+* [Pydantic](https://docs.pydantic.dev/) for the data parts.
 
 ## Installation
 
-Create and activate a <a href="https://fastapi.tiangolo.com/virtual-environments/" target="_blank">virtual environment</a> and then install FastAPI:
+Create and activate a [virtual environment](https://fastapi.tiangolo.com/virtual-environments/) and then install FastAPI:
 
 <div class="termy">
 
@@ -202,7 +202,7 @@ async def read_item(item_id: int, q: str | None = None):
 
 **Note**:
 
-If you don't know, check the _"In a hurry?"_ section about <a href="https://fastapi.tiangolo.com/async/#in-a-hurry" target="_blank">`async` and `await` in the docs</a>.
+If you don't know, check the _"In a hurry?"_ section about [`async` and `await` in the docs](https://fastapi.tiangolo.com/async/#in-a-hurry).
 
 </details>
 
@@ -240,17 +240,17 @@ INFO:     Application startup complete.
 <details markdown="1">
 <summary>About the command <code>fastapi dev main.py</code>...</summary>
 
-The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using <a href="https://www.uvicorn.dev" target="_blank">Uvicorn</a>.
+The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using [Uvicorn](https://www.uvicorn.dev).
 
 By default, `fastapi dev` will start with auto-reload enabled for local development.
 
-You can read more about it in the <a href="https://fastapi.tiangolo.com/fastapi-cli/" target="_blank">FastAPI CLI docs</a>.
+You can read more about it in the [FastAPI CLI docs](https://fastapi.tiangolo.com/fastapi-cli/).
 
 </details>
 
 ### Check it
 
-Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.
+Open your browser at [http://127.0.0.1:8000/items/5?q=somequery](http://127.0.0.1:8000/items/5?q=somequery).
 
 You will see the JSON response as:
 
@@ -267,17 +267,17 @@ You already created an API that:
 
 ### Interactive API docs
 
-Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
-You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" target="_blank">Swagger UI</a>):
+You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui)):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ### Alternative API docs
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc).
 
-You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" target="_blank">ReDoc</a>):
+You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc)):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -319,7 +319,7 @@ The `fastapi dev` server should reload automatically.
 
 ### Interactive API docs upgrade
 
-Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 * The interactive API documentation will be automatically updated, including the new body:
 
@@ -335,7 +335,7 @@ Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:
 
 ### Alternative API docs upgrade
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc).
 
 * The alternative documentation will also reflect the new query parameter and body:
 
@@ -445,7 +445,7 @@ For a more complete example including more features, see the <a href="https://fa
 * A very powerful and easy to use **<dfn title="also known as components, resources, providers, services, injectables">Dependency Injection</dfn>** system.
 * Security and authentication, including support for **OAuth2** with **JWT tokens** and **HTTP Basic** auth.
 * More advanced (but equally easy) techniques for declaring **deeply nested JSON models** (thanks to Pydantic).
-* **GraphQL** integration with <a href="https://strawberry.rocks" target="_blank">Strawberry</a> and other libraries.
+* **GraphQL** integration with [Strawberry](https://strawberry.rocks) and other libraries.
 * Many extra features (thanks to Starlette) as:
     * **WebSockets**
     * extremely easy tests based on HTTPX and `pytest`
@@ -455,7 +455,7 @@ For a more complete example including more features, see the <a href="https://fa
 
 ### Deploy your app (optional)
 
-You can optionally deploy your FastAPI app to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>, go and join the waiting list if you haven't. 🚀
+You can optionally deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com), go and join the waiting list if you haven't. 🚀
 
 If you already have a **FastAPI Cloud** account (we invited you from the waiting list 😉), you can deploy your application with one command.
 
@@ -491,7 +491,7 @@ That's it! Now you can access your app at that URL. ✨
 
 #### About FastAPI Cloud
 
-**<a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com)** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 
@@ -507,9 +507,9 @@ Follow your cloud provider's guides to deploy FastAPI apps with them. 🤓
 
 ## Performance
 
-Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" target="_blank">one of the fastest Python frameworks available</a>, only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
+Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as [one of the fastest Python frameworks available](https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7), only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
 
-To understand more about it, see the section <a href="https://fastapi.tiangolo.com/benchmarks/" target="_blank">Benchmarks</a>.
+To understand more about it, see the section [Benchmarks](https://fastapi.tiangolo.com/benchmarks/).
 
 ## Dependencies
 
@@ -521,19 +521,19 @@ When you install FastAPI with `pip install "fastapi[standard]"` it comes with th
 
 Used by Pydantic:
 
-* <a href="https://github.com/JoshData/python-email-validator" target="_blank"><code>email-validator</code></a> - for email validation.
+* [`email-validator`](https://github.com/JoshData/python-email-validator) - for email validation.
 
 Used by Starlette:
 
-* <a href="https://www.python-httpx.org" target="_blank"><code>httpx</code></a> - Required if you want to use the `TestClient`.
-* <a href="https://jinja.palletsprojects.com" target="_blank"><code>jinja2</code></a> - Required if you want to use the default template configuration.
-* <a href="https://github.com/Kludex/python-multipart" target="_blank"><code>python-multipart</code></a> - Required if you want to support form <dfn title="converting the string that comes from an HTTP request into Python data">"parsing"</dfn>, with `request.form()`.
+* [`httpx`](https://www.python-httpx.org) - Required if you want to use the `TestClient`.
+* [`jinja2`](https://jinja.palletsprojects.com) - Required if you want to use the default template configuration.
+* [`python-multipart`](https://github.com/Kludex/python-multipart) - Required if you want to support form <dfn title="converting the string that comes from an HTTP request into Python data">"parsing"</dfn>, with `request.form()`.
 
 Used by FastAPI:
 
-* <a href="https://www.uvicorn.dev" target="_blank"><code>uvicorn</code></a> - for the server that loads and serves your application. This includes `uvicorn[standard]`, which includes some dependencies (e.g. `uvloop`) needed for high performance serving.
+* [`uvicorn`](https://www.uvicorn.dev) - for the server that loads and serves your application. This includes `uvicorn[standard]`, which includes some dependencies (e.g. `uvloop`) needed for high performance serving.
 * `fastapi-cli[standard]` - to provide the `fastapi` command.
-    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>.
+    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to [FastAPI Cloud](https://fastapicloud.com).
 
 ### Without `standard` Dependencies
 
@@ -549,13 +549,13 @@ There are some additional dependencies you might want to install.
 
 Additional optional Pydantic dependencies:
 
-* <a href="https://docs.pydantic.dev/latest/usage/pydantic_settings/" target="_blank"><code>pydantic-settings</code></a> - for settings management.
-* <a href="https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/" target="_blank"><code>pydantic-extra-types</code></a> - for extra types to be used with Pydantic.
+* [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
+* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
 
 Additional optional FastAPI dependencies:
 
-* <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
-* <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Required if you want to use `UJSONResponse`.
+* [`orjson`](https://github.com/ijl/orjson) - Required if you want to use `ORJSONResponse`.
+* [`ujson`](https://github.com/esnme/ultrajson) - Required if you want to use `UJSONResponse`.
 
 ## License
 

--- a/docs/en/docs/_llm-test.md
+++ b/docs/en/docs/_llm-test.md
@@ -11,7 +11,7 @@ Use as follows:
 * Check if things are okay in the translation.
 * If necessary, improve your language specific prompt, the general prompt, or the English document.
 * Then manually fix the remaining issues in the translation, so that it is a good translation.
-* Retranslate, having the good translation in place. The ideal result would be that the LLM makes no changes anymore to the translation. That means that the general prompt and your language specific prompt are as good as they can be (It will sometimes make a few seemingly random changes, the reason is that [LLMs are not deterministic algorithms](https://doublespeak.chat/#/handbook#deterministic-output){target=_blank}).
+* Retranslate, having the good translation in place. The ideal result would be that the LLM makes no changes anymore to the translation. That means that the general prompt and your language specific prompt are as good as they can be (It will sometimes make a few seemingly random changes, the reason is that [LLMs are not deterministic algorithms](https://doublespeak.chat/#/handbook#deterministic-output)).
 
 The tests:
 
@@ -169,15 +169,15 @@ See sections `### Special blocks` and `### Tab blocks` in the general prompt in 
 The link text should get translated, the link address should remain unchanged:
 
 * [Link to heading above](#code-snippets)
-* [Internal link](index.md#installation){target=_blank}
-* [External link](https://sqlmodel.tiangolo.com/){target=_blank}
-* [Link to a style](https://fastapi.tiangolo.com/css/styles.css){target=_blank}
-* [Link to a script](https://fastapi.tiangolo.com/js/logic.js){target=_blank}
-* [Link to an image](https://fastapi.tiangolo.com/img/foo.jpg){target=_blank}
+* [Internal link](index.md#installation)
+* [External link](https://sqlmodel.tiangolo.com/)
+* [Link to a style](https://fastapi.tiangolo.com/css/styles.css)
+* [Link to a script](https://fastapi.tiangolo.com/js/logic.js)
+* [Link to an image](https://fastapi.tiangolo.com/img/foo.jpg)
 
 The link text should get translated, the link address should point to the translation:
 
-* [FastAPI link](https://fastapi.tiangolo.com/){target=_blank}
+* [FastAPI link](https://fastapi.tiangolo.com/)
 
 ////
 

--- a/docs/en/docs/_llm-test.md
+++ b/docs/en/docs/_llm-test.md
@@ -11,7 +11,7 @@ Use as follows:
 * Check if things are okay in the translation.
 * If necessary, improve your language specific prompt, the general prompt, or the English document.
 * Then manually fix the remaining issues in the translation, so that it is a good translation.
-* Retranslate, having the good translation in place. The ideal result would be that the LLM makes no changes anymore to the translation. That means that the general prompt and your language specific prompt are as good as they can be (It will sometimes make a few seemingly random changes, the reason is that <a href="https://doublespeak.chat/#/handbook#deterministic-output" class="external-link" target="_blank">LLMs are not deterministic algorithms</a>).
+* Retranslate, having the good translation in place. The ideal result would be that the LLM makes no changes anymore to the translation. That means that the general prompt and your language specific prompt are as good as they can be (It will sometimes make a few seemingly random changes, the reason is that [LLMs are not deterministic algorithms](https://doublespeak.chat/#/handbook#deterministic-output){target=_blank}).
 
 The tests:
 
@@ -169,15 +169,15 @@ See sections `### Special blocks` and `### Tab blocks` in the general prompt in 
 The link text should get translated, the link address should remain unchanged:
 
 * [Link to heading above](#code-snippets)
-* [Internal link](index.md#installation){.internal-link target=_blank}
-* <a href="https://sqlmodel.tiangolo.com/" class="external-link" target="_blank">External link</a>
-* <a href="https://fastapi.tiangolo.com/css/styles.css" class="external-link" target="_blank">Link to a style</a>
-* <a href="https://fastapi.tiangolo.com/js/logic.js" class="external-link" target="_blank">Link to a script</a>
-* <a href="https://fastapi.tiangolo.com/img/foo.jpg" class="external-link" target="_blank">Link to an image</a>
+* [Internal link](index.md#installation){target=_blank}
+* [External link](https://sqlmodel.tiangolo.com/){target=_blank}
+* [Link to a style](https://fastapi.tiangolo.com/css/styles.css){target=_blank}
+* [Link to a script](https://fastapi.tiangolo.com/js/logic.js){target=_blank}
+* [Link to an image](https://fastapi.tiangolo.com/img/foo.jpg){target=_blank}
 
 The link text should get translated, the link address should point to the translation:
 
-* <a href="https://fastapi.tiangolo.com/" class="external-link" target="_blank">FastAPI link</a>
+* [FastAPI link](https://fastapi.tiangolo.com/){target=_blank}
 
 ////
 

--- a/docs/en/docs/advanced/additional-responses.md
+++ b/docs/en/docs/advanced/additional-responses.md
@@ -243,5 +243,5 @@ For example:
 
 To see what exactly you can include in the responses, you can check these sections in the OpenAPI specification:
 
-* [OpenAPI Responses Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#responses-object){target=_blank}, it includes the `Response Object`.
-* [OpenAPI Response Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#response-object){target=_blank}, you can include anything from this directly in each response inside your `responses` parameter. Including `description`, `headers`, `content` (inside of this is that you declare different media types and JSON Schemas), and `links`.
+* [OpenAPI Responses Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#responses-object), it includes the `Response Object`.
+* [OpenAPI Response Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#response-object), you can include anything from this directly in each response inside your `responses` parameter. Including `description`, `headers`, `content` (inside of this is that you declare different media types and JSON Schemas), and `links`.

--- a/docs/en/docs/advanced/additional-responses.md
+++ b/docs/en/docs/advanced/additional-responses.md
@@ -243,5 +243,5 @@ For example:
 
 To see what exactly you can include in the responses, you can check these sections in the OpenAPI specification:
 
-* <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#responses-object" class="external-link" target="_blank">OpenAPI Responses Object</a>, it includes the `Response Object`.
-* <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#response-object" class="external-link" target="_blank">OpenAPI Response Object</a>, you can include anything from this directly in each response inside your `responses` parameter. Including `description`, `headers`, `content` (inside of this is that you declare different media types and JSON Schemas), and `links`.
+* [OpenAPI Responses Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#responses-object){target=_blank}, it includes the `Response Object`.
+* [OpenAPI Response Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#response-object){target=_blank}, you can include anything from this directly in each response inside your `responses` parameter. Including `description`, `headers`, `content` (inside of this is that you declare different media types and JSON Schemas), and `links`.

--- a/docs/en/docs/advanced/additional-status-codes.md
+++ b/docs/en/docs/advanced/additional-status-codes.md
@@ -38,4 +38,4 @@ You could also use `from starlette.responses import JSONResponse`.
 
 If you return additional status codes and responses directly, they won't be included in the OpenAPI schema (the API docs), because FastAPI doesn't have a way to know beforehand what you are going to return.
 
-But you can document that in your code, using: [Additional Responses](additional-responses.md){.internal-link target=_blank}.
+But you can document that in your code, using: [Additional Responses](additional-responses.md){target=_blank}.

--- a/docs/en/docs/advanced/additional-status-codes.md
+++ b/docs/en/docs/advanced/additional-status-codes.md
@@ -38,4 +38,4 @@ You could also use `from starlette.responses import JSONResponse`.
 
 If you return additional status codes and responses directly, they won't be included in the OpenAPI schema (the API docs), because FastAPI doesn't have a way to know beforehand what you are going to return.
 
-But you can document that in your code, using: [Additional Responses](additional-responses.md){target=_blank}.
+But you can document that in your code, using: [Additional Responses](additional-responses.md).

--- a/docs/en/docs/advanced/advanced-dependencies.md
+++ b/docs/en/docs/advanced/advanced-dependencies.md
@@ -132,7 +132,7 @@ If you have this specific use case using SQLModel (or SQLAlchemy), you could exp
 
 That way the session would release the database connection, so other requests could use it.
 
-If you have a different use case that needs to exit early from a dependency with `yield`, please create a <a href="https://github.com/fastapi/fastapi/discussions/new?category=questions" class="external-link" target="_blank">GitHub Discussion Question</a> with your specific use case and why you would benefit from having early closing for dependencies with `yield`.
+If you have a different use case that needs to exit early from a dependency with `yield`, please create a [GitHub Discussion Question](https://github.com/fastapi/fastapi/discussions/new?category=questions){target=_blank} with your specific use case and why you would benefit from having early closing for dependencies with `yield`.
 
 If there are compelling use cases for early closing in dependencies with `yield`, I would consider adding a new way to opt in to early closing.
 
@@ -144,7 +144,7 @@ This was changed in version 0.110.0 to fix unhandled memory consumption from for
 
 ### Background Tasks and Dependencies with `yield`, Technical Details { #background-tasks-and-dependencies-with-yield-technical-details }
 
-Before FastAPI 0.106.0, raising exceptions after `yield` was not possible, the exit code in dependencies with `yield` was executed *after* the response was sent, so [Exception Handlers](../tutorial/handling-errors.md#install-custom-exception-handlers){.internal-link target=_blank} would have already run.
+Before FastAPI 0.106.0, raising exceptions after `yield` was not possible, the exit code in dependencies with `yield` was executed *after* the response was sent, so [Exception Handlers](../tutorial/handling-errors.md#install-custom-exception-handlers){target=_blank} would have already run.
 
 This was designed this way mainly to allow using the same objects "yielded" by dependencies inside of background tasks, because the exit code would be executed after the background tasks were finished.
 

--- a/docs/en/docs/advanced/advanced-dependencies.md
+++ b/docs/en/docs/advanced/advanced-dependencies.md
@@ -132,7 +132,7 @@ If you have this specific use case using SQLModel (or SQLAlchemy), you could exp
 
 That way the session would release the database connection, so other requests could use it.
 
-If you have a different use case that needs to exit early from a dependency with `yield`, please create a [GitHub Discussion Question](https://github.com/fastapi/fastapi/discussions/new?category=questions){target=_blank} with your specific use case and why you would benefit from having early closing for dependencies with `yield`.
+If you have a different use case that needs to exit early from a dependency with `yield`, please create a [GitHub Discussion Question](https://github.com/fastapi/fastapi/discussions/new?category=questions) with your specific use case and why you would benefit from having early closing for dependencies with `yield`.
 
 If there are compelling use cases for early closing in dependencies with `yield`, I would consider adding a new way to opt in to early closing.
 
@@ -144,7 +144,7 @@ This was changed in version 0.110.0 to fix unhandled memory consumption from for
 
 ### Background Tasks and Dependencies with `yield`, Technical Details { #background-tasks-and-dependencies-with-yield-technical-details }
 
-Before FastAPI 0.106.0, raising exceptions after `yield` was not possible, the exit code in dependencies with `yield` was executed *after* the response was sent, so [Exception Handlers](../tutorial/handling-errors.md#install-custom-exception-handlers){target=_blank} would have already run.
+Before FastAPI 0.106.0, raising exceptions after `yield` was not possible, the exit code in dependencies with `yield` was executed *after* the response was sent, so [Exception Handlers](../tutorial/handling-errors.md#install-custom-exception-handlers) would have already run.
 
 This was designed this way mainly to allow using the same objects "yielded" by dependencies inside of background tasks, because the exit code would be executed after the background tasks were finished.
 

--- a/docs/en/docs/advanced/async-tests.md
+++ b/docs/en/docs/advanced/async-tests.md
@@ -16,11 +16,11 @@ Even if your **FastAPI** application uses normal `def` functions instead of `asy
 
 The `TestClient` does some magic inside to call the asynchronous FastAPI application in your normal `def` test functions, using standard pytest. But that magic doesn't work anymore when we're using it inside asynchronous functions. By running our tests asynchronously, we can no longer use the `TestClient` inside our test functions.
 
-The `TestClient` is based on [HTTPX](https://www.python-httpx.org){target=_blank}, and luckily, we can use it directly to test the API.
+The `TestClient` is based on [HTTPX](https://www.python-httpx.org), and luckily, we can use it directly to test the API.
 
 ## Example { #example }
 
-For a simple example, let's consider a file structure similar to the one described in [Bigger Applications](../tutorial/bigger-applications.md){target=_blank} and [Testing](../tutorial/testing.md){target=_blank}:
+For a simple example, let's consider a file structure similar to the one described in [Bigger Applications](../tutorial/bigger-applications.md) and [Testing](../tutorial/testing.md):
 
 ```
 .
@@ -84,7 +84,7 @@ Note that we're using async/await with the new `AsyncClient` - the request is as
 
 /// warning
 
-If your application relies on lifespan events, the `AsyncClient` won't trigger these events. To ensure they are triggered, use `LifespanManager` from [florimondmanca/asgi-lifespan](https://github.com/florimondmanca/asgi-lifespan#usage){target=_blank}.
+If your application relies on lifespan events, the `AsyncClient` won't trigger these events. To ensure they are triggered, use `LifespanManager` from [florimondmanca/asgi-lifespan](https://github.com/florimondmanca/asgi-lifespan#usage).
 
 ///
 
@@ -94,6 +94,6 @@ As the testing function is now asynchronous, you can now also call (and `await`)
 
 /// tip
 
-If you encounter a `RuntimeError: Task attached to a different loop` when integrating asynchronous function calls in your tests (e.g. when using [MongoDB's MotorClient](https://stackoverflow.com/questions/41584243/runtimeerror-task-attached-to-a-different-loop){target=_blank}), remember to instantiate objects that need an event loop only within async functions, e.g. an `@app.on_event("startup")` callback.
+If you encounter a `RuntimeError: Task attached to a different loop` when integrating asynchronous function calls in your tests (e.g. when using [MongoDB's MotorClient](https://stackoverflow.com/questions/41584243/runtimeerror-task-attached-to-a-different-loop)), remember to instantiate objects that need an event loop only within async functions, e.g. an `@app.on_event("startup")` callback.
 
 ///

--- a/docs/en/docs/advanced/async-tests.md
+++ b/docs/en/docs/advanced/async-tests.md
@@ -16,11 +16,11 @@ Even if your **FastAPI** application uses normal `def` functions instead of `asy
 
 The `TestClient` does some magic inside to call the asynchronous FastAPI application in your normal `def` test functions, using standard pytest. But that magic doesn't work anymore when we're using it inside asynchronous functions. By running our tests asynchronously, we can no longer use the `TestClient` inside our test functions.
 
-The `TestClient` is based on <a href="https://www.python-httpx.org" class="external-link" target="_blank">HTTPX</a>, and luckily, we can use it directly to test the API.
+The `TestClient` is based on [HTTPX](https://www.python-httpx.org){target=_blank}, and luckily, we can use it directly to test the API.
 
 ## Example { #example }
 
-For a simple example, let's consider a file structure similar to the one described in [Bigger Applications](../tutorial/bigger-applications.md){.internal-link target=_blank} and [Testing](../tutorial/testing.md){.internal-link target=_blank}:
+For a simple example, let's consider a file structure similar to the one described in [Bigger Applications](../tutorial/bigger-applications.md){target=_blank} and [Testing](../tutorial/testing.md){target=_blank}:
 
 ```
 .
@@ -84,7 +84,7 @@ Note that we're using async/await with the new `AsyncClient` - the request is as
 
 /// warning
 
-If your application relies on lifespan events, the `AsyncClient` won't trigger these events. To ensure they are triggered, use `LifespanManager` from <a href="https://github.com/florimondmanca/asgi-lifespan#usage" class="external-link" target="_blank">florimondmanca/asgi-lifespan</a>.
+If your application relies on lifespan events, the `AsyncClient` won't trigger these events. To ensure they are triggered, use `LifespanManager` from [florimondmanca/asgi-lifespan](https://github.com/florimondmanca/asgi-lifespan#usage){target=_blank}.
 
 ///
 
@@ -94,6 +94,6 @@ As the testing function is now asynchronous, you can now also call (and `await`)
 
 /// tip
 
-If you encounter a `RuntimeError: Task attached to a different loop` when integrating asynchronous function calls in your tests (e.g. when using <a href="https://stackoverflow.com/questions/41584243/runtimeerror-task-attached-to-a-different-loop" class="external-link" target="_blank">MongoDB's MotorClient</a>), remember to instantiate objects that need an event loop only within async functions, e.g. an `@app.on_event("startup")` callback.
+If you encounter a `RuntimeError: Task attached to a different loop` when integrating asynchronous function calls in your tests (e.g. when using [MongoDB's MotorClient](https://stackoverflow.com/questions/41584243/runtimeerror-task-attached-to-a-different-loop){target=_blank}), remember to instantiate objects that need an event loop only within async functions, e.g. an `@app.on_event("startup")` callback.
 
 ///

--- a/docs/en/docs/advanced/behind-a-proxy.md
+++ b/docs/en/docs/advanced/behind-a-proxy.md
@@ -16,9 +16,9 @@ But for security, as the server doesn't know it is behind a trusted proxy, it wo
 
 The proxy headers are:
 
-* [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For){target=_blank}
-* [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto){target=_blank}
-* [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host){target=_blank}
+* [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For)
+* [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto)
+* [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host)
 
 ///
 
@@ -60,7 +60,7 @@ https://mysuperapp.com/items/
 
 /// tip
 
-If you want to learn more about HTTPS, check the guide [About HTTPS](../deployment/https.md){target=_blank}.
+If you want to learn more about HTTPS, check the guide [About HTTPS](../deployment/https.md).
 
 ///
 
@@ -228,7 +228,7 @@ Passing the `root_path` to `FastAPI` would be the equivalent of passing the `--r
 
 Keep in mind that the server (Uvicorn) won't use that `root_path` for anything else than passing it to the app.
 
-But if you go with your browser to [http://127.0.0.1:8000/app](http://127.0.0.1:8000/app){target=_blank} you will see the normal response:
+But if you go with your browser to [http://127.0.0.1:8000/app](http://127.0.0.1:8000/app) you will see the normal response:
 
 ```JSON
 {
@@ -251,9 +251,9 @@ In a case like that (without a stripped path prefix), the proxy would listen on 
 
 ## Testing locally with Traefik { #testing-locally-with-traefik }
 
-You can easily run the experiment locally with a stripped path prefix using [Traefik](https://docs.traefik.io/){target=_blank}.
+You can easily run the experiment locally with a stripped path prefix using [Traefik](https://docs.traefik.io/).
 
-[Download Traefik](https://github.com/containous/traefik/releases){target=_blank}, it's a single binary, you can extract the compressed file and run it directly from the terminal.
+[Download Traefik](https://github.com/containous/traefik/releases), it's a single binary, you can extract the compressed file and run it directly from the terminal.
 
 Then create a file `traefik.toml` with:
 
@@ -330,7 +330,7 @@ $ fastapi run main.py --forwarded-allow-ips="*" --root-path /api/v1
 
 ### Check the responses { #check-the-responses }
 
-Now, if you go to the URL with the port for Uvicorn: [http://127.0.0.1:8000/app](http://127.0.0.1:8000/app){target=_blank}, you will see the normal response:
+Now, if you go to the URL with the port for Uvicorn: [http://127.0.0.1:8000/app](http://127.0.0.1:8000/app), you will see the normal response:
 
 ```JSON
 {
@@ -345,7 +345,7 @@ Notice that even though you are accessing it at `http://127.0.0.1:8000/app` it s
 
 ///
 
-And now open the URL with the port for Traefik, including the path prefix: [http://127.0.0.1:9999/api/v1/app](http://127.0.0.1:9999/api/v1/app){target=_blank}.
+And now open the URL with the port for Traefik, including the path prefix: [http://127.0.0.1:9999/api/v1/app](http://127.0.0.1:9999/api/v1/app).
 
 We get the same response:
 
@@ -370,13 +370,13 @@ But here's the fun part. ✨
 
 The "official" way to access the app would be through the proxy with the path prefix that we defined. So, as we would expect, if you try the docs UI served by Uvicorn directly, without the path prefix in the URL, it won't work, because it expects to be accessed through the proxy.
 
-You can check it at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}:
+You can check it at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs):
 
 <img src="/img/tutorial/behind-a-proxy/image01.png">
 
 But if we access the docs UI at the "official" URL using the proxy with port `9999`, at `/api/v1/docs`, it works correctly! 🎉
 
-You can check it at [http://127.0.0.1:9999/api/v1/docs](http://127.0.0.1:9999/api/v1/docs){target=_blank}:
+You can check it at [http://127.0.0.1:9999/api/v1/docs](http://127.0.0.1:9999/api/v1/docs):
 
 <img src="/img/tutorial/behind-a-proxy/image02.png">
 
@@ -433,7 +433,7 @@ Notice the auto-generated server with a `url` value of `/api/v1`, taken from the
 
 ///
 
-In the docs UI at [http://127.0.0.1:9999/api/v1/docs](http://127.0.0.1:9999/api/v1/docs){target=_blank} it would look like:
+In the docs UI at [http://127.0.0.1:9999/api/v1/docs](http://127.0.0.1:9999/api/v1/docs) it would look like:
 
 <img src="/img/tutorial/behind-a-proxy/image03.png">
 
@@ -461,6 +461,6 @@ and then it won't include it in the OpenAPI schema.
 
 ## Mounting a sub-application { #mounting-a-sub-application }
 
-If you need to mount a sub-application (as described in [Sub Applications - Mounts](sub-applications.md){target=_blank}) while also using a proxy with `root_path`, you can do it normally, as you would expect.
+If you need to mount a sub-application (as described in [Sub Applications - Mounts](sub-applications.md)) while also using a proxy with `root_path`, you can do it normally, as you would expect.
 
 FastAPI will internally use the `root_path` smartly, so it will just work. ✨

--- a/docs/en/docs/advanced/behind-a-proxy.md
+++ b/docs/en/docs/advanced/behind-a-proxy.md
@@ -16,9 +16,9 @@ But for security, as the server doesn't know it is behind a trusted proxy, it wo
 
 The proxy headers are:
 
-* <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For" class="external-link" target="_blank">X-Forwarded-For</a>
-* <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto" class="external-link" target="_blank">X-Forwarded-Proto</a>
-* <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host" class="external-link" target="_blank">X-Forwarded-Host</a>
+* [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For){target=_blank}
+* [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto){target=_blank}
+* [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host){target=_blank}
 
 ///
 
@@ -60,7 +60,7 @@ https://mysuperapp.com/items/
 
 /// tip
 
-If you want to learn more about HTTPS, check the guide [About HTTPS](../deployment/https.md){.internal-link target=_blank}.
+If you want to learn more about HTTPS, check the guide [About HTTPS](../deployment/https.md){target=_blank}.
 
 ///
 
@@ -228,7 +228,7 @@ Passing the `root_path` to `FastAPI` would be the equivalent of passing the `--r
 
 Keep in mind that the server (Uvicorn) won't use that `root_path` for anything else than passing it to the app.
 
-But if you go with your browser to <a href="http://127.0.0.1:8000/app" class="external-link" target="_blank">http://127.0.0.1:8000/app</a> you will see the normal response:
+But if you go with your browser to [http://127.0.0.1:8000/app](http://127.0.0.1:8000/app){target=_blank} you will see the normal response:
 
 ```JSON
 {
@@ -251,9 +251,9 @@ In a case like that (without a stripped path prefix), the proxy would listen on 
 
 ## Testing locally with Traefik { #testing-locally-with-traefik }
 
-You can easily run the experiment locally with a stripped path prefix using <a href="https://docs.traefik.io/" class="external-link" target="_blank">Traefik</a>.
+You can easily run the experiment locally with a stripped path prefix using [Traefik](https://docs.traefik.io/){target=_blank}.
 
-<a href="https://github.com/containous/traefik/releases" class="external-link" target="_blank">Download Traefik</a>, it's a single binary, you can extract the compressed file and run it directly from the terminal.
+[Download Traefik](https://github.com/containous/traefik/releases){target=_blank}, it's a single binary, you can extract the compressed file and run it directly from the terminal.
 
 Then create a file `traefik.toml` with:
 
@@ -330,7 +330,7 @@ $ fastapi run main.py --forwarded-allow-ips="*" --root-path /api/v1
 
 ### Check the responses { #check-the-responses }
 
-Now, if you go to the URL with the port for Uvicorn: <a href="http://127.0.0.1:8000/app" class="external-link" target="_blank">http://127.0.0.1:8000/app</a>, you will see the normal response:
+Now, if you go to the URL with the port for Uvicorn: [http://127.0.0.1:8000/app](http://127.0.0.1:8000/app){target=_blank}, you will see the normal response:
 
 ```JSON
 {
@@ -345,7 +345,7 @@ Notice that even though you are accessing it at `http://127.0.0.1:8000/app` it s
 
 ///
 
-And now open the URL with the port for Traefik, including the path prefix: <a href="http://127.0.0.1:9999/api/v1/app" class="external-link" target="_blank">http://127.0.0.1:9999/api/v1/app</a>.
+And now open the URL with the port for Traefik, including the path prefix: [http://127.0.0.1:9999/api/v1/app](http://127.0.0.1:9999/api/v1/app){target=_blank}.
 
 We get the same response:
 
@@ -370,13 +370,13 @@ But here's the fun part. ✨
 
 The "official" way to access the app would be through the proxy with the path prefix that we defined. So, as we would expect, if you try the docs UI served by Uvicorn directly, without the path prefix in the URL, it won't work, because it expects to be accessed through the proxy.
 
-You can check it at <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>:
+You can check it at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}:
 
 <img src="/img/tutorial/behind-a-proxy/image01.png">
 
 But if we access the docs UI at the "official" URL using the proxy with port `9999`, at `/api/v1/docs`, it works correctly! 🎉
 
-You can check it at <a href="http://127.0.0.1:9999/api/v1/docs" class="external-link" target="_blank">http://127.0.0.1:9999/api/v1/docs</a>:
+You can check it at [http://127.0.0.1:9999/api/v1/docs](http://127.0.0.1:9999/api/v1/docs){target=_blank}:
 
 <img src="/img/tutorial/behind-a-proxy/image02.png">
 
@@ -433,7 +433,7 @@ Notice the auto-generated server with a `url` value of `/api/v1`, taken from the
 
 ///
 
-In the docs UI at <a href="http://127.0.0.1:9999/api/v1/docs" class="external-link" target="_blank">http://127.0.0.1:9999/api/v1/docs</a> it would look like:
+In the docs UI at [http://127.0.0.1:9999/api/v1/docs](http://127.0.0.1:9999/api/v1/docs){target=_blank} it would look like:
 
 <img src="/img/tutorial/behind-a-proxy/image03.png">
 
@@ -461,6 +461,6 @@ and then it won't include it in the OpenAPI schema.
 
 ## Mounting a sub-application { #mounting-a-sub-application }
 
-If you need to mount a sub-application (as described in [Sub Applications - Mounts](sub-applications.md){.internal-link target=_blank}) while also using a proxy with `root_path`, you can do it normally, as you would expect.
+If you need to mount a sub-application (as described in [Sub Applications - Mounts](sub-applications.md){target=_blank}) while also using a proxy with `root_path`, you can do it normally, as you would expect.
 
 FastAPI will internally use the `root_path` smartly, so it will just work. ✨

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -2,7 +2,7 @@
 
 By default, **FastAPI** will return JSON responses.
 
-You can override it by returning a `Response` directly as seen in [Return a Response directly](response-directly.md){target=_blank}.
+You can override it by returning a `Response` directly as seen in [Return a Response directly](response-directly.md).
 
 But if you return a `Response` directly (or any subclass, like `JSONResponse`), the data won't be automatically converted (even if you declare a `response_model`), and the documentation won't be automatically generated (for example, including the specific "media type", in the HTTP header `Content-Type` as part of the generated OpenAPI).
 
@@ -20,15 +20,15 @@ If you use a response class with no media type, FastAPI will expect your respons
 
 By default FastAPI returns JSON responses.
 
-If you declare a [Response Model](../tutorial/response-model.md){target=_blank} FastAPI will use it to serialize the data to JSON, using Pydantic.
+If you declare a [Response Model](../tutorial/response-model.md) FastAPI will use it to serialize the data to JSON, using Pydantic.
 
-If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md){target=_blank} and put it in a `JSONResponse`.
+If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md) and put it in a `JSONResponse`.
 
 If you declare a `response_class` with a JSON media type (`application/json`), like is the case with the `JSONResponse`, the data you return will be automatically converted (and filtered) with any Pydantic `response_model` that you declared in the *path operation decorator*. But the data won't be serialized to JSON bytes with Pydantic, instead it will be converted with the `jsonable_encoder` and then passed to the `JSONResponse` class, which will serialize it to bytes using the standard JSON library in Python.
 
 ### JSON Performance { #json-performance }
 
-In short, if you want the maximum performance, use a [Response Model](../tutorial/response-model.md){target=_blank} and don't declare a `response_class` in the *path operation decorator*.
+In short, if you want the maximum performance, use a [Response Model](../tutorial/response-model.md) and don't declare a `response_class` in the *path operation decorator*.
 
 {* ../../docs_src/response_model/tutorial001_01_py310.py ln[15:17] hl[16] *}
 
@@ -53,7 +53,7 @@ And it will be documented as such in OpenAPI.
 
 ### Return a `Response` { #return-a-response }
 
-As seen in [Return a Response directly](response-directly.md){target=_blank}, you can also override the response directly in your *path operation*, by returning it.
+As seen in [Return a Response directly](response-directly.md), you can also override the response directly in your *path operation*, by returning it.
 
 The same example from above, returning an `HTMLResponse`, could look like:
 
@@ -189,9 +189,9 @@ This would be even more important with large or infinite streams.
 
 /// tip
 
-Instead of returning a `StreamingResponse` directly, you should probably follow the style in [Stream Data](./stream-data.md){target=_blank}, it's much more convenient and handles cancellation behind the scenes for you.
+Instead of returning a `StreamingResponse` directly, you should probably follow the style in [Stream Data](./stream-data.md), it's much more convenient and handles cancellation behind the scenes for you.
 
-If you are streaming JSON Lines, follow the [Stream JSON Lines](../tutorial/stream-json-lines.md){target=_blank} tutorial.
+If you are streaming JSON Lines, follow the [Stream JSON Lines](../tutorial/stream-json-lines.md) tutorial.
 
 ///
 
@@ -220,7 +220,7 @@ In this case, you can return the file path directly from your *path operation* f
 
 You can create your own custom response class, inheriting from `Response` and using it.
 
-For example, let's say that you want to use [`orjson`](https://github.com/ijl/orjson){target=_blank} with some settings.
+For example, let's say that you want to use [`orjson`](https://github.com/ijl/orjson) with some settings.
 
 Let's say you want it to return indented and formatted JSON, so you want to use the orjson option `orjson.OPT_INDENT_2`.
 
@@ -246,7 +246,7 @@ Of course, you will probably find much better ways to take advantage of this tha
 
 ### `orjson` or Response Model { #orjson-or-response-model }
 
-If what you are looking for is performance, you are probably better off using a [Response Model](../tutorial/response-model.md){target=_blank} than an `orjson` response.
+If what you are looking for is performance, you are probably better off using a [Response Model](../tutorial/response-model.md) than an `orjson` response.
 
 With a response model, FastAPI will use Pydantic to serialize the data to JSON, without using intermediate steps, like converting it with `jsonable_encoder`, which would happen in any other case.
 
@@ -270,4 +270,4 @@ You can still override `response_class` in *path operations* as before.
 
 ## Additional documentation { #additional-documentation }
 
-You can also declare the media type and many other details in OpenAPI using `responses`: [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.
+You can also declare the media type and many other details in OpenAPI using `responses`: [Additional Responses in OpenAPI](additional-responses.md).

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -2,7 +2,7 @@
 
 By default, **FastAPI** will return JSON responses.
 
-You can override it by returning a `Response` directly as seen in [Return a Response directly](response-directly.md){.internal-link target=_blank}.
+You can override it by returning a `Response` directly as seen in [Return a Response directly](response-directly.md){target=_blank}.
 
 But if you return a `Response` directly (or any subclass, like `JSONResponse`), the data won't be automatically converted (even if you declare a `response_model`), and the documentation won't be automatically generated (for example, including the specific "media type", in the HTTP header `Content-Type` as part of the generated OpenAPI).
 
@@ -20,15 +20,15 @@ If you use a response class with no media type, FastAPI will expect your respons
 
 By default FastAPI returns JSON responses.
 
-If you declare a [Response Model](../tutorial/response-model.md){.internal-link target=_blank} FastAPI will use it to serialize the data to JSON, using Pydantic.
+If you declare a [Response Model](../tutorial/response-model.md){target=_blank} FastAPI will use it to serialize the data to JSON, using Pydantic.
 
-If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md){.internal-link target=_blank} and put it in a `JSONResponse`.
+If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md){target=_blank} and put it in a `JSONResponse`.
 
 If you declare a `response_class` with a JSON media type (`application/json`), like is the case with the `JSONResponse`, the data you return will be automatically converted (and filtered) with any Pydantic `response_model` that you declared in the *path operation decorator*. But the data won't be serialized to JSON bytes with Pydantic, instead it will be converted with the `jsonable_encoder` and then passed to the `JSONResponse` class, which will serialize it to bytes using the standard JSON library in Python.
 
 ### JSON Performance { #json-performance }
 
-In short, if you want the maximum performance, use a [Response Model](../tutorial/response-model.md){.internal-link target=_blank} and don't declare a `response_class` in the *path operation decorator*.
+In short, if you want the maximum performance, use a [Response Model](../tutorial/response-model.md){target=_blank} and don't declare a `response_class` in the *path operation decorator*.
 
 {* ../../docs_src/response_model/tutorial001_01_py310.py ln[15:17] hl[16] *}
 
@@ -53,7 +53,7 @@ And it will be documented as such in OpenAPI.
 
 ### Return a `Response` { #return-a-response }
 
-As seen in [Return a Response directly](response-directly.md){.internal-link target=_blank}, you can also override the response directly in your *path operation*, by returning it.
+As seen in [Return a Response directly](response-directly.md){target=_blank}, you can also override the response directly in your *path operation*, by returning it.
 
 The same example from above, returning an `HTMLResponse`, could look like:
 
@@ -189,9 +189,9 @@ This would be even more important with large or infinite streams.
 
 /// tip
 
-Instead of returning a `StreamingResponse` directly, you should probably follow the style in [Stream Data](./stream-data.md){.internal-link target=_blank}, it's much more convenient and handles cancellation behind the scenes for you.
+Instead of returning a `StreamingResponse` directly, you should probably follow the style in [Stream Data](./stream-data.md){target=_blank}, it's much more convenient and handles cancellation behind the scenes for you.
 
-If you are streaming JSON Lines, follow the [Stream JSON Lines](../tutorial/stream-json-lines.md){.internal-link target=_blank} tutorial.
+If you are streaming JSON Lines, follow the [Stream JSON Lines](../tutorial/stream-json-lines.md){target=_blank} tutorial.
 
 ///
 
@@ -220,7 +220,7 @@ In this case, you can return the file path directly from your *path operation* f
 
 You can create your own custom response class, inheriting from `Response` and using it.
 
-For example, let's say that you want to use <a href="https://github.com/ijl/orjson" class="external-link" target="_blank">`orjson`</a> with some settings.
+For example, let's say that you want to use [`orjson`](https://github.com/ijl/orjson){target=_blank} with some settings.
 
 Let's say you want it to return indented and formatted JSON, so you want to use the orjson option `orjson.OPT_INDENT_2`.
 
@@ -246,7 +246,7 @@ Of course, you will probably find much better ways to take advantage of this tha
 
 ### `orjson` or Response Model { #orjson-or-response-model }
 
-If what you are looking for is performance, you are probably better off using a [Response Model](../tutorial/response-model.md){.internal-link target=_blank} than an `orjson` response.
+If what you are looking for is performance, you are probably better off using a [Response Model](../tutorial/response-model.md){target=_blank} than an `orjson` response.
 
 With a response model, FastAPI will use Pydantic to serialize the data to JSON, without using intermediate steps, like converting it with `jsonable_encoder`, which would happen in any other case.
 
@@ -270,4 +270,4 @@ You can still override `response_class` in *path operations* as before.
 
 ## Additional documentation { #additional-documentation }
 
-You can also declare the media type and many other details in OpenAPI using `responses`: [Additional Responses in OpenAPI](additional-responses.md){.internal-link target=_blank}.
+You can also declare the media type and many other details in OpenAPI using `responses`: [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.

--- a/docs/en/docs/advanced/dataclasses.md
+++ b/docs/en/docs/advanced/dataclasses.md
@@ -2,11 +2,11 @@
 
 FastAPI is built on top of **Pydantic**, and I have been showing you how to use Pydantic models to declare requests and responses.
 
-But FastAPI also supports using [`dataclasses`](https://docs.python.org/3/library/dataclasses.html){target=_blank} the same way:
+But FastAPI also supports using [`dataclasses`](https://docs.python.org/3/library/dataclasses.html) the same way:
 
 {* ../../docs_src/dataclasses_/tutorial001_py310.py hl[1,6:11,18:19] *}
 
-This is still supported thanks to **Pydantic**, as it has [internal support for `dataclasses`](https://docs.pydantic.dev/latest/concepts/dataclasses/#use-of-stdlib-dataclasses-with-basemodel){target=_blank}.
+This is still supported thanks to **Pydantic**, as it has [internal support for `dataclasses`](https://docs.pydantic.dev/latest/concepts/dataclasses/#use-of-stdlib-dataclasses-with-basemodel).
 
 So, even with the code above that doesn't use Pydantic explicitly, FastAPI is using Pydantic to convert those standard dataclasses to Pydantic's own flavor of dataclasses.
 
@@ -74,7 +74,7 @@ In that case, you can simply swap the standard `dataclasses` with `pydantic.data
 
     As always, in FastAPI you can combine `def` and `async def` as needed.
 
-    If you need a refresher about when to use which, check out the section _"In a hurry?"_ in the docs about [`async` and `await`](../async.md#in-a-hurry){target=_blank}.
+    If you need a refresher about when to use which, check out the section _"In a hurry?"_ in the docs about [`async` and `await`](../async.md#in-a-hurry).
 
 9. This *path operation function* is not returning dataclasses (although it could), but a list of dictionaries with internal data.
 
@@ -88,7 +88,7 @@ Check the in-code annotation tips above to see more specific details.
 
 You can also combine `dataclasses` with other Pydantic models, inherit from them, include them in your own models, etc.
 
-To learn more, check the [Pydantic docs about dataclasses](https://docs.pydantic.dev/latest/concepts/dataclasses/){target=_blank}.
+To learn more, check the [Pydantic docs about dataclasses](https://docs.pydantic.dev/latest/concepts/dataclasses/).
 
 ## Version { #version }
 

--- a/docs/en/docs/advanced/dataclasses.md
+++ b/docs/en/docs/advanced/dataclasses.md
@@ -2,11 +2,11 @@
 
 FastAPI is built on top of **Pydantic**, and I have been showing you how to use Pydantic models to declare requests and responses.
 
-But FastAPI also supports using <a href="https://docs.python.org/3/library/dataclasses.html" class="external-link" target="_blank">`dataclasses`</a> the same way:
+But FastAPI also supports using [`dataclasses`](https://docs.python.org/3/library/dataclasses.html){target=_blank} the same way:
 
 {* ../../docs_src/dataclasses_/tutorial001_py310.py hl[1,6:11,18:19] *}
 
-This is still supported thanks to **Pydantic**, as it has <a href="https://docs.pydantic.dev/latest/concepts/dataclasses/#use-of-stdlib-dataclasses-with-basemodel" class="external-link" target="_blank">internal support for `dataclasses`</a>.
+This is still supported thanks to **Pydantic**, as it has [internal support for `dataclasses`](https://docs.pydantic.dev/latest/concepts/dataclasses/#use-of-stdlib-dataclasses-with-basemodel){target=_blank}.
 
 So, even with the code above that doesn't use Pydantic explicitly, FastAPI is using Pydantic to convert those standard dataclasses to Pydantic's own flavor of dataclasses.
 
@@ -74,7 +74,7 @@ In that case, you can simply swap the standard `dataclasses` with `pydantic.data
 
     As always, in FastAPI you can combine `def` and `async def` as needed.
 
-    If you need a refresher about when to use which, check out the section _"In a hurry?"_ in the docs about [`async` and `await`](../async.md#in-a-hurry){.internal-link target=_blank}.
+    If you need a refresher about when to use which, check out the section _"In a hurry?"_ in the docs about [`async` and `await`](../async.md#in-a-hurry){target=_blank}.
 
 9. This *path operation function* is not returning dataclasses (although it could), but a list of dictionaries with internal data.
 
@@ -88,7 +88,7 @@ Check the in-code annotation tips above to see more specific details.
 
 You can also combine `dataclasses` with other Pydantic models, inherit from them, include them in your own models, etc.
 
-To learn more, check the <a href="https://docs.pydantic.dev/latest/concepts/dataclasses/" class="external-link" target="_blank">Pydantic docs about dataclasses</a>.
+To learn more, check the [Pydantic docs about dataclasses](https://docs.pydantic.dev/latest/concepts/dataclasses/){target=_blank}.
 
 ## Version { #version }
 

--- a/docs/en/docs/advanced/events.md
+++ b/docs/en/docs/advanced/events.md
@@ -150,11 +150,11 @@ Because of that, it's now recommended to instead use the `lifespan` as explained
 
 Just a technical detail for the curious nerds. 🤓
 
-Underneath, in the ASGI technical specification, this is part of the <a href="https://asgi.readthedocs.io/en/latest/specs/lifespan.html" class="external-link" target="_blank">Lifespan Protocol</a>, and it defines events called `startup` and `shutdown`.
+Underneath, in the ASGI technical specification, this is part of the [Lifespan Protocol](https://asgi.readthedocs.io/en/latest/specs/lifespan.html){target=_blank}, and it defines events called `startup` and `shutdown`.
 
 /// info
 
-You can read more about the Starlette `lifespan` handlers in <a href="https://www.starlette.dev/lifespan/" class="external-link" target="_blank">Starlette's  Lifespan' docs</a>.
+You can read more about the Starlette `lifespan` handlers in [Starlette's  Lifespan' docs](https://www.starlette.dev/lifespan/){target=_blank}.
 
 Including how to handle lifespan state that can be used in other areas of your code.
 
@@ -162,4 +162,4 @@ Including how to handle lifespan state that can be used in other areas of your c
 
 ## Sub Applications { #sub-applications }
 
-🚨 Keep in mind that these lifespan events (startup and shutdown) will only be executed for the main application, not for [Sub Applications - Mounts](sub-applications.md){.internal-link target=_blank}.
+🚨 Keep in mind that these lifespan events (startup and shutdown) will only be executed for the main application, not for [Sub Applications - Mounts](sub-applications.md){target=_blank}.

--- a/docs/en/docs/advanced/events.md
+++ b/docs/en/docs/advanced/events.md
@@ -150,11 +150,11 @@ Because of that, it's now recommended to instead use the `lifespan` as explained
 
 Just a technical detail for the curious nerds. 🤓
 
-Underneath, in the ASGI technical specification, this is part of the [Lifespan Protocol](https://asgi.readthedocs.io/en/latest/specs/lifespan.html){target=_blank}, and it defines events called `startup` and `shutdown`.
+Underneath, in the ASGI technical specification, this is part of the [Lifespan Protocol](https://asgi.readthedocs.io/en/latest/specs/lifespan.html), and it defines events called `startup` and `shutdown`.
 
 /// info
 
-You can read more about the Starlette `lifespan` handlers in [Starlette's  Lifespan' docs](https://www.starlette.dev/lifespan/){target=_blank}.
+You can read more about the Starlette `lifespan` handlers in [Starlette's  Lifespan' docs](https://www.starlette.dev/lifespan/).
 
 Including how to handle lifespan state that can be used in other areas of your code.
 
@@ -162,4 +162,4 @@ Including how to handle lifespan state that can be used in other areas of your c
 
 ## Sub Applications { #sub-applications }
 
-🚨 Keep in mind that these lifespan events (startup and shutdown) will only be executed for the main application, not for [Sub Applications - Mounts](sub-applications.md){target=_blank}.
+🚨 Keep in mind that these lifespan events (startup and shutdown) will only be executed for the main application, not for [Sub Applications - Mounts](sub-applications.md).

--- a/docs/en/docs/advanced/generate-clients.md
+++ b/docs/en/docs/advanced/generate-clients.md
@@ -8,11 +8,11 @@ In this guide, you'll learn how to generate a **TypeScript SDK** for your FastAP
 
 ## Open Source SDK Generators { #open-source-sdk-generators }
 
-A versatile option is the [OpenAPI Generator](https://openapi-generator.tech/){target=_blank}, which supports **many programming languages** and can generate SDKs from your OpenAPI specification.
+A versatile option is the [OpenAPI Generator](https://openapi-generator.tech/), which supports **many programming languages** and can generate SDKs from your OpenAPI specification.
 
-For **TypeScript clients**, [Hey API](https://heyapi.dev/){target=_blank} is a purpose-built solution, providing an optimized experience for the TypeScript ecosystem.
+For **TypeScript clients**, [Hey API](https://heyapi.dev/) is a purpose-built solution, providing an optimized experience for the TypeScript ecosystem.
 
-You can discover more SDK generators on [OpenAPI.Tools](https://openapi.tools/#sdk){target=_blank}.
+You can discover more SDK generators on [OpenAPI.Tools](https://openapi.tools/#sdk).
 
 /// tip
 
@@ -24,15 +24,15 @@ FastAPI automatically generates **OpenAPI 3.1** specifications, so any tool you 
 
 This section highlights **venture-backed** and **company-supported** solutions from companies that sponsor FastAPI. These products provide **additional features** and **integrations** on top of high-quality generated SDKs.
 
-By ✨ [**sponsoring FastAPI**](../help-fastapi.md#sponsor-the-author){target=_blank} ✨, these companies help ensure the framework and its **ecosystem** remain healthy and **sustainable**.
+By ✨ [**sponsoring FastAPI**](../help-fastapi.md#sponsor-the-author) ✨, these companies help ensure the framework and its **ecosystem** remain healthy and **sustainable**.
 
 Their sponsorship also demonstrates a strong commitment to the FastAPI **community** (you), showing that they care not only about offering a **great service** but also about supporting a **robust and thriving framework**, FastAPI. 🙇
 
 For example, you might want to try:
 
-* [Speakeasy](https://speakeasy.com/editor?utm_source=fastapi+repo&utm_medium=github+sponsorship){target=_blank}
-* [Stainless](https://www.stainless.com/?utm_source=fastapi&utm_medium=referral){target=_blank}
-* [liblab](https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi){target=_blank}
+* [Speakeasy](https://speakeasy.com/editor?utm_source=fastapi+repo&utm_medium=github+sponsorship)
+* [Stainless](https://www.stainless.com/?utm_source=fastapi&utm_medium=referral)
+* [liblab](https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi)
 
 Some of these solutions may also be open source or offer free tiers, so you can try them without a financial commitment. Other commercial SDK generators are available and can be found online. 🤓
 
@@ -66,7 +66,7 @@ npx @hey-api/openapi-ts -i http://localhost:8000/openapi.json -o src/client
 
 This will generate a TypeScript SDK in `./src/client`.
 
-You can learn how to [install `@hey-api/openapi-ts`](https://heyapi.dev/openapi-ts/get-started){target=_blank} and read about the [generated output](https://heyapi.dev/openapi-ts/output){target=_blank} on their website.
+You can learn how to [install `@hey-api/openapi-ts`](https://heyapi.dev/openapi-ts/get-started) and read about the [generated output](https://heyapi.dev/openapi-ts/output) on their website.
 
 ### Using the SDK { #using-the-sdk }
 

--- a/docs/en/docs/advanced/generate-clients.md
+++ b/docs/en/docs/advanced/generate-clients.md
@@ -8,11 +8,11 @@ In this guide, you'll learn how to generate a **TypeScript SDK** for your FastAP
 
 ## Open Source SDK Generators { #open-source-sdk-generators }
 
-A versatile option is the <a href="https://openapi-generator.tech/" class="external-link" target="_blank">OpenAPI Generator</a>, which supports **many programming languages** and can generate SDKs from your OpenAPI specification.
+A versatile option is the [OpenAPI Generator](https://openapi-generator.tech/){target=_blank}, which supports **many programming languages** and can generate SDKs from your OpenAPI specification.
 
-For **TypeScript clients**, <a href="https://heyapi.dev/" class="external-link" target="_blank">Hey API</a> is a purpose-built solution, providing an optimized experience for the TypeScript ecosystem.
+For **TypeScript clients**, [Hey API](https://heyapi.dev/){target=_blank} is a purpose-built solution, providing an optimized experience for the TypeScript ecosystem.
 
-You can discover more SDK generators on <a href="https://openapi.tools/#sdk" class="external-link" target="_blank">OpenAPI.Tools</a>.
+You can discover more SDK generators on [OpenAPI.Tools](https://openapi.tools/#sdk){target=_blank}.
 
 /// tip
 
@@ -24,15 +24,15 @@ FastAPI automatically generates **OpenAPI 3.1** specifications, so any tool you 
 
 This section highlights **venture-backed** and **company-supported** solutions from companies that sponsor FastAPI. These products provide **additional features** and **integrations** on top of high-quality generated SDKs.
 
-By ✨ [**sponsoring FastAPI**](../help-fastapi.md#sponsor-the-author){.internal-link target=_blank} ✨, these companies help ensure the framework and its **ecosystem** remain healthy and **sustainable**.
+By ✨ [**sponsoring FastAPI**](../help-fastapi.md#sponsor-the-author){target=_blank} ✨, these companies help ensure the framework and its **ecosystem** remain healthy and **sustainable**.
 
 Their sponsorship also demonstrates a strong commitment to the FastAPI **community** (you), showing that they care not only about offering a **great service** but also about supporting a **robust and thriving framework**, FastAPI. 🙇
 
 For example, you might want to try:
 
-* <a href="https://speakeasy.com/editor?utm_source=fastapi+repo&utm_medium=github+sponsorship" class="external-link" target="_blank">Speakeasy</a>
-* <a href="https://www.stainless.com/?utm_source=fastapi&utm_medium=referral" class="external-link" target="_blank">Stainless</a>
-* <a href="https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi" class="external-link" target="_blank">liblab</a>
+* [Speakeasy](https://speakeasy.com/editor?utm_source=fastapi+repo&utm_medium=github+sponsorship){target=_blank}
+* [Stainless](https://www.stainless.com/?utm_source=fastapi&utm_medium=referral){target=_blank}
+* [liblab](https://developers.liblab.com/tutorials/sdk-for-fastapi?utm_source=fastapi){target=_blank}
 
 Some of these solutions may also be open source or offer free tiers, so you can try them without a financial commitment. Other commercial SDK generators are available and can be found online. 🤓
 
@@ -66,7 +66,7 @@ npx @hey-api/openapi-ts -i http://localhost:8000/openapi.json -o src/client
 
 This will generate a TypeScript SDK in `./src/client`.
 
-You can learn how to <a href="https://heyapi.dev/openapi-ts/get-started" class="external-link" target="_blank">install `@hey-api/openapi-ts`</a> and read about the <a href="https://heyapi.dev/openapi-ts/output" class="external-link" target="_blank">generated output</a> on their website.
+You can learn how to [install `@hey-api/openapi-ts`](https://heyapi.dev/openapi-ts/get-started){target=_blank} and read about the [generated output](https://heyapi.dev/openapi-ts/output){target=_blank} on their website.
 
 ### Using the SDK { #using-the-sdk }
 

--- a/docs/en/docs/advanced/index.md
+++ b/docs/en/docs/advanced/index.md
@@ -2,7 +2,7 @@
 
 ## Additional Features { #additional-features }
 
-The main [Tutorial - User Guide](../tutorial/index.md){.internal-link target=_blank} should be enough to give you a tour through all the main features of **FastAPI**.
+The main [Tutorial - User Guide](../tutorial/index.md){target=_blank} should be enough to give you a tour through all the main features of **FastAPI**.
 
 In the next sections you will see other options, configurations, and additional features.
 
@@ -16,6 +16,6 @@ And it's possible that for your use case, the solution is in one of them.
 
 ## Read the Tutorial first { #read-the-tutorial-first }
 
-You could still use most of the features in **FastAPI** with the knowledge from the main [Tutorial - User Guide](../tutorial/index.md){.internal-link target=_blank}.
+You could still use most of the features in **FastAPI** with the knowledge from the main [Tutorial - User Guide](../tutorial/index.md){target=_blank}.
 
 And the next sections assume you already read it, and assume that you know those main ideas.

--- a/docs/en/docs/advanced/index.md
+++ b/docs/en/docs/advanced/index.md
@@ -2,7 +2,7 @@
 
 ## Additional Features { #additional-features }
 
-The main [Tutorial - User Guide](../tutorial/index.md){target=_blank} should be enough to give you a tour through all the main features of **FastAPI**.
+The main [Tutorial - User Guide](../tutorial/index.md) should be enough to give you a tour through all the main features of **FastAPI**.
 
 In the next sections you will see other options, configurations, and additional features.
 
@@ -16,6 +16,6 @@ And it's possible that for your use case, the solution is in one of them.
 
 ## Read the Tutorial first { #read-the-tutorial-first }
 
-You could still use most of the features in **FastAPI** with the knowledge from the main [Tutorial - User Guide](../tutorial/index.md){target=_blank}.
+You could still use most of the features in **FastAPI** with the knowledge from the main [Tutorial - User Guide](../tutorial/index.md).
 
 And the next sections assume you already read it, and assume that you know those main ideas.

--- a/docs/en/docs/advanced/json-base64-bytes.md
+++ b/docs/en/docs/advanced/json-base64-bytes.md
@@ -4,7 +4,7 @@ If your app needs to receive and send JSON data, but you need to include binary 
 
 ## Base64 vs Files { #base64-vs-files }
 
-Consider first if you can use [Request Files](../tutorial/request-files.md){.internal-link target=_blank} for uploading binary data and [Custom Response - FileResponse](./custom-response.md#fileresponse--fileresponse-){.internal-link target=_blank} for sending binary data, instead of encoding it in JSON.
+Consider first if you can use [Request Files](../tutorial/request-files.md){target=_blank} for uploading binary data and [Custom Response - FileResponse](./custom-response.md#fileresponse--fileresponse-){target=_blank} for sending binary data, instead of encoding it in JSON.
 
 JSON can only contain UTF-8 encoded strings, so it can't contain raw bytes.
 

--- a/docs/en/docs/advanced/json-base64-bytes.md
+++ b/docs/en/docs/advanced/json-base64-bytes.md
@@ -4,7 +4,7 @@ If your app needs to receive and send JSON data, but you need to include binary 
 
 ## Base64 vs Files { #base64-vs-files }
 
-Consider first if you can use [Request Files](../tutorial/request-files.md){target=_blank} for uploading binary data and [Custom Response - FileResponse](./custom-response.md#fileresponse--fileresponse-){target=_blank} for sending binary data, instead of encoding it in JSON.
+Consider first if you can use [Request Files](../tutorial/request-files.md) for uploading binary data and [Custom Response - FileResponse](./custom-response.md#fileresponse--fileresponse-) for sending binary data, instead of encoding it in JSON.
 
 JSON can only contain UTF-8 encoded strings, so it can't contain raw bytes.
 

--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -1,8 +1,8 @@
 # Advanced Middleware { #advanced-middleware }
 
-In the main tutorial you read how to add [Custom Middleware](../tutorial/middleware.md){target=_blank} to your application.
+In the main tutorial you read how to add [Custom Middleware](../tutorial/middleware.md) to your application.
 
-And then you also read how to handle [CORS with the `CORSMiddleware`](../tutorial/cors.md){target=_blank}.
+And then you also read how to handle [CORS with the `CORSMiddleware`](../tutorial/cors.md).
 
 In this section we'll see how to use other middlewares.
 
@@ -91,7 +91,7 @@ There are many other ASGI middlewares.
 
 For example:
 
-* [Uvicorn's `ProxyHeadersMiddleware`](https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py){target=_blank}
-* [MessagePack](https://github.com/florimondmanca/msgpack-asgi){target=_blank}
+* [Uvicorn's `ProxyHeadersMiddleware`](https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py)
+* [MessagePack](https://github.com/florimondmanca/msgpack-asgi)
 
-To see other available middlewares check [Starlette's Middleware docs](https://www.starlette.dev/middleware/){target=_blank} and the [ASGI Awesome List](https://github.com/florimondmanca/awesome-asgi){target=_blank}.
+To see other available middlewares check [Starlette's Middleware docs](https://www.starlette.dev/middleware/) and the [ASGI Awesome List](https://github.com/florimondmanca/awesome-asgi).

--- a/docs/en/docs/advanced/middleware.md
+++ b/docs/en/docs/advanced/middleware.md
@@ -1,8 +1,8 @@
 # Advanced Middleware { #advanced-middleware }
 
-In the main tutorial you read how to add [Custom Middleware](../tutorial/middleware.md){.internal-link target=_blank} to your application.
+In the main tutorial you read how to add [Custom Middleware](../tutorial/middleware.md){target=_blank} to your application.
 
-And then you also read how to handle [CORS with the `CORSMiddleware`](../tutorial/cors.md){.internal-link target=_blank}.
+And then you also read how to handle [CORS with the `CORSMiddleware`](../tutorial/cors.md){target=_blank}.
 
 In this section we'll see how to use other middlewares.
 
@@ -91,7 +91,7 @@ There are many other ASGI middlewares.
 
 For example:
 
-* <a href="https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py" class="external-link" target="_blank">Uvicorn's `ProxyHeadersMiddleware`</a>
-* <a href="https://github.com/florimondmanca/msgpack-asgi" class="external-link" target="_blank">MessagePack</a>
+* [Uvicorn's `ProxyHeadersMiddleware`](https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py){target=_blank}
+* [MessagePack](https://github.com/florimondmanca/msgpack-asgi){target=_blank}
 
-To see other available middlewares check <a href="https://www.starlette.dev/middleware/" class="external-link" target="_blank">Starlette's Middleware docs</a> and the <a href="https://github.com/florimondmanca/awesome-asgi" class="external-link" target="_blank">ASGI Awesome List</a>.
+To see other available middlewares check [Starlette's Middleware docs](https://www.starlette.dev/middleware/){target=_blank} and the [ASGI Awesome List](https://github.com/florimondmanca/awesome-asgi){target=_blank}.

--- a/docs/en/docs/advanced/openapi-callbacks.md
+++ b/docs/en/docs/advanced/openapi-callbacks.md
@@ -35,7 +35,7 @@ This part is pretty normal, most of the code is probably already familiar to you
 
 /// tip
 
-The `callback_url` query parameter uses a Pydantic [Url](https://docs.pydantic.dev/latest/api/networks/){target=_blank} type.
+The `callback_url` query parameter uses a Pydantic [Url](https://docs.pydantic.dev/latest/api/networks/) type.
 
 ///
 
@@ -66,7 +66,7 @@ This example doesn't implement the callback itself (that could be just a line of
 
 The actual callback is just an HTTP request.
 
-When implementing the callback yourself, you could use something like [HTTPX](https://www.python-httpx.org){target=_blank} or [Requests](https://requests.readthedocs.io/){target=_blank}.
+When implementing the callback yourself, you could use something like [HTTPX](https://www.python-httpx.org) or [Requests](https://requests.readthedocs.io/).
 
 ///
 
@@ -106,11 +106,11 @@ It should look just like a normal FastAPI *path operation*:
 There are 2 main differences from a normal *path operation*:
 
 * It doesn't need to have any actual code, because your app will never call this code. It's only used to document the *external API*. So, the function could just have `pass`.
-* The *path* can contain an [OpenAPI 3 expression](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression){target=_blank} (see more below) where it can use variables with parameters and parts of the original request sent to *your API*.
+* The *path* can contain an [OpenAPI 3 expression](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression) (see more below) where it can use variables with parameters and parts of the original request sent to *your API*.
 
 ### The callback path expression { #the-callback-path-expression }
 
-The callback *path* can have an [OpenAPI 3 expression](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression){target=_blank} that can contain parts of the original request sent to *your API*.
+The callback *path* can have an [OpenAPI 3 expression](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression) that can contain parts of the original request sent to *your API*.
 
 In this case, it's the `str`:
 
@@ -179,7 +179,7 @@ Notice that you are not passing the router itself (`invoices_callback_router`) t
 
 ### Check the docs { #check-the-docs }
 
-Now you can start your app and go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+Now you can start your app and go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 You will see your docs including a "Callbacks" section for your *path operation* that shows how the *external API* should look like:
 

--- a/docs/en/docs/advanced/openapi-callbacks.md
+++ b/docs/en/docs/advanced/openapi-callbacks.md
@@ -35,7 +35,7 @@ This part is pretty normal, most of the code is probably already familiar to you
 
 /// tip
 
-The `callback_url` query parameter uses a Pydantic <a href="https://docs.pydantic.dev/latest/api/networks/" class="external-link" target="_blank">Url</a> type.
+The `callback_url` query parameter uses a Pydantic [Url](https://docs.pydantic.dev/latest/api/networks/){target=_blank} type.
 
 ///
 
@@ -66,7 +66,7 @@ This example doesn't implement the callback itself (that could be just a line of
 
 The actual callback is just an HTTP request.
 
-When implementing the callback yourself, you could use something like <a href="https://www.python-httpx.org" class="external-link" target="_blank">HTTPX</a> or <a href="https://requests.readthedocs.io/" class="external-link" target="_blank">Requests</a>.
+When implementing the callback yourself, you could use something like [HTTPX](https://www.python-httpx.org){target=_blank} or [Requests](https://requests.readthedocs.io/){target=_blank}.
 
 ///
 
@@ -106,11 +106,11 @@ It should look just like a normal FastAPI *path operation*:
 There are 2 main differences from a normal *path operation*:
 
 * It doesn't need to have any actual code, because your app will never call this code. It's only used to document the *external API*. So, the function could just have `pass`.
-* The *path* can contain an <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression" class="external-link" target="_blank">OpenAPI 3 expression</a> (see more below) where it can use variables with parameters and parts of the original request sent to *your API*.
+* The *path* can contain an [OpenAPI 3 expression](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression){target=_blank} (see more below) where it can use variables with parameters and parts of the original request sent to *your API*.
 
 ### The callback path expression { #the-callback-path-expression }
 
-The callback *path* can have an <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression" class="external-link" target="_blank">OpenAPI 3 expression</a> that can contain parts of the original request sent to *your API*.
+The callback *path* can have an [OpenAPI 3 expression](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#key-expression){target=_blank} that can contain parts of the original request sent to *your API*.
 
 In this case, it's the `str`:
 
@@ -179,7 +179,7 @@ Notice that you are not passing the router itself (`invoices_callback_router`) t
 
 ### Check the docs { #check-the-docs }
 
-Now you can start your app and go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now you can start your app and go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
 You will see your docs including a "Callbacks" section for your *path operation* that shows how the *external API* should look like:
 

--- a/docs/en/docs/advanced/openapi-webhooks.md
+++ b/docs/en/docs/advanced/openapi-webhooks.md
@@ -48,7 +48,7 @@ This is because it is expected that **your users** would define the actual **URL
 
 ### Check the docs { #check-the-docs }
 
-Now you can start your app and go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+Now you can start your app and go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 You will see your docs have the normal *path operations* and now also some **webhooks**:
 

--- a/docs/en/docs/advanced/openapi-webhooks.md
+++ b/docs/en/docs/advanced/openapi-webhooks.md
@@ -48,7 +48,7 @@ This is because it is expected that **your users** would define the actual **URL
 
 ### Check the docs { #check-the-docs }
 
-Now you can start your app and go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now you can start your app and go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
 You will see your docs have the normal *path operations* and now also some **webhooks**:
 

--- a/docs/en/docs/advanced/path-operation-advanced-configuration.md
+++ b/docs/en/docs/advanced/path-operation-advanced-configuration.md
@@ -60,7 +60,7 @@ That defines the metadata about the main response of a *path operation*.
 
 You can also declare additional responses with their models, status codes, etc.
 
-There's a whole chapter here in the documentation about it, you can read it at [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.
+There's a whole chapter here in the documentation about it, you can read it at [Additional Responses in OpenAPI](additional-responses.md).
 
 ## OpenAPI Extra { #openapi-extra }
 
@@ -68,7 +68,7 @@ When you declare a *path operation* in your application, **FastAPI** automatical
 
 /// note | Technical details
 
-In the OpenAPI specification it is called the [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object){target=_blank}.
+In the OpenAPI specification it is called the [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object).
 
 ///
 
@@ -82,7 +82,7 @@ This *path operation*-specific OpenAPI schema is normally generated automaticall
 
 This is a low level extension point.
 
-If you only need to declare additional responses, a more convenient way to do it is with [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.
+If you only need to declare additional responses, a more convenient way to do it is with [Additional Responses in OpenAPI](additional-responses.md).
 
 ///
 

--- a/docs/en/docs/advanced/path-operation-advanced-configuration.md
+++ b/docs/en/docs/advanced/path-operation-advanced-configuration.md
@@ -60,7 +60,7 @@ That defines the metadata about the main response of a *path operation*.
 
 You can also declare additional responses with their models, status codes, etc.
 
-There's a whole chapter here in the documentation about it, you can read it at [Additional Responses in OpenAPI](additional-responses.md){.internal-link target=_blank}.
+There's a whole chapter here in the documentation about it, you can read it at [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.
 
 ## OpenAPI Extra { #openapi-extra }
 
@@ -68,7 +68,7 @@ When you declare a *path operation* in your application, **FastAPI** automatical
 
 /// note | Technical details
 
-In the OpenAPI specification it is called the <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object" class="external-link" target="_blank">Operation Object</a>.
+In the OpenAPI specification it is called the [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object){target=_blank}.
 
 ///
 
@@ -82,7 +82,7 @@ This *path operation*-specific OpenAPI schema is normally generated automaticall
 
 This is a low level extension point.
 
-If you only need to declare additional responses, a more convenient way to do it is with [Additional Responses in OpenAPI](additional-responses.md){.internal-link target=_blank}.
+If you only need to declare additional responses, a more convenient way to do it is with [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.
 
 ///
 

--- a/docs/en/docs/advanced/response-change-status-code.md
+++ b/docs/en/docs/advanced/response-change-status-code.md
@@ -1,6 +1,6 @@
 # Response - Change Status Code { #response-change-status-code }
 
-You probably read before that you can set a default [Response Status Code](../tutorial/response-status-code.md){.internal-link target=_blank}.
+You probably read before that you can set a default [Response Status Code](../tutorial/response-status-code.md){target=_blank}.
 
 But in some cases you need to return a different status code than the default.
 

--- a/docs/en/docs/advanced/response-change-status-code.md
+++ b/docs/en/docs/advanced/response-change-status-code.md
@@ -1,6 +1,6 @@
 # Response - Change Status Code { #response-change-status-code }
 
-You probably read before that you can set a default [Response Status Code](../tutorial/response-status-code.md){target=_blank}.
+You probably read before that you can set a default [Response Status Code](../tutorial/response-status-code.md).
 
 But in some cases you need to return a different status code than the default.
 

--- a/docs/en/docs/advanced/response-cookies.md
+++ b/docs/en/docs/advanced/response-cookies.md
@@ -20,7 +20,7 @@ You can also declare the `Response` parameter in dependencies, and set cookies (
 
 You can also create cookies when returning a `Response` directly in your code.
 
-To do that, you can create a response as described in [Return a Response Directly](response-directly.md){.internal-link target=_blank}.
+To do that, you can create a response as described in [Return a Response Directly](response-directly.md){target=_blank}.
 
 Then set Cookies in it, and then return it:
 
@@ -48,4 +48,4 @@ And as the `Response` can be used frequently to set headers and cookies, **FastA
 
 ///
 
-To see all the available parameters and options, check the <a href="https://www.starlette.dev/responses/#set-cookie" class="external-link" target="_blank">documentation in Starlette</a>.
+To see all the available parameters and options, check the [documentation in Starlette](https://www.starlette.dev/responses/#set-cookie){target=_blank}.

--- a/docs/en/docs/advanced/response-cookies.md
+++ b/docs/en/docs/advanced/response-cookies.md
@@ -20,7 +20,7 @@ You can also declare the `Response` parameter in dependencies, and set cookies (
 
 You can also create cookies when returning a `Response` directly in your code.
 
-To do that, you can create a response as described in [Return a Response Directly](response-directly.md){target=_blank}.
+To do that, you can create a response as described in [Return a Response Directly](response-directly.md).
 
 Then set Cookies in it, and then return it:
 
@@ -48,4 +48,4 @@ And as the `Response` can be used frequently to set headers and cookies, **FastA
 
 ///
 
-To see all the available parameters and options, check the [documentation in Starlette](https://www.starlette.dev/responses/#set-cookie){target=_blank}.
+To see all the available parameters and options, check the [documentation in Starlette](https://www.starlette.dev/responses/#set-cookie).

--- a/docs/en/docs/advanced/response-directly.md
+++ b/docs/en/docs/advanced/response-directly.md
@@ -2,15 +2,15 @@
 
 When you create a **FastAPI** *path operation* you can normally return any data from it: a `dict`, a `list`, a Pydantic model, a database model, etc.
 
-If you declare a [Response Model](../tutorial/response-model.md){target=_blank} FastAPI will use it to serialize the data to JSON, using Pydantic.
+If you declare a [Response Model](../tutorial/response-model.md) FastAPI will use it to serialize the data to JSON, using Pydantic.
 
-If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md){target=_blank} and put it in a `JSONResponse`.
+If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md) and put it in a `JSONResponse`.
 
 You could also create a `JSONResponse` directly and return it.
 
 /// tip
 
-You will normally have much better performance using a [Response Model](../tutorial/response-model.md){target=_blank} than returning a `JSONResponse` directly, as that way it serializes the data using Pydantic, in Rust.
+You will normally have much better performance using a [Response Model](../tutorial/response-model.md) than returning a `JSONResponse` directly, as that way it serializes the data using Pydantic, in Rust.
 
 ///
 
@@ -56,7 +56,7 @@ The example above shows all the parts you need, but it's not very useful yet, as
 
 Now, let's see how you could use that to return a custom response.
 
-Let's say that you want to return an [XML](https://en.wikipedia.org/wiki/XML){target=_blank} response.
+Let's say that you want to return an [XML](https://en.wikipedia.org/wiki/XML) response.
 
 You could put your XML content in a string, put that in a `Response`, and return it:
 
@@ -64,7 +64,7 @@ You could put your XML content in a string, put that in a `Response`, and return
 
 ## How a Response Model Works { #how-a-response-model-works }
 
-When you declare a [Response Model - Return Type](../tutorial/response-model.md){target=_blank} in a path operation, **FastAPI** will use it to serialize the data to JSON, using Pydantic.
+When you declare a [Response Model - Return Type](../tutorial/response-model.md) in a path operation, **FastAPI** will use it to serialize the data to JSON, using Pydantic.
 
 {* ../../docs_src/response_model/tutorial001_01_py310.py hl[16,21] *}
 
@@ -78,6 +78,6 @@ Instead it takes the JSON bytes generated with Pydantic using the response model
 
 When you return a `Response` directly its data is not validated, converted (serialized), or documented automatically.
 
-But you can still document it as described in [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.
+But you can still document it as described in [Additional Responses in OpenAPI](additional-responses.md).
 
 You can see in later sections how to use/declare these custom `Response`s while still having automatic data conversion, documentation, etc.

--- a/docs/en/docs/advanced/response-directly.md
+++ b/docs/en/docs/advanced/response-directly.md
@@ -2,15 +2,15 @@
 
 When you create a **FastAPI** *path operation* you can normally return any data from it: a `dict`, a `list`, a Pydantic model, a database model, etc.
 
-If you declare a [Response Model](../tutorial/response-model.md){.internal-link target=_blank} FastAPI will use it to serialize the data to JSON, using Pydantic.
+If you declare a [Response Model](../tutorial/response-model.md){target=_blank} FastAPI will use it to serialize the data to JSON, using Pydantic.
 
-If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md){.internal-link target=_blank} and put it in a `JSONResponse`.
+If you don't declare a response model, FastAPI will use the `jsonable_encoder` explained in [JSON Compatible Encoder](../tutorial/encoder.md){target=_blank} and put it in a `JSONResponse`.
 
 You could also create a `JSONResponse` directly and return it.
 
 /// tip
 
-You will normally have much better performance using a [Response Model](../tutorial/response-model.md){.internal-link target=_blank} than returning a `JSONResponse` directly, as that way it serializes the data using Pydantic, in Rust.
+You will normally have much better performance using a [Response Model](../tutorial/response-model.md){target=_blank} than returning a `JSONResponse` directly, as that way it serializes the data using Pydantic, in Rust.
 
 ///
 
@@ -56,7 +56,7 @@ The example above shows all the parts you need, but it's not very useful yet, as
 
 Now, let's see how you could use that to return a custom response.
 
-Let's say that you want to return an <a href="https://en.wikipedia.org/wiki/XML" class="external-link" target="_blank">XML</a> response.
+Let's say that you want to return an [XML](https://en.wikipedia.org/wiki/XML){target=_blank} response.
 
 You could put your XML content in a string, put that in a `Response`, and return it:
 
@@ -64,7 +64,7 @@ You could put your XML content in a string, put that in a `Response`, and return
 
 ## How a Response Model Works { #how-a-response-model-works }
 
-When you declare a [Response Model - Return Type](../tutorial/response-model.md){.internal-link target=_blank} in a path operation, **FastAPI** will use it to serialize the data to JSON, using Pydantic.
+When you declare a [Response Model - Return Type](../tutorial/response-model.md){target=_blank} in a path operation, **FastAPI** will use it to serialize the data to JSON, using Pydantic.
 
 {* ../../docs_src/response_model/tutorial001_01_py310.py hl[16,21] *}
 
@@ -78,6 +78,6 @@ Instead it takes the JSON bytes generated with Pydantic using the response model
 
 When you return a `Response` directly its data is not validated, converted (serialized), or documented automatically.
 
-But you can still document it as described in [Additional Responses in OpenAPI](additional-responses.md){.internal-link target=_blank}.
+But you can still document it as described in [Additional Responses in OpenAPI](additional-responses.md){target=_blank}.
 
 You can see in later sections how to use/declare these custom `Response`s while still having automatic data conversion, documentation, etc.

--- a/docs/en/docs/advanced/response-headers.md
+++ b/docs/en/docs/advanced/response-headers.md
@@ -20,7 +20,7 @@ You can also declare the `Response` parameter in dependencies, and set headers (
 
 You can also add headers when you return a `Response` directly.
 
-Create a response as described in [Return a Response Directly](response-directly.md){.internal-link target=_blank} and pass the headers as an additional parameter:
+Create a response as described in [Return a Response Directly](response-directly.md){target=_blank} and pass the headers as an additional parameter:
 
 {* ../../docs_src/response_headers/tutorial001_py310.py hl[10:12] *}
 
@@ -36,6 +36,6 @@ And as the `Response` can be used frequently to set headers and cookies, **FastA
 
 ## Custom Headers { #custom-headers }
 
-Keep in mind that custom proprietary headers can be added <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers" class="external-link" target="_blank">using the `X-` prefix</a>.
+Keep in mind that custom proprietary headers can be added [using the `X-` prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers){target=_blank}.
 
-But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations (read more in [CORS (Cross-Origin Resource Sharing)](../tutorial/cors.md){.internal-link target=_blank}), using the parameter `expose_headers` documented in <a href="https://www.starlette.dev/middleware/#corsmiddleware" class="external-link" target="_blank">Starlette's CORS docs</a>.
+But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations (read more in [CORS (Cross-Origin Resource Sharing)](../tutorial/cors.md){target=_blank}), using the parameter `expose_headers` documented in [Starlette's CORS docs](https://www.starlette.dev/middleware/#corsmiddleware){target=_blank}.

--- a/docs/en/docs/advanced/response-headers.md
+++ b/docs/en/docs/advanced/response-headers.md
@@ -20,7 +20,7 @@ You can also declare the `Response` parameter in dependencies, and set headers (
 
 You can also add headers when you return a `Response` directly.
 
-Create a response as described in [Return a Response Directly](response-directly.md){target=_blank} and pass the headers as an additional parameter:
+Create a response as described in [Return a Response Directly](response-directly.md) and pass the headers as an additional parameter:
 
 {* ../../docs_src/response_headers/tutorial001_py310.py hl[10:12] *}
 
@@ -36,6 +36,6 @@ And as the `Response` can be used frequently to set headers and cookies, **FastA
 
 ## Custom Headers { #custom-headers }
 
-Keep in mind that custom proprietary headers can be added [using the `X-` prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers){target=_blank}.
+Keep in mind that custom proprietary headers can be added [using the `X-` prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).
 
-But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations (read more in [CORS (Cross-Origin Resource Sharing)](../tutorial/cors.md){target=_blank}), using the parameter `expose_headers` documented in [Starlette's CORS docs](https://www.starlette.dev/middleware/#corsmiddleware){target=_blank}.
+But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations (read more in [CORS (Cross-Origin Resource Sharing)](../tutorial/cors.md)), using the parameter `expose_headers` documented in [Starlette's CORS docs](https://www.starlette.dev/middleware/#corsmiddleware).

--- a/docs/en/docs/advanced/security/http-basic-auth.md
+++ b/docs/en/docs/advanced/security/http-basic-auth.md
@@ -32,7 +32,7 @@ Here's a more complete example.
 
 Use a dependency to check if the username and password are correct.
 
-For this, use the Python standard module [`secrets`](https://docs.python.org/3/library/secrets.html){target=_blank} to check the username and password.
+For this, use the Python standard module [`secrets`](https://docs.python.org/3/library/secrets.html) to check the username and password.
 
 `secrets.compare_digest()` needs to take `bytes` or a `str` that only contains ASCII characters (the ones in English), this means it wouldn't work with characters like `á`, as in `Sebastián`.
 

--- a/docs/en/docs/advanced/security/http-basic-auth.md
+++ b/docs/en/docs/advanced/security/http-basic-auth.md
@@ -32,7 +32,7 @@ Here's a more complete example.
 
 Use a dependency to check if the username and password are correct.
 
-For this, use the Python standard module <a href="https://docs.python.org/3/library/secrets.html" class="external-link" target="_blank">`secrets`</a> to check the username and password.
+For this, use the Python standard module [`secrets`](https://docs.python.org/3/library/secrets.html){target=_blank} to check the username and password.
 
 `secrets.compare_digest()` needs to take `bytes` or a `str` that only contains ASCII characters (the ones in English), this means it wouldn't work with characters like `á`, as in `Sebastián`.
 

--- a/docs/en/docs/advanced/security/index.md
+++ b/docs/en/docs/advanced/security/index.md
@@ -2,7 +2,7 @@
 
 ## Additional Features { #additional-features }
 
-There are some extra features to handle security apart from the ones covered in the [Tutorial - User Guide: Security](../../tutorial/security/index.md){target=_blank}.
+There are some extra features to handle security apart from the ones covered in the [Tutorial - User Guide: Security](../../tutorial/security/index.md).
 
 /// tip
 
@@ -14,6 +14,6 @@ And it's possible that for your use case, the solution is in one of them.
 
 ## Read the Tutorial first { #read-the-tutorial-first }
 
-The next sections assume you already read the main [Tutorial - User Guide: Security](../../tutorial/security/index.md){target=_blank}.
+The next sections assume you already read the main [Tutorial - User Guide: Security](../../tutorial/security/index.md).
 
 They are all based on the same concepts, but allow some extra functionalities.

--- a/docs/en/docs/advanced/security/index.md
+++ b/docs/en/docs/advanced/security/index.md
@@ -2,7 +2,7 @@
 
 ## Additional Features { #additional-features }
 
-There are some extra features to handle security apart from the ones covered in the [Tutorial - User Guide: Security](../../tutorial/security/index.md){.internal-link target=_blank}.
+There are some extra features to handle security apart from the ones covered in the [Tutorial - User Guide: Security](../../tutorial/security/index.md){target=_blank}.
 
 /// tip
 
@@ -14,6 +14,6 @@ And it's possible that for your use case, the solution is in one of them.
 
 ## Read the Tutorial first { #read-the-tutorial-first }
 
-The next sections assume you already read the main [Tutorial - User Guide: Security](../../tutorial/security/index.md){.internal-link target=_blank}.
+The next sections assume you already read the main [Tutorial - User Guide: Security](../../tutorial/security/index.md){target=_blank}.
 
 They are all based on the same concepts, but allow some extra functionalities.

--- a/docs/en/docs/advanced/security/oauth2-scopes.md
+++ b/docs/en/docs/advanced/security/oauth2-scopes.md
@@ -60,7 +60,7 @@ For OAuth2 they are just strings.
 
 ## Global view { #global-view }
 
-First, let's quickly see the parts that change from the examples in the main **Tutorial - User Guide** for [OAuth2 with Password (and hashing), Bearer with JWT tokens](../../tutorial/security/oauth2-jwt.md){.internal-link target=_blank}. Now using OAuth2 scopes:
+First, let's quickly see the parts that change from the examples in the main **Tutorial - User Guide** for [OAuth2 with Password (and hashing), Bearer with JWT tokens](../../tutorial/security/oauth2-jwt.md){target=_blank}. Now using OAuth2 scopes:
 
 {* ../../docs_src/security/tutorial005_an_py310.py hl[5,9,13,47,65,106,108:116,122:126,130:136,141,157] *}
 
@@ -271,4 +271,4 @@ But in the end, they are implementing the same OAuth2 standard.
 
 ## `Security` in decorator `dependencies` { #security-in-decorator-dependencies }
 
-The same way you can define a `list` of `Depends` in the decorator's `dependencies` parameter (as explained in [Dependencies in path operation decorators](../../tutorial/dependencies/dependencies-in-path-operation-decorators.md){.internal-link target=_blank}), you could also use `Security` with `scopes` there.
+The same way you can define a `list` of `Depends` in the decorator's `dependencies` parameter (as explained in [Dependencies in path operation decorators](../../tutorial/dependencies/dependencies-in-path-operation-decorators.md){target=_blank}), you could also use `Security` with `scopes` there.

--- a/docs/en/docs/advanced/security/oauth2-scopes.md
+++ b/docs/en/docs/advanced/security/oauth2-scopes.md
@@ -60,7 +60,7 @@ For OAuth2 they are just strings.
 
 ## Global view { #global-view }
 
-First, let's quickly see the parts that change from the examples in the main **Tutorial - User Guide** for [OAuth2 with Password (and hashing), Bearer with JWT tokens](../../tutorial/security/oauth2-jwt.md){target=_blank}. Now using OAuth2 scopes:
+First, let's quickly see the parts that change from the examples in the main **Tutorial - User Guide** for [OAuth2 with Password (and hashing), Bearer with JWT tokens](../../tutorial/security/oauth2-jwt.md). Now using OAuth2 scopes:
 
 {* ../../docs_src/security/tutorial005_an_py310.py hl[5,9,13,47,65,106,108:116,122:126,130:136,141,157] *}
 
@@ -271,4 +271,4 @@ But in the end, they are implementing the same OAuth2 standard.
 
 ## `Security` in decorator `dependencies` { #security-in-decorator-dependencies }
 
-The same way you can define a `list` of `Depends` in the decorator's `dependencies` parameter (as explained in [Dependencies in path operation decorators](../../tutorial/dependencies/dependencies-in-path-operation-decorators.md){target=_blank}), you could also use `Security` with `scopes` there.
+The same way you can define a `list` of `Depends` in the decorator's `dependencies` parameter (as explained in [Dependencies in path operation decorators](../../tutorial/dependencies/dependencies-in-path-operation-decorators.md)), you could also use `Security` with `scopes` there.

--- a/docs/en/docs/advanced/settings.md
+++ b/docs/en/docs/advanced/settings.md
@@ -8,7 +8,7 @@ For this reason it's common to provide them in environment variables that are re
 
 /// tip
 
-To understand environment variables you can read [Environment Variables](../environment-variables.md){target=_blank}.
+To understand environment variables you can read [Environment Variables](../environment-variables.md).
 
 ///
 
@@ -20,11 +20,11 @@ That means that any value read in Python from an environment variable will be a 
 
 ## Pydantic `Settings` { #pydantic-settings }
 
-Fortunately, Pydantic provides a great utility to handle these settings coming from environment variables with [Pydantic: Settings management](https://docs.pydantic.dev/latest/concepts/pydantic_settings/){target=_blank}.
+Fortunately, Pydantic provides a great utility to handle these settings coming from environment variables with [Pydantic: Settings management](https://docs.pydantic.dev/latest/concepts/pydantic_settings/).
 
 ### Install `pydantic-settings` { #install-pydantic-settings }
 
-First, make sure you create your [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install the `pydantic-settings` package:
+First, make sure you create your [virtual environment](../virtual-environments.md), activate it, and then install the `pydantic-settings` package:
 
 <div class="termy">
 
@@ -100,7 +100,7 @@ And the `items_per_user` would keep its default value of `50`.
 
 ## Settings in another module { #settings-in-another-module }
 
-You could put those settings in another module file as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md){target=_blank}.
+You could put those settings in another module file as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md).
 
 For example, you could have a file `config.py` with:
 
@@ -112,7 +112,7 @@ And then use it in a file `main.py`:
 
 /// tip
 
-You would also need a file `__init__.py` as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md){target=_blank}.
+You would also need a file `__init__.py` as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md).
 
 ///
 
@@ -172,7 +172,7 @@ But a dotenv file doesn't really have to have that exact filename.
 
 ///
 
-Pydantic has support for reading from these types of files using an external library. You can read more at [Pydantic Settings: Dotenv (.env) support](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support){target=_blank}.
+Pydantic has support for reading from these types of files using an external library. You can read more at [Pydantic Settings: Dotenv (.env) support](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support).
 
 /// tip
 
@@ -197,7 +197,7 @@ And then update your `config.py` with:
 
 /// tip
 
-The `model_config` attribute is used just for Pydantic configuration. You can read more at [Pydantic: Concepts: Configuration](https://docs.pydantic.dev/latest/concepts/config/){target=_blank}.
+The `model_config` attribute is used just for Pydantic configuration. You can read more at [Pydantic: Concepts: Configuration](https://docs.pydantic.dev/latest/concepts/config/).
 
 ///
 
@@ -291,7 +291,7 @@ In the case of our dependency `get_settings()`, the function doesn't even take a
 
 That way, it behaves almost as if it was just a global variable. But as it uses a dependency function, then we can override it easily for testing.
 
-`@lru_cache` is part of `functools` which is part of Python's standard library, you can read more about it in the [Python docs for `@lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache){target=_blank}.
+`@lru_cache` is part of `functools` which is part of Python's standard library, you can read more about it in the [Python docs for `@lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache).
 
 ## Recap { #recap }
 

--- a/docs/en/docs/advanced/settings.md
+++ b/docs/en/docs/advanced/settings.md
@@ -8,7 +8,7 @@ For this reason it's common to provide them in environment variables that are re
 
 /// tip
 
-To understand environment variables you can read [Environment Variables](../environment-variables.md){.internal-link target=_blank}.
+To understand environment variables you can read [Environment Variables](../environment-variables.md){target=_blank}.
 
 ///
 
@@ -20,11 +20,11 @@ That means that any value read in Python from an environment variable will be a 
 
 ## Pydantic `Settings` { #pydantic-settings }
 
-Fortunately, Pydantic provides a great utility to handle these settings coming from environment variables with <a href="https://docs.pydantic.dev/latest/concepts/pydantic_settings/" class="external-link" target="_blank">Pydantic: Settings management</a>.
+Fortunately, Pydantic provides a great utility to handle these settings coming from environment variables with [Pydantic: Settings management](https://docs.pydantic.dev/latest/concepts/pydantic_settings/){target=_blank}.
 
 ### Install `pydantic-settings` { #install-pydantic-settings }
 
-First, make sure you create your [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install the `pydantic-settings` package:
+First, make sure you create your [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install the `pydantic-settings` package:
 
 <div class="termy">
 
@@ -100,7 +100,7 @@ And the `items_per_user` would keep its default value of `50`.
 
 ## Settings in another module { #settings-in-another-module }
 
-You could put those settings in another module file as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md){.internal-link target=_blank}.
+You could put those settings in another module file as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md){target=_blank}.
 
 For example, you could have a file `config.py` with:
 
@@ -112,7 +112,7 @@ And then use it in a file `main.py`:
 
 /// tip
 
-You would also need a file `__init__.py` as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md){.internal-link target=_blank}.
+You would also need a file `__init__.py` as you saw in [Bigger Applications - Multiple Files](../tutorial/bigger-applications.md){target=_blank}.
 
 ///
 
@@ -172,7 +172,7 @@ But a dotenv file doesn't really have to have that exact filename.
 
 ///
 
-Pydantic has support for reading from these types of files using an external library. You can read more at <a href="https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support" class="external-link" target="_blank">Pydantic Settings: Dotenv (.env) support</a>.
+Pydantic has support for reading from these types of files using an external library. You can read more at [Pydantic Settings: Dotenv (.env) support](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support){target=_blank}.
 
 /// tip
 
@@ -197,7 +197,7 @@ And then update your `config.py` with:
 
 /// tip
 
-The `model_config` attribute is used just for Pydantic configuration. You can read more at <a href="https://docs.pydantic.dev/latest/concepts/config/" class="external-link" target="_blank">Pydantic: Concepts: Configuration</a>.
+The `model_config` attribute is used just for Pydantic configuration. You can read more at [Pydantic: Concepts: Configuration](https://docs.pydantic.dev/latest/concepts/config/){target=_blank}.
 
 ///
 
@@ -291,7 +291,7 @@ In the case of our dependency `get_settings()`, the function doesn't even take a
 
 That way, it behaves almost as if it was just a global variable. But as it uses a dependency function, then we can override it easily for testing.
 
-`@lru_cache` is part of `functools` which is part of Python's standard library, you can read more about it in the <a href="https://docs.python.org/3/library/functools.html#functools.lru_cache" class="external-link" target="_blank">Python docs for `@lru_cache`</a>.
+`@lru_cache` is part of `functools` which is part of Python's standard library, you can read more about it in the [Python docs for `@lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache){target=_blank}.
 
 ## Recap { #recap }
 

--- a/docs/en/docs/advanced/stream-data.md
+++ b/docs/en/docs/advanced/stream-data.md
@@ -1,6 +1,6 @@
 # Stream Data { #stream-data }
 
-If you want to stream data that can be structured as JSON, you should [Stream JSON Lines](../tutorial/stream-json-lines.md){.internal-link target=_blank}.
+If you want to stream data that can be structured as JSON, you should [Stream JSON Lines](../tutorial/stream-json-lines.md){target=_blank}.
 
 But if you want to **stream pure binary data** or strings, here's how you can do it.
 
@@ -104,7 +104,7 @@ To avoid blocking the event loop, you can simply declare the *path operation fun
 
 /// tip
 
-If you need to call blocking code from inside of an async function, or an async function from inside of a blocking function, you could use <a href="https://asyncer.tiangolo.com" class="external-link" target="_blank">Asyncer</a>, a sibling library to FastAPI.
+If you need to call blocking code from inside of an async function, or an async function from inside of a blocking function, you could use [Asyncer](https://asyncer.tiangolo.com){target=_blank}, a sibling library to FastAPI.
 
 ///
 

--- a/docs/en/docs/advanced/stream-data.md
+++ b/docs/en/docs/advanced/stream-data.md
@@ -1,6 +1,6 @@
 # Stream Data { #stream-data }
 
-If you want to stream data that can be structured as JSON, you should [Stream JSON Lines](../tutorial/stream-json-lines.md){target=_blank}.
+If you want to stream data that can be structured as JSON, you should [Stream JSON Lines](../tutorial/stream-json-lines.md).
 
 But if you want to **stream pure binary data** or strings, here's how you can do it.
 
@@ -104,7 +104,7 @@ To avoid blocking the event loop, you can simply declare the *path operation fun
 
 /// tip
 
-If you need to call blocking code from inside of an async function, or an async function from inside of a blocking function, you could use [Asyncer](https://asyncer.tiangolo.com){target=_blank}, a sibling library to FastAPI.
+If you need to call blocking code from inside of an async function, or an async function from inside of a blocking function, you could use [Asyncer](https://asyncer.tiangolo.com), a sibling library to FastAPI.
 
 ///
 

--- a/docs/en/docs/advanced/sub-applications.md
+++ b/docs/en/docs/advanced/sub-applications.md
@@ -42,13 +42,13 @@ $ fastapi dev main.py
 
 </div>
 
-And open the docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+And open the docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 You will see the automatic API docs for the main app, including only its own _path operations_:
 
 <img src="/img/tutorial/sub-applications/image01.png">
 
-And then, open the docs for the sub-application, at [http://127.0.0.1:8000/subapi/docs](http://127.0.0.1:8000/subapi/docs){target=_blank}.
+And then, open the docs for the sub-application, at [http://127.0.0.1:8000/subapi/docs](http://127.0.0.1:8000/subapi/docs).
 
 You will see the automatic API docs for the sub-application, including only its own _path operations_, all under the correct sub-path prefix `/subapi`:
 
@@ -64,4 +64,4 @@ That way, the sub-application will know to use that path prefix for the docs UI.
 
 And the sub-application could also have its own mounted sub-applications and everything would work correctly, because FastAPI handles all these `root_path`s automatically.
 
-You will learn more about the `root_path` and how to use it explicitly in the section about [Behind a Proxy](behind-a-proxy.md){target=_blank}.
+You will learn more about the `root_path` and how to use it explicitly in the section about [Behind a Proxy](behind-a-proxy.md).

--- a/docs/en/docs/advanced/sub-applications.md
+++ b/docs/en/docs/advanced/sub-applications.md
@@ -42,13 +42,13 @@ $ fastapi dev main.py
 
 </div>
 
-And open the docs at <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+And open the docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
 You will see the automatic API docs for the main app, including only its own _path operations_:
 
 <img src="/img/tutorial/sub-applications/image01.png">
 
-And then, open the docs for the sub-application, at <a href="http://127.0.0.1:8000/subapi/docs" class="external-link" target="_blank">http://127.0.0.1:8000/subapi/docs</a>.
+And then, open the docs for the sub-application, at [http://127.0.0.1:8000/subapi/docs](http://127.0.0.1:8000/subapi/docs){target=_blank}.
 
 You will see the automatic API docs for the sub-application, including only its own _path operations_, all under the correct sub-path prefix `/subapi`:
 
@@ -64,4 +64,4 @@ That way, the sub-application will know to use that path prefix for the docs UI.
 
 And the sub-application could also have its own mounted sub-applications and everything would work correctly, because FastAPI handles all these `root_path`s automatically.
 
-You will learn more about the `root_path` and how to use it explicitly in the section about [Behind a Proxy](behind-a-proxy.md){.internal-link target=_blank}.
+You will learn more about the `root_path` and how to use it explicitly in the section about [Behind a Proxy](behind-a-proxy.md){target=_blank}.

--- a/docs/en/docs/advanced/templates.md
+++ b/docs/en/docs/advanced/templates.md
@@ -8,7 +8,7 @@ There are utilities to configure it easily that you can use directly in your **F
 
 ## Install dependencies { #install-dependencies }
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and install `jinja2`:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and install `jinja2`:
 
 <div class="termy">
 
@@ -123,4 +123,4 @@ And because you are using `StaticFiles`, that CSS file would be served automatic
 
 ## More details { #more-details }
 
-For more details, including how to test templates, check [Starlette's docs on templates](https://www.starlette.dev/templates/){target=_blank}.
+For more details, including how to test templates, check [Starlette's docs on templates](https://www.starlette.dev/templates/).

--- a/docs/en/docs/advanced/templates.md
+++ b/docs/en/docs/advanced/templates.md
@@ -8,7 +8,7 @@ There are utilities to configure it easily that you can use directly in your **F
 
 ## Install dependencies { #install-dependencies }
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and install `jinja2`:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and install `jinja2`:
 
 <div class="termy">
 
@@ -123,4 +123,4 @@ And because you are using `StaticFiles`, that CSS file would be served automatic
 
 ## More details { #more-details }
 
-For more details, including how to test templates, check <a href="https://www.starlette.dev/templates/" class="external-link" target="_blank">Starlette's docs on templates</a>.
+For more details, including how to test templates, check [Starlette's docs on templates](https://www.starlette.dev/templates/){target=_blank}.

--- a/docs/en/docs/advanced/testing-websockets.md
+++ b/docs/en/docs/advanced/testing-websockets.md
@@ -8,6 +8,6 @@ For this, you use the `TestClient` in a `with` statement, connecting to the WebS
 
 /// note
 
-For more details, check Starlette's documentation for [testing WebSockets](https://www.starlette.dev/testclient/#testing-websocket-sessions){target=_blank}.
+For more details, check Starlette's documentation for [testing WebSockets](https://www.starlette.dev/testclient/#testing-websocket-sessions).
 
 ///

--- a/docs/en/docs/advanced/testing-websockets.md
+++ b/docs/en/docs/advanced/testing-websockets.md
@@ -8,6 +8,6 @@ For this, you use the `TestClient` in a `with` statement, connecting to the WebS
 
 /// note
 
-For more details, check Starlette's documentation for <a href="https://www.starlette.dev/testclient/#testing-websocket-sessions" class="external-link" target="_blank">testing WebSockets</a>.
+For more details, check Starlette's documentation for [testing WebSockets](https://www.starlette.dev/testclient/#testing-websocket-sessions){target=_blank}.
 
 ///

--- a/docs/en/docs/advanced/using-request-directly.md
+++ b/docs/en/docs/advanced/using-request-directly.md
@@ -15,7 +15,7 @@ But there are situations where you might need to access the `Request` object dir
 
 ## Details about the `Request` object { #details-about-the-request-object }
 
-As **FastAPI** is actually **Starlette** underneath, with a layer of several tools on top, you can use Starlette's [`Request`](https://www.starlette.dev/requests/){target=_blank} object directly when you need to.
+As **FastAPI** is actually **Starlette** underneath, with a layer of several tools on top, you can use Starlette's [`Request`](https://www.starlette.dev/requests/) object directly when you need to.
 
 It would also mean that if you get data from the `Request` object directly (for example, read the body) it won't be validated, converted or documented (with OpenAPI, for the automatic API user interface) by FastAPI.
 
@@ -45,7 +45,7 @@ The same way, you can declare any other parameter as normally, and additionally,
 
 ## `Request` documentation { #request-documentation }
 
-You can read more details about the [`Request` object in the official Starlette documentation site](https://www.starlette.dev/requests/){target=_blank}.
+You can read more details about the [`Request` object in the official Starlette documentation site](https://www.starlette.dev/requests/).
 
 /// note | Technical Details
 

--- a/docs/en/docs/advanced/using-request-directly.md
+++ b/docs/en/docs/advanced/using-request-directly.md
@@ -15,7 +15,7 @@ But there are situations where you might need to access the `Request` object dir
 
 ## Details about the `Request` object { #details-about-the-request-object }
 
-As **FastAPI** is actually **Starlette** underneath, with a layer of several tools on top, you can use Starlette's <a href="https://www.starlette.dev/requests/" class="external-link" target="_blank">`Request`</a> object directly when you need to.
+As **FastAPI** is actually **Starlette** underneath, with a layer of several tools on top, you can use Starlette's [`Request`](https://www.starlette.dev/requests/){target=_blank} object directly when you need to.
 
 It would also mean that if you get data from the `Request` object directly (for example, read the body) it won't be validated, converted or documented (with OpenAPI, for the automatic API user interface) by FastAPI.
 
@@ -45,7 +45,7 @@ The same way, you can declare any other parameter as normally, and additionally,
 
 ## `Request` documentation { #request-documentation }
 
-You can read more details about the <a href="https://www.starlette.dev/requests/" class="external-link" target="_blank">`Request` object in the official Starlette documentation site</a>.
+You can read more details about the [`Request` object in the official Starlette documentation site](https://www.starlette.dev/requests/){target=_blank}.
 
 /// note | Technical Details
 

--- a/docs/en/docs/advanced/websockets.md
+++ b/docs/en/docs/advanced/websockets.md
@@ -1,10 +1,10 @@
 # WebSockets { #websockets }
 
-You can use <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API" class="external-link" target="_blank">WebSockets</a> with **FastAPI**.
+You can use [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API){target=_blank} with **FastAPI**.
 
 ## Install `websockets` { #install-websockets }
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and install `websockets` (a Python library that makes it easy to use the "WebSocket" protocol):
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and install `websockets` (a Python library that makes it easy to use the "WebSocket" protocol):
 
 <div class="termy">
 
@@ -76,7 +76,7 @@ $ fastapi dev main.py
 
 </div>
 
-Open your browser at <a href="http://127.0.0.1:8000" class="external-link" target="_blank">http://127.0.0.1:8000</a>.
+Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000){target=_blank}.
 
 You will see a simple page like:
 
@@ -115,7 +115,7 @@ They work the same way as for other FastAPI endpoints/*path operations*:
 
 As this is a WebSocket it doesn't really make sense to raise an `HTTPException`, instead we raise a `WebSocketException`.
 
-You can use a closing code from the <a href="https://tools.ietf.org/html/rfc6455#section-7.4.1" class="external-link" target="_blank">valid codes defined in the specification</a>.
+You can use a closing code from the [valid codes defined in the specification](https://tools.ietf.org/html/rfc6455#section-7.4.1){target=_blank}.
 
 ///
 
@@ -133,7 +133,7 @@ $ fastapi dev main.py
 
 </div>
 
-Open your browser at <a href="http://127.0.0.1:8000" class="external-link" target="_blank">http://127.0.0.1:8000</a>.
+Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000){target=_blank}.
 
 There you can set:
 
@@ -174,7 +174,7 @@ The app above is a minimal and simple example to demonstrate how to handle and b
 
 But keep in mind that, as everything is handled in memory, in a single list, it will only work while the process is running, and will only work with a single process.
 
-If you need something easy to integrate with FastAPI but that is more robust, supported by Redis, PostgreSQL or others, check <a href="https://github.com/encode/broadcaster" class="external-link" target="_blank">encode/broadcaster</a>.
+If you need something easy to integrate with FastAPI but that is more robust, supported by Redis, PostgreSQL or others, check [encode/broadcaster](https://github.com/encode/broadcaster){target=_blank}.
 
 ///
 
@@ -182,5 +182,5 @@ If you need something easy to integrate with FastAPI but that is more robust, su
 
 To learn more about the options, check Starlette's documentation for:
 
-* <a href="https://www.starlette.dev/websockets/" class="external-link" target="_blank">The `WebSocket` class</a>.
-* <a href="https://www.starlette.dev/endpoints/#websocketendpoint" class="external-link" target="_blank">Class-based WebSocket handling</a>.
+* [The `WebSocket` class](https://www.starlette.dev/websockets/){target=_blank}.
+* [Class-based WebSocket handling](https://www.starlette.dev/endpoints/#websocketendpoint){target=_blank}.

--- a/docs/en/docs/advanced/websockets.md
+++ b/docs/en/docs/advanced/websockets.md
@@ -1,10 +1,10 @@
 # WebSockets { #websockets }
 
-You can use [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API){target=_blank} with **FastAPI**.
+You can use [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) with **FastAPI**.
 
 ## Install `websockets` { #install-websockets }
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and install `websockets` (a Python library that makes it easy to use the "WebSocket" protocol):
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and install `websockets` (a Python library that makes it easy to use the "WebSocket" protocol):
 
 <div class="termy">
 
@@ -76,7 +76,7 @@ $ fastapi dev main.py
 
 </div>
 
-Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000){target=_blank}.
+Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
 You will see a simple page like:
 
@@ -115,7 +115,7 @@ They work the same way as for other FastAPI endpoints/*path operations*:
 
 As this is a WebSocket it doesn't really make sense to raise an `HTTPException`, instead we raise a `WebSocketException`.
 
-You can use a closing code from the [valid codes defined in the specification](https://tools.ietf.org/html/rfc6455#section-7.4.1){target=_blank}.
+You can use a closing code from the [valid codes defined in the specification](https://tools.ietf.org/html/rfc6455#section-7.4.1).
 
 ///
 
@@ -133,7 +133,7 @@ $ fastapi dev main.py
 
 </div>
 
-Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000){target=_blank}.
+Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
 There you can set:
 
@@ -174,7 +174,7 @@ The app above is a minimal and simple example to demonstrate how to handle and b
 
 But keep in mind that, as everything is handled in memory, in a single list, it will only work while the process is running, and will only work with a single process.
 
-If you need something easy to integrate with FastAPI but that is more robust, supported by Redis, PostgreSQL or others, check [encode/broadcaster](https://github.com/encode/broadcaster){target=_blank}.
+If you need something easy to integrate with FastAPI but that is more robust, supported by Redis, PostgreSQL or others, check [encode/broadcaster](https://github.com/encode/broadcaster).
 
 ///
 
@@ -182,5 +182,5 @@ If you need something easy to integrate with FastAPI but that is more robust, su
 
 To learn more about the options, check Starlette's documentation for:
 
-* [The `WebSocket` class](https://www.starlette.dev/websockets/){target=_blank}.
-* [Class-based WebSocket handling](https://www.starlette.dev/endpoints/#websocketendpoint){target=_blank}.
+* [The `WebSocket` class](https://www.starlette.dev/websockets/).
+* [Class-based WebSocket handling](https://www.starlette.dev/endpoints/#websocketendpoint).

--- a/docs/en/docs/advanced/wsgi.md
+++ b/docs/en/docs/advanced/wsgi.md
@@ -1,6 +1,6 @@
 # Including WSGI - Flask, Django, others { #including-wsgi-flask-django-others }
 
-You can mount WSGI applications as you saw with [Sub Applications - Mounts](sub-applications.md){target=_blank}, [Behind a Proxy](behind-a-proxy.md){target=_blank}.
+You can mount WSGI applications as you saw with [Sub Applications - Mounts](sub-applications.md), [Behind a Proxy](behind-a-proxy.md).
 
 For that, you can use the `WSGIMiddleware` and use it to wrap your WSGI application, for example, Flask, Django, etc.
 
@@ -36,13 +36,13 @@ Now, every request under the path `/v1/` will be handled by the Flask applicatio
 
 And the rest will be handled by **FastAPI**.
 
-If you run it and go to [http://localhost:8000/v1/](http://localhost:8000/v1/){target=_blank} you will see the response from Flask:
+If you run it and go to [http://localhost:8000/v1/](http://localhost:8000/v1/) you will see the response from Flask:
 
 ```txt
 Hello, World from Flask!
 ```
 
-And if you go to [http://localhost:8000/v2](http://localhost:8000/v2){target=_blank} you will see the response from FastAPI:
+And if you go to [http://localhost:8000/v2](http://localhost:8000/v2) you will see the response from FastAPI:
 
 ```JSON
 {

--- a/docs/en/docs/advanced/wsgi.md
+++ b/docs/en/docs/advanced/wsgi.md
@@ -1,6 +1,6 @@
 # Including WSGI - Flask, Django, others { #including-wsgi-flask-django-others }
 
-You can mount WSGI applications as you saw with [Sub Applications - Mounts](sub-applications.md){.internal-link target=_blank}, [Behind a Proxy](behind-a-proxy.md){.internal-link target=_blank}.
+You can mount WSGI applications as you saw with [Sub Applications - Mounts](sub-applications.md){target=_blank}, [Behind a Proxy](behind-a-proxy.md){target=_blank}.
 
 For that, you can use the `WSGIMiddleware` and use it to wrap your WSGI application, for example, Flask, Django, etc.
 
@@ -36,13 +36,13 @@ Now, every request under the path `/v1/` will be handled by the Flask applicatio
 
 And the rest will be handled by **FastAPI**.
 
-If you run it and go to <a href="http://localhost:8000/v1/" class="external-link" target="_blank">http://localhost:8000/v1/</a> you will see the response from Flask:
+If you run it and go to [http://localhost:8000/v1/](http://localhost:8000/v1/){target=_blank} you will see the response from Flask:
 
 ```txt
 Hello, World from Flask!
 ```
 
-And if you go to <a href="http://localhost:8000/v2" class="external-link" target="_blank">http://localhost:8000/v2</a> you will see the response from FastAPI:
+And if you go to [http://localhost:8000/v2](http://localhost:8000/v2){target=_blank} you will see the response from FastAPI:
 
 ```JSON
 {

--- a/docs/en/docs/alternatives.md
+++ b/docs/en/docs/alternatives.md
@@ -14,7 +14,7 @@ But at some point, there was no other option than creating something that provid
 
 ## Previous tools { #previous-tools }
 
-### <a href="https://www.djangoproject.com/" class="external-link" target="_blank">Django</a> { #django }
+### <a href="https://www.djangoproject.com/" target="_blank">Django</a> { #django }
 
 It's the most popular Python framework and is widely trusted. It is used to build systems like Instagram.
 
@@ -22,7 +22,7 @@ It's relatively tightly coupled with relational databases (like MySQL or Postgre
 
 It was created to generate the HTML in the backend, not to create APIs used by a modern frontend (like React, Vue.js and Angular) or by other systems (like <abbr title="Internet of Things">IoT</abbr> devices) communicating with it.
 
-### <a href="https://www.django-rest-framework.org/" class="external-link" target="_blank">Django REST Framework</a> { #django-rest-framework }
+### <a href="https://www.django-rest-framework.org/" target="_blank">Django REST Framework</a> { #django-rest-framework }
 
 Django REST framework was created to be a flexible toolkit for building Web APIs using Django underneath, to improve its API capabilities.
 
@@ -42,7 +42,7 @@ Have an automatic API documentation web user interface.
 
 ///
 
-### <a href="https://flask.palletsprojects.com" class="external-link" target="_blank">Flask</a> { #flask }
+### <a href="https://flask.palletsprojects.com" target="_blank">Flask</a> { #flask }
 
 Flask is a "microframework", it doesn't include database integrations nor many of the things that come by default in Django.
 
@@ -64,7 +64,7 @@ Have a simple and easy to use routing system.
 
 ///
 
-### <a href="https://requests.readthedocs.io" class="external-link" target="_blank">Requests</a> { #requests }
+### <a href="https://requests.readthedocs.io" target="_blank">Requests</a> { #requests }
 
 **FastAPI** is not actually an alternative to **Requests**. Their scope is very different.
 
@@ -106,7 +106,7 @@ See the similarities in `requests.get(...)` and `@app.get(...)`.
 
 ///
 
-### <a href="https://swagger.io/" class="external-link" target="_blank">Swagger</a> / <a href="https://github.com/OAI/OpenAPI-Specification/" class="external-link" target="_blank">OpenAPI</a> { #swagger-openapi }
+### <a href="https://swagger.io/" target="_blank">Swagger</a> / <a href="https://github.com/OAI/OpenAPI-Specification/" target="_blank">OpenAPI</a> { #swagger-openapi }
 
 The main feature I wanted from Django REST Framework was the automatic API documentation.
 
@@ -124,8 +124,8 @@ Adopt and use an open standard for API specifications, instead of a custom schem
 
 And integrate standards-based user interface tools:
 
-* <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>
-* <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>
+* <a href="https://github.com/swagger-api/swagger-ui" target="_blank">Swagger UI</a>
+* <a href="https://github.com/Rebilly/ReDoc" target="_blank">ReDoc</a>
 
 These two were chosen for being fairly popular and stable, but doing a quick search, you could find dozens of alternative user interfaces for OpenAPI (that you can use with **FastAPI**).
 
@@ -135,7 +135,7 @@ These two were chosen for being fairly popular and stable, but doing a quick sea
 
 There are several Flask REST frameworks, but after investing the time and work into investigating them, I found that many are discontinued or abandoned, with several standing issues that made them unfit.
 
-### <a href="https://marshmallow.readthedocs.io/en/stable/" class="external-link" target="_blank">Marshmallow</a> { #marshmallow }
+### <a href="https://marshmallow.readthedocs.io/en/stable/" target="_blank">Marshmallow</a> { #marshmallow }
 
 One of the main features needed by API systems is data "<dfn title="also called marshalling, conversion">serialization</dfn>" which is taking data from the code (Python) and converting it into something that can be sent through the network. For example, converting an object containing data from a database into a JSON object. Converting `datetime` objects into strings, etc.
 
@@ -153,7 +153,7 @@ Use code to define "schemas" that provide data types and validation, automatical
 
 ///
 
-### <a href="https://webargs.readthedocs.io/en/latest/" class="external-link" target="_blank">Webargs</a> { #webargs }
+### <a href="https://webargs.readthedocs.io/en/latest/" target="_blank">Webargs</a> { #webargs }
 
 Another big feature required by APIs is <dfn title="reading and converting to Python data">parsing</dfn> data from incoming requests.
 
@@ -175,7 +175,7 @@ Have automatic validation of incoming request data.
 
 ///
 
-### <a href="https://apispec.readthedocs.io/en/stable/" class="external-link" target="_blank">APISpec</a> { #apispec }
+### <a href="https://apispec.readthedocs.io/en/stable/" target="_blank">APISpec</a> { #apispec }
 
 Marshmallow and Webargs provide validation, parsing and serialization as plug-ins.
 
@@ -205,7 +205,7 @@ Support the open standard for APIs, OpenAPI.
 
 ///
 
-### <a href="https://flask-apispec.readthedocs.io/en/latest/" class="external-link" target="_blank">Flask-apispec</a> { #flask-apispec }
+### <a href="https://flask-apispec.readthedocs.io/en/latest/" target="_blank">Flask-apispec</a> { #flask-apispec }
 
 It's a Flask plug-in, that ties together Webargs, Marshmallow and APISpec.
 
@@ -219,9 +219,9 @@ This combination of Flask, Flask-apispec with Marshmallow and Webargs was my fav
 
 Using it led to the creation of several Flask full-stack generators. These are the main stacks I (and several external teams) have been using up to now:
 
-* <a href="https://github.com/tiangolo/full-stack" class="external-link" target="_blank">https://github.com/tiangolo/full-stack</a>
-* <a href="https://github.com/tiangolo/full-stack-flask-couchbase" class="external-link" target="_blank">https://github.com/tiangolo/full-stack-flask-couchbase</a>
-* <a href="https://github.com/tiangolo/full-stack-flask-couchdb" class="external-link" target="_blank">https://github.com/tiangolo/full-stack-flask-couchdb</a>
+* <a href="https://github.com/tiangolo/full-stack" target="_blank">https://github.com/tiangolo/full-stack</a>
+* <a href="https://github.com/tiangolo/full-stack-flask-couchbase" target="_blank">https://github.com/tiangolo/full-stack-flask-couchbase</a>
+* <a href="https://github.com/tiangolo/full-stack-flask-couchdb" target="_blank">https://github.com/tiangolo/full-stack-flask-couchdb</a>
 
 And these same full-stack generators were the base of the [**FastAPI** Project Generators](project-generation.md){.internal-link target=_blank}.
 
@@ -237,7 +237,7 @@ Generate the OpenAPI schema automatically, from the same code that defines seria
 
 ///
 
-### <a href="https://nestjs.com/" class="external-link" target="_blank">NestJS</a> (and <a href="https://angular.io/" class="external-link" target="_blank">Angular</a>) { #nestjs-and-angular }
+### <a href="https://nestjs.com/" target="_blank">NestJS</a> (and <a href="https://angular.io/" target="_blank">Angular</a>) { #nestjs-and-angular }
 
 This isn't even Python, NestJS is a JavaScript (TypeScript) NodeJS framework inspired by Angular.
 
@@ -259,13 +259,13 @@ Have a powerful dependency injection system. Find a way to minimize code repetit
 
 ///
 
-### <a href="https://sanic.readthedocs.io/en/latest/" class="external-link" target="_blank">Sanic</a> { #sanic }
+### <a href="https://sanic.readthedocs.io/en/latest/" target="_blank">Sanic</a> { #sanic }
 
 It was one of the first extremely fast Python frameworks based on `asyncio`. It was made to be very similar to Flask.
 
 /// note | Technical Details
 
-It used <a href="https://github.com/MagicStack/uvloop" class="external-link" target="_blank">`uvloop`</a> instead of the default Python `asyncio` loop. That's what made it so fast.
+It used <a href="https://github.com/MagicStack/uvloop" target="_blank">`uvloop`</a> instead of the default Python `asyncio` loop. That's what made it so fast.
 
 It clearly inspired Uvicorn and Starlette, that are currently faster than Sanic in open benchmarks.
 
@@ -279,7 +279,7 @@ That's why **FastAPI** is based on Starlette, as it is the fastest framework ava
 
 ///
 
-### <a href="https://falconframework.org/" class="external-link" target="_blank">Falcon</a> { #falcon }
+### <a href="https://falconframework.org/" target="_blank">Falcon</a> { #falcon }
 
 Falcon is another high performance Python framework, it is designed to be minimal, and work as the foundation of other frameworks like Hug.
 
@@ -297,7 +297,7 @@ Although in FastAPI it's optional, and is used mainly to set headers, cookies, a
 
 ///
 
-### <a href="https://moltenframework.com/" class="external-link" target="_blank">Molten</a> { #molten }
+### <a href="https://moltenframework.com/" target="_blank">Molten</a> { #molten }
 
 I discovered Molten in the first stages of building **FastAPI**. And it has quite similar ideas:
 
@@ -321,7 +321,7 @@ This actually inspired updating parts of Pydantic, to support the same validatio
 
 ///
 
-### <a href="https://github.com/hugapi/hug" class="external-link" target="_blank">Hug</a> { #hug }
+### <a href="https://github.com/hugapi/hug" target="_blank">Hug</a> { #hug }
 
 Hug was one of the first frameworks to implement the declaration of API parameter types using Python type hints. This was a great idea that inspired other tools to do the same.
 
@@ -337,7 +337,7 @@ As it is based on the previous standard for synchronous Python web frameworks (W
 
 /// info
 
-Hug was created by Timothy Crosley, the same creator of <a href="https://github.com/timothycrosley/isort" class="external-link" target="_blank">`isort`</a>, a great tool to automatically sort imports in Python files.
+Hug was created by Timothy Crosley, the same creator of <a href="https://github.com/timothycrosley/isort" target="_blank">`isort`</a>, a great tool to automatically sort imports in Python files.
 
 ///
 
@@ -351,7 +351,7 @@ Hug inspired **FastAPI** to declare a `response` parameter in functions to set h
 
 ///
 
-### <a href="https://github.com/encode/apistar" class="external-link" target="_blank">APIStar</a> (<= 0.5) { #apistar-0-5 }
+### <a href="https://github.com/encode/apistar" target="_blank">APIStar</a> (<= 0.5) { #apistar-0-5 }
 
 Right before deciding to build **FastAPI** I found **APIStar** server. It had almost everything I was looking for and had a great design.
 
@@ -401,7 +401,7 @@ I consider **FastAPI** a "spiritual successor" to APIStar, while improving and i
 
 ## Used by **FastAPI** { #used-by-fastapi }
 
-### <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> { #pydantic }
+### <a href="https://docs.pydantic.dev/" target="_blank">Pydantic</a> { #pydantic }
 
 Pydantic is a library to define data validation, serialization and documentation (using JSON Schema) based on Python type hints.
 
@@ -417,7 +417,7 @@ Handle all the data validation, data serialization and automatic model documenta
 
 ///
 
-### <a href="https://www.starlette.dev/" class="external-link" target="_blank">Starlette</a> { #starlette }
+### <a href="https://www.starlette.dev/" target="_blank">Starlette</a> { #starlette }
 
 Starlette is a lightweight <dfn title="The new standard for building asynchronous Python web applications">ASGI</dfn> framework/toolkit, which is ideal for building high-performance asyncio services.
 
@@ -462,7 +462,7 @@ So, anything that you can do with Starlette, you can do it directly with **FastA
 
 ///
 
-### <a href="https://www.uvicorn.dev/" class="external-link" target="_blank">Uvicorn</a> { #uvicorn }
+### <a href="https://www.uvicorn.dev/" target="_blank">Uvicorn</a> { #uvicorn }
 
 Uvicorn is a lightning-fast ASGI server, built on uvloop and httptools.
 

--- a/docs/en/docs/alternatives.md
+++ b/docs/en/docs/alternatives.md
@@ -14,7 +14,7 @@ But at some point, there was no other option than creating something that provid
 
 ## Previous tools { #previous-tools }
 
-### <a href="https://www.djangoproject.com/" target="_blank">Django</a> { #django }
+### [Django](https://www.djangoproject.com/) { #django }
 
 It's the most popular Python framework and is widely trusted. It is used to build systems like Instagram.
 
@@ -22,7 +22,7 @@ It's relatively tightly coupled with relational databases (like MySQL or Postgre
 
 It was created to generate the HTML in the backend, not to create APIs used by a modern frontend (like React, Vue.js and Angular) or by other systems (like <abbr title="Internet of Things">IoT</abbr> devices) communicating with it.
 
-### <a href="https://www.django-rest-framework.org/" target="_blank">Django REST Framework</a> { #django-rest-framework }
+### [Django REST Framework](https://www.django-rest-framework.org/) { #django-rest-framework }
 
 Django REST framework was created to be a flexible toolkit for building Web APIs using Django underneath, to improve its API capabilities.
 
@@ -42,7 +42,7 @@ Have an automatic API documentation web user interface.
 
 ///
 
-### <a href="https://flask.palletsprojects.com" target="_blank">Flask</a> { #flask }
+### [Flask](https://flask.palletsprojects.com) { #flask }
 
 Flask is a "microframework", it doesn't include database integrations nor many of the things that come by default in Django.
 
@@ -64,7 +64,7 @@ Have a simple and easy to use routing system.
 
 ///
 
-### <a href="https://requests.readthedocs.io" target="_blank">Requests</a> { #requests }
+### [Requests](https://requests.readthedocs.io) { #requests }
 
 **FastAPI** is not actually an alternative to **Requests**. Their scope is very different.
 
@@ -106,7 +106,7 @@ See the similarities in `requests.get(...)` and `@app.get(...)`.
 
 ///
 
-### <a href="https://swagger.io/" target="_blank">Swagger</a> / <a href="https://github.com/OAI/OpenAPI-Specification/" target="_blank">OpenAPI</a> { #swagger-openapi }
+### [Swagger](https://swagger.io/) / [OpenAPI](https://github.com/OAI/OpenAPI-Specification/) { #swagger-openapi }
 
 The main feature I wanted from Django REST Framework was the automatic API documentation.
 
@@ -124,8 +124,8 @@ Adopt and use an open standard for API specifications, instead of a custom schem
 
 And integrate standards-based user interface tools:
 
-* <a href="https://github.com/swagger-api/swagger-ui" target="_blank">Swagger UI</a>
-* <a href="https://github.com/Rebilly/ReDoc" target="_blank">ReDoc</a>
+* [Swagger UI](https://github.com/swagger-api/swagger-ui)
+* [ReDoc](https://github.com/Rebilly/ReDoc)
 
 These two were chosen for being fairly popular and stable, but doing a quick search, you could find dozens of alternative user interfaces for OpenAPI (that you can use with **FastAPI**).
 
@@ -135,7 +135,7 @@ These two were chosen for being fairly popular and stable, but doing a quick sea
 
 There are several Flask REST frameworks, but after investing the time and work into investigating them, I found that many are discontinued or abandoned, with several standing issues that made them unfit.
 
-### <a href="https://marshmallow.readthedocs.io/en/stable/" target="_blank">Marshmallow</a> { #marshmallow }
+### [Marshmallow](https://marshmallow.readthedocs.io/en/stable/) { #marshmallow }
 
 One of the main features needed by API systems is data "<dfn title="also called marshalling, conversion">serialization</dfn>" which is taking data from the code (Python) and converting it into something that can be sent through the network. For example, converting an object containing data from a database into a JSON object. Converting `datetime` objects into strings, etc.
 
@@ -153,7 +153,7 @@ Use code to define "schemas" that provide data types and validation, automatical
 
 ///
 
-### <a href="https://webargs.readthedocs.io/en/latest/" target="_blank">Webargs</a> { #webargs }
+### [Webargs](https://webargs.readthedocs.io/en/latest/) { #webargs }
 
 Another big feature required by APIs is <dfn title="reading and converting to Python data">parsing</dfn> data from incoming requests.
 
@@ -175,7 +175,7 @@ Have automatic validation of incoming request data.
 
 ///
 
-### <a href="https://apispec.readthedocs.io/en/stable/" target="_blank">APISpec</a> { #apispec }
+### [APISpec](https://apispec.readthedocs.io/en/stable/) { #apispec }
 
 Marshmallow and Webargs provide validation, parsing and serialization as plug-ins.
 
@@ -205,7 +205,7 @@ Support the open standard for APIs, OpenAPI.
 
 ///
 
-### <a href="https://flask-apispec.readthedocs.io/en/latest/" target="_blank">Flask-apispec</a> { #flask-apispec }
+### [Flask-apispec](https://flask-apispec.readthedocs.io/en/latest/) { #flask-apispec }
 
 It's a Flask plug-in, that ties together Webargs, Marshmallow and APISpec.
 
@@ -219,11 +219,11 @@ This combination of Flask, Flask-apispec with Marshmallow and Webargs was my fav
 
 Using it led to the creation of several Flask full-stack generators. These are the main stacks I (and several external teams) have been using up to now:
 
-* <a href="https://github.com/tiangolo/full-stack" target="_blank">https://github.com/tiangolo/full-stack</a>
-* <a href="https://github.com/tiangolo/full-stack-flask-couchbase" target="_blank">https://github.com/tiangolo/full-stack-flask-couchbase</a>
-* <a href="https://github.com/tiangolo/full-stack-flask-couchdb" target="_blank">https://github.com/tiangolo/full-stack-flask-couchdb</a>
+* [https://github.com/tiangolo/full-stack](https://github.com/tiangolo/full-stack)
+* [https://github.com/tiangolo/full-stack-flask-couchbase](https://github.com/tiangolo/full-stack-flask-couchbase)
+* [https://github.com/tiangolo/full-stack-flask-couchdb](https://github.com/tiangolo/full-stack-flask-couchdb)
 
-And these same full-stack generators were the base of the [**FastAPI** Project Generators](project-generation.md){.internal-link target=_blank}.
+And these same full-stack generators were the base of the [**FastAPI** Project Generators](project-generation.md).
 
 /// info
 
@@ -237,7 +237,7 @@ Generate the OpenAPI schema automatically, from the same code that defines seria
 
 ///
 
-### <a href="https://nestjs.com/" target="_blank">NestJS</a> (and <a href="https://angular.io/" target="_blank">Angular</a>) { #nestjs-and-angular }
+### [NestJS](https://nestjs.com/) (and [Angular](https://angular.io/)) { #nestjs-and-angular }
 
 This isn't even Python, NestJS is a JavaScript (TypeScript) NodeJS framework inspired by Angular.
 
@@ -259,13 +259,13 @@ Have a powerful dependency injection system. Find a way to minimize code repetit
 
 ///
 
-### <a href="https://sanic.readthedocs.io/en/latest/" target="_blank">Sanic</a> { #sanic }
+### [Sanic](https://sanic.readthedocs.io/en/latest/) { #sanic }
 
 It was one of the first extremely fast Python frameworks based on `asyncio`. It was made to be very similar to Flask.
 
 /// note | Technical Details
 
-It used <a href="https://github.com/MagicStack/uvloop" target="_blank">`uvloop`</a> instead of the default Python `asyncio` loop. That's what made it so fast.
+It used [`uvloop`](https://github.com/MagicStack/uvloop) instead of the default Python `asyncio` loop. That's what made it so fast.
 
 It clearly inspired Uvicorn and Starlette, that are currently faster than Sanic in open benchmarks.
 
@@ -279,7 +279,7 @@ That's why **FastAPI** is based on Starlette, as it is the fastest framework ava
 
 ///
 
-### <a href="https://falconframework.org/" target="_blank">Falcon</a> { #falcon }
+### [Falcon](https://falconframework.org/) { #falcon }
 
 Falcon is another high performance Python framework, it is designed to be minimal, and work as the foundation of other frameworks like Hug.
 
@@ -297,7 +297,7 @@ Although in FastAPI it's optional, and is used mainly to set headers, cookies, a
 
 ///
 
-### <a href="https://moltenframework.com/" target="_blank">Molten</a> { #molten }
+### [Molten](https://moltenframework.com/) { #molten }
 
 I discovered Molten in the first stages of building **FastAPI**. And it has quite similar ideas:
 
@@ -321,7 +321,7 @@ This actually inspired updating parts of Pydantic, to support the same validatio
 
 ///
 
-### <a href="https://github.com/hugapi/hug" target="_blank">Hug</a> { #hug }
+### [Hug](https://github.com/hugapi/hug) { #hug }
 
 Hug was one of the first frameworks to implement the declaration of API parameter types using Python type hints. This was a great idea that inspired other tools to do the same.
 
@@ -337,7 +337,7 @@ As it is based on the previous standard for synchronous Python web frameworks (W
 
 /// info
 
-Hug was created by Timothy Crosley, the same creator of <a href="https://github.com/timothycrosley/isort" target="_blank">`isort`</a>, a great tool to automatically sort imports in Python files.
+Hug was created by Timothy Crosley, the same creator of [`isort`](https://github.com/timothycrosley/isort), a great tool to automatically sort imports in Python files.
 
 ///
 
@@ -351,7 +351,7 @@ Hug inspired **FastAPI** to declare a `response` parameter in functions to set h
 
 ///
 
-### <a href="https://github.com/encode/apistar" target="_blank">APIStar</a> (<= 0.5) { #apistar-0-5 }
+### [APIStar](https://github.com/encode/apistar) (<= 0.5) { #apistar-0-5 }
 
 Right before deciding to build **FastAPI** I found **APIStar** server. It had almost everything I was looking for and had a great design.
 
@@ -401,7 +401,7 @@ I consider **FastAPI** a "spiritual successor" to APIStar, while improving and i
 
 ## Used by **FastAPI** { #used-by-fastapi }
 
-### <a href="https://docs.pydantic.dev/" target="_blank">Pydantic</a> { #pydantic }
+### [Pydantic](https://docs.pydantic.dev/) { #pydantic }
 
 Pydantic is a library to define data validation, serialization and documentation (using JSON Schema) based on Python type hints.
 
@@ -417,7 +417,7 @@ Handle all the data validation, data serialization and automatic model documenta
 
 ///
 
-### <a href="https://www.starlette.dev/" target="_blank">Starlette</a> { #starlette }
+### [Starlette](https://www.starlette.dev/) { #starlette }
 
 Starlette is a lightweight <dfn title="The new standard for building asynchronous Python web applications">ASGI</dfn> framework/toolkit, which is ideal for building high-performance asyncio services.
 
@@ -462,7 +462,7 @@ So, anything that you can do with Starlette, you can do it directly with **FastA
 
 ///
 
-### <a href="https://www.uvicorn.dev/" target="_blank">Uvicorn</a> { #uvicorn }
+### [Uvicorn](https://www.uvicorn.dev/) { #uvicorn }
 
 Uvicorn is a lightning-fast ASGI server, built on uvloop and httptools.
 
@@ -476,10 +476,10 @@ The main web server to run **FastAPI** applications.
 
 You can also use the `--workers` command line option to have an asynchronous multi-process server.
 
-Check more details in the [Deployment](deployment/index.md){.internal-link target=_blank} section.
+Check more details in the [Deployment](deployment/index.md) section.
 
 ///
 
 ## Benchmarks and speed { #benchmarks-and-speed }
 
-To understand, compare, and see the difference between Uvicorn, Starlette and FastAPI, check the section about [Benchmarks](benchmarks.md){.internal-link target=_blank}.
+To understand, compare, and see the difference between Uvicorn, Starlette and FastAPI, check the section about [Benchmarks](benchmarks.md).

--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -141,7 +141,7 @@ You and your crush eat the burgers and have a nice time. ✨
 
 /// info
 
-Beautiful illustrations by [Ketrina Thompson](https://www.instagram.com/ketrinadrawsalot){target=_blank}. 🎨
+Beautiful illustrations by [Ketrina Thompson](https://www.instagram.com/ketrinadrawsalot). 🎨
 
 ///
 
@@ -207,7 +207,7 @@ There was not much talk or flirting as most of the time was spent waiting 🕙 i
 
 /// info
 
-Beautiful illustrations by [Ketrina Thompson](https://www.instagram.com/ketrinadrawsalot){target=_blank}. 🎨
+Beautiful illustrations by [Ketrina Thompson](https://www.instagram.com/ketrinadrawsalot). 🎨
 
 ///
 
@@ -251,7 +251,7 @@ This kind of asynchronicity is what made NodeJS popular (even though NodeJS is n
 
 And that's the same level of performance you get with **FastAPI**.
 
-And as you can have parallelism and asynchronicity at the same time, you get higher performance than most of the tested NodeJS frameworks and on par with Go, which is a compiled language closer to C [(all thanks to Starlette)](https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=query&l=zijmkf-1){target=_blank}.
+And as you can have parallelism and asynchronicity at the same time, you get higher performance than most of the tested NodeJS frameworks and on par with Go, which is a compiled language closer to C [(all thanks to Starlette)](https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=query&l=zijmkf-1).
 
 ### Is concurrency better than parallelism? { #is-concurrency-better-than-parallelism }
 
@@ -298,7 +298,7 @@ But you can also exploit the benefits of parallelism and multiprocessing (having
 
 That, plus the simple fact that Python is the main language for **Data Science**, Machine Learning and especially Deep Learning, make FastAPI a very good match for Data Science / Machine Learning web APIs and applications (among many others).
 
-To see how to achieve this parallelism in production see the section about [Deployment](deployment/index.md){target=_blank}.
+To see how to achieve this parallelism in production see the section about [Deployment](deployment/index.md).
 
 ## `async` and `await` { #async-and-await }
 
@@ -363,13 +363,13 @@ But if you want to use `async` / `await` without FastAPI, you can do it as well.
 
 ### Write your own async code { #write-your-own-async-code }
 
-Starlette (and **FastAPI**) are based on [AnyIO](https://anyio.readthedocs.io/en/stable/){target=_blank}, which makes it compatible with both Python's standard library [asyncio](https://docs.python.org/3/library/asyncio-task.html){target=_blank} and [Trio](https://trio.readthedocs.io/en/stable/){target=_blank}.
+Starlette (and **FastAPI**) are based on [AnyIO](https://anyio.readthedocs.io/en/stable/), which makes it compatible with both Python's standard library [asyncio](https://docs.python.org/3/library/asyncio-task.html) and [Trio](https://trio.readthedocs.io/en/stable/).
 
-In particular, you can directly use [AnyIO](https://anyio.readthedocs.io/en/stable/){target=_blank} for your advanced concurrency use cases that require more advanced patterns in your own code.
+In particular, you can directly use [AnyIO](https://anyio.readthedocs.io/en/stable/) for your advanced concurrency use cases that require more advanced patterns in your own code.
 
-And even if you were not using FastAPI, you could also write your own async applications with [AnyIO](https://anyio.readthedocs.io/en/stable/){target=_blank} to be highly compatible and get its benefits (e.g. *structured concurrency*).
+And even if you were not using FastAPI, you could also write your own async applications with [AnyIO](https://anyio.readthedocs.io/en/stable/) to be highly compatible and get its benefits (e.g. *structured concurrency*).
 
-I created another library on top of AnyIO, as a thin layer on top, to improve a bit the type annotations and get better **autocompletion**, **inline errors**, etc. It also has a friendly introduction and tutorial to help you **understand** and write **your own async code**: [Asyncer](https://asyncer.tiangolo.com/){target=_blank}. It would be particularly useful if you need to **combine async code with regular** (blocking/synchronous) code.
+I created another library on top of AnyIO, as a thin layer on top, to improve a bit the type annotations and get better **autocompletion**, **inline errors**, etc. It also has a friendly introduction and tutorial to help you **understand** and write **your own async code**: [Asyncer](https://asyncer.tiangolo.com/). It would be particularly useful if you need to **combine async code with regular** (blocking/synchronous) code.
 
 ### Other forms of asynchronous code { #other-forms-of-asynchronous-code }
 
@@ -381,7 +381,7 @@ This same syntax (or almost identical) was also included recently in modern vers
 
 But before that, handling asynchronous code was quite more complex and difficult.
 
-In previous versions of Python, you could have used threads or [Gevent](https://www.gevent.org/){target=_blank}. But the code is way more complex to understand, debug, and think about.
+In previous versions of Python, you could have used threads or [Gevent](https://www.gevent.org/). But the code is way more complex to understand, debug, and think about.
 
 In previous versions of NodeJS / Browser JavaScript, you would have used "callbacks". Which leads to "callback hell".
 
@@ -419,15 +419,15 @@ When you declare a *path operation function* with normal `def` instead of `async
 
 If you are coming from another async framework that does not work in the way described above and you are used to defining trivial compute-only *path operation functions* with plain `def` for a tiny performance gain (about 100 nanoseconds), please note that in **FastAPI** the effect would be quite opposite. In these cases, it's better to use `async def` unless your *path operation functions* use code that performs blocking <abbr title="Input/Output: disk reading or writing, network communications.">I/O</abbr>.
 
-Still, in both situations, chances are that **FastAPI** will [still be faster](index.md#performance){target=_blank} than (or at least comparable to) your previous framework.
+Still, in both situations, chances are that **FastAPI** will [still be faster](index.md#performance) than (or at least comparable to) your previous framework.
 
 ### Dependencies { #dependencies }
 
-The same applies for [dependencies](tutorial/dependencies/index.md){target=_blank}. If a dependency is a standard `def` function instead of `async def`, it is run in the external threadpool.
+The same applies for [dependencies](tutorial/dependencies/index.md). If a dependency is a standard `def` function instead of `async def`, it is run in the external threadpool.
 
 ### Sub-dependencies { #sub-dependencies }
 
-You can have multiple dependencies and [sub-dependencies](tutorial/dependencies/sub-dependencies.md){target=_blank} requiring each other (as parameters of the function definitions), some of them might be created with `async def` and some with normal `def`. It would still work, and the ones created with normal `def` would be called on an external thread (from the threadpool) instead of being "awaited".
+You can have multiple dependencies and [sub-dependencies](tutorial/dependencies/sub-dependencies.md) requiring each other (as parameters of the function definitions), some of them might be created with `async def` and some with normal `def`. It would still work, and the ones created with normal `def` would be called on an external thread (from the threadpool) instead of being "awaited".
 
 ### Other utility functions { #other-utility-functions }
 

--- a/docs/en/docs/async.md
+++ b/docs/en/docs/async.md
@@ -141,7 +141,7 @@ You and your crush eat the burgers and have a nice time. ✨
 
 /// info
 
-Beautiful illustrations by <a href="https://www.instagram.com/ketrinadrawsalot" class="external-link" target="_blank">Ketrina Thompson</a>. 🎨
+Beautiful illustrations by [Ketrina Thompson](https://www.instagram.com/ketrinadrawsalot){target=_blank}. 🎨
 
 ///
 
@@ -207,7 +207,7 @@ There was not much talk or flirting as most of the time was spent waiting 🕙 i
 
 /// info
 
-Beautiful illustrations by <a href="https://www.instagram.com/ketrinadrawsalot" class="external-link" target="_blank">Ketrina Thompson</a>. 🎨
+Beautiful illustrations by [Ketrina Thompson](https://www.instagram.com/ketrinadrawsalot){target=_blank}. 🎨
 
 ///
 
@@ -251,7 +251,7 @@ This kind of asynchronicity is what made NodeJS popular (even though NodeJS is n
 
 And that's the same level of performance you get with **FastAPI**.
 
-And as you can have parallelism and asynchronicity at the same time, you get higher performance than most of the tested NodeJS frameworks and on par with Go, which is a compiled language closer to C <a href="https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=query&l=zijmkf-1" class="external-link" target="_blank">(all thanks to Starlette)</a>.
+And as you can have parallelism and asynchronicity at the same time, you get higher performance than most of the tested NodeJS frameworks and on par with Go, which is a compiled language closer to C [(all thanks to Starlette)](https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=query&l=zijmkf-1){target=_blank}.
 
 ### Is concurrency better than parallelism? { #is-concurrency-better-than-parallelism }
 
@@ -298,7 +298,7 @@ But you can also exploit the benefits of parallelism and multiprocessing (having
 
 That, plus the simple fact that Python is the main language for **Data Science**, Machine Learning and especially Deep Learning, make FastAPI a very good match for Data Science / Machine Learning web APIs and applications (among many others).
 
-To see how to achieve this parallelism in production see the section about [Deployment](deployment/index.md){.internal-link target=_blank}.
+To see how to achieve this parallelism in production see the section about [Deployment](deployment/index.md){target=_blank}.
 
 ## `async` and `await` { #async-and-await }
 
@@ -363,13 +363,13 @@ But if you want to use `async` / `await` without FastAPI, you can do it as well.
 
 ### Write your own async code { #write-your-own-async-code }
 
-Starlette (and **FastAPI**) are based on <a href="https://anyio.readthedocs.io/en/stable/" class="external-link" target="_blank">AnyIO</a>, which makes it compatible with both Python's standard library <a href="https://docs.python.org/3/library/asyncio-task.html" class="external-link" target="_blank">asyncio</a> and <a href="https://trio.readthedocs.io/en/stable/" class="external-link" target="_blank">Trio</a>.
+Starlette (and **FastAPI**) are based on [AnyIO](https://anyio.readthedocs.io/en/stable/){target=_blank}, which makes it compatible with both Python's standard library [asyncio](https://docs.python.org/3/library/asyncio-task.html){target=_blank} and [Trio](https://trio.readthedocs.io/en/stable/){target=_blank}.
 
-In particular, you can directly use <a href="https://anyio.readthedocs.io/en/stable/" class="external-link" target="_blank">AnyIO</a> for your advanced concurrency use cases that require more advanced patterns in your own code.
+In particular, you can directly use [AnyIO](https://anyio.readthedocs.io/en/stable/){target=_blank} for your advanced concurrency use cases that require more advanced patterns in your own code.
 
-And even if you were not using FastAPI, you could also write your own async applications with <a href="https://anyio.readthedocs.io/en/stable/" class="external-link" target="_blank">AnyIO</a> to be highly compatible and get its benefits (e.g. *structured concurrency*).
+And even if you were not using FastAPI, you could also write your own async applications with [AnyIO](https://anyio.readthedocs.io/en/stable/){target=_blank} to be highly compatible and get its benefits (e.g. *structured concurrency*).
 
-I created another library on top of AnyIO, as a thin layer on top, to improve a bit the type annotations and get better **autocompletion**, **inline errors**, etc. It also has a friendly introduction and tutorial to help you **understand** and write **your own async code**: <a href="https://asyncer.tiangolo.com/" class="external-link" target="_blank">Asyncer</a>. It would be particularly useful if you need to **combine async code with regular** (blocking/synchronous) code.
+I created another library on top of AnyIO, as a thin layer on top, to improve a bit the type annotations and get better **autocompletion**, **inline errors**, etc. It also has a friendly introduction and tutorial to help you **understand** and write **your own async code**: [Asyncer](https://asyncer.tiangolo.com/){target=_blank}. It would be particularly useful if you need to **combine async code with regular** (blocking/synchronous) code.
 
 ### Other forms of asynchronous code { #other-forms-of-asynchronous-code }
 
@@ -381,7 +381,7 @@ This same syntax (or almost identical) was also included recently in modern vers
 
 But before that, handling asynchronous code was quite more complex and difficult.
 
-In previous versions of Python, you could have used threads or <a href="https://www.gevent.org/" class="external-link" target="_blank">Gevent</a>. But the code is way more complex to understand, debug, and think about.
+In previous versions of Python, you could have used threads or [Gevent](https://www.gevent.org/){target=_blank}. But the code is way more complex to understand, debug, and think about.
 
 In previous versions of NodeJS / Browser JavaScript, you would have used "callbacks". Which leads to "callback hell".
 
@@ -419,15 +419,15 @@ When you declare a *path operation function* with normal `def` instead of `async
 
 If you are coming from another async framework that does not work in the way described above and you are used to defining trivial compute-only *path operation functions* with plain `def` for a tiny performance gain (about 100 nanoseconds), please note that in **FastAPI** the effect would be quite opposite. In these cases, it's better to use `async def` unless your *path operation functions* use code that performs blocking <abbr title="Input/Output: disk reading or writing, network communications.">I/O</abbr>.
 
-Still, in both situations, chances are that **FastAPI** will [still be faster](index.md#performance){.internal-link target=_blank} than (or at least comparable to) your previous framework.
+Still, in both situations, chances are that **FastAPI** will [still be faster](index.md#performance){target=_blank} than (or at least comparable to) your previous framework.
 
 ### Dependencies { #dependencies }
 
-The same applies for [dependencies](tutorial/dependencies/index.md){.internal-link target=_blank}. If a dependency is a standard `def` function instead of `async def`, it is run in the external threadpool.
+The same applies for [dependencies](tutorial/dependencies/index.md){target=_blank}. If a dependency is a standard `def` function instead of `async def`, it is run in the external threadpool.
 
 ### Sub-dependencies { #sub-dependencies }
 
-You can have multiple dependencies and [sub-dependencies](tutorial/dependencies/sub-dependencies.md){.internal-link target=_blank} requiring each other (as parameters of the function definitions), some of them might be created with `async def` and some with normal `def`. It would still work, and the ones created with normal `def` would be called on an external thread (from the threadpool) instead of being "awaited".
+You can have multiple dependencies and [sub-dependencies](tutorial/dependencies/sub-dependencies.md){target=_blank} requiring each other (as parameters of the function definitions), some of them might be created with `async def` and some with normal `def`. It would still work, and the ones created with normal `def` would be called on an external thread (from the threadpool) instead of being "awaited".
 
 ### Other utility functions { #other-utility-functions }
 

--- a/docs/en/docs/benchmarks.md
+++ b/docs/en/docs/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks { #benchmarks }
 
-Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as [one of the fastest Python frameworks available](https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7){target=_blank}, only below Starlette and Uvicorn themselves (used internally by FastAPI).
+Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as [one of the fastest Python frameworks available](https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7), only below Starlette and Uvicorn themselves (used internally by FastAPI).
 
 But when checking benchmarks and comparisons you should keep the following in mind.
 

--- a/docs/en/docs/benchmarks.md
+++ b/docs/en/docs/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks { #benchmarks }
 
-Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" class="external-link" target="_blank">one of the fastest Python frameworks available</a>, only below Starlette and Uvicorn themselves (used internally by FastAPI).
+Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as [one of the fastest Python frameworks available](https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7){target=_blank}, only below Starlette and Uvicorn themselves (used internally by FastAPI).
 
 But when checking benchmarks and comparisons you should keep the following in mind.
 

--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -1,14 +1,14 @@
 # Development - Contributing
 
-First, you might want to see the basic ways to [help FastAPI and get help](help-fastapi.md){target=_blank}.
+First, you might want to see the basic ways to [help FastAPI and get help](help-fastapi.md).
 
 ## Developing
 
-If you already cloned the [fastapi repository](https://github.com/fastapi/fastapi){target=_blank} and you want to deep dive in the code, here are some guidelines to set up your environment.
+If you already cloned the [fastapi repository](https://github.com/fastapi/fastapi) and you want to deep dive in the code, here are some guidelines to set up your environment.
 
 ### Install requirements
 
-Create a virtual environment and install the required packages with [`uv`](https://github.com/astral-sh/uv){target=_blank}:
+Create a virtual environment and install the required packages with [`uv`](https://github.com/astral-sh/uv):
 
 <div class="termy">
 
@@ -112,7 +112,7 @@ $ mkdocs serve --dev-addr 127.0.0.1:8008
 
 The instructions here show you how to use the script at `./scripts/docs.py` with the `python` program directly.
 
-But you can also use [Typer CLI](https://typer.tiangolo.com/typer-cli/){target=_blank}, and you will get autocompletion in your terminal for the commands after installing completion.
+But you can also use [Typer CLI](https://typer.tiangolo.com/typer-cli/), and you will get autocompletion in your terminal for the commands after installing completion.
 
 If you install Typer CLI, you can install completion with:
 
@@ -129,7 +129,7 @@ Completion will take effect once you restart the terminal.
 
 ### Docs Structure
 
-The documentation uses [MkDocs](https://www.mkdocs.org/){target=_blank}.
+The documentation uses [MkDocs](https://www.mkdocs.org/).
 
 And there are extra tools/scripts in place to handle translations in `./scripts/docs.py`.
 
@@ -183,31 +183,31 @@ Translation pull requests are made by LLMs guided with prompts designed by the F
 
 #### LLM Prompt per Language
 
-Each language has a directory: [https://github.com/fastapi/fastapi/tree/master/docs](https://github.com/fastapi/fastapi/tree/master/docs){target=_blank}, in it you can see a file `llm-prompt.md` with the prompt specific for that language.
+Each language has a directory: [https://github.com/fastapi/fastapi/tree/master/docs](https://github.com/fastapi/fastapi/tree/master/docs), in it you can see a file `llm-prompt.md` with the prompt specific for that language.
 
-For example, for Spanish, the prompt is at: [`docs/es/llm-prompt.md`](https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md){target=_blank}.
+For example, for Spanish, the prompt is at: [`docs/es/llm-prompt.md`](https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md).
 
 If you see mistakes in your language, you can make suggestions to the prompt in that file for your language, and request the specific pages you would like to re-generate after the changes.
 
 #### Reviewing Translation PRs
 
-You can also check the currently [existing pull requests](https://github.com/fastapi/fastapi/pulls){target=_blank} for your language. You can filter the pull requests by the ones with the label for your language. For example, for Spanish, the label is [`lang-es`](https://github.com/fastapi/fastapi/pulls?q=is%3Aopen+sort%3Aupdated-desc+label%3Alang-es+label%3Aawaiting-review){target=_blank}.
+You can also check the currently [existing pull requests](https://github.com/fastapi/fastapi/pulls) for your language. You can filter the pull requests by the ones with the label for your language. For example, for Spanish, the label is [`lang-es`](https://github.com/fastapi/fastapi/pulls?q=is%3Aopen+sort%3Aupdated-desc+label%3Alang-es+label%3Aawaiting-review).
 
 When reviewing a pull request, it's better not to suggest changes in the same pull request, because it is LLM generated, and it won't be possible to make sure that small individual changes are replicated in other similar sections, or that they are preserved when translating the same content again.
 
-Instead of adding suggestions to the translation PR, make the suggestions to the LLM prompt file for that language, in a new PR. For example, for Spanish, the LLM prompt file is at: [`docs/es/llm-prompt.md`](https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md){target=_blank}.
+Instead of adding suggestions to the translation PR, make the suggestions to the LLM prompt file for that language, in a new PR. For example, for Spanish, the LLM prompt file is at: [`docs/es/llm-prompt.md`](https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md).
 
 /// tip
 
-Check the docs about [adding a pull request review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews){target=_blank} to approve it or request changes.
+Check the docs about [adding a pull request review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews) to approve it or request changes.
 
 ///
 
 #### Subscribe to Notifications for Your Language
 
-Check if there's a [GitHub Discussion](https://github.com/fastapi/fastapi/discussions/categories/translations){target=_blank} to coordinate translations for your language. You can subscribe to it, and when there's a new pull request to review, an automatic comment will be added to the discussion.
+Check if there's a [GitHub Discussion](https://github.com/fastapi/fastapi/discussions/categories/translations) to coordinate translations for your language. You can subscribe to it, and when there's a new pull request to review, an automatic comment will be added to the discussion.
 
-To check the 2-letter code for the language you want to translate, you can use the table [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes){target=_blank}.
+To check the 2-letter code for the language you want to translate, you can use the table [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
 
 #### Request a New Language
 
@@ -240,7 +240,7 @@ The same applies to comments and descriptions, please don't copy paste the conte
 
 ### Human Effort Denial of Service
 
-Using automated tools and AI to submit PRs or comments that we have to carefully review and handle would be the equivalent of a [Denial-of-service attack](https://en.wikipedia.org/wiki/Denial-of-service_attack){target=_blank} on our human effort.
+Using automated tools and AI to submit PRs or comments that we have to carefully review and handle would be the equivalent of a [Denial-of-service attack](https://en.wikipedia.org/wiki/Denial-of-service_attack) on our human effort.
 
 It would be very little effort from the person submitting the PR (an LLM prompt) that generates a large amount of effort on our side (carefully reviewing code).
 

--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -1,14 +1,14 @@
 # Development - Contributing
 
-First, you might want to see the basic ways to [help FastAPI and get help](help-fastapi.md){.internal-link target=_blank}.
+First, you might want to see the basic ways to [help FastAPI and get help](help-fastapi.md){target=_blank}.
 
 ## Developing
 
-If you already cloned the <a href="https://github.com/fastapi/fastapi" class="external-link" target="_blank">fastapi repository</a> and you want to deep dive in the code, here are some guidelines to set up your environment.
+If you already cloned the [fastapi repository](https://github.com/fastapi/fastapi){target=_blank} and you want to deep dive in the code, here are some guidelines to set up your environment.
 
 ### Install requirements
 
-Create a virtual environment and install the required packages with <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">`uv`</a>:
+Create a virtual environment and install the required packages with [`uv`](https://github.com/astral-sh/uv){target=_blank}:
 
 <div class="termy">
 
@@ -112,7 +112,7 @@ $ mkdocs serve --dev-addr 127.0.0.1:8008
 
 The instructions here show you how to use the script at `./scripts/docs.py` with the `python` program directly.
 
-But you can also use <a href="https://typer.tiangolo.com/typer-cli/" class="external-link" target="_blank">Typer CLI</a>, and you will get autocompletion in your terminal for the commands after installing completion.
+But you can also use [Typer CLI](https://typer.tiangolo.com/typer-cli/){target=_blank}, and you will get autocompletion in your terminal for the commands after installing completion.
 
 If you install Typer CLI, you can install completion with:
 
@@ -129,7 +129,7 @@ Completion will take effect once you restart the terminal.
 
 ### Docs Structure
 
-The documentation uses <a href="https://www.mkdocs.org/" class="external-link" target="_blank">MkDocs</a>.
+The documentation uses [MkDocs](https://www.mkdocs.org/){target=_blank}.
 
 And there are extra tools/scripts in place to handle translations in `./scripts/docs.py`.
 
@@ -183,31 +183,31 @@ Translation pull requests are made by LLMs guided with prompts designed by the F
 
 #### LLM Prompt per Language
 
-Each language has a directory: <a href="https://github.com/fastapi/fastapi/tree/master/docs" class="external-link" target="_blank">https://github.com/fastapi/fastapi/tree/master/docs</a>, in it you can see a file `llm-prompt.md` with the prompt specific for that language.
+Each language has a directory: [https://github.com/fastapi/fastapi/tree/master/docs](https://github.com/fastapi/fastapi/tree/master/docs){target=_blank}, in it you can see a file `llm-prompt.md` with the prompt specific for that language.
 
-For example, for Spanish, the prompt is at: <a href="https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md" class="external-link" target="_blank">`docs/es/llm-prompt.md`</a>.
+For example, for Spanish, the prompt is at: [`docs/es/llm-prompt.md`](https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md){target=_blank}.
 
 If you see mistakes in your language, you can make suggestions to the prompt in that file for your language, and request the specific pages you would like to re-generate after the changes.
 
 #### Reviewing Translation PRs
 
-You can also check the currently <a href="https://github.com/fastapi/fastapi/pulls" class="external-link" target="_blank">existing pull requests</a> for your language. You can filter the pull requests by the ones with the label for your language. For example, for Spanish, the label is <a href="https://github.com/fastapi/fastapi/pulls?q=is%3Aopen+sort%3Aupdated-desc+label%3Alang-es+label%3Aawaiting-review" class="external-link" target="_blank">`lang-es`</a>.
+You can also check the currently [existing pull requests](https://github.com/fastapi/fastapi/pulls){target=_blank} for your language. You can filter the pull requests by the ones with the label for your language. For example, for Spanish, the label is [`lang-es`](https://github.com/fastapi/fastapi/pulls?q=is%3Aopen+sort%3Aupdated-desc+label%3Alang-es+label%3Aawaiting-review){target=_blank}.
 
 When reviewing a pull request, it's better not to suggest changes in the same pull request, because it is LLM generated, and it won't be possible to make sure that small individual changes are replicated in other similar sections, or that they are preserved when translating the same content again.
 
-Instead of adding suggestions to the translation PR, make the suggestions to the LLM prompt file for that language, in a new PR. For example, for Spanish, the LLM prompt file is at: <a href="https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md" class="external-link" target="_blank">`docs/es/llm-prompt.md`</a>.
+Instead of adding suggestions to the translation PR, make the suggestions to the LLM prompt file for that language, in a new PR. For example, for Spanish, the LLM prompt file is at: [`docs/es/llm-prompt.md`](https://github.com/fastapi/fastapi/blob/master/docs/es/llm-prompt.md){target=_blank}.
 
 /// tip
 
-Check the docs about <a href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews" class="external-link" target="_blank">adding a pull request review</a> to approve it or request changes.
+Check the docs about [adding a pull request review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews){target=_blank} to approve it or request changes.
 
 ///
 
 #### Subscribe to Notifications for Your Language
 
-Check if there's a <a href="https://github.com/fastapi/fastapi/discussions/categories/translations" class="external-link" target="_blank">GitHub Discussion</a> to coordinate translations for your language. You can subscribe to it, and when there's a new pull request to review, an automatic comment will be added to the discussion.
+Check if there's a [GitHub Discussion](https://github.com/fastapi/fastapi/discussions/categories/translations){target=_blank} to coordinate translations for your language. You can subscribe to it, and when there's a new pull request to review, an automatic comment will be added to the discussion.
 
-To check the 2-letter code for the language you want to translate, you can use the table <a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" class="external-link" target="_blank">List of ISO 639-1 codes</a>.
+To check the 2-letter code for the language you want to translate, you can use the table [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes){target=_blank}.
 
 #### Request a New Language
 
@@ -240,7 +240,7 @@ The same applies to comments and descriptions, please don't copy paste the conte
 
 ### Human Effort Denial of Service
 
-Using automated tools and AI to submit PRs or comments that we have to carefully review and handle would be the equivalent of a <a href="https://en.wikipedia.org/wiki/Denial-of-service_attack" class="external-link" target="_blank">Denial-of-service attack</a> on our human effort.
+Using automated tools and AI to submit PRs or comments that we have to carefully review and handle would be the equivalent of a [Denial-of-service attack](https://en.wikipedia.org/wiki/Denial-of-service_attack){target=_blank} on our human effort.
 
 It would be very little effort from the person submitting the PR (an LLM prompt) that generates a large amount of effort on our side (carefully reviewing code).
 

--- a/docs/en/docs/deployment/cloud.md
+++ b/docs/en/docs/deployment/cloud.md
@@ -6,7 +6,7 @@ In most of the cases, the main cloud providers have guides to deploy FastAPI wit
 
 ## FastAPI Cloud { #fastapi-cloud }
 
-**[FastAPI Cloud](https://fastapicloud.com){target=_blank}** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com)** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 
@@ -16,9 +16,9 @@ FastAPI Cloud is the primary sponsor and funding provider for the *FastAPI and f
 
 ## Cloud Providers - Sponsors { #cloud-providers-sponsors }
 
-Some other cloud providers ✨ [**sponsor FastAPI**](../help-fastapi.md#sponsor-the-author){target=_blank} ✨ too. 🙇
+Some other cloud providers ✨ [**sponsor FastAPI**](../help-fastapi.md#sponsor-the-author) ✨ too. 🙇
 
 You might also want to consider them to follow their guides and try their services:
 
-* [Render](https://docs.render.com/deploy-fastapi?utm_source=deploydoc&utm_medium=referral&utm_campaign=fastapi){target=_blank}
-* [Railway](https://docs.railway.com/guides/fastapi?utm_medium=integration&utm_source=docs&utm_campaign=fastapi){target=_blank}
+* [Render](https://docs.render.com/deploy-fastapi?utm_source=deploydoc&utm_medium=referral&utm_campaign=fastapi)
+* [Railway](https://docs.railway.com/guides/fastapi?utm_medium=integration&utm_source=docs&utm_campaign=fastapi)

--- a/docs/en/docs/deployment/cloud.md
+++ b/docs/en/docs/deployment/cloud.md
@@ -6,7 +6,7 @@ In most of the cases, the main cloud providers have guides to deploy FastAPI wit
 
 ## FastAPI Cloud { #fastapi-cloud }
 
-**<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com){target=_blank}** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 
@@ -16,9 +16,9 @@ FastAPI Cloud is the primary sponsor and funding provider for the *FastAPI and f
 
 ## Cloud Providers - Sponsors { #cloud-providers-sponsors }
 
-Some other cloud providers ✨ [**sponsor FastAPI**](../help-fastapi.md#sponsor-the-author){.internal-link target=_blank} ✨ too. 🙇
+Some other cloud providers ✨ [**sponsor FastAPI**](../help-fastapi.md#sponsor-the-author){target=_blank} ✨ too. 🙇
 
 You might also want to consider them to follow their guides and try their services:
 
-* <a href="https://docs.render.com/deploy-fastapi?utm_source=deploydoc&utm_medium=referral&utm_campaign=fastapi" class="external-link" target="_blank">Render</a>
-* <a href="https://docs.railway.com/guides/fastapi?utm_medium=integration&utm_source=docs&utm_campaign=fastapi" class="external-link" target="_blank">Railway</a>
+* [Render](https://docs.render.com/deploy-fastapi?utm_source=deploydoc&utm_medium=referral&utm_campaign=fastapi){target=_blank}
+* [Railway](https://docs.railway.com/guides/fastapi?utm_medium=integration&utm_source=docs&utm_campaign=fastapi){target=_blank}

--- a/docs/en/docs/deployment/concepts.md
+++ b/docs/en/docs/deployment/concepts.md
@@ -25,7 +25,7 @@ But for now, let's check these important **conceptual ideas**. These concepts al
 
 ## Security - HTTPS { #security-https }
 
-In the [previous chapter about HTTPS](https.md){.internal-link target=_blank} we learned about how HTTPS provides encryption for your API.
+In the [previous chapter about HTTPS](https.md){target=_blank} we learned about how HTTPS provides encryption for your API.
 
 We also saw that HTTPS is normally provided by a component **external** to your application server, a **TLS Termination Proxy**.
 
@@ -190,7 +190,7 @@ When you run **multiple processes** of the same API program, they are commonly c
 
 ### Worker Processes and Ports { #worker-processes-and-ports }
 
-Remember from the docs [About HTTPS](https.md){.internal-link target=_blank} that only one process can be listening on one combination of port and IP address in a server?
+Remember from the docs [About HTTPS](https.md){target=_blank} that only one process can be listening on one combination of port and IP address in a server?
 
 This is still true.
 
@@ -243,7 +243,7 @@ Here are some possible combinations and strategies:
 
 Don't worry if some of these items about **containers**, Docker, or Kubernetes don't make a lot of sense yet.
 
-I'll tell you more about container images, Docker, Kubernetes, etc. in a future chapter: [FastAPI in Containers - Docker](docker.md){.internal-link target=_blank}.
+I'll tell you more about container images, Docker, Kubernetes, etc. in a future chapter: [FastAPI in Containers - Docker](docker.md){target=_blank}.
 
 ///
 
@@ -281,7 +281,7 @@ Here are some possible ideas:
 
 /// tip
 
-I'll give you more concrete examples for doing this with containers in a future chapter: [FastAPI in Containers - Docker](docker.md){.internal-link target=_blank}.
+I'll give you more concrete examples for doing this with containers in a future chapter: [FastAPI in Containers - Docker](docker.md){target=_blank}.
 
 ///
 

--- a/docs/en/docs/deployment/concepts.md
+++ b/docs/en/docs/deployment/concepts.md
@@ -25,7 +25,7 @@ But for now, let's check these important **conceptual ideas**. These concepts al
 
 ## Security - HTTPS { #security-https }
 
-In the [previous chapter about HTTPS](https.md){target=_blank} we learned about how HTTPS provides encryption for your API.
+In the [previous chapter about HTTPS](https.md) we learned about how HTTPS provides encryption for your API.
 
 We also saw that HTTPS is normally provided by a component **external** to your application server, a **TLS Termination Proxy**.
 
@@ -190,7 +190,7 @@ When you run **multiple processes** of the same API program, they are commonly c
 
 ### Worker Processes and Ports { #worker-processes-and-ports }
 
-Remember from the docs [About HTTPS](https.md){target=_blank} that only one process can be listening on one combination of port and IP address in a server?
+Remember from the docs [About HTTPS](https.md) that only one process can be listening on one combination of port and IP address in a server?
 
 This is still true.
 
@@ -243,7 +243,7 @@ Here are some possible combinations and strategies:
 
 Don't worry if some of these items about **containers**, Docker, or Kubernetes don't make a lot of sense yet.
 
-I'll tell you more about container images, Docker, Kubernetes, etc. in a future chapter: [FastAPI in Containers - Docker](docker.md){target=_blank}.
+I'll tell you more about container images, Docker, Kubernetes, etc. in a future chapter: [FastAPI in Containers - Docker](docker.md).
 
 ///
 
@@ -281,7 +281,7 @@ Here are some possible ideas:
 
 /// tip
 
-I'll give you more concrete examples for doing this with containers in a future chapter: [FastAPI in Containers - Docker](docker.md){target=_blank}.
+I'll give you more concrete examples for doing this with containers in a future chapter: [FastAPI in Containers - Docker](docker.md).
 
 ///
 

--- a/docs/en/docs/deployment/docker.md
+++ b/docs/en/docs/deployment/docker.md
@@ -1,6 +1,6 @@
 # FastAPI in Containers - Docker { #fastapi-in-containers-docker }
 
-When deploying FastAPI applications a common approach is to build a **Linux container image**. It's normally done using <a href="https://www.docker.com/" class="external-link" target="_blank">**Docker**</a>. You can then deploy that container image in one of a few possible ways.
+When deploying FastAPI applications a common approach is to build a **Linux container image**. It's normally done using [**Docker**](https://www.docker.com/){target=_blank}. You can then deploy that container image in one of a few possible ways.
 
 Using Linux containers has several advantages including **security**, **replicability**, **simplicity**, and others.
 
@@ -60,16 +60,16 @@ And the **container** itself (in contrast to the **container image**) is the act
 
 Docker has been one of the main tools to create and manage **container images** and **containers**.
 
-And there's a public <a href="https://hub.docker.com/" class="external-link" target="_blank">Docker Hub</a> with pre-made **official container images** for many tools, environments, databases, and applications.
+And there's a public [Docker Hub](https://hub.docker.com/){target=_blank} with pre-made **official container images** for many tools, environments, databases, and applications.
 
-For example, there's an official <a href="https://hub.docker.com/_/python" class="external-link" target="_blank">Python Image</a>.
+For example, there's an official [Python Image](https://hub.docker.com/_/python){target=_blank}.
 
 And there are many other images for different things like databases, for example for:
 
-* <a href="https://hub.docker.com/_/postgres" class="external-link" target="_blank">PostgreSQL</a>
-* <a href="https://hub.docker.com/_/mysql" class="external-link" target="_blank">MySQL</a>
-* <a href="https://hub.docker.com/_/mongo" class="external-link" target="_blank">MongoDB</a>
-* <a href="https://hub.docker.com/_/redis" class="external-link" target="_blank">Redis</a>, etc.
+* [PostgreSQL](https://hub.docker.com/_/postgres){target=_blank}
+* [MySQL](https://hub.docker.com/_/mysql){target=_blank}
+* [MongoDB](https://hub.docker.com/_/mongo){target=_blank}
+* [Redis](https://hub.docker.com/_/redis){target=_blank}, etc.
 
 By using a pre-made container image it's very easy to **combine** and use different tools. For example, to try out a new database. In most cases, you can use the **official images**, and just configure them with environment variables.
 
@@ -111,7 +111,7 @@ It would depend mainly on the tool you use to **install** those requirements.
 
 The most common way to do it is to have a file `requirements.txt` with the package names and their versions, one per line.
 
-You would of course use the same ideas you read in [About FastAPI versions](versions.md){.internal-link target=_blank} to set the ranges of versions.
+You would of course use the same ideas you read in [About FastAPI versions](versions.md){target=_blank} to set the ranges of versions.
 
 For example, your `requirements.txt` could look like:
 
@@ -238,7 +238,7 @@ Make sure to **always** use the **exec form** of the `CMD` instruction, as expla
 
 #### Use `CMD` - Exec Form { #use-cmd-exec-form }
 
-The <a href="https://docs.docker.com/reference/dockerfile/#cmd" class="external-link" target="_blank">`CMD`</a> Docker instruction can be written using two forms:
+The [`CMD`](https://docs.docker.com/reference/dockerfile/#cmd){target=_blank} Docker instruction can be written using two forms:
 
 ✅ **Exec** form:
 
@@ -254,11 +254,11 @@ CMD ["fastapi", "run", "app/main.py", "--port", "80"]
 CMD fastapi run app/main.py --port 80
 ```
 
-Make sure to always use the **exec** form to ensure that FastAPI can shutdown gracefully and [lifespan events](../advanced/events.md){.internal-link target=_blank} are triggered.
+Make sure to always use the **exec** form to ensure that FastAPI can shutdown gracefully and [lifespan events](../advanced/events.md){target=_blank} are triggered.
 
-You can read more about it in the <a href="https://docs.docker.com/reference/dockerfile/#shell-and-exec-form" class="external-link" target="_blank">Docker docs for shell and exec form</a>.
+You can read more about it in the [Docker docs for shell and exec form](https://docs.docker.com/reference/dockerfile/#shell-and-exec-form){target=_blank}.
 
-This can be quite noticeable when using `docker compose`. See this Docker Compose FAQ section for more technical details: <a href="https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop" class="external-link" target="_blank">Why do my services take 10 seconds to recreate or stop?</a>.
+This can be quite noticeable when using `docker compose`. See this Docker Compose FAQ section for more technical details: [Why do my services take 10 seconds to recreate or stop?](https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop){target=_blank}.
 
 #### Directory Structure { #directory-structure }
 
@@ -352,7 +352,7 @@ $ docker run -d --name mycontainer -p 80:80 myimage
 
 ## Check it { #check-it }
 
-You should be able to check it in your Docker container's URL, for example: <a href="http://192.168.99.100/items/5?q=somequery" class="external-link" target="_blank">http://192.168.99.100/items/5?q=somequery</a> or <a href="http://127.0.0.1/items/5?q=somequery" class="external-link" target="_blank">http://127.0.0.1/items/5?q=somequery</a> (or equivalent, using your Docker host).
+You should be able to check it in your Docker container's URL, for example: [http://192.168.99.100/items/5?q=somequery](http://192.168.99.100/items/5?q=somequery){target=_blank} or [http://127.0.0.1/items/5?q=somequery](http://127.0.0.1/items/5?q=somequery){target=_blank} (or equivalent, using your Docker host).
 
 You will see something like:
 
@@ -362,17 +362,17 @@ You will see something like:
 
 ## Interactive API docs { #interactive-api-docs }
 
-Now you can go to <a href="http://192.168.99.100/docs" class="external-link" target="_blank">http://192.168.99.100/docs</a> or <a href="http://127.0.0.1/docs" class="external-link" target="_blank">http://127.0.0.1/docs</a> (or equivalent, using your Docker host).
+Now you can go to [http://192.168.99.100/docs](http://192.168.99.100/docs){target=_blank} or [http://127.0.0.1/docs](http://127.0.0.1/docs){target=_blank} (or equivalent, using your Docker host).
 
-You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui){target=_blank}):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ## Alternative API docs { #alternative-api-docs }
 
-And you can also go to <a href="http://192.168.99.100/redoc" class="external-link" target="_blank">http://192.168.99.100/redoc</a> or <a href="http://127.0.0.1/redoc" class="external-link" target="_blank">http://127.0.0.1/redoc</a> (or equivalent, using your Docker host).
+And you can also go to [http://192.168.99.100/redoc](http://192.168.99.100/redoc){target=_blank} or [http://127.0.0.1/redoc](http://127.0.0.1/redoc){target=_blank} (or equivalent, using your Docker host).
 
-You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
+You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc){target=_blank}):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -413,7 +413,7 @@ When you pass the file to `fastapi run` it will detect automatically that it is 
 
 ## Deployment Concepts { #deployment-concepts }
 
-Let's talk again about some of the same [Deployment Concepts](concepts.md){.internal-link target=_blank} in terms of containers.
+Let's talk again about some of the same [Deployment Concepts](concepts.md){target=_blank} in terms of containers.
 
 Containers are mainly a tool to simplify the process of **building and deploying** an application, but they don't enforce a particular approach to handle these **deployment concepts**, and there are several possible strategies.
 
@@ -432,7 +432,7 @@ Let's review these **deployment concepts** in terms of containers:
 
 If we focus just on the **container image** for a FastAPI application (and later the running **container**), HTTPS normally would be handled **externally** by another tool.
 
-It could be another container, for example with <a href="https://traefik.io/" class="external-link" target="_blank">Traefik</a>, handling **HTTPS** and **automatic** acquisition of **certificates**.
+It could be another container, for example with [Traefik](https://traefik.io/){target=_blank}, handling **HTTPS** and **automatic** acquisition of **certificates**.
 
 /// tip
 
@@ -558,7 +558,7 @@ If you have **multiple containers**, probably each one running a **single proces
 
 /// info
 
-If you are using Kubernetes, this would probably be an <a href="https://kubernetes.io/docs/concepts/workloads/pods/init-containers/" class="external-link" target="_blank">Init Container</a>.
+If you are using Kubernetes, this would probably be an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/){target=_blank}.
 
 ///
 
@@ -570,7 +570,7 @@ If you have a simple setup, with a **single container** that then starts multipl
 
 ### Base Docker Image { #base-docker-image }
 
-There used to be an official FastAPI Docker image: <a href="https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker" class="external-link" target="_blank">tiangolo/uvicorn-gunicorn-fastapi</a>. But it is now deprecated. ⛔️
+There used to be an official FastAPI Docker image: [tiangolo/uvicorn-gunicorn-fastapi](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker){target=_blank}. But it is now deprecated. ⛔️
 
 You should probably **not** use this base Docker image (or any other similar one).
 
@@ -600,7 +600,7 @@ For example:
 
 ## Docker Image with `uv` { #docker-image-with-uv }
 
-If you are using <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">uv</a> to install and manage your project, you can follow their <a href="https://docs.astral.sh/uv/guides/integration/docker/" class="external-link" target="_blank">uv Docker guide</a>.
+If you are using [uv](https://github.com/astral-sh/uv){target=_blank} to install and manage your project, you can follow their [uv Docker guide](https://docs.astral.sh/uv/guides/integration/docker/){target=_blank}.
 
 ## Recap { #recap }
 

--- a/docs/en/docs/deployment/docker.md
+++ b/docs/en/docs/deployment/docker.md
@@ -1,6 +1,6 @@
 # FastAPI in Containers - Docker { #fastapi-in-containers-docker }
 
-When deploying FastAPI applications a common approach is to build a **Linux container image**. It's normally done using [**Docker**](https://www.docker.com/){target=_blank}. You can then deploy that container image in one of a few possible ways.
+When deploying FastAPI applications a common approach is to build a **Linux container image**. It's normally done using [**Docker**](https://www.docker.com/). You can then deploy that container image in one of a few possible ways.
 
 Using Linux containers has several advantages including **security**, **replicability**, **simplicity**, and others.
 
@@ -60,16 +60,16 @@ And the **container** itself (in contrast to the **container image**) is the act
 
 Docker has been one of the main tools to create and manage **container images** and **containers**.
 
-And there's a public [Docker Hub](https://hub.docker.com/){target=_blank} with pre-made **official container images** for many tools, environments, databases, and applications.
+And there's a public [Docker Hub](https://hub.docker.com/) with pre-made **official container images** for many tools, environments, databases, and applications.
 
-For example, there's an official [Python Image](https://hub.docker.com/_/python){target=_blank}.
+For example, there's an official [Python Image](https://hub.docker.com/_/python).
 
 And there are many other images for different things like databases, for example for:
 
-* [PostgreSQL](https://hub.docker.com/_/postgres){target=_blank}
-* [MySQL](https://hub.docker.com/_/mysql){target=_blank}
-* [MongoDB](https://hub.docker.com/_/mongo){target=_blank}
-* [Redis](https://hub.docker.com/_/redis){target=_blank}, etc.
+* [PostgreSQL](https://hub.docker.com/_/postgres)
+* [MySQL](https://hub.docker.com/_/mysql)
+* [MongoDB](https://hub.docker.com/_/mongo)
+* [Redis](https://hub.docker.com/_/redis), etc.
 
 By using a pre-made container image it's very easy to **combine** and use different tools. For example, to try out a new database. In most cases, you can use the **official images**, and just configure them with environment variables.
 
@@ -111,7 +111,7 @@ It would depend mainly on the tool you use to **install** those requirements.
 
 The most common way to do it is to have a file `requirements.txt` with the package names and their versions, one per line.
 
-You would of course use the same ideas you read in [About FastAPI versions](versions.md){target=_blank} to set the ranges of versions.
+You would of course use the same ideas you read in [About FastAPI versions](versions.md) to set the ranges of versions.
 
 For example, your `requirements.txt` could look like:
 
@@ -238,7 +238,7 @@ Make sure to **always** use the **exec form** of the `CMD` instruction, as expla
 
 #### Use `CMD` - Exec Form { #use-cmd-exec-form }
 
-The [`CMD`](https://docs.docker.com/reference/dockerfile/#cmd){target=_blank} Docker instruction can be written using two forms:
+The [`CMD`](https://docs.docker.com/reference/dockerfile/#cmd) Docker instruction can be written using two forms:
 
 ✅ **Exec** form:
 
@@ -254,11 +254,11 @@ CMD ["fastapi", "run", "app/main.py", "--port", "80"]
 CMD fastapi run app/main.py --port 80
 ```
 
-Make sure to always use the **exec** form to ensure that FastAPI can shutdown gracefully and [lifespan events](../advanced/events.md){target=_blank} are triggered.
+Make sure to always use the **exec** form to ensure that FastAPI can shutdown gracefully and [lifespan events](../advanced/events.md) are triggered.
 
-You can read more about it in the [Docker docs for shell and exec form](https://docs.docker.com/reference/dockerfile/#shell-and-exec-form){target=_blank}.
+You can read more about it in the [Docker docs for shell and exec form](https://docs.docker.com/reference/dockerfile/#shell-and-exec-form).
 
-This can be quite noticeable when using `docker compose`. See this Docker Compose FAQ section for more technical details: [Why do my services take 10 seconds to recreate or stop?](https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop){target=_blank}.
+This can be quite noticeable when using `docker compose`. See this Docker Compose FAQ section for more technical details: [Why do my services take 10 seconds to recreate or stop?](https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop).
 
 #### Directory Structure { #directory-structure }
 
@@ -352,7 +352,7 @@ $ docker run -d --name mycontainer -p 80:80 myimage
 
 ## Check it { #check-it }
 
-You should be able to check it in your Docker container's URL, for example: [http://192.168.99.100/items/5?q=somequery](http://192.168.99.100/items/5?q=somequery){target=_blank} or [http://127.0.0.1/items/5?q=somequery](http://127.0.0.1/items/5?q=somequery){target=_blank} (or equivalent, using your Docker host).
+You should be able to check it in your Docker container's URL, for example: [http://192.168.99.100/items/5?q=somequery](http://192.168.99.100/items/5?q=somequery) or [http://127.0.0.1/items/5?q=somequery](http://127.0.0.1/items/5?q=somequery) (or equivalent, using your Docker host).
 
 You will see something like:
 
@@ -362,17 +362,17 @@ You will see something like:
 
 ## Interactive API docs { #interactive-api-docs }
 
-Now you can go to [http://192.168.99.100/docs](http://192.168.99.100/docs){target=_blank} or [http://127.0.0.1/docs](http://127.0.0.1/docs){target=_blank} (or equivalent, using your Docker host).
+Now you can go to [http://192.168.99.100/docs](http://192.168.99.100/docs) or [http://127.0.0.1/docs](http://127.0.0.1/docs) (or equivalent, using your Docker host).
 
-You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui){target=_blank}):
+You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui)):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ## Alternative API docs { #alternative-api-docs }
 
-And you can also go to [http://192.168.99.100/redoc](http://192.168.99.100/redoc){target=_blank} or [http://127.0.0.1/redoc](http://127.0.0.1/redoc){target=_blank} (or equivalent, using your Docker host).
+And you can also go to [http://192.168.99.100/redoc](http://192.168.99.100/redoc) or [http://127.0.0.1/redoc](http://127.0.0.1/redoc) (or equivalent, using your Docker host).
 
-You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc){target=_blank}):
+You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc)):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -413,7 +413,7 @@ When you pass the file to `fastapi run` it will detect automatically that it is 
 
 ## Deployment Concepts { #deployment-concepts }
 
-Let's talk again about some of the same [Deployment Concepts](concepts.md){target=_blank} in terms of containers.
+Let's talk again about some of the same [Deployment Concepts](concepts.md) in terms of containers.
 
 Containers are mainly a tool to simplify the process of **building and deploying** an application, but they don't enforce a particular approach to handle these **deployment concepts**, and there are several possible strategies.
 
@@ -432,7 +432,7 @@ Let's review these **deployment concepts** in terms of containers:
 
 If we focus just on the **container image** for a FastAPI application (and later the running **container**), HTTPS normally would be handled **externally** by another tool.
 
-It could be another container, for example with [Traefik](https://traefik.io/){target=_blank}, handling **HTTPS** and **automatic** acquisition of **certificates**.
+It could be another container, for example with [Traefik](https://traefik.io/), handling **HTTPS** and **automatic** acquisition of **certificates**.
 
 /// tip
 
@@ -558,7 +558,7 @@ If you have **multiple containers**, probably each one running a **single proces
 
 /// info
 
-If you are using Kubernetes, this would probably be an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/){target=_blank}.
+If you are using Kubernetes, this would probably be an [Init Container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/).
 
 ///
 
@@ -570,7 +570,7 @@ If you have a simple setup, with a **single container** that then starts multipl
 
 ### Base Docker Image { #base-docker-image }
 
-There used to be an official FastAPI Docker image: [tiangolo/uvicorn-gunicorn-fastapi](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker){target=_blank}. But it is now deprecated. ⛔️
+There used to be an official FastAPI Docker image: [tiangolo/uvicorn-gunicorn-fastapi](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker). But it is now deprecated. ⛔️
 
 You should probably **not** use this base Docker image (or any other similar one).
 
@@ -600,7 +600,7 @@ For example:
 
 ## Docker Image with `uv` { #docker-image-with-uv }
 
-If you are using [uv](https://github.com/astral-sh/uv){target=_blank} to install and manage your project, you can follow their [uv Docker guide](https://docs.astral.sh/uv/guides/integration/docker/){target=_blank}.
+If you are using [uv](https://github.com/astral-sh/uv) to install and manage your project, you can follow their [uv Docker guide](https://docs.astral.sh/uv/guides/integration/docker/).
 
 ## Recap { #recap }
 

--- a/docs/en/docs/deployment/fastapicloud.md
+++ b/docs/en/docs/deployment/fastapicloud.md
@@ -1,6 +1,6 @@
 # FastAPI Cloud { #fastapi-cloud }
 
-You can deploy your FastAPI app to <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a> with **one command**, go and join the waiting list if you haven't. 🚀
+You can deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com){target=_blank} with **one command**, go and join the waiting list if you haven't. 🚀
 
 ## Login { #login }
 
@@ -40,7 +40,7 @@ That's it! Now you can access your app at that URL. ✨
 
 ## About FastAPI Cloud { #about-fastapi-cloud }
 
-**<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com){target=_blank}** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 

--- a/docs/en/docs/deployment/fastapicloud.md
+++ b/docs/en/docs/deployment/fastapicloud.md
@@ -1,6 +1,6 @@
 # FastAPI Cloud { #fastapi-cloud }
 
-You can deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com){target=_blank} with **one command**, go and join the waiting list if you haven't. 🚀
+You can deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com) with **one command**, go and join the waiting list if you haven't. 🚀
 
 ## Login { #login }
 
@@ -40,7 +40,7 @@ That's it! Now you can access your app at that URL. ✨
 
 ## About FastAPI Cloud { #about-fastapi-cloud }
 
-**[FastAPI Cloud](https://fastapicloud.com){target=_blank}** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com)** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 

--- a/docs/en/docs/deployment/https.md
+++ b/docs/en/docs/deployment/https.md
@@ -10,7 +10,7 @@ If you are in a hurry or don't care, continue with the next sections for step by
 
 ///
 
-To **learn the basics of HTTPS**, from a consumer perspective, check <a href="https://howhttps.works/" class="external-link" target="_blank">https://howhttps.works/</a>.
+To **learn the basics of HTTPS**, from a consumer perspective, check [https://howhttps.works/](https://howhttps.works/){target=_blank}.
 
 Now, from a **developer's perspective**, here are several things to keep in mind while thinking about HTTPS:
 
@@ -28,13 +28,13 @@ Now, from a **developer's perspective**, here are several things to keep in mind
 * **By default**, that would mean that you can only have **one HTTPS certificate per IP address**.
     * No matter how big your server is or how small each application you have on it might be.
     * There is a **solution** to this, however.
-* There's an **extension** to the **TLS** protocol (the one handling the encryption at the TCP level, before HTTP) called **<a href="https://en.wikipedia.org/wiki/Server_Name_Indication" class="external-link" target="_blank"><abbr title="Server Name Indication">SNI</abbr></a>**.
+* There's an **extension** to the **TLS** protocol (the one handling the encryption at the TCP level, before HTTP) called **<a href="https://en.wikipedia.org/wiki/Server_Name_Indication" target="_blank"><abbr title="Server Name Indication">SNI</abbr></a>**.
     * This SNI extension allows one single server (with a **single IP address**) to have **several HTTPS certificates** and serve **multiple HTTPS domains/applications**.
     * For this to work, a **single** component (program) running on the server, listening on the **public IP address**, must have **all the HTTPS certificates** in the server.
 * **After** obtaining a secure connection, the communication protocol is **still HTTP**.
     * The contents are **encrypted**, even though they are being sent with the **HTTP protocol**.
 
-It is a common practice to have **one program/HTTP server** running on the server (the machine, host, etc.) and **managing all the HTTPS parts**: receiving the **encrypted HTTPS requests**, sending the **decrypted HTTP requests** to the actual HTTP application running in the same server (the **FastAPI** application, in this case), take the **HTTP response** from the application, **encrypt it** using the appropriate **HTTPS certificate** and sending it back to the client using **HTTPS**. This server is often called a **<a href="https://en.wikipedia.org/wiki/TLS_termination_proxy" class="external-link" target="_blank">TLS Termination Proxy</a>**.
+It is a common practice to have **one program/HTTP server** running on the server (the machine, host, etc.) and **managing all the HTTPS parts**: receiving the **encrypted HTTPS requests**, sending the **decrypted HTTP requests** to the actual HTTP application running in the same server (the **FastAPI** application, in this case), take the **HTTP response** from the application, **encrypt it** using the appropriate **HTTPS certificate** and sending it back to the client using **HTTPS**. This server is often called a **[TLS Termination Proxy](https://en.wikipedia.org/wiki/TLS_termination_proxy){target=_blank}**.
 
 Some of the options you could use as a TLS Termination Proxy are:
 
@@ -49,7 +49,7 @@ Before Let's Encrypt, these **HTTPS certificates** were sold by trusted third pa
 
 The process to acquire one of these certificates used to be cumbersome, require quite some paperwork and the certificates were quite expensive.
 
-But then **<a href="https://letsencrypt.org/" class="external-link" target="_blank">Let's Encrypt</a>** was created.
+But then **[Let's Encrypt](https://letsencrypt.org/){target=_blank}** was created.
 
 It is a project from the Linux Foundation. It provides **HTTPS certificates for free**, in an automated way. These certificates use all the standard cryptographic security, and are short-lived (about 3 months), so the **security is actually better** because of their reduced lifespan.
 
@@ -200,9 +200,9 @@ This **proxy** would normally set some HTTP headers on the fly before transmitti
 
 The proxy headers are:
 
-* <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For" class="external-link" target="_blank">X-Forwarded-For</a>
-* <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto" class="external-link" target="_blank">X-Forwarded-Proto</a>
-* <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host" class="external-link" target="_blank">X-Forwarded-Host</a>
+* [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For){target=_blank}
+* [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto){target=_blank}
+* [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host){target=_blank}
 
 ///
 
@@ -218,7 +218,7 @@ This would be useful for example to properly handle redirects.
 
 /// tip
 
-You can learn more about this in the documentation for [Behind a Proxy - Enable Proxy Forwarded Headers](../advanced/behind-a-proxy.md#enable-proxy-forwarded-headers){.internal-link target=_blank}
+You can learn more about this in the documentation for [Behind a Proxy - Enable Proxy Forwarded Headers](../advanced/behind-a-proxy.md#enable-proxy-forwarded-headers){target=_blank}
 
 ///
 

--- a/docs/en/docs/deployment/https.md
+++ b/docs/en/docs/deployment/https.md
@@ -10,7 +10,7 @@ If you are in a hurry or don't care, continue with the next sections for step by
 
 ///
 
-To **learn the basics of HTTPS**, from a consumer perspective, check [https://howhttps.works/](https://howhttps.works/){target=_blank}.
+To **learn the basics of HTTPS**, from a consumer perspective, check [https://howhttps.works/](https://howhttps.works/).
 
 Now, from a **developer's perspective**, here are several things to keep in mind while thinking about HTTPS:
 
@@ -28,13 +28,13 @@ Now, from a **developer's perspective**, here are several things to keep in mind
 * **By default**, that would mean that you can only have **one HTTPS certificate per IP address**.
     * No matter how big your server is or how small each application you have on it might be.
     * There is a **solution** to this, however.
-* There's an **extension** to the **TLS** protocol (the one handling the encryption at the TCP level, before HTTP) called **<a href="https://en.wikipedia.org/wiki/Server_Name_Indication" target="_blank"><abbr title="Server Name Indication">SNI</abbr></a>**.
+* There's an **extension** to the **TLS** protocol (the one handling the encryption at the TCP level, before HTTP) called **[<abbr title="Server Name Indication">SNI</abbr>](https://en.wikipedia.org/wiki/Server_Name_Indication)**.
     * This SNI extension allows one single server (with a **single IP address**) to have **several HTTPS certificates** and serve **multiple HTTPS domains/applications**.
     * For this to work, a **single** component (program) running on the server, listening on the **public IP address**, must have **all the HTTPS certificates** in the server.
 * **After** obtaining a secure connection, the communication protocol is **still HTTP**.
     * The contents are **encrypted**, even though they are being sent with the **HTTP protocol**.
 
-It is a common practice to have **one program/HTTP server** running on the server (the machine, host, etc.) and **managing all the HTTPS parts**: receiving the **encrypted HTTPS requests**, sending the **decrypted HTTP requests** to the actual HTTP application running in the same server (the **FastAPI** application, in this case), take the **HTTP response** from the application, **encrypt it** using the appropriate **HTTPS certificate** and sending it back to the client using **HTTPS**. This server is often called a **[TLS Termination Proxy](https://en.wikipedia.org/wiki/TLS_termination_proxy){target=_blank}**.
+It is a common practice to have **one program/HTTP server** running on the server (the machine, host, etc.) and **managing all the HTTPS parts**: receiving the **encrypted HTTPS requests**, sending the **decrypted HTTP requests** to the actual HTTP application running in the same server (the **FastAPI** application, in this case), take the **HTTP response** from the application, **encrypt it** using the appropriate **HTTPS certificate** and sending it back to the client using **HTTPS**. This server is often called a **[TLS Termination Proxy](https://en.wikipedia.org/wiki/TLS_termination_proxy)**.
 
 Some of the options you could use as a TLS Termination Proxy are:
 
@@ -49,7 +49,7 @@ Before Let's Encrypt, these **HTTPS certificates** were sold by trusted third pa
 
 The process to acquire one of these certificates used to be cumbersome, require quite some paperwork and the certificates were quite expensive.
 
-But then **[Let's Encrypt](https://letsencrypt.org/){target=_blank}** was created.
+But then **[Let's Encrypt](https://letsencrypt.org/)** was created.
 
 It is a project from the Linux Foundation. It provides **HTTPS certificates for free**, in an automated way. These certificates use all the standard cryptographic security, and are short-lived (about 3 months), so the **security is actually better** because of their reduced lifespan.
 
@@ -200,9 +200,9 @@ This **proxy** would normally set some HTTP headers on the fly before transmitti
 
 The proxy headers are:
 
-* [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For){target=_blank}
-* [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto){target=_blank}
-* [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host){target=_blank}
+* [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For)
+* [X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Proto)
+* [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host)
 
 ///
 
@@ -218,7 +218,7 @@ This would be useful for example to properly handle redirects.
 
 /// tip
 
-You can learn more about this in the documentation for [Behind a Proxy - Enable Proxy Forwarded Headers](../advanced/behind-a-proxy.md#enable-proxy-forwarded-headers){target=_blank}
+You can learn more about this in the documentation for [Behind a Proxy - Enable Proxy Forwarded Headers](../advanced/behind-a-proxy.md#enable-proxy-forwarded-headers)
 
 ///
 

--- a/docs/en/docs/deployment/index.md
+++ b/docs/en/docs/deployment/index.md
@@ -16,7 +16,7 @@ There are several ways to do it depending on your specific use case and the tool
 
 You could **deploy a server** yourself using a combination of tools, you could use a **cloud service** that does part of the work for you, or other possible options.
 
-For example, we, the team behind FastAPI, built [**FastAPI Cloud**](https://fastapicloud.com){target=_blank}, to make deploying FastAPI apps to the cloud as streamlined as possible, with the same developer experience of working with FastAPI.
+For example, we, the team behind FastAPI, built [**FastAPI Cloud**](https://fastapicloud.com), to make deploying FastAPI apps to the cloud as streamlined as possible, with the same developer experience of working with FastAPI.
 
 I will show you some of the main concepts you should probably keep in mind when deploying a **FastAPI** application (although most of it applies to any other type of web application).
 

--- a/docs/en/docs/deployment/index.md
+++ b/docs/en/docs/deployment/index.md
@@ -16,7 +16,7 @@ There are several ways to do it depending on your specific use case and the tool
 
 You could **deploy a server** yourself using a combination of tools, you could use a **cloud service** that does part of the work for you, or other possible options.
 
-For example, we, the team behind FastAPI, built <a href="https://fastapicloud.com" class="external-link" target="_blank">**FastAPI Cloud**</a>, to make deploying FastAPI apps to the cloud as streamlined as possible, with the same developer experience of working with FastAPI.
+For example, we, the team behind FastAPI, built [**FastAPI Cloud**](https://fastapicloud.com){target=_blank}, to make deploying FastAPI apps to the cloud as streamlined as possible, with the same developer experience of working with FastAPI.
 
 I will show you some of the main concepts you should probably keep in mind when deploying a **FastAPI** application (although most of it applies to any other type of web application).
 

--- a/docs/en/docs/deployment/manually.md
+++ b/docs/en/docs/deployment/manually.md
@@ -52,11 +52,11 @@ The main thing you need to run a **FastAPI** application (or any other ASGI appl
 
 There are several alternatives, including:
 
-* [Uvicorn](https://www.uvicorn.dev/){target=_blank}: a high performance ASGI server.
-* [Hypercorn](https://hypercorn.readthedocs.io/){target=_blank}: an ASGI server compatible with HTTP/2 and Trio among other features.
-* [Daphne](https://github.com/django/daphne){target=_blank}: the ASGI server built for Django Channels.
-* [Granian](https://github.com/emmett-framework/granian){target=_blank}: A Rust HTTP server for Python applications.
-* [NGINX Unit](https://unit.nginx.org/howto/fastapi/){target=_blank}: NGINX Unit is a lightweight and versatile web application runtime.
+* [Uvicorn](https://www.uvicorn.dev/): a high performance ASGI server.
+* [Hypercorn](https://hypercorn.readthedocs.io/): an ASGI server compatible with HTTP/2 and Trio among other features.
+* [Daphne](https://github.com/django/daphne): the ASGI server built for Django Channels.
+* [Granian](https://github.com/emmett-framework/granian): A Rust HTTP server for Python applications.
+* [NGINX Unit](https://unit.nginx.org/howto/fastapi/): NGINX Unit is a lightweight and versatile web application runtime.
 
 ## Server Machine and Server Program { #server-machine-and-server-program }
 
@@ -74,7 +74,7 @@ When you install FastAPI, it comes with a production server, Uvicorn, and you ca
 
 But you can also install an ASGI server manually.
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then you can install the server application.
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then you can install the server application.
 
 For example, to install Uvicorn:
 

--- a/docs/en/docs/deployment/manually.md
+++ b/docs/en/docs/deployment/manually.md
@@ -52,11 +52,11 @@ The main thing you need to run a **FastAPI** application (or any other ASGI appl
 
 There are several alternatives, including:
 
-* <a href="https://www.uvicorn.dev/" class="external-link" target="_blank">Uvicorn</a>: a high performance ASGI server.
-* <a href="https://hypercorn.readthedocs.io/" class="external-link" target="_blank">Hypercorn</a>: an ASGI server compatible with HTTP/2 and Trio among other features.
-* <a href="https://github.com/django/daphne" class="external-link" target="_blank">Daphne</a>: the ASGI server built for Django Channels.
-* <a href="https://github.com/emmett-framework/granian" class="external-link" target="_blank">Granian</a>: A Rust HTTP server for Python applications.
-* <a href="https://unit.nginx.org/howto/fastapi/" class="external-link" target="_blank">NGINX Unit</a>: NGINX Unit is a lightweight and versatile web application runtime.
+* [Uvicorn](https://www.uvicorn.dev/){target=_blank}: a high performance ASGI server.
+* [Hypercorn](https://hypercorn.readthedocs.io/){target=_blank}: an ASGI server compatible with HTTP/2 and Trio among other features.
+* [Daphne](https://github.com/django/daphne){target=_blank}: the ASGI server built for Django Channels.
+* [Granian](https://github.com/emmett-framework/granian){target=_blank}: A Rust HTTP server for Python applications.
+* [NGINX Unit](https://unit.nginx.org/howto/fastapi/){target=_blank}: NGINX Unit is a lightweight and versatile web application runtime.
 
 ## Server Machine and Server Program { #server-machine-and-server-program }
 
@@ -74,7 +74,7 @@ When you install FastAPI, it comes with a production server, Uvicorn, and you ca
 
 But you can also install an ASGI server manually.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then you can install the server application.
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then you can install the server application.
 
 For example, to install Uvicorn:
 

--- a/docs/en/docs/deployment/server-workers.md
+++ b/docs/en/docs/deployment/server-workers.md
@@ -13,13 +13,13 @@ Up to this point, with all the tutorials in the docs, you have probably been run
 
 When deploying applications you will probably want to have some **replication of processes** to take advantage of **multiple cores** and to be able to handle more requests.
 
-As you saw in the previous chapter about [Deployment Concepts](concepts.md){target=_blank}, there are multiple strategies you can use.
+As you saw in the previous chapter about [Deployment Concepts](concepts.md), there are multiple strategies you can use.
 
 Here I'll show you how to use **Uvicorn** with **worker processes** using the `fastapi` command or the `uvicorn` command directly.
 
 /// info
 
-If you are using containers, for example with Docker or Kubernetes, I'll tell you more about that in the next chapter: [FastAPI in Containers - Docker](docker.md){target=_blank}.
+If you are using containers, for example with Docker or Kubernetes, I'll tell you more about that in the next chapter: [FastAPI in Containers - Docker](docker.md).
 
 In particular, when running on **Kubernetes** you will probably **not** want to use workers and instead run **a single Uvicorn process per container**, but I'll tell you about it later in that chapter.
 
@@ -126,7 +126,7 @@ From the list of deployment concepts from above, using workers would mainly help
 
 ## Containers and Docker { #containers-and-docker }
 
-In the next chapter about [FastAPI in Containers - Docker](docker.md){target=_blank} I'll explain some strategies you could use to handle the other **deployment concepts**.
+In the next chapter about [FastAPI in Containers - Docker](docker.md) I'll explain some strategies you could use to handle the other **deployment concepts**.
 
 I'll show you how to **build your own image from scratch** to run a single Uvicorn process. It is a simple process and is probably what you would want to do when using a distributed container management system like **Kubernetes**.
 

--- a/docs/en/docs/deployment/server-workers.md
+++ b/docs/en/docs/deployment/server-workers.md
@@ -13,13 +13,13 @@ Up to this point, with all the tutorials in the docs, you have probably been run
 
 When deploying applications you will probably want to have some **replication of processes** to take advantage of **multiple cores** and to be able to handle more requests.
 
-As you saw in the previous chapter about [Deployment Concepts](concepts.md){.internal-link target=_blank}, there are multiple strategies you can use.
+As you saw in the previous chapter about [Deployment Concepts](concepts.md){target=_blank}, there are multiple strategies you can use.
 
 Here I'll show you how to use **Uvicorn** with **worker processes** using the `fastapi` command or the `uvicorn` command directly.
 
 /// info
 
-If you are using containers, for example with Docker or Kubernetes, I'll tell you more about that in the next chapter: [FastAPI in Containers - Docker](docker.md){.internal-link target=_blank}.
+If you are using containers, for example with Docker or Kubernetes, I'll tell you more about that in the next chapter: [FastAPI in Containers - Docker](docker.md){target=_blank}.
 
 In particular, when running on **Kubernetes** you will probably **not** want to use workers and instead run **a single Uvicorn process per container**, but I'll tell you about it later in that chapter.
 
@@ -126,7 +126,7 @@ From the list of deployment concepts from above, using workers would mainly help
 
 ## Containers and Docker { #containers-and-docker }
 
-In the next chapter about [FastAPI in Containers - Docker](docker.md){.internal-link target=_blank} I'll explain some strategies you could use to handle the other **deployment concepts**.
+In the next chapter about [FastAPI in Containers - Docker](docker.md){target=_blank} I'll explain some strategies you could use to handle the other **deployment concepts**.
 
 I'll show you how to **build your own image from scratch** to run a single Uvicorn process. It is a simple process and is probably what you would want to do when using a distributed container management system like **Kubernetes**.
 

--- a/docs/en/docs/deployment/versions.md
+++ b/docs/en/docs/deployment/versions.md
@@ -4,7 +4,7 @@
 
 New features are added frequently, bugs are fixed regularly, and the code is still continuously improving.
 
-That's why the current versions are still `0.x.x`, this reflects that each version could potentially have breaking changes. This follows the <a href="https://semver.org/" class="external-link" target="_blank">Semantic Versioning</a> conventions.
+That's why the current versions are still `0.x.x`, this reflects that each version could potentially have breaking changes. This follows the [Semantic Versioning](https://semver.org/){target=_blank} conventions.
 
 You can create production applications with **FastAPI** right now (and you have probably been doing it for some time), you just have to make sure that you use a version that works correctly with the rest of your code.
 
@@ -34,7 +34,7 @@ If you use any other tool to manage your installations, like `uv`, Poetry, Pipen
 
 ## Available versions { #available-versions }
 
-You can see the available versions (e.g. to check what is the current latest) in the [Release Notes](../release-notes.md){.internal-link target=_blank}.
+You can see the available versions (e.g. to check what is the current latest) in the [Release Notes](../release-notes.md){target=_blank}.
 
 ## About versions { #about-versions }
 
@@ -66,7 +66,7 @@ The "MINOR" is the number in the middle, for example, in `0.2.3`, the MINOR vers
 
 You should add tests for your app.
 
-With **FastAPI** it's very easy (thanks to Starlette), check the docs: [Testing](../tutorial/testing.md){.internal-link target=_blank}
+With **FastAPI** it's very easy (thanks to Starlette), check the docs: [Testing](../tutorial/testing.md){target=_blank}
 
 After you have tests, then you can upgrade the **FastAPI** version to a more recent one, and make sure that all your code is working correctly by running your tests.
 

--- a/docs/en/docs/deployment/versions.md
+++ b/docs/en/docs/deployment/versions.md
@@ -4,7 +4,7 @@
 
 New features are added frequently, bugs are fixed regularly, and the code is still continuously improving.
 
-That's why the current versions are still `0.x.x`, this reflects that each version could potentially have breaking changes. This follows the [Semantic Versioning](https://semver.org/){target=_blank} conventions.
+That's why the current versions are still `0.x.x`, this reflects that each version could potentially have breaking changes. This follows the [Semantic Versioning](https://semver.org/) conventions.
 
 You can create production applications with **FastAPI** right now (and you have probably been doing it for some time), you just have to make sure that you use a version that works correctly with the rest of your code.
 
@@ -34,7 +34,7 @@ If you use any other tool to manage your installations, like `uv`, Poetry, Pipen
 
 ## Available versions { #available-versions }
 
-You can see the available versions (e.g. to check what is the current latest) in the [Release Notes](../release-notes.md){target=_blank}.
+You can see the available versions (e.g. to check what is the current latest) in the [Release Notes](../release-notes.md).
 
 ## About versions { #about-versions }
 
@@ -66,7 +66,7 @@ The "MINOR" is the number in the middle, for example, in `0.2.3`, the MINOR vers
 
 You should add tests for your app.
 
-With **FastAPI** it's very easy (thanks to Starlette), check the docs: [Testing](../tutorial/testing.md){target=_blank}
+With **FastAPI** it's very easy (thanks to Starlette), check the docs: [Testing](../tutorial/testing.md)
 
 After you have tests, then you can upgrade the **FastAPI** version to a more recent one, and make sure that all your code is working correctly by running your tests.
 

--- a/docs/en/docs/editor-support.md
+++ b/docs/en/docs/editor-support.md
@@ -1,12 +1,12 @@
 # Editor Support { #editor-support }
 
-The official [FastAPI Extension](https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode){target=_blank} enhances your FastAPI development workflow with *path operation* discovery, navigation, as well as FastAPI Cloud deployment, and live log streaming.
+The official [FastAPI Extension](https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode) enhances your FastAPI development workflow with *path operation* discovery, navigation, as well as FastAPI Cloud deployment, and live log streaming.
 
-For more details about the extension, refer to the README on the [GitHub repository](https://github.com/fastapi/fastapi-vscode){target=_blank}.
+For more details about the extension, refer to the README on the [GitHub repository](https://github.com/fastapi/fastapi-vscode).
 
 ## Setup and Installation { #setup-and-installation }
 
-The **FastAPI Extension** is available for both [VS Code](https://code.visualstudio.com/){target=_blank} and [Cursor](https://www.cursor.com/){target=_blank}. It can be installed directly from the Extensions panel in each editor by searching for "FastAPI" and selecting the extension published by **FastAPI Labs**. The extension also works in browser-based editors such as [vscode.dev](https://vscode.dev){target=_blank} and [github.dev](https://github.dev){target=_blank}.
+The **FastAPI Extension** is available for both [VS Code](https://code.visualstudio.com/) and [Cursor](https://www.cursor.com/). It can be installed directly from the Extensions panel in each editor by searching for "FastAPI" and selecting the extension published by **FastAPI Labs**. The extension also works in browser-based editors such as [vscode.dev](https://vscode.dev) and [github.dev](https://github.dev).
 
 ### Application Discovery { #application-discovery }
 
@@ -17,7 +17,7 @@ By default, the extension will automatically discover FastAPI applications in yo
 - **Path Operation Explorer** - A sidebar tree view of all <dfn title="routes, endpoints">*path operations*</dfn> in your application. Click to jump to any route or router definition.
 - **Route Search** - Search by path, method, or name with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd> (on macOS: <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd>).
 - **CodeLens Navigation** - Clickable links above test client calls (e.g. `client.get('/items')`) that jump to the matching *path operation* for quick navigation between tests and implementation.
-- **Deploy to FastAPI Cloud** - One-click deployment of your app to [FastAPI Cloud](https://fastapicloud.com/){target=_blank}.
+- **Deploy to FastAPI Cloud** - One-click deployment of your app to [FastAPI Cloud](https://fastapicloud.com/).
 - **Stream Application Logs** - Real-time log streaming from your FastAPI Cloud-deployed application with level filtering and text search.
 
 If you'd like to familiarize yourself with the extension's features, you can checkout the extension walkthrough by opening the Command Palette (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or on macOS: <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>) and selecting "Welcome: Open walkthrough..." and then choosing the "Get started with FastAPI" walkthrough.

--- a/docs/en/docs/editor-support.md
+++ b/docs/en/docs/editor-support.md
@@ -1,12 +1,12 @@
 # Editor Support { #editor-support }
 
-The official <a href="https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode" class="external-link" target="_blank">FastAPI Extension</a> enhances your FastAPI development workflow with *path operation* discovery, navigation, as well as FastAPI Cloud deployment, and live log streaming.
+The official [FastAPI Extension](https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode){target=_blank} enhances your FastAPI development workflow with *path operation* discovery, navigation, as well as FastAPI Cloud deployment, and live log streaming.
 
-For more details about the extension, refer to the README on the <a href="https://github.com/fastapi/fastapi-vscode" class="external-link" target="_blank">GitHub repository</a>.
+For more details about the extension, refer to the README on the [GitHub repository](https://github.com/fastapi/fastapi-vscode){target=_blank}.
 
 ## Setup and Installation { #setup-and-installation }
 
-The **FastAPI Extension** is available for both <a href="https://code.visualstudio.com/" class="external-link" target="_blank">VS Code</a> and <a href="https://www.cursor.com/" class="external-link" target="_blank">Cursor</a>. It can be installed directly from the Extensions panel in each editor by searching for "FastAPI" and selecting the extension published by **FastAPI Labs**. The extension also works in browser-based editors such as <a href="https://vscode.dev" class="external-link" target="_blank">vscode.dev</a> and <a href="https://github.dev" class="external-link" target="_blank">github.dev</a>.
+The **FastAPI Extension** is available for both [VS Code](https://code.visualstudio.com/){target=_blank} and [Cursor](https://www.cursor.com/){target=_blank}. It can be installed directly from the Extensions panel in each editor by searching for "FastAPI" and selecting the extension published by **FastAPI Labs**. The extension also works in browser-based editors such as [vscode.dev](https://vscode.dev){target=_blank} and [github.dev](https://github.dev){target=_blank}.
 
 ### Application Discovery { #application-discovery }
 
@@ -17,7 +17,7 @@ By default, the extension will automatically discover FastAPI applications in yo
 - **Path Operation Explorer** - A sidebar tree view of all <dfn title="routes, endpoints">*path operations*</dfn> in your application. Click to jump to any route or router definition.
 - **Route Search** - Search by path, method, or name with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd> (on macOS: <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd>).
 - **CodeLens Navigation** - Clickable links above test client calls (e.g. `client.get('/items')`) that jump to the matching *path operation* for quick navigation between tests and implementation.
-- **Deploy to FastAPI Cloud** - One-click deployment of your app to <a href="https://fastapicloud.com/" class="external-link" target="_blank">FastAPI Cloud</a>.
+- **Deploy to FastAPI Cloud** - One-click deployment of your app to [FastAPI Cloud](https://fastapicloud.com/){target=_blank}.
 - **Stream Application Logs** - Real-time log streaming from your FastAPI Cloud-deployed application with level filtering and text search.
 
 If you'd like to familiarize yourself with the extension's features, you can checkout the extension walkthrough by opening the Command Palette (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or on macOS: <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>) and selecting "Welcome: Open walkthrough..." and then choosing the "Get started with FastAPI" walkthrough.

--- a/docs/en/docs/environment-variables.md
+++ b/docs/en/docs/environment-variables.md
@@ -65,7 +65,7 @@ print(f"Hello {name} from Python")
 
 /// tip
 
-The second argument to <a href="https://docs.python.org/3.8/library/os.html#os.getenv" class="external-link" target="_blank">`os.getenv()`</a> is the default value to return.
+The second argument to [`os.getenv()`](https://docs.python.org/3.8/library/os.html#os.getenv){target=_blank} is the default value to return.
 
 If not provided, it's `None` by default, here we provide `"World"` as the default value to use.
 
@@ -153,7 +153,7 @@ Hello World from Python
 
 /// tip
 
-You can read more about it at <a href="https://12factor.net/config" class="external-link" target="_blank">The Twelve-Factor App: Config</a>.
+You can read more about it at [The Twelve-Factor App: Config](https://12factor.net/config){target=_blank}.
 
 ///
 
@@ -163,7 +163,7 @@ These environment variables can only handle **text strings**, as they are extern
 
 That means that **any value** read in Python from an environment variable **will be a `str`**, and any conversion to a different type or any validation has to be done in code.
 
-You will learn more about using environment variables for handling **application settings** in the [Advanced User Guide - Settings and Environment Variables](./advanced/settings.md){.internal-link target=_blank}.
+You will learn more about using environment variables for handling **application settings** in the [Advanced User Guide - Settings and Environment Variables](./advanced/settings.md){target=_blank}.
 
 ## `PATH` Environment Variable { #path-environment-variable }
 
@@ -285,13 +285,13 @@ $ C:\opt\custompython\bin\python
 
 ////
 
-This information will be useful when learning about [Virtual Environments](virtual-environments.md){.internal-link target=_blank}.
+This information will be useful when learning about [Virtual Environments](virtual-environments.md){target=_blank}.
 
 ## Conclusion { #conclusion }
 
 With this you should have a basic understanding of what **environment variables** are and how to use them in Python.
 
-You can also read more about them in the <a href="https://en.wikipedia.org/wiki/Environment_variable" class="external-link" target="_blank">Wikipedia for Environment Variable</a>.
+You can also read more about them in the [Wikipedia for Environment Variable](https://en.wikipedia.org/wiki/Environment_variable){target=_blank}.
 
 In many cases it's not very obvious how environment variables would be useful and applicable right away. But they keep showing up in many different scenarios when you are developing, so it's good to know about them.
 

--- a/docs/en/docs/environment-variables.md
+++ b/docs/en/docs/environment-variables.md
@@ -65,7 +65,7 @@ print(f"Hello {name} from Python")
 
 /// tip
 
-The second argument to [`os.getenv()`](https://docs.python.org/3.8/library/os.html#os.getenv){target=_blank} is the default value to return.
+The second argument to [`os.getenv()`](https://docs.python.org/3.8/library/os.html#os.getenv) is the default value to return.
 
 If not provided, it's `None` by default, here we provide `"World"` as the default value to use.
 
@@ -153,7 +153,7 @@ Hello World from Python
 
 /// tip
 
-You can read more about it at [The Twelve-Factor App: Config](https://12factor.net/config){target=_blank}.
+You can read more about it at [The Twelve-Factor App: Config](https://12factor.net/config).
 
 ///
 
@@ -163,7 +163,7 @@ These environment variables can only handle **text strings**, as they are extern
 
 That means that **any value** read in Python from an environment variable **will be a `str`**, and any conversion to a different type or any validation has to be done in code.
 
-You will learn more about using environment variables for handling **application settings** in the [Advanced User Guide - Settings and Environment Variables](./advanced/settings.md){target=_blank}.
+You will learn more about using environment variables for handling **application settings** in the [Advanced User Guide - Settings and Environment Variables](./advanced/settings.md).
 
 ## `PATH` Environment Variable { #path-environment-variable }
 
@@ -285,13 +285,13 @@ $ C:\opt\custompython\bin\python
 
 ////
 
-This information will be useful when learning about [Virtual Environments](virtual-environments.md){target=_blank}.
+This information will be useful when learning about [Virtual Environments](virtual-environments.md).
 
 ## Conclusion { #conclusion }
 
 With this you should have a basic understanding of what **environment variables** are and how to use them in Python.
 
-You can also read more about them in the [Wikipedia for Environment Variable](https://en.wikipedia.org/wiki/Environment_variable){target=_blank}.
+You can also read more about them in the [Wikipedia for Environment Variable](https://en.wikipedia.org/wiki/Environment_variable).
 
 In many cases it's not very obvious how environment variables would be useful and applicable right away. But they keep showing up in many different scenarios when you are developing, so it's good to know about them.
 

--- a/docs/en/docs/external-links.md
+++ b/docs/en/docs/external-links.md
@@ -16,7 +16,7 @@ But now that FastAPI is the backend framework with the most GitHub stars across 
 
 ## GitHub Repositories
 
-Most starred <a href="https://github.com/topics/fastapi" class="external-link" target="_blank">GitHub repositories with the topic `fastapi`</a>:
+Most starred [GitHub repositories with the topic `fastapi`](https://github.com/topics/fastapi){target=_blank}:
 
 {% for repo in topic_repos %}
 

--- a/docs/en/docs/external-links.md
+++ b/docs/en/docs/external-links.md
@@ -16,7 +16,7 @@ But now that FastAPI is the backend framework with the most GitHub stars across 
 
 ## GitHub Repositories
 
-Most starred [GitHub repositories with the topic `fastapi`](https://github.com/topics/fastapi){target=_blank}:
+Most starred [GitHub repositories with the topic `fastapi`](https://github.com/topics/fastapi):
 
 {% for repo in topic_repos %}
 

--- a/docs/en/docs/fastapi-cli.md
+++ b/docs/en/docs/fastapi-cli.md
@@ -52,7 +52,7 @@ FastAPI CLI takes the path to your Python program (e.g. `main.py`) and automatic
 
 For production you would use `fastapi run` instead. 🚀
 
-Internally, **FastAPI CLI** uses [Uvicorn](https://www.uvicorn.dev){target=_blank}, a high-performance, production-ready, ASGI server. 😎
+Internally, **FastAPI CLI** uses [Uvicorn](https://www.uvicorn.dev), a high-performance, production-ready, ASGI server. 😎
 
 ## `fastapi dev` { #fastapi-dev }
 
@@ -70,6 +70,6 @@ In most cases you would (and should) have a "termination proxy" handling HTTPS f
 
 /// tip
 
-You can learn more about it in the [deployment documentation](deployment/index.md){target=_blank}.
+You can learn more about it in the [deployment documentation](deployment/index.md).
 
 ///

--- a/docs/en/docs/fastapi-cli.md
+++ b/docs/en/docs/fastapi-cli.md
@@ -52,7 +52,7 @@ FastAPI CLI takes the path to your Python program (e.g. `main.py`) and automatic
 
 For production you would use `fastapi run` instead. 🚀
 
-Internally, **FastAPI CLI** uses <a href="https://www.uvicorn.dev" class="external-link" target="_blank">Uvicorn</a>, a high-performance, production-ready, ASGI server. 😎
+Internally, **FastAPI CLI** uses [Uvicorn](https://www.uvicorn.dev){target=_blank}, a high-performance, production-ready, ASGI server. 😎
 
 ## `fastapi dev` { #fastapi-dev }
 
@@ -70,6 +70,6 @@ In most cases you would (and should) have a "termination proxy" handling HTTPS f
 
 /// tip
 
-You can learn more about it in the [deployment documentation](deployment/index.md){.internal-link target=_blank}.
+You can learn more about it in the [deployment documentation](deployment/index.md){target=_blank}.
 
 ///

--- a/docs/en/docs/fastapi-people.md
+++ b/docs/en/docs/fastapi-people.md
@@ -21,7 +21,7 @@ This is me:
 
 </div>
 
-I'm the creator of **FastAPI**. You can read more about that in [Help FastAPI - Get Help - Connect with the author](help-fastapi.md#connect-with-the-author){.internal-link target=_blank}.
+I'm the creator of **FastAPI**. You can read more about that in [Help FastAPI - Get Help - Connect with the author](help-fastapi.md#connect-with-the-author){target=_blank}.
 
 ...But here I want to show you the community.
 
@@ -31,10 +31,10 @@ I'm the creator of **FastAPI**. You can read more about that in [Help FastAPI - 
 
 These are the people that:
 
-* [Help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank}.
-* [Create Pull Requests](help-fastapi.md#create-a-pull-request){.internal-link target=_blank}.
-* Review Pull Requests, [especially important for translations](contributing.md#translations){.internal-link target=_blank}.
-* Help [manage the repository](management-tasks.md){.internal-link target=_blank} (team members).
+* [Help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank}.
+* [Create Pull Requests](help-fastapi.md#create-a-pull-request){target=_blank}.
+* Review Pull Requests, [especially important for translations](contributing.md#translations){target=_blank}.
+* Help [manage the repository](management-tasks.md){target=_blank} (team members).
 
 All these tasks help maintain the repository.
 
@@ -44,7 +44,7 @@ A round of applause to them. 👏 🙇
 
 This is the current list of team members. 😎
 
-They have different levels of involvement and permissions, they can perform [repository management tasks](./management-tasks.md){.internal-link target=_blank} and together we  [manage the FastAPI repository](./management.md){.internal-link target=_blank}.
+They have different levels of involvement and permissions, they can perform [repository management tasks](./management-tasks.md){target=_blank} and together we  [manage the FastAPI repository](./management.md){target=_blank}.
 
 <div class="user-list user-list-center">
 
@@ -56,11 +56,11 @@ They have different levels of involvement and permissions, they can perform [rep
 
 </div>
 
-Although the team members have the permissions to perform privileged tasks, all the [help from others maintaining FastAPI](./help-fastapi.md#help-maintain-fastapi){.internal-link target=_blank} is very much appreciated! 🙇‍♂️
+Although the team members have the permissions to perform privileged tasks, all the [help from others maintaining FastAPI](./help-fastapi.md#help-maintain-fastapi){target=_blank} is very much appreciated! 🙇‍♂️
 
 ## FastAPI Experts
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank}. 🙇
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank}. 🙇
 
 They have proven to be **FastAPI Experts** by helping many others. ✨
 
@@ -68,7 +68,7 @@ They have proven to be **FastAPI Experts** by helping many others. ✨
 
 You could become an official FastAPI Expert too!
 
-Just [help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank}. 🤓
+Just [help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank}. 🤓
 
 ///
 
@@ -82,7 +82,7 @@ You can see the **FastAPI Experts** for:
 
 ### FastAPI Experts - Last Month
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank} during the last month. 🤓
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last month. 🤓
 
 <div class="user-list user-list-center">
 
@@ -100,7 +100,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 ### FastAPI Experts - 3 Months
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank} during the last 3 months. 😎
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last 3 months. 😎
 
 <div class="user-list user-list-center">
 
@@ -118,7 +118,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 ### FastAPI Experts - 6 Months
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank} during the last 6 months. 🧐
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last 6 months. 🧐
 
 <div class="user-list user-list-center">
 
@@ -136,7 +136,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 ### FastAPI Experts - 1 Year
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank} during the last year. 🧑‍🔬
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last year. 🧑‍🔬
 
 <div class="user-list user-list-center">
 
@@ -156,7 +156,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 Here are the all time **FastAPI Experts**. 🤓🤯
 
-These are the users that have [helped others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){.internal-link target=_blank} through *all time*. 🧙
+These are the users that have [helped others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} through *all time*. 🧙
 
 <div class="user-list user-list-center">
 
@@ -176,7 +176,7 @@ These are the users that have [helped others the most with questions in GitHub](
 
 Here are the **Top Contributors**. 👷
 
-These users have [created the most Pull Requests](help-fastapi.md#create-a-pull-request){.internal-link target=_blank} that have been *merged*.
+These users have [created the most Pull Requests](help-fastapi.md#create-a-pull-request){target=_blank} that have been *merged*.
 
 They have contributed source code, documentation, etc. 📦
 
@@ -194,13 +194,13 @@ They have contributed source code, documentation, etc. 📦
 
 </div>
 
-There are hundreds of other contributors, you can see them all in the <a href="https://github.com/fastapi/fastapi/graphs/contributors" class="external-link" target="_blank">FastAPI GitHub Contributors page</a>. 👷
+There are hundreds of other contributors, you can see them all in the [FastAPI GitHub Contributors page](https://github.com/fastapi/fastapi/graphs/contributors){target=_blank}. 👷
 
 ## Top Translation Reviewers
 
 These users are the **Top Translation Reviewers**. 🕵️
 
-Translation reviewers have the [**power to approve translations**](contributing.md#translations){.internal-link target=_blank} of the documentation. Without them, there wouldn't be documentation in several other languages.
+Translation reviewers have the [**power to approve translations**](contributing.md#translations){target=_blank} of the documentation. Without them, there wouldn't be documentation in several other languages.
 
 <div class="user-list user-list-center">
 {% for user in (translation_reviewers.values() | list)[:50] %}
@@ -219,7 +219,7 @@ Translation reviewers have the [**power to approve translations**](contributing.
 
 These are the **Sponsors**. 😎
 
-They are supporting my work with **FastAPI** (and others), mainly through <a href="https://github.com/sponsors/tiangolo" class="external-link" target="_blank">GitHub Sponsors</a>.
+They are supporting my work with **FastAPI** (and others), mainly through [GitHub Sponsors](https://github.com/sponsors/tiangolo){target=_blank}.
 
 {% if sponsors %}
 
@@ -278,7 +278,7 @@ The main intention of this page is to highlight the effort of the community to h
 
 Especially including efforts that are normally less visible, and in many cases more arduous, like helping others with questions and reviewing Pull Requests with translations.
 
-The data is calculated each month, you can read the <a href="https://github.com/fastapi/fastapi/blob/master/scripts/" class="external-link" target="_blank">source code here</a>.
+The data is calculated each month, you can read the [source code here](https://github.com/fastapi/fastapi/blob/master/scripts/){target=_blank}.
 
 Here I'm also highlighting contributions from sponsors.
 

--- a/docs/en/docs/fastapi-people.md
+++ b/docs/en/docs/fastapi-people.md
@@ -16,12 +16,12 @@ This is me:
 <div class="user-list user-list-center">
 {% for user in people.maintainers %}
 
-<div class="user"><a href="{{ contributors.tiangolo.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ contributors.tiangolo.avatarUrl }}"/></div><div class="title">@{{ contributors.tiangolo.login }}</div></a> <div class="count">Answers: {{ user.answers }}</div><div class="count">Pull Requests: {{ contributors.tiangolo.count }}</div></div>
+<div class="user"><a href="{{ contributors.tiangolo.url }}"><div class="avatar-wrapper"><img src="{{ contributors.tiangolo.avatarUrl }}"/></div><div class="title">@{{ contributors.tiangolo.login }}</div></a> <div class="count">Answers: {{ user.answers }}</div><div class="count">Pull Requests: {{ contributors.tiangolo.count }}</div></div>
 {% endfor %}
 
 </div>
 
-I'm the creator of **FastAPI**. You can read more about that in [Help FastAPI - Get Help - Connect with the author](help-fastapi.md#connect-with-the-author){target=_blank}.
+I'm the creator of **FastAPI**. You can read more about that in [Help FastAPI - Get Help - Connect with the author](help-fastapi.md#connect-with-the-author).
 
 ...But here I want to show you the community.
 
@@ -31,10 +31,10 @@ I'm the creator of **FastAPI**. You can read more about that in [Help FastAPI - 
 
 These are the people that:
 
-* [Help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank}.
-* [Create Pull Requests](help-fastapi.md#create-a-pull-request){target=_blank}.
-* Review Pull Requests, [especially important for translations](contributing.md#translations){target=_blank}.
-* Help [manage the repository](management-tasks.md){target=_blank} (team members).
+* [Help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github).
+* [Create Pull Requests](help-fastapi.md#create-a-pull-request).
+* Review Pull Requests, [especially important for translations](contributing.md#translations).
+* Help [manage the repository](management-tasks.md) (team members).
 
 All these tasks help maintain the repository.
 
@@ -44,23 +44,23 @@ A round of applause to them. 👏 🙇
 
 This is the current list of team members. 😎
 
-They have different levels of involvement and permissions, they can perform [repository management tasks](./management-tasks.md){target=_blank} and together we  [manage the FastAPI repository](./management.md){target=_blank}.
+They have different levels of involvement and permissions, they can perform [repository management tasks](./management-tasks.md) and together we  [manage the FastAPI repository](./management.md).
 
 <div class="user-list user-list-center">
 
 {% for user in members["members"] %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatar_url }}"/></div><div class="title">@{{ user.login }}</div></a></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatar_url }}"/></div><div class="title">@{{ user.login }}</div></a></div>
 
 {% endfor %}
 
 </div>
 
-Although the team members have the permissions to perform privileged tasks, all the [help from others maintaining FastAPI](./help-fastapi.md#help-maintain-fastapi){target=_blank} is very much appreciated! 🙇‍♂️
+Although the team members have the permissions to perform privileged tasks, all the [help from others maintaining FastAPI](./help-fastapi.md#help-maintain-fastapi) is very much appreciated! 🙇‍♂️
 
 ## FastAPI Experts
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank}. 🙇
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github). 🙇
 
 They have proven to be **FastAPI Experts** by helping many others. ✨
 
@@ -68,7 +68,7 @@ They have proven to be **FastAPI Experts** by helping many others. ✨
 
 You could become an official FastAPI Expert too!
 
-Just [help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank}. 🤓
+Just [help others with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github). 🤓
 
 ///
 
@@ -82,7 +82,7 @@ You can see the **FastAPI Experts** for:
 
 ### FastAPI Experts - Last Month
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last month. 🤓
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github) during the last month. 🤓
 
 <div class="user-list user-list-center">
 
@@ -90,7 +90,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% if user.login not in skip_users %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
 {% endif %}
 
@@ -100,7 +100,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 ### FastAPI Experts - 3 Months
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last 3 months. 😎
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github) during the last 3 months. 😎
 
 <div class="user-list user-list-center">
 
@@ -108,7 +108,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% if user.login not in skip_users %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
 {% endif %}
 
@@ -118,7 +118,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 ### FastAPI Experts - 6 Months
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last 6 months. 🧐
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github) during the last 6 months. 🧐
 
 <div class="user-list user-list-center">
 
@@ -126,7 +126,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% if user.login not in skip_users %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
 {% endif %}
 
@@ -136,7 +136,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 ### FastAPI Experts - 1 Year
 
-These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} during the last year. 🧑‍🔬
+These are the users that have been [helping others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github) during the last year. 🧑‍🔬
 
 <div class="user-list user-list-center">
 
@@ -144,7 +144,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% if user.login not in skip_users %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
 {% endif %}
 
@@ -156,7 +156,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 Here are the all time **FastAPI Experts**. 🤓🤯
 
-These are the users that have [helped others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github){target=_blank} through *all time*. 🧙
+These are the users that have [helped others the most with questions in GitHub](help-fastapi.md#help-others-with-questions-in-github) through *all time*. 🧙
 
 <div class="user-list user-list-center">
 
@@ -164,7 +164,7 @@ These are the users that have [helped others the most with questions in GitHub](
 
 {% if user.login not in skip_users %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
 {% endif %}
 
@@ -176,7 +176,7 @@ These are the users that have [helped others the most with questions in GitHub](
 
 Here are the **Top Contributors**. 👷
 
-These users have [created the most Pull Requests](help-fastapi.md#create-a-pull-request){target=_blank} that have been *merged*.
+These users have [created the most Pull Requests](help-fastapi.md#create-a-pull-request) that have been *merged*.
 
 They have contributed source code, documentation, etc. 📦
 
@@ -186,7 +186,7 @@ They have contributed source code, documentation, etc. 📦
 
 {% if user.login not in skip_users %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Pull Requests: {{ user.count }}</div></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Pull Requests: {{ user.count }}</div></div>
 
 {% endif %}
 
@@ -194,20 +194,20 @@ They have contributed source code, documentation, etc. 📦
 
 </div>
 
-There are hundreds of other contributors, you can see them all in the [FastAPI GitHub Contributors page](https://github.com/fastapi/fastapi/graphs/contributors){target=_blank}. 👷
+There are hundreds of other contributors, you can see them all in the [FastAPI GitHub Contributors page](https://github.com/fastapi/fastapi/graphs/contributors). 👷
 
 ## Top Translation Reviewers
 
 These users are the **Top Translation Reviewers**. 🕵️
 
-Translation reviewers have the [**power to approve translations**](contributing.md#translations){target=_blank} of the documentation. Without them, there wouldn't be documentation in several other languages.
+Translation reviewers have the [**power to approve translations**](contributing.md#translations) of the documentation. Without them, there wouldn't be documentation in several other languages.
 
 <div class="user-list user-list-center">
 {% for user in (translation_reviewers.values() | list)[:50] %}
 
 {% if user.login not in skip_users %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Reviews: {{ user.count }}</div></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Reviews: {{ user.count }}</div></div>
 
 {% endif %}
 
@@ -219,7 +219,7 @@ Translation reviewers have the [**power to approve translations**](contributing.
 
 These are the **Sponsors**. 😎
 
-They are supporting my work with **FastAPI** (and others), mainly through [GitHub Sponsors](https://github.com/sponsors/tiangolo){target=_blank}.
+They are supporting my work with **FastAPI** (and others), mainly through [GitHub Sponsors](https://github.com/sponsors/tiangolo).
 
 {% if sponsors %}
 
@@ -228,7 +228,7 @@ They are supporting my work with **FastAPI** (and others), mainly through [GitHu
 ### Gold Sponsors
 
 {% for sponsor in sponsors.gold -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+<a href="{{ sponsor.url }}" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
 {% endfor %}
 {% endif %}
 
@@ -237,7 +237,7 @@ They are supporting my work with **FastAPI** (and others), mainly through [GitHu
 ### Silver Sponsors
 
 {% for sponsor in sponsors.silver -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+<a href="{{ sponsor.url }}" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
 {% endfor %}
 {% endif %}
 
@@ -246,7 +246,7 @@ They are supporting my work with **FastAPI** (and others), mainly through [GitHu
 ### Bronze Sponsors
 
 {% for sponsor in sponsors.bronze -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+<a href="{{ sponsor.url }}" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
 {% endfor %}
 {% endif %}
 
@@ -262,7 +262,7 @@ They are supporting my work with **FastAPI** (and others), mainly through [GitHu
 {% for user in group %}
 {% if user.login not in sponsors_badge.logins %}
 
-<div class="user"><a href="{{ user.url }}" target="_blank"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a></div>
+<div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a></div>
 
 {% endif %}
 {% endfor %}
@@ -278,7 +278,7 @@ The main intention of this page is to highlight the effort of the community to h
 
 Especially including efforts that are normally less visible, and in many cases more arduous, like helping others with questions and reviewing Pull Requests with translations.
 
-The data is calculated each month, you can read the [source code here](https://github.com/fastapi/fastapi/blob/master/scripts/){target=_blank}.
+The data is calculated each month, you can read the [source code here](https://github.com/fastapi/fastapi/blob/master/scripts/).
 
 Here I'm also highlighting contributions from sponsors.
 

--- a/docs/en/docs/features.md
+++ b/docs/en/docs/features.md
@@ -6,8 +6,8 @@
 
 ### Based on open standards { #based-on-open-standards }
 
-* [**OpenAPI**](https://github.com/OAI/OpenAPI-Specification){target=_blank} for API creation, including declarations of <dfn title="also known as: endpoints, routes">path</dfn> <dfn title="also known as HTTP methods, as POST, GET, PUT, DELETE">operations</dfn>, parameters, request bodies, security, etc.
-* Automatic data model documentation with [**JSON Schema**](https://json-schema.org/){target=_blank} (as OpenAPI itself is based on JSON Schema).
+* [**OpenAPI**](https://github.com/OAI/OpenAPI-Specification) for API creation, including declarations of <dfn title="also known as: endpoints, routes">path</dfn> <dfn title="also known as HTTP methods, as POST, GET, PUT, DELETE">operations</dfn>, parameters, request bodies, security, etc.
+* Automatic data model documentation with [**JSON Schema**](https://json-schema.org/) (as OpenAPI itself is based on JSON Schema).
 * Designed around these standards, after a meticulous study. Instead of an afterthought layer on top.
 * This also allows using automatic **client code generation** in many languages.
 
@@ -15,11 +15,11 @@
 
 Interactive API documentation and exploration web user interfaces. As the framework is based on OpenAPI, there are multiple options, 2 included by default.
 
-* [**Swagger UI**](https://github.com/swagger-api/swagger-ui){target=_blank}, with interactive exploration, call and test your API directly from the browser.
+* [**Swagger UI**](https://github.com/swagger-api/swagger-ui), with interactive exploration, call and test your API directly from the browser.
 
 ![Swagger UI interaction](https://fastapi.tiangolo.com/img/index/index-03-swagger-02.png)
 
-* Alternative API documentation with [**ReDoc**](https://github.com/Rebilly/ReDoc){target=_blank}.
+* Alternative API documentation with [**ReDoc**](https://github.com/Rebilly/ReDoc).
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-06-redoc-02.png)
 
@@ -27,7 +27,7 @@ Interactive API documentation and exploration web user interfaces. As the framew
 
 It's all based on standard **Python type** declarations (thanks to Pydantic). No new syntax to learn. Just standard modern Python.
 
-If you need a 2 minute refresher of how to use Python types (even if you don't use FastAPI), check the short tutorial: [Python Types](python-types.md){target=_blank}.
+If you need a 2 minute refresher of how to use Python types (even if you don't use FastAPI), check the short tutorial: [Python Types](python-types.md).
 
 You write standard Python with types:
 
@@ -75,7 +75,7 @@ Pass the keys and values of the `second_user_data` dict directly as key-value ar
 
 All the framework was designed to be easy and intuitive to use, all the decisions were tested on multiple editors even before starting development, to ensure the best development experience.
 
-In the Python developer surveys, it's clear [that one of the most used features is "autocompletion"](https://www.jetbrains.com/research/python-developers-survey-2017/#tools-and-features){target=_blank}.
+In the Python developer surveys, it's clear [that one of the most used features is "autocompletion"](https://www.jetbrains.com/research/python-developers-survey-2017/#tools-and-features).
 
 The whole **FastAPI** framework is based to satisfy that. Autocompletion works everywhere.
 
@@ -83,11 +83,11 @@ You will rarely need to come back to the docs.
 
 Here's how your editor might help you:
 
-* in [Visual Studio Code](https://code.visualstudio.com/){target=_blank}:
+* in [Visual Studio Code](https://code.visualstudio.com/):
 
 ![editor support](https://fastapi.tiangolo.com/img/vscode-completion.png)
 
-* in [PyCharm](https://www.jetbrains.com/pycharm/){target=_blank}:
+* in [PyCharm](https://www.jetbrains.com/pycharm/):
 
 ![editor support](https://fastapi.tiangolo.com/img/pycharm-completion.png)
 
@@ -124,7 +124,7 @@ Security and authentication integrated. Without any compromise with databases or
 All the security schemes defined in OpenAPI, including:
 
 * HTTP Basic.
-* **OAuth2** (also with **JWT tokens**). Check the tutorial on [OAuth2 with JWT](tutorial/security/oauth2-jwt.md){target=_blank}.
+* **OAuth2** (also with **JWT tokens**). Check the tutorial on [OAuth2 with JWT](tutorial/security/oauth2-jwt.md).
 * API keys in:
     * Headers.
     * Query parameters.
@@ -159,13 +159,13 @@ Any integration is designed to be so simple to use (with dependencies) that you 
 
 ## Starlette features { #starlette-features }
 
-**FastAPI** is fully compatible with (and based on) [**Starlette**](https://www.starlette.dev/){target=_blank}. So, any additional Starlette code you have, will also work.
+**FastAPI** is fully compatible with (and based on) [**Starlette**](https://www.starlette.dev/). So, any additional Starlette code you have, will also work.
 
 `FastAPI` is actually a sub-class of `Starlette`. So, if you already know or use Starlette, most of the functionality will work the same way.
 
 With **FastAPI** you get all of **Starlette**'s features (as FastAPI is just Starlette on steroids):
 
-* Seriously impressive performance. It is [one of the fastest Python frameworks available, on par with **NodeJS** and **Go**](https://github.com/encode/starlette#performance){target=_blank}.
+* Seriously impressive performance. It is [one of the fastest Python frameworks available, on par with **NodeJS** and **Go**](https://github.com/encode/starlette#performance).
 * **WebSocket** support.
 * In-process background tasks.
 * Startup and shutdown events.
@@ -177,7 +177,7 @@ With **FastAPI** you get all of **Starlette**'s features (as FastAPI is just Sta
 
 ## Pydantic features { #pydantic-features }
 
-**FastAPI** is fully compatible with (and based on) [**Pydantic**](https://docs.pydantic.dev/){target=_blank}. So, any additional Pydantic code you have, will also work.
+**FastAPI** is fully compatible with (and based on) [**Pydantic**](https://docs.pydantic.dev/). So, any additional Pydantic code you have, will also work.
 
 Including external libraries also based on Pydantic, as <abbr title="Object-Relational Mapper">ORM</abbr>s, <abbr title="Object-Document Mapper">ODM</abbr>s for databases.
 

--- a/docs/en/docs/features.md
+++ b/docs/en/docs/features.md
@@ -6,8 +6,8 @@
 
 ### Based on open standards { #based-on-open-standards }
 
-* <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank"><strong>OpenAPI</strong></a> for API creation, including declarations of <dfn title="also known as: endpoints, routes">path</dfn> <dfn title="also known as HTTP methods, as POST, GET, PUT, DELETE">operations</dfn>, parameters, request bodies, security, etc.
-* Automatic data model documentation with <a href="https://json-schema.org/" class="external-link" target="_blank"><strong>JSON Schema</strong></a> (as OpenAPI itself is based on JSON Schema).
+* [**OpenAPI**](https://github.com/OAI/OpenAPI-Specification){target=_blank} for API creation, including declarations of <dfn title="also known as: endpoints, routes">path</dfn> <dfn title="also known as HTTP methods, as POST, GET, PUT, DELETE">operations</dfn>, parameters, request bodies, security, etc.
+* Automatic data model documentation with [**JSON Schema**](https://json-schema.org/){target=_blank} (as OpenAPI itself is based on JSON Schema).
 * Designed around these standards, after a meticulous study. Instead of an afterthought layer on top.
 * This also allows using automatic **client code generation** in many languages.
 
@@ -15,11 +15,11 @@
 
 Interactive API documentation and exploration web user interfaces. As the framework is based on OpenAPI, there are multiple options, 2 included by default.
 
-* <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank"><strong>Swagger UI</strong></a>, with interactive exploration, call and test your API directly from the browser.
+* [**Swagger UI**](https://github.com/swagger-api/swagger-ui){target=_blank}, with interactive exploration, call and test your API directly from the browser.
 
 ![Swagger UI interaction](https://fastapi.tiangolo.com/img/index/index-03-swagger-02.png)
 
-* Alternative API documentation with <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank"><strong>ReDoc</strong></a>.
+* Alternative API documentation with [**ReDoc**](https://github.com/Rebilly/ReDoc){target=_blank}.
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-06-redoc-02.png)
 
@@ -27,7 +27,7 @@ Interactive API documentation and exploration web user interfaces. As the framew
 
 It's all based on standard **Python type** declarations (thanks to Pydantic). No new syntax to learn. Just standard modern Python.
 
-If you need a 2 minute refresher of how to use Python types (even if you don't use FastAPI), check the short tutorial: [Python Types](python-types.md){.internal-link target=_blank}.
+If you need a 2 minute refresher of how to use Python types (even if you don't use FastAPI), check the short tutorial: [Python Types](python-types.md){target=_blank}.
 
 You write standard Python with types:
 
@@ -75,7 +75,7 @@ Pass the keys and values of the `second_user_data` dict directly as key-value ar
 
 All the framework was designed to be easy and intuitive to use, all the decisions were tested on multiple editors even before starting development, to ensure the best development experience.
 
-In the Python developer surveys, it's clear <a href="https://www.jetbrains.com/research/python-developers-survey-2017/#tools-and-features" class="external-link" target="_blank">that one of the most used features is "autocompletion"</a>.
+In the Python developer surveys, it's clear [that one of the most used features is "autocompletion"](https://www.jetbrains.com/research/python-developers-survey-2017/#tools-and-features){target=_blank}.
 
 The whole **FastAPI** framework is based to satisfy that. Autocompletion works everywhere.
 
@@ -83,11 +83,11 @@ You will rarely need to come back to the docs.
 
 Here's how your editor might help you:
 
-* in <a href="https://code.visualstudio.com/" class="external-link" target="_blank">Visual Studio Code</a>:
+* in [Visual Studio Code](https://code.visualstudio.com/){target=_blank}:
 
 ![editor support](https://fastapi.tiangolo.com/img/vscode-completion.png)
 
-* in <a href="https://www.jetbrains.com/pycharm/" class="external-link" target="_blank">PyCharm</a>:
+* in [PyCharm](https://www.jetbrains.com/pycharm/){target=_blank}:
 
 ![editor support](https://fastapi.tiangolo.com/img/pycharm-completion.png)
 
@@ -124,7 +124,7 @@ Security and authentication integrated. Without any compromise with databases or
 All the security schemes defined in OpenAPI, including:
 
 * HTTP Basic.
-* **OAuth2** (also with **JWT tokens**). Check the tutorial on [OAuth2 with JWT](tutorial/security/oauth2-jwt.md){.internal-link target=_blank}.
+* **OAuth2** (also with **JWT tokens**). Check the tutorial on [OAuth2 with JWT](tutorial/security/oauth2-jwt.md){target=_blank}.
 * API keys in:
     * Headers.
     * Query parameters.
@@ -159,13 +159,13 @@ Any integration is designed to be so simple to use (with dependencies) that you 
 
 ## Starlette features { #starlette-features }
 
-**FastAPI** is fully compatible with (and based on) <a href="https://www.starlette.dev/" class="external-link" target="_blank"><strong>Starlette</strong></a>. So, any additional Starlette code you have, will also work.
+**FastAPI** is fully compatible with (and based on) [**Starlette**](https://www.starlette.dev/){target=_blank}. So, any additional Starlette code you have, will also work.
 
 `FastAPI` is actually a sub-class of `Starlette`. So, if you already know or use Starlette, most of the functionality will work the same way.
 
 With **FastAPI** you get all of **Starlette**'s features (as FastAPI is just Starlette on steroids):
 
-* Seriously impressive performance. It is <a href="https://github.com/encode/starlette#performance" class="external-link" target="_blank">one of the fastest Python frameworks available, on par with **NodeJS** and **Go**</a>.
+* Seriously impressive performance. It is [one of the fastest Python frameworks available, on par with **NodeJS** and **Go**](https://github.com/encode/starlette#performance){target=_blank}.
 * **WebSocket** support.
 * In-process background tasks.
 * Startup and shutdown events.
@@ -177,7 +177,7 @@ With **FastAPI** you get all of **Starlette**'s features (as FastAPI is just Sta
 
 ## Pydantic features { #pydantic-features }
 
-**FastAPI** is fully compatible with (and based on) <a href="https://docs.pydantic.dev/" class="external-link" target="_blank"><strong>Pydantic</strong></a>. So, any additional Pydantic code you have, will also work.
+**FastAPI** is fully compatible with (and based on) [**Pydantic**](https://docs.pydantic.dev/){target=_blank}. So, any additional Pydantic code you have, will also work.
 
 Including external libraries also based on Pydantic, as <abbr title="Object-Relational Mapper">ORM</abbr>s, <abbr title="Object-Document Mapper">ODM</abbr>s for databases.
 

--- a/docs/en/docs/help-fastapi.md
+++ b/docs/en/docs/help-fastapi.md
@@ -12,7 +12,7 @@ And there are several ways to get help too.
 
 ## Subscribe to the newsletter { #subscribe-to-the-newsletter }
 
-You can subscribe to the (infrequent) [**FastAPI and friends** newsletter](newsletter.md){target=_blank} to stay updated about:
+You can subscribe to the (infrequent) [**FastAPI and friends** newsletter](newsletter.md) to stay updated about:
 
 * News about FastAPI and friends 🚀
 * Guides 📝
@@ -22,17 +22,17 @@ You can subscribe to the (infrequent) [**FastAPI and friends** newsletter](newsl
 
 ## Follow FastAPI on X (Twitter) { #follow-fastapi-on-x-twitter }
 
-[Follow @fastapi on **X (Twitter)**](https://x.com/fastapi){target=_blank} to get the latest news about **FastAPI**. 🐦
+[Follow @fastapi on **X (Twitter)**](https://x.com/fastapi) to get the latest news about **FastAPI**. 🐦
 
 ## Star **FastAPI** in GitHub { #star-fastapi-in-github }
 
-You can "star" FastAPI in GitHub (clicking the star button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi){target=_blank}. ⭐️
+You can "star" FastAPI in GitHub (clicking the star button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi). ⭐️
 
 By adding a star, other users will be able to find it more easily and see that it has been already useful for others.
 
 ## Watch the GitHub repository for releases { #watch-the-github-repository-for-releases }
 
-You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi){target=_blank}. 👀
+You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi). 👀
 
 There you can select "Releases only".
 
@@ -40,45 +40,45 @@ By doing it, you will receive notifications (in your email) whenever there's a n
 
 ## Connect with the author { #connect-with-the-author }
 
-You can connect with [me (Sebastián Ramírez / `tiangolo`)](https://tiangolo.com){target=_blank}, the author.
+You can connect with [me (Sebastián Ramírez / `tiangolo`)](https://tiangolo.com), the author.
 
 You can:
 
-* [Follow me on **GitHub**](https://github.com/tiangolo){target=_blank}.
+* [Follow me on **GitHub**](https://github.com/tiangolo).
     * See other Open Source projects I have created that could help you.
     * Follow me to see when I create a new Open Source project.
-* [Follow me on **X (Twitter)**](https://x.com/tiangolo){target=_blank} or [Mastodon](https://fosstodon.org/@tiangolo){target=_blank}.
+* [Follow me on **X (Twitter)**](https://x.com/tiangolo) or [Mastodon](https://fosstodon.org/@tiangolo).
     * Tell me how you use FastAPI (I love to hear that).
     * Hear when I make announcements or release new tools.
-    * You can also [follow @fastapi on X (Twitter)](https://x.com/fastapi){target=_blank} (a separate account).
-* [Follow me on **LinkedIn**](https://www.linkedin.com/in/tiangolo/){target=_blank}.
+    * You can also [follow @fastapi on X (Twitter)](https://x.com/fastapi) (a separate account).
+* [Follow me on **LinkedIn**](https://www.linkedin.com/in/tiangolo/).
     * Hear when I make announcements or release new tools (although I use X (Twitter) more often 🤷‍♂).
-* Read what I write (or follow me) on [**Dev.to**](https://dev.to/tiangolo){target=_blank} or [**Medium**](https://medium.com/@tiangolo){target=_blank}.
+* Read what I write (or follow me) on [**Dev.to**](https://dev.to/tiangolo) or [**Medium**](https://medium.com/@tiangolo).
     * Read other ideas, articles, and read about tools I have created.
     * Follow me to read when I publish something new.
 
 ## Tweet about **FastAPI** { #tweet-about-fastapi }
 
-[Tweet about **FastAPI**](https://x.com/compose/tweet?text=I'm loving @fastapi because... https://github.com/fastapi/fastapi){target=_blank} and let me and others know why you like it. 🎉
+[Tweet about **FastAPI**](https://x.com/compose/tweet?text=I'm loving @fastapi because... https://github.com/fastapi/fastapi) and let me and others know why you like it. 🎉
 
 I love to hear about how **FastAPI** is being used, what you have liked in it, in which project/company are you using it, etc.
 
 ## Vote for FastAPI { #vote-for-fastapi }
 
-* [Vote for **FastAPI** in Slant](https://www.slant.co/options/34241/~fastapi-review){target=_blank}.
-* [Vote for **FastAPI** in AlternativeTo](https://alternativeto.net/software/fastapi/about/){target=_blank}.
-* [Say you use **FastAPI** on StackShare](https://stackshare.io/pypi-fastapi){target=_blank}.
+* [Vote for **FastAPI** in Slant](https://www.slant.co/options/34241/~fastapi-review).
+* [Vote for **FastAPI** in AlternativeTo](https://alternativeto.net/software/fastapi/about/).
+* [Say you use **FastAPI** on StackShare](https://stackshare.io/pypi-fastapi).
 
 ## Help others with questions in GitHub { #help-others-with-questions-in-github }
 
 You can try and help others with their questions in:
 
-* [GitHub Discussions](https://github.com/fastapi/fastapi/discussions/categories/questions?discussions_q=category%3AQuestions+is%3Aunanswered){target=_blank}
-* [GitHub Issues](https://github.com/fastapi/fastapi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aquestion+-label%3Aanswered+){target=_blank}
+* [GitHub Discussions](https://github.com/fastapi/fastapi/discussions/categories/questions?discussions_q=category%3AQuestions+is%3Aunanswered)
+* [GitHub Issues](https://github.com/fastapi/fastapi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aquestion+-label%3Aanswered+)
 
 In many cases you might already know the answer for those questions. 🤓
 
-If you are helping a lot of people with their questions, you will become an official [FastAPI Expert](fastapi-people.md#fastapi-experts){target=_blank}. 🎉
+If you are helping a lot of people with their questions, you will become an official [FastAPI Expert](fastapi-people.md#fastapi-experts). 🎉
 
 Just remember, the most important point is: try to be kind. People come with their frustrations and in many cases don't ask in the best way, but try as best as you can to be kind. 🤗
 
@@ -104,7 +104,7 @@ For most of the cases and most of the questions there's something related to the
 
 In many cases they will only copy a fragment of the code, but that's not enough to **reproduce the problem**.
 
-* You can ask them to provide a [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example){target=_blank}, that you can **copy-paste** and run locally to see the same error or behavior they are seeing, or to understand their use case better.
+* You can ask them to provide a [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example), that you can **copy-paste** and run locally to see the same error or behavior they are seeing, or to understand their use case better.
 
 * If you are feeling too generous, you can try to **create an example** like that yourself, just based on the description of the problem. Just keep in mind that this might take a lot of time and it might be better to ask them to clarify the problem first.
 
@@ -125,7 +125,7 @@ If they reply, there's a high chance you would have solved their problem, congra
 
 ## Watch the GitHub repository { #watch-the-github-repository }
 
-You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi){target=_blank}. 👀
+You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi). 👀
 
 If you select "Watching" instead of "Releases only" you will receive notifications when someone creates a new issue or question. You can also specify that you only want to be notified about new issues, or discussions, or PRs, etc.
 
@@ -133,7 +133,7 @@ Then you can try and help them solve those questions.
 
 ## Ask Questions { #ask-questions }
 
-You can [create a new question](https://github.com/fastapi/fastapi/discussions/new?category=questions){target=_blank} in the GitHub repository, for example to:
+You can [create a new question](https://github.com/fastapi/fastapi/discussions/new?category=questions) in the GitHub repository, for example to:
 
 * Ask a **question** or ask about a **problem**.
 * Suggest a new **feature**.
@@ -196,12 +196,12 @@ So, it's really important that you actually read and run the code, and let me kn
 
 ## Create a Pull Request { #create-a-pull-request }
 
-You can [contribute](contributing.md){target=_blank} to the source code with Pull Requests, for example:
+You can [contribute](contributing.md) to the source code with Pull Requests, for example:
 
 * To fix a typo you found on the documentation.
-* To share an article, video, or podcast you created or found about FastAPI by [editing this file](https://github.com/fastapi/fastapi/edit/master/docs/en/data/external_links.yml){target=_blank}.
+* To share an article, video, or podcast you created or found about FastAPI by [editing this file](https://github.com/fastapi/fastapi/edit/master/docs/en/data/external_links.yml).
     * Make sure you add your link to the start of the corresponding section.
-* To help [translate the documentation](contributing.md#translations){target=_blank} to your language.
+* To help [translate the documentation](contributing.md#translations) to your language.
     * You can also help to review the translations created by others.
 * To propose new documentation sections.
 * To fix an existing issue/bug.
@@ -218,8 +218,8 @@ There's a lot of work to do, and for most of it, **YOU** can do it.
 
 The main tasks that you can do right now are:
 
-* [Help others with questions in GitHub](#help-others-with-questions-in-github){target=_blank} (see the section above).
-* [Review Pull Requests](#review-pull-requests){target=_blank} (see the section above).
+* [Help others with questions in GitHub](#help-others-with-questions-in-github) (see the section above).
+* [Review Pull Requests](#review-pull-requests) (see the section above).
 
 Those two tasks are what **consume time the most**. That's the main work of maintaining FastAPI.
 
@@ -227,11 +227,11 @@ If you can help me with that, **you are helping me maintain FastAPI** and making
 
 ## Join the chat { #join-the-chat }
 
-Join the 👥 [Discord chat server](https://discord.gg/VQjSZaeJmf){target=_blank} 👥 and hang out with others in the FastAPI community.
+Join the 👥 [Discord chat server](https://discord.gg/VQjSZaeJmf) 👥 and hang out with others in the FastAPI community.
 
 /// tip
 
-For questions, ask them in [GitHub Discussions](https://github.com/fastapi/fastapi/discussions/new?category=questions){target=_blank}, there's a much better chance you will receive help by the [FastAPI Experts](fastapi-people.md#fastapi-experts){target=_blank}.
+For questions, ask them in [GitHub Discussions](https://github.com/fastapi/fastapi/discussions/new?category=questions), there's a much better chance you will receive help by the [FastAPI Experts](fastapi-people.md#fastapi-experts).
 
 Use the chat only for other general conversations.
 
@@ -243,13 +243,13 @@ Keep in mind that as chats allow more "free conversation", it's easy to ask ques
 
 In GitHub, the template will guide you to write the right question so that you can more easily get a good answer, or even solve the problem yourself even before asking. And in GitHub I can make sure I always answer everything, even if it takes some time. I can't personally do that with the chat systems. 😅
 
-Conversations in the chat systems are also not as easily searchable as in GitHub, so questions and answers might get lost in the conversation. And only the ones in GitHub count to become a [FastAPI Expert](fastapi-people.md#fastapi-experts){target=_blank}, so you will most probably receive more attention in GitHub.
+Conversations in the chat systems are also not as easily searchable as in GitHub, so questions and answers might get lost in the conversation. And only the ones in GitHub count to become a [FastAPI Expert](fastapi-people.md#fastapi-experts), so you will most probably receive more attention in GitHub.
 
 On the other side, there are thousands of users in the chat systems, so there's a high chance you'll find someone to talk to there, almost all the time. 😄
 
 ## Sponsor the author { #sponsor-the-author }
 
-If your **product/company** depends on or is related to **FastAPI** and you want to reach its users, you can sponsor the author (me) through [GitHub sponsors](https://github.com/sponsors/tiangolo){target=_blank}. Depending on the tier, you could get some extra benefits, like a badge in the docs. 🎁
+If your **product/company** depends on or is related to **FastAPI** and you want to reach its users, you can sponsor the author (me) through [GitHub sponsors](https://github.com/sponsors/tiangolo). Depending on the tier, you could get some extra benefits, like a badge in the docs. 🎁
 
 ---
 

--- a/docs/en/docs/help-fastapi.md
+++ b/docs/en/docs/help-fastapi.md
@@ -12,7 +12,7 @@ And there are several ways to get help too.
 
 ## Subscribe to the newsletter { #subscribe-to-the-newsletter }
 
-You can subscribe to the (infrequent) [**FastAPI and friends** newsletter](newsletter.md){.internal-link target=_blank} to stay updated about:
+You can subscribe to the (infrequent) [**FastAPI and friends** newsletter](newsletter.md){target=_blank} to stay updated about:
 
 * News about FastAPI and friends 🚀
 * Guides 📝
@@ -22,17 +22,17 @@ You can subscribe to the (infrequent) [**FastAPI and friends** newsletter](newsl
 
 ## Follow FastAPI on X (Twitter) { #follow-fastapi-on-x-twitter }
 
-<a href="https://x.com/fastapi" class="external-link" target="_blank">Follow @fastapi on **X (Twitter)**</a> to get the latest news about **FastAPI**. 🐦
+[Follow @fastapi on **X (Twitter)**](https://x.com/fastapi){target=_blank} to get the latest news about **FastAPI**. 🐦
 
 ## Star **FastAPI** in GitHub { #star-fastapi-in-github }
 
-You can "star" FastAPI in GitHub (clicking the star button at the top right): <a href="https://github.com/fastapi/fastapi" class="external-link" target="_blank">https://github.com/fastapi/fastapi</a>. ⭐️
+You can "star" FastAPI in GitHub (clicking the star button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi){target=_blank}. ⭐️
 
 By adding a star, other users will be able to find it more easily and see that it has been already useful for others.
 
 ## Watch the GitHub repository for releases { #watch-the-github-repository-for-releases }
 
-You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): <a href="https://github.com/fastapi/fastapi" class="external-link" target="_blank">https://github.com/fastapi/fastapi</a>. 👀
+You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi){target=_blank}. 👀
 
 There you can select "Releases only".
 
@@ -40,45 +40,45 @@ By doing it, you will receive notifications (in your email) whenever there's a n
 
 ## Connect with the author { #connect-with-the-author }
 
-You can connect with <a href="https://tiangolo.com" class="external-link" target="_blank">me (Sebastián Ramírez / `tiangolo`)</a>, the author.
+You can connect with [me (Sebastián Ramírez / `tiangolo`)](https://tiangolo.com){target=_blank}, the author.
 
 You can:
 
-* <a href="https://github.com/tiangolo" class="external-link" target="_blank">Follow me on **GitHub**</a>.
+* [Follow me on **GitHub**](https://github.com/tiangolo){target=_blank}.
     * See other Open Source projects I have created that could help you.
     * Follow me to see when I create a new Open Source project.
-* <a href="https://x.com/tiangolo" class="external-link" target="_blank">Follow me on **X (Twitter)**</a> or <a href="https://fosstodon.org/@tiangolo" class="external-link" target="_blank">Mastodon</a>.
+* [Follow me on **X (Twitter)**](https://x.com/tiangolo){target=_blank} or [Mastodon](https://fosstodon.org/@tiangolo){target=_blank}.
     * Tell me how you use FastAPI (I love to hear that).
     * Hear when I make announcements or release new tools.
-    * You can also <a href="https://x.com/fastapi" class="external-link" target="_blank">follow @fastapi on X (Twitter)</a> (a separate account).
-* <a href="https://www.linkedin.com/in/tiangolo/" class="external-link" target="_blank">Follow me on **LinkedIn**</a>.
+    * You can also [follow @fastapi on X (Twitter)](https://x.com/fastapi){target=_blank} (a separate account).
+* [Follow me on **LinkedIn**](https://www.linkedin.com/in/tiangolo/){target=_blank}.
     * Hear when I make announcements or release new tools (although I use X (Twitter) more often 🤷‍♂).
-* Read what I write (or follow me) on <a href="https://dev.to/tiangolo" class="external-link" target="_blank">**Dev.to**</a> or <a href="https://medium.com/@tiangolo" class="external-link" target="_blank">**Medium**</a>.
+* Read what I write (or follow me) on [**Dev.to**](https://dev.to/tiangolo){target=_blank} or [**Medium**](https://medium.com/@tiangolo){target=_blank}.
     * Read other ideas, articles, and read about tools I have created.
     * Follow me to read when I publish something new.
 
 ## Tweet about **FastAPI** { #tweet-about-fastapi }
 
-<a href="https://x.com/compose/tweet?text=I'm loving @fastapi because... https://github.com/fastapi/fastapi" class="external-link" target="_blank">Tweet about **FastAPI**</a> and let me and others know why you like it. 🎉
+[Tweet about **FastAPI**](https://x.com/compose/tweet?text=I'm loving @fastapi because... https://github.com/fastapi/fastapi){target=_blank} and let me and others know why you like it. 🎉
 
 I love to hear about how **FastAPI** is being used, what you have liked in it, in which project/company are you using it, etc.
 
 ## Vote for FastAPI { #vote-for-fastapi }
 
-* <a href="https://www.slant.co/options/34241/~fastapi-review" class="external-link" target="_blank">Vote for **FastAPI** in Slant</a>.
-* <a href="https://alternativeto.net/software/fastapi/about/" class="external-link" target="_blank">Vote for **FastAPI** in AlternativeTo</a>.
-* <a href="https://stackshare.io/pypi-fastapi" class="external-link" target="_blank">Say you use **FastAPI** on StackShare</a>.
+* [Vote for **FastAPI** in Slant](https://www.slant.co/options/34241/~fastapi-review){target=_blank}.
+* [Vote for **FastAPI** in AlternativeTo](https://alternativeto.net/software/fastapi/about/){target=_blank}.
+* [Say you use **FastAPI** on StackShare](https://stackshare.io/pypi-fastapi){target=_blank}.
 
 ## Help others with questions in GitHub { #help-others-with-questions-in-github }
 
 You can try and help others with their questions in:
 
-* <a href="https://github.com/fastapi/fastapi/discussions/categories/questions?discussions_q=category%3AQuestions+is%3Aunanswered" class="external-link" target="_blank">GitHub Discussions</a>
-* <a href="https://github.com/fastapi/fastapi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aquestion+-label%3Aanswered+" class="external-link" target="_blank">GitHub Issues</a>
+* [GitHub Discussions](https://github.com/fastapi/fastapi/discussions/categories/questions?discussions_q=category%3AQuestions+is%3Aunanswered){target=_blank}
+* [GitHub Issues](https://github.com/fastapi/fastapi/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aquestion+-label%3Aanswered+){target=_blank}
 
 In many cases you might already know the answer for those questions. 🤓
 
-If you are helping a lot of people with their questions, you will become an official [FastAPI Expert](fastapi-people.md#fastapi-experts){.internal-link target=_blank}. 🎉
+If you are helping a lot of people with their questions, you will become an official [FastAPI Expert](fastapi-people.md#fastapi-experts){target=_blank}. 🎉
 
 Just remember, the most important point is: try to be kind. People come with their frustrations and in many cases don't ask in the best way, but try as best as you can to be kind. 🤗
 
@@ -104,7 +104,7 @@ For most of the cases and most of the questions there's something related to the
 
 In many cases they will only copy a fragment of the code, but that's not enough to **reproduce the problem**.
 
-* You can ask them to provide a <a href="https://stackoverflow.com/help/minimal-reproducible-example" class="external-link" target="_blank">minimal, reproducible, example</a>, that you can **copy-paste** and run locally to see the same error or behavior they are seeing, or to understand their use case better.
+* You can ask them to provide a [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example){target=_blank}, that you can **copy-paste** and run locally to see the same error or behavior they are seeing, or to understand their use case better.
 
 * If you are feeling too generous, you can try to **create an example** like that yourself, just based on the description of the problem. Just keep in mind that this might take a lot of time and it might be better to ask them to clarify the problem first.
 
@@ -125,7 +125,7 @@ If they reply, there's a high chance you would have solved their problem, congra
 
 ## Watch the GitHub repository { #watch-the-github-repository }
 
-You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): <a href="https://github.com/fastapi/fastapi" class="external-link" target="_blank">https://github.com/fastapi/fastapi</a>. 👀
+You can "watch" FastAPI in GitHub (clicking the "watch" button at the top right): [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi){target=_blank}. 👀
 
 If you select "Watching" instead of "Releases only" you will receive notifications when someone creates a new issue or question. You can also specify that you only want to be notified about new issues, or discussions, or PRs, etc.
 
@@ -133,7 +133,7 @@ Then you can try and help them solve those questions.
 
 ## Ask Questions { #ask-questions }
 
-You can <a href="https://github.com/fastapi/fastapi/discussions/new?category=questions" class="external-link" target="_blank">create a new question</a> in the GitHub repository, for example to:
+You can [create a new question](https://github.com/fastapi/fastapi/discussions/new?category=questions){target=_blank} in the GitHub repository, for example to:
 
 * Ask a **question** or ask about a **problem**.
 * Suggest a new **feature**.
@@ -196,12 +196,12 @@ So, it's really important that you actually read and run the code, and let me kn
 
 ## Create a Pull Request { #create-a-pull-request }
 
-You can [contribute](contributing.md){.internal-link target=_blank} to the source code with Pull Requests, for example:
+You can [contribute](contributing.md){target=_blank} to the source code with Pull Requests, for example:
 
 * To fix a typo you found on the documentation.
-* To share an article, video, or podcast you created or found about FastAPI by <a href="https://github.com/fastapi/fastapi/edit/master/docs/en/data/external_links.yml" class="external-link" target="_blank">editing this file</a>.
+* To share an article, video, or podcast you created or found about FastAPI by [editing this file](https://github.com/fastapi/fastapi/edit/master/docs/en/data/external_links.yml){target=_blank}.
     * Make sure you add your link to the start of the corresponding section.
-* To help [translate the documentation](contributing.md#translations){.internal-link target=_blank} to your language.
+* To help [translate the documentation](contributing.md#translations){target=_blank} to your language.
     * You can also help to review the translations created by others.
 * To propose new documentation sections.
 * To fix an existing issue/bug.
@@ -218,8 +218,8 @@ There's a lot of work to do, and for most of it, **YOU** can do it.
 
 The main tasks that you can do right now are:
 
-* [Help others with questions in GitHub](#help-others-with-questions-in-github){.internal-link target=_blank} (see the section above).
-* [Review Pull Requests](#review-pull-requests){.internal-link target=_blank} (see the section above).
+* [Help others with questions in GitHub](#help-others-with-questions-in-github){target=_blank} (see the section above).
+* [Review Pull Requests](#review-pull-requests){target=_blank} (see the section above).
 
 Those two tasks are what **consume time the most**. That's the main work of maintaining FastAPI.
 
@@ -227,11 +227,11 @@ If you can help me with that, **you are helping me maintain FastAPI** and making
 
 ## Join the chat { #join-the-chat }
 
-Join the 👥 <a href="https://discord.gg/VQjSZaeJmf" class="external-link" target="_blank">Discord chat server</a> 👥 and hang out with others in the FastAPI community.
+Join the 👥 [Discord chat server](https://discord.gg/VQjSZaeJmf){target=_blank} 👥 and hang out with others in the FastAPI community.
 
 /// tip
 
-For questions, ask them in <a href="https://github.com/fastapi/fastapi/discussions/new?category=questions" class="external-link" target="_blank">GitHub Discussions</a>, there's a much better chance you will receive help by the [FastAPI Experts](fastapi-people.md#fastapi-experts){.internal-link target=_blank}.
+For questions, ask them in [GitHub Discussions](https://github.com/fastapi/fastapi/discussions/new?category=questions){target=_blank}, there's a much better chance you will receive help by the [FastAPI Experts](fastapi-people.md#fastapi-experts){target=_blank}.
 
 Use the chat only for other general conversations.
 
@@ -243,13 +243,13 @@ Keep in mind that as chats allow more "free conversation", it's easy to ask ques
 
 In GitHub, the template will guide you to write the right question so that you can more easily get a good answer, or even solve the problem yourself even before asking. And in GitHub I can make sure I always answer everything, even if it takes some time. I can't personally do that with the chat systems. 😅
 
-Conversations in the chat systems are also not as easily searchable as in GitHub, so questions and answers might get lost in the conversation. And only the ones in GitHub count to become a [FastAPI Expert](fastapi-people.md#fastapi-experts){.internal-link target=_blank}, so you will most probably receive more attention in GitHub.
+Conversations in the chat systems are also not as easily searchable as in GitHub, so questions and answers might get lost in the conversation. And only the ones in GitHub count to become a [FastAPI Expert](fastapi-people.md#fastapi-experts){target=_blank}, so you will most probably receive more attention in GitHub.
 
 On the other side, there are thousands of users in the chat systems, so there's a high chance you'll find someone to talk to there, almost all the time. 😄
 
 ## Sponsor the author { #sponsor-the-author }
 
-If your **product/company** depends on or is related to **FastAPI** and you want to reach its users, you can sponsor the author (me) through <a href="https://github.com/sponsors/tiangolo" class="external-link" target="_blank">GitHub sponsors</a>. Depending on the tier, you could get some extra benefits, like a badge in the docs. 🎁
+If your **product/company** depends on or is related to **FastAPI** and you want to reach its users, you can sponsor the author (me) through [GitHub sponsors](https://github.com/sponsors/tiangolo){target=_blank}. Depending on the tier, you could get some extra benefits, like a badge in the docs. 🎁
 
 ---
 

--- a/docs/en/docs/history-design-future.md
+++ b/docs/en/docs/history-design-future.md
@@ -1,6 +1,6 @@
 # History, Design and Future { #history-design-and-future }
 
-Some time ago, [a **FastAPI** user asked](https://github.com/fastapi/fastapi/issues/3#issuecomment-454956920){target=_blank}:
+Some time ago, [a **FastAPI** user asked](https://github.com/fastapi/fastapi/issues/3#issuecomment-454956920):
 
 > What’s the history of this project? It seems to have come from nowhere to awesome in a few weeks [...]
 
@@ -14,7 +14,7 @@ As part of that, I needed to investigate, test and use many alternatives.
 
 The history of **FastAPI** is in great part the history of its predecessors.
 
-As said in the section [Alternatives](alternatives.md){target=_blank}:
+As said in the section [Alternatives](alternatives.md):
 
 <blockquote markdown="1">
 
@@ -44,7 +44,7 @@ Then I spent some time designing the developer "API" I wanted to have as a user 
 
 I tested several ideas in the most popular Python editors: PyCharm, VS Code, Jedi based editors.
 
-By the last [Python Developer Survey](https://www.jetbrains.com/research/python-developers-survey-2018/#development-tools){target=_blank}, that covers about 80% of the users.
+By the last [Python Developer Survey](https://www.jetbrains.com/research/python-developers-survey-2018/#development-tools), that covers about 80% of the users.
 
 It means that **FastAPI** was specifically tested with the editors used by 80% of the Python developers. And as most of the other editors tend to work similarly, all its benefits should work for virtually all editors.
 
@@ -54,11 +54,11 @@ All in a way that provided the best development experience for all the developer
 
 ## Requirements { #requirements }
 
-After testing several alternatives, I decided that I was going to use [**Pydantic**](https://docs.pydantic.dev/){target=_blank} for its advantages.
+After testing several alternatives, I decided that I was going to use [**Pydantic**](https://docs.pydantic.dev/) for its advantages.
 
 Then I contributed to it, to make it fully compliant with JSON Schema, to support different ways to define constraint declarations, and to improve editor support (type checks, autocompletion) based on the tests in several editors.
 
-During the development, I also contributed to [**Starlette**](https://www.starlette.dev/){target=_blank}, the other key requirement.
+During the development, I also contributed to [**Starlette**](https://www.starlette.dev/), the other key requirement.
 
 ## Development { #development }
 
@@ -76,4 +76,4 @@ But still, there are many improvements and features to come.
 
 **FastAPI** has a great future ahead.
 
-And [your help](help-fastapi.md){target=_blank} is greatly appreciated.
+And [your help](help-fastapi.md) is greatly appreciated.

--- a/docs/en/docs/history-design-future.md
+++ b/docs/en/docs/history-design-future.md
@@ -1,6 +1,6 @@
 # History, Design and Future { #history-design-and-future }
 
-Some time ago, <a href="https://github.com/fastapi/fastapi/issues/3#issuecomment-454956920" class="external-link" target="_blank">a **FastAPI** user asked</a>:
+Some time ago, [a **FastAPI** user asked](https://github.com/fastapi/fastapi/issues/3#issuecomment-454956920){target=_blank}:
 
 > What’s the history of this project? It seems to have come from nowhere to awesome in a few weeks [...]
 
@@ -14,7 +14,7 @@ As part of that, I needed to investigate, test and use many alternatives.
 
 The history of **FastAPI** is in great part the history of its predecessors.
 
-As said in the section [Alternatives](alternatives.md){.internal-link target=_blank}:
+As said in the section [Alternatives](alternatives.md){target=_blank}:
 
 <blockquote markdown="1">
 
@@ -44,7 +44,7 @@ Then I spent some time designing the developer "API" I wanted to have as a user 
 
 I tested several ideas in the most popular Python editors: PyCharm, VS Code, Jedi based editors.
 
-By the last <a href="https://www.jetbrains.com/research/python-developers-survey-2018/#development-tools" class="external-link" target="_blank">Python Developer Survey</a>, that covers about 80% of the users.
+By the last [Python Developer Survey](https://www.jetbrains.com/research/python-developers-survey-2018/#development-tools){target=_blank}, that covers about 80% of the users.
 
 It means that **FastAPI** was specifically tested with the editors used by 80% of the Python developers. And as most of the other editors tend to work similarly, all its benefits should work for virtually all editors.
 
@@ -54,11 +54,11 @@ All in a way that provided the best development experience for all the developer
 
 ## Requirements { #requirements }
 
-After testing several alternatives, I decided that I was going to use <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">**Pydantic**</a> for its advantages.
+After testing several alternatives, I decided that I was going to use [**Pydantic**](https://docs.pydantic.dev/){target=_blank} for its advantages.
 
 Then I contributed to it, to make it fully compliant with JSON Schema, to support different ways to define constraint declarations, and to improve editor support (type checks, autocompletion) based on the tests in several editors.
 
-During the development, I also contributed to <a href="https://www.starlette.dev/" class="external-link" target="_blank">**Starlette**</a>, the other key requirement.
+During the development, I also contributed to [**Starlette**](https://www.starlette.dev/){target=_blank}, the other key requirement.
 
 ## Development { #development }
 
@@ -76,4 +76,4 @@ But still, there are many improvements and features to come.
 
 **FastAPI** has a great future ahead.
 
-And [your help](help-fastapi.md){.internal-link target=_blank} is greatly appreciated.
+And [your help](help-fastapi.md){target=_blank} is greatly appreciated.

--- a/docs/en/docs/how-to/authentication-error-status-code.md
+++ b/docs/en/docs/how-to/authentication-error-status-code.md
@@ -2,7 +2,7 @@
 
 Before FastAPI version `0.122.0`, when the integrated security utilities returned an error to the client after a failed authentication, they used the HTTP status code `403 Forbidden`.
 
-Starting with FastAPI version `0.122.0`, they use the more appropriate HTTP status code `401 Unauthorized`, and return a sensible `WWW-Authenticate` header in the response, following the HTTP specifications, [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235#section-3.1){target=_blank}, [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-401-unauthorized){target=_blank}.
+Starting with FastAPI version `0.122.0`, they use the more appropriate HTTP status code `401 Unauthorized`, and return a sensible `WWW-Authenticate` header in the response, following the HTTP specifications, [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235#section-3.1), [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-401-unauthorized).
 
 But if for some reason your clients depend on the old behavior, you can revert to it by overriding the method `make_not_authenticated_error` in your security classes.
 

--- a/docs/en/docs/how-to/authentication-error-status-code.md
+++ b/docs/en/docs/how-to/authentication-error-status-code.md
@@ -2,7 +2,7 @@
 
 Before FastAPI version `0.122.0`, when the integrated security utilities returned an error to the client after a failed authentication, they used the HTTP status code `403 Forbidden`.
 
-Starting with FastAPI version `0.122.0`, they use the more appropriate HTTP status code `401 Unauthorized`, and return a sensible `WWW-Authenticate` header in the response, following the HTTP specifications, <a href="https://datatracker.ietf.org/doc/html/rfc7235#section-3.1" class="external-link" target="_blank">RFC 7235</a>, <a href="https://datatracker.ietf.org/doc/html/rfc9110#name-401-unauthorized" class="external-link" target="_blank">RFC 9110</a>.
+Starting with FastAPI version `0.122.0`, they use the more appropriate HTTP status code `401 Unauthorized`, and return a sensible `WWW-Authenticate` header in the response, following the HTTP specifications, [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235#section-3.1){target=_blank}, [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-401-unauthorized){target=_blank}.
 
 But if for some reason your clients depend on the old behavior, you can revert to it by overriding the method `make_not_authenticated_error` in your security classes.
 

--- a/docs/en/docs/how-to/conditional-openapi.md
+++ b/docs/en/docs/how-to/conditional-openapi.md
@@ -10,7 +10,7 @@ That doesn't add any extra security to your API, the *path operations* will stil
 
 If there's a security flaw in your code, it will still exist.
 
-Hiding the documentation just makes it more difficult to understand how to interact with your API, and could make it more difficult for you to debug it in production. It could be considered simply a form of [Security through obscurity](https://en.wikipedia.org/wiki/Security_through_obscurity){target=_blank}.
+Hiding the documentation just makes it more difficult to understand how to interact with your API, and could make it more difficult for you to debug it in production. It could be considered simply a form of [Security through obscurity](https://en.wikipedia.org/wiki/Security_through_obscurity).
 
 If you want to secure your API, there are several better things you can do, for example:
 

--- a/docs/en/docs/how-to/conditional-openapi.md
+++ b/docs/en/docs/how-to/conditional-openapi.md
@@ -10,7 +10,7 @@ That doesn't add any extra security to your API, the *path operations* will stil
 
 If there's a security flaw in your code, it will still exist.
 
-Hiding the documentation just makes it more difficult to understand how to interact with your API, and could make it more difficult for you to debug it in production. It could be considered simply a form of <a href="https://en.wikipedia.org/wiki/Security_through_obscurity" class="external-link" target="_blank">Security through obscurity</a>.
+Hiding the documentation just makes it more difficult to understand how to interact with your API, and could make it more difficult for you to debug it in production. It could be considered simply a form of [Security through obscurity](https://en.wikipedia.org/wiki/Security_through_obscurity){target=_blank}.
 
 If you want to secure your API, there are several better things you can do, for example:
 

--- a/docs/en/docs/how-to/configure-swagger-ui.md
+++ b/docs/en/docs/how-to/configure-swagger-ui.md
@@ -1,6 +1,6 @@
 # Configure Swagger UI { #configure-swagger-ui }
 
-You can configure some extra [Swagger UI parameters](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/){target=_blank}.
+You can configure some extra [Swagger UI parameters](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/).
 
 To configure them, pass the `swagger_ui_parameters` argument when creating the `FastAPI()` app object or to the `get_swagger_ui_html()` function.
 
@@ -50,7 +50,7 @@ For example, to disable `deepLinking` you could pass these settings to `swagger_
 
 ## Other Swagger UI Parameters { #other-swagger-ui-parameters }
 
-To see all the other possible configurations you can use, read the official [docs for Swagger UI parameters](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/){target=_blank}.
+To see all the other possible configurations you can use, read the official [docs for Swagger UI parameters](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/).
 
 ## JavaScript-only settings { #javascript-only-settings }
 

--- a/docs/en/docs/how-to/configure-swagger-ui.md
+++ b/docs/en/docs/how-to/configure-swagger-ui.md
@@ -1,6 +1,6 @@
 # Configure Swagger UI { #configure-swagger-ui }
 
-You can configure some extra <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">Swagger UI parameters</a>.
+You can configure some extra [Swagger UI parameters](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/){target=_blank}.
 
 To configure them, pass the `swagger_ui_parameters` argument when creating the `FastAPI()` app object or to the `get_swagger_ui_html()` function.
 
@@ -50,7 +50,7 @@ For example, to disable `deepLinking` you could pass these settings to `swagger_
 
 ## Other Swagger UI Parameters { #other-swagger-ui-parameters }
 
-To see all the other possible configurations you can use, read the official <a href="https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/" class="external-link" target="_blank">docs for Swagger UI parameters</a>.
+To see all the other possible configurations you can use, read the official [docs for Swagger UI parameters](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/){target=_blank}.
 
 ## JavaScript-only settings { #javascript-only-settings }
 

--- a/docs/en/docs/how-to/custom-docs-ui-assets.md
+++ b/docs/en/docs/how-to/custom-docs-ui-assets.md
@@ -54,7 +54,7 @@ Now, to be able to test that everything works, create a *path operation*:
 
 ### Test it { #test-it }
 
-Now, you should be able to go to your docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}, and reload the page, it will load those assets from the new CDN.
+Now, you should be able to go to your docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs), and reload the page, it will load those assets from the new CDN.
 
 ## Self-hosting JavaScript and CSS for docs { #self-hosting-javascript-and-css-for-docs }
 
@@ -93,12 +93,12 @@ You can probably right-click each link and select an option similar to "Save lin
 
 **Swagger UI** uses the files:
 
-* [`swagger-ui-bundle.js`](https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js){target=_blank}
-* [`swagger-ui.css`](https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css){target=_blank}
+* [`swagger-ui-bundle.js`](https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js)
+* [`swagger-ui.css`](https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css)
 
 And **ReDoc** uses the file:
 
-* [`redoc.standalone.js`](https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js){target=_blank}
+* [`redoc.standalone.js`](https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js)
 
 After that, your file structure could look like:
 
@@ -122,7 +122,7 @@ After that, your file structure could look like:
 
 ### Test the static files { #test-the-static-files }
 
-Start your application and go to [http://127.0.0.1:8000/static/redoc.standalone.js](http://127.0.0.1:8000/static/redoc.standalone.js){target=_blank}.
+Start your application and go to [http://127.0.0.1:8000/static/redoc.standalone.js](http://127.0.0.1:8000/static/redoc.standalone.js).
 
 You should see a very long JavaScript file for **ReDoc**.
 
@@ -180,6 +180,6 @@ Now, to be able to test that everything works, create a *path operation*:
 
 ### Test Static Files UI { #test-static-files-ui }
 
-Now, you should be able to disconnect your WiFi, go to your docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}, and reload the page.
+Now, you should be able to disconnect your WiFi, go to your docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs), and reload the page.
 
 And even without Internet, you would be able to see the docs for your API and interact with it.

--- a/docs/en/docs/how-to/custom-docs-ui-assets.md
+++ b/docs/en/docs/how-to/custom-docs-ui-assets.md
@@ -54,7 +54,7 @@ Now, to be able to test that everything works, create a *path operation*:
 
 ### Test it { #test-it }
 
-Now, you should be able to go to your docs at <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>, and reload the page, it will load those assets from the new CDN.
+Now, you should be able to go to your docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}, and reload the page, it will load those assets from the new CDN.
 
 ## Self-hosting JavaScript and CSS for docs { #self-hosting-javascript-and-css-for-docs }
 
@@ -93,12 +93,12 @@ You can probably right-click each link and select an option similar to "Save lin
 
 **Swagger UI** uses the files:
 
-* <a href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js" class="external-link" target="_blank">`swagger-ui-bundle.js`</a>
-* <a href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" class="external-link" target="_blank">`swagger-ui.css`</a>
+* [`swagger-ui-bundle.js`](https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js){target=_blank}
+* [`swagger-ui.css`](https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css){target=_blank}
 
 And **ReDoc** uses the file:
 
-* <a href="https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js" class="external-link" target="_blank">`redoc.standalone.js`</a>
+* [`redoc.standalone.js`](https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js){target=_blank}
 
 After that, your file structure could look like:
 
@@ -122,7 +122,7 @@ After that, your file structure could look like:
 
 ### Test the static files { #test-the-static-files }
 
-Start your application and go to <a href="http://127.0.0.1:8000/static/redoc.standalone.js" class="external-link" target="_blank">http://127.0.0.1:8000/static/redoc.standalone.js</a>.
+Start your application and go to [http://127.0.0.1:8000/static/redoc.standalone.js](http://127.0.0.1:8000/static/redoc.standalone.js){target=_blank}.
 
 You should see a very long JavaScript file for **ReDoc**.
 
@@ -180,6 +180,6 @@ Now, to be able to test that everything works, create a *path operation*:
 
 ### Test Static Files UI { #test-static-files-ui }
 
-Now, you should be able to disconnect your WiFi, go to your docs at <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>, and reload the page.
+Now, you should be able to disconnect your WiFi, go to your docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}, and reload the page.
 
 And even without Internet, you would be able to see the docs for your API and interact with it.

--- a/docs/en/docs/how-to/custom-request-and-route.md
+++ b/docs/en/docs/how-to/custom-request-and-route.md
@@ -18,7 +18,7 @@ If you are just starting with **FastAPI** you might want to skip this section.
 
 Some use cases include:
 
-* Converting non-JSON request bodies to JSON (e.g. <a href="https://msgpack.org/index.html" class="external-link" target="_blank">`msgpack`</a>).
+* Converting non-JSON request bodies to JSON (e.g. [`msgpack`](https://msgpack.org/index.html){target=_blank}).
 * Decompressing gzip-compressed request bodies.
 * Automatically logging all request bodies.
 
@@ -32,7 +32,7 @@ And an `APIRoute` subclass to use that custom request class.
 
 /// tip
 
-This is a toy example to demonstrate how it works, if you need Gzip support, you can use the provided [`GzipMiddleware`](../advanced/middleware.md#gzipmiddleware){.internal-link target=_blank}.
+This is a toy example to demonstrate how it works, if you need Gzip support, you can use the provided [`GzipMiddleware`](../advanced/middleware.md#gzipmiddleware){target=_blank}.
 
 ///
 
@@ -66,7 +66,7 @@ The `scope` `dict` and `receive` function are both part of the ASGI specificatio
 
 And those two things, `scope` and `receive`, are what is needed to create a new `Request` instance.
 
-To learn more about the `Request` check <a href="https://www.starlette.dev/requests/" class="external-link" target="_blank">Starlette's docs about Requests</a>.
+To learn more about the `Request` check [Starlette's docs about Requests](https://www.starlette.dev/requests/){target=_blank}.
 
 ///
 
@@ -82,7 +82,7 @@ But because of our changes in `GzipRequest.body`, the request body will be autom
 
 /// tip
 
-To solve this same problem, it's probably a lot easier to use the `body` in a custom handler for `RequestValidationError` ([Handling Errors](../tutorial/handling-errors.md#use-the-requestvalidationerror-body){.internal-link target=_blank}).
+To solve this same problem, it's probably a lot easier to use the `body` in a custom handler for `RequestValidationError` ([Handling Errors](../tutorial/handling-errors.md#use-the-requestvalidationerror-body){target=_blank}).
 
 But this example is still valid and it shows how to interact with the internal components.
 

--- a/docs/en/docs/how-to/custom-request-and-route.md
+++ b/docs/en/docs/how-to/custom-request-and-route.md
@@ -18,7 +18,7 @@ If you are just starting with **FastAPI** you might want to skip this section.
 
 Some use cases include:
 
-* Converting non-JSON request bodies to JSON (e.g. [`msgpack`](https://msgpack.org/index.html){target=_blank}).
+* Converting non-JSON request bodies to JSON (e.g. [`msgpack`](https://msgpack.org/index.html)).
 * Decompressing gzip-compressed request bodies.
 * Automatically logging all request bodies.
 
@@ -32,7 +32,7 @@ And an `APIRoute` subclass to use that custom request class.
 
 /// tip
 
-This is a toy example to demonstrate how it works, if you need Gzip support, you can use the provided [`GzipMiddleware`](../advanced/middleware.md#gzipmiddleware){target=_blank}.
+This is a toy example to demonstrate how it works, if you need Gzip support, you can use the provided [`GzipMiddleware`](../advanced/middleware.md#gzipmiddleware).
 
 ///
 
@@ -66,7 +66,7 @@ The `scope` `dict` and `receive` function are both part of the ASGI specificatio
 
 And those two things, `scope` and `receive`, are what is needed to create a new `Request` instance.
 
-To learn more about the `Request` check [Starlette's docs about Requests](https://www.starlette.dev/requests/){target=_blank}.
+To learn more about the `Request` check [Starlette's docs about Requests](https://www.starlette.dev/requests/).
 
 ///
 
@@ -82,7 +82,7 @@ But because of our changes in `GzipRequest.body`, the request body will be autom
 
 /// tip
 
-To solve this same problem, it's probably a lot easier to use the `body` in a custom handler for `RequestValidationError` ([Handling Errors](../tutorial/handling-errors.md#use-the-requestvalidationerror-body){target=_blank}).
+To solve this same problem, it's probably a lot easier to use the `body` in a custom handler for `RequestValidationError` ([Handling Errors](../tutorial/handling-errors.md#use-the-requestvalidationerror-body)).
 
 But this example is still valid and it shows how to interact with the internal components.
 

--- a/docs/en/docs/how-to/extending-openapi.md
+++ b/docs/en/docs/how-to/extending-openapi.md
@@ -37,7 +37,7 @@ The parameter `summary` is available in OpenAPI 3.1.0 and above, supported by Fa
 
 Using the information above, you can use the same utility function to generate the OpenAPI schema and override each part that you need.
 
-For example, let's add [ReDoc's OpenAPI extension to include a custom logo](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md#x-logo){target=_blank}.
+For example, let's add [ReDoc's OpenAPI extension to include a custom logo](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md#x-logo).
 
 ### Normal **FastAPI** { #normal-fastapi }
 
@@ -75,6 +75,6 @@ Now you can replace the `.openapi()` method with your new function.
 
 ### Check it { #check-it }
 
-Once you go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc){target=_blank} you will see that you are using your custom logo (in this example, **FastAPI**'s logo):
+Once you go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc) you will see that you are using your custom logo (in this example, **FastAPI**'s logo):
 
 <img src="/img/tutorial/extending-openapi/image01.png">

--- a/docs/en/docs/how-to/extending-openapi.md
+++ b/docs/en/docs/how-to/extending-openapi.md
@@ -37,7 +37,7 @@ The parameter `summary` is available in OpenAPI 3.1.0 and above, supported by Fa
 
 Using the information above, you can use the same utility function to generate the OpenAPI schema and override each part that you need.
 
-For example, let's add <a href="https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md#x-logo" class="external-link" target="_blank">ReDoc's OpenAPI extension to include a custom logo</a>.
+For example, let's add [ReDoc's OpenAPI extension to include a custom logo](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md#x-logo){target=_blank}.
 
 ### Normal **FastAPI** { #normal-fastapi }
 
@@ -75,6 +75,6 @@ Now you can replace the `.openapi()` method with your new function.
 
 ### Check it { #check-it }
 
-Once you go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a> you will see that you are using your custom logo (in this example, **FastAPI**'s logo):
+Once you go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc){target=_blank} you will see that you are using your custom logo (in this example, **FastAPI**'s logo):
 
 <img src="/img/tutorial/extending-openapi/image01.png">

--- a/docs/en/docs/how-to/general.md
+++ b/docs/en/docs/how-to/general.md
@@ -4,40 +4,40 @@ Here are several pointers to other places in the docs, for general or frequent q
 
 ## Filter Data - Security { #filter-data-security }
 
-To ensure that you don't return more data than you should, read the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md){.internal-link target=_blank}.
+To ensure that you don't return more data than you should, read the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md){target=_blank}.
 
 ## Optimize Response Performance - Response Model - Return Type { #optimize-response-performance-response-model-return-type }
 
-To optimize performance when returning JSON data, use a return type or response model, that way Pydantic will handle the serialization to JSON on the Rust side, without going through Python. Read more in the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md){.internal-link target=_blank}.
+To optimize performance when returning JSON data, use a return type or response model, that way Pydantic will handle the serialization to JSON on the Rust side, without going through Python. Read more in the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md){target=_blank}.
 
 ## Documentation Tags - OpenAPI { #documentation-tags-openapi }
 
-To add tags to your *path operations*, and group them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Tags](../tutorial/path-operation-configuration.md#tags){.internal-link target=_blank}.
+To add tags to your *path operations*, and group them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Tags](../tutorial/path-operation-configuration.md#tags){target=_blank}.
 
 ## Documentation Summary and Description - OpenAPI { #documentation-summary-and-description-openapi }
 
-To add a summary and description to your *path operations*, and show them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Summary and Description](../tutorial/path-operation-configuration.md#summary-and-description){.internal-link target=_blank}.
+To add a summary and description to your *path operations*, and show them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Summary and Description](../tutorial/path-operation-configuration.md#summary-and-description){target=_blank}.
 
 ## Documentation Response description - OpenAPI { #documentation-response-description-openapi }
 
-To define the description of the response, shown in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Response description](../tutorial/path-operation-configuration.md#response-description){.internal-link target=_blank}.
+To define the description of the response, shown in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Response description](../tutorial/path-operation-configuration.md#response-description){target=_blank}.
 
 ## Documentation Deprecate a *Path Operation* - OpenAPI { #documentation-deprecate-a-path-operation-openapi }
 
-To deprecate a *path operation*, and show it in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Deprecation](../tutorial/path-operation-configuration.md#deprecate-a-path-operation){.internal-link target=_blank}.
+To deprecate a *path operation*, and show it in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Deprecation](../tutorial/path-operation-configuration.md#deprecate-a-path-operation){target=_blank}.
 
 ## Convert any Data to JSON-compatible { #convert-any-data-to-json-compatible }
 
-To convert any data to JSON-compatible, read the docs for [Tutorial - JSON Compatible Encoder](../tutorial/encoder.md){.internal-link target=_blank}.
+To convert any data to JSON-compatible, read the docs for [Tutorial - JSON Compatible Encoder](../tutorial/encoder.md){target=_blank}.
 
 ## OpenAPI Metadata - Docs { #openapi-metadata-docs }
 
-To add metadata to your OpenAPI schema, including a license, version, contact, etc, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md){.internal-link target=_blank}.
+To add metadata to your OpenAPI schema, including a license, version, contact, etc, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md){target=_blank}.
 
 ## OpenAPI Custom URL { #openapi-custom-url }
 
-To customize the OpenAPI URL (or remove it), read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#openapi-url){.internal-link target=_blank}.
+To customize the OpenAPI URL (or remove it), read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#openapi-url){target=_blank}.
 
 ## OpenAPI Docs URLs { #openapi-docs-urls }
 
-To update the URLs used for the automatically generated docs user interfaces, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#docs-urls){.internal-link target=_blank}.
+To update the URLs used for the automatically generated docs user interfaces, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#docs-urls){target=_blank}.

--- a/docs/en/docs/how-to/general.md
+++ b/docs/en/docs/how-to/general.md
@@ -4,40 +4,40 @@ Here are several pointers to other places in the docs, for general or frequent q
 
 ## Filter Data - Security { #filter-data-security }
 
-To ensure that you don't return more data than you should, read the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md){target=_blank}.
+To ensure that you don't return more data than you should, read the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md).
 
 ## Optimize Response Performance - Response Model - Return Type { #optimize-response-performance-response-model-return-type }
 
-To optimize performance when returning JSON data, use a return type or response model, that way Pydantic will handle the serialization to JSON on the Rust side, without going through Python. Read more in the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md){target=_blank}.
+To optimize performance when returning JSON data, use a return type or response model, that way Pydantic will handle the serialization to JSON on the Rust side, without going through Python. Read more in the docs for [Tutorial - Response Model - Return Type](../tutorial/response-model.md).
 
 ## Documentation Tags - OpenAPI { #documentation-tags-openapi }
 
-To add tags to your *path operations*, and group them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Tags](../tutorial/path-operation-configuration.md#tags){target=_blank}.
+To add tags to your *path operations*, and group them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Tags](../tutorial/path-operation-configuration.md#tags).
 
 ## Documentation Summary and Description - OpenAPI { #documentation-summary-and-description-openapi }
 
-To add a summary and description to your *path operations*, and show them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Summary and Description](../tutorial/path-operation-configuration.md#summary-and-description){target=_blank}.
+To add a summary and description to your *path operations*, and show them in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Summary and Description](../tutorial/path-operation-configuration.md#summary-and-description).
 
 ## Documentation Response description - OpenAPI { #documentation-response-description-openapi }
 
-To define the description of the response, shown in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Response description](../tutorial/path-operation-configuration.md#response-description){target=_blank}.
+To define the description of the response, shown in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Response description](../tutorial/path-operation-configuration.md#response-description).
 
 ## Documentation Deprecate a *Path Operation* - OpenAPI { #documentation-deprecate-a-path-operation-openapi }
 
-To deprecate a *path operation*, and show it in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Deprecation](../tutorial/path-operation-configuration.md#deprecate-a-path-operation){target=_blank}.
+To deprecate a *path operation*, and show it in the docs UI, read the docs for [Tutorial - Path Operation Configurations - Deprecation](../tutorial/path-operation-configuration.md#deprecate-a-path-operation).
 
 ## Convert any Data to JSON-compatible { #convert-any-data-to-json-compatible }
 
-To convert any data to JSON-compatible, read the docs for [Tutorial - JSON Compatible Encoder](../tutorial/encoder.md){target=_blank}.
+To convert any data to JSON-compatible, read the docs for [Tutorial - JSON Compatible Encoder](../tutorial/encoder.md).
 
 ## OpenAPI Metadata - Docs { #openapi-metadata-docs }
 
-To add metadata to your OpenAPI schema, including a license, version, contact, etc, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md){target=_blank}.
+To add metadata to your OpenAPI schema, including a license, version, contact, etc, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md).
 
 ## OpenAPI Custom URL { #openapi-custom-url }
 
-To customize the OpenAPI URL (or remove it), read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#openapi-url){target=_blank}.
+To customize the OpenAPI URL (or remove it), read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#openapi-url).
 
 ## OpenAPI Docs URLs { #openapi-docs-urls }
 
-To update the URLs used for the automatically generated docs user interfaces, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#docs-urls){target=_blank}.
+To update the URLs used for the automatically generated docs user interfaces, read the docs for [Tutorial - Metadata and Docs URLs](../tutorial/metadata.md#docs-urls).

--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -18,18 +18,18 @@ Make sure you evaluate if the **benefits** for your use case compensate the **dr
 
 Here are some of the **GraphQL** libraries that have **ASGI** support. You could use them with **FastAPI**:
 
-* <a href="https://strawberry.rocks/" class="external-link" target="_blank">Strawberry</a> 🍓
-    * With <a href="https://strawberry.rocks/docs/integrations/fastapi" class="external-link" target="_blank">docs for FastAPI</a>
-* <a href="https://ariadnegraphql.org/" class="external-link" target="_blank">Ariadne</a>
-    * With <a href="https://ariadnegraphql.org/docs/fastapi-integration" class="external-link" target="_blank">docs for FastAPI</a>
-* <a href="https://tartiflette.io/" class="external-link" target="_blank">Tartiflette</a>
-    * With <a href="https://tartiflette.github.io/tartiflette-asgi/" class="external-link" target="_blank">Tartiflette ASGI</a> to provide ASGI integration
-* <a href="https://graphene-python.org/" class="external-link" target="_blank">Graphene</a>
-    * With <a href="https://github.com/ciscorn/starlette-graphene3" class="external-link" target="_blank">starlette-graphene3</a>
+* [Strawberry](https://strawberry.rocks/){target=_blank} 🍓
+    * With [docs for FastAPI](https://strawberry.rocks/docs/integrations/fastapi){target=_blank}
+* [Ariadne](https://ariadnegraphql.org/){target=_blank}
+    * With [docs for FastAPI](https://ariadnegraphql.org/docs/fastapi-integration){target=_blank}
+* [Tartiflette](https://tartiflette.io/){target=_blank}
+    * With [Tartiflette ASGI](https://tartiflette.github.io/tartiflette-asgi/){target=_blank} to provide ASGI integration
+* [Graphene](https://graphene-python.org/){target=_blank}
+    * With [starlette-graphene3](https://github.com/ciscorn/starlette-graphene3){target=_blank}
 
 ## GraphQL with Strawberry { #graphql-with-strawberry }
 
-If you need or want to work with **GraphQL**, <a href="https://strawberry.rocks/" class="external-link" target="_blank">**Strawberry**</a> is the **recommended** library as it has the design closest to **FastAPI's** design, it's all based on **type annotations**.
+If you need or want to work with **GraphQL**, [**Strawberry**](https://strawberry.rocks/){target=_blank} is the **recommended** library as it has the design closest to **FastAPI's** design, it's all based on **type annotations**.
 
 Depending on your use case, you might prefer to use a different library, but if you asked me, I would probably suggest you try **Strawberry**.
 
@@ -37,24 +37,24 @@ Here's a small preview of how you could integrate Strawberry with FastAPI:
 
 {* ../../docs_src/graphql_/tutorial001_py310.py hl[3,22,25] *}
 
-You can learn more about Strawberry in the <a href="https://strawberry.rocks/" class="external-link" target="_blank">Strawberry documentation</a>.
+You can learn more about Strawberry in the [Strawberry documentation](https://strawberry.rocks/){target=_blank}.
 
-And also the docs about <a href="https://strawberry.rocks/docs/integrations/fastapi" class="external-link" target="_blank">Strawberry with FastAPI</a>.
+And also the docs about [Strawberry with FastAPI](https://strawberry.rocks/docs/integrations/fastapi){target=_blank}.
 
 ## Older `GraphQLApp` from Starlette { #older-graphqlapp-from-starlette }
 
-Previous versions of Starlette included a `GraphQLApp` class to integrate with <a href="https://graphene-python.org/" class="external-link" target="_blank">Graphene</a>.
+Previous versions of Starlette included a `GraphQLApp` class to integrate with [Graphene](https://graphene-python.org/){target=_blank}.
 
-It was deprecated from Starlette, but if you have code that used it, you can easily **migrate** to <a href="https://github.com/ciscorn/starlette-graphene3" class="external-link" target="_blank">starlette-graphene3</a>, that covers the same use case and has an **almost identical interface**.
+It was deprecated from Starlette, but if you have code that used it, you can easily **migrate** to [starlette-graphene3](https://github.com/ciscorn/starlette-graphene3){target=_blank}, that covers the same use case and has an **almost identical interface**.
 
 /// tip
 
-If you need GraphQL, I still would recommend you check out <a href="https://strawberry.rocks/" class="external-link" target="_blank">Strawberry</a>, as it's based on type annotations instead of custom classes and types.
+If you need GraphQL, I still would recommend you check out [Strawberry](https://strawberry.rocks/){target=_blank}, as it's based on type annotations instead of custom classes and types.
 
 ///
 
 ## Learn More { #learn-more }
 
-You can learn more about **GraphQL** in the <a href="https://graphql.org/" class="external-link" target="_blank">official GraphQL documentation</a>.
+You can learn more about **GraphQL** in the [official GraphQL documentation](https://graphql.org/){target=_blank}.
 
 You can also read more about each those libraries described above in their links.

--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -18,18 +18,18 @@ Make sure you evaluate if the **benefits** for your use case compensate the **dr
 
 Here are some of the **GraphQL** libraries that have **ASGI** support. You could use them with **FastAPI**:
 
-* [Strawberry](https://strawberry.rocks/){target=_blank} 🍓
-    * With [docs for FastAPI](https://strawberry.rocks/docs/integrations/fastapi){target=_blank}
-* [Ariadne](https://ariadnegraphql.org/){target=_blank}
-    * With [docs for FastAPI](https://ariadnegraphql.org/docs/fastapi-integration){target=_blank}
-* [Tartiflette](https://tartiflette.io/){target=_blank}
-    * With [Tartiflette ASGI](https://tartiflette.github.io/tartiflette-asgi/){target=_blank} to provide ASGI integration
-* [Graphene](https://graphene-python.org/){target=_blank}
-    * With [starlette-graphene3](https://github.com/ciscorn/starlette-graphene3){target=_blank}
+* [Strawberry](https://strawberry.rocks/) 🍓
+    * With [docs for FastAPI](https://strawberry.rocks/docs/integrations/fastapi)
+* [Ariadne](https://ariadnegraphql.org/)
+    * With [docs for FastAPI](https://ariadnegraphql.org/docs/fastapi-integration)
+* [Tartiflette](https://tartiflette.io/)
+    * With [Tartiflette ASGI](https://tartiflette.github.io/tartiflette-asgi/) to provide ASGI integration
+* [Graphene](https://graphene-python.org/)
+    * With [starlette-graphene3](https://github.com/ciscorn/starlette-graphene3)
 
 ## GraphQL with Strawberry { #graphql-with-strawberry }
 
-If you need or want to work with **GraphQL**, [**Strawberry**](https://strawberry.rocks/){target=_blank} is the **recommended** library as it has the design closest to **FastAPI's** design, it's all based on **type annotations**.
+If you need or want to work with **GraphQL**, [**Strawberry**](https://strawberry.rocks/) is the **recommended** library as it has the design closest to **FastAPI's** design, it's all based on **type annotations**.
 
 Depending on your use case, you might prefer to use a different library, but if you asked me, I would probably suggest you try **Strawberry**.
 
@@ -37,24 +37,24 @@ Here's a small preview of how you could integrate Strawberry with FastAPI:
 
 {* ../../docs_src/graphql_/tutorial001_py310.py hl[3,22,25] *}
 
-You can learn more about Strawberry in the [Strawberry documentation](https://strawberry.rocks/){target=_blank}.
+You can learn more about Strawberry in the [Strawberry documentation](https://strawberry.rocks/).
 
-And also the docs about [Strawberry with FastAPI](https://strawberry.rocks/docs/integrations/fastapi){target=_blank}.
+And also the docs about [Strawberry with FastAPI](https://strawberry.rocks/docs/integrations/fastapi).
 
 ## Older `GraphQLApp` from Starlette { #older-graphqlapp-from-starlette }
 
-Previous versions of Starlette included a `GraphQLApp` class to integrate with [Graphene](https://graphene-python.org/){target=_blank}.
+Previous versions of Starlette included a `GraphQLApp` class to integrate with [Graphene](https://graphene-python.org/).
 
-It was deprecated from Starlette, but if you have code that used it, you can easily **migrate** to [starlette-graphene3](https://github.com/ciscorn/starlette-graphene3){target=_blank}, that covers the same use case and has an **almost identical interface**.
+It was deprecated from Starlette, but if you have code that used it, you can easily **migrate** to [starlette-graphene3](https://github.com/ciscorn/starlette-graphene3), that covers the same use case and has an **almost identical interface**.
 
 /// tip
 
-If you need GraphQL, I still would recommend you check out [Strawberry](https://strawberry.rocks/){target=_blank}, as it's based on type annotations instead of custom classes and types.
+If you need GraphQL, I still would recommend you check out [Strawberry](https://strawberry.rocks/), as it's based on type annotations instead of custom classes and types.
 
 ///
 
 ## Learn More { #learn-more }
 
-You can learn more about **GraphQL** in the [official GraphQL documentation](https://graphql.org/){target=_blank}.
+You can learn more about **GraphQL** in the [official GraphQL documentation](https://graphql.org/).
 
 You can also read more about each those libraries described above in their links.

--- a/docs/en/docs/how-to/index.md
+++ b/docs/en/docs/how-to/index.md
@@ -8,6 +8,6 @@ If something seems interesting and useful to your project, go ahead and check it
 
 /// tip
 
-If you want to **learn FastAPI** in a structured way (recommended), go and read the [Tutorial - User Guide](../tutorial/index.md){.internal-link target=_blank} chapter by chapter instead.
+If you want to **learn FastAPI** in a structured way (recommended), go and read the [Tutorial - User Guide](../tutorial/index.md){target=_blank} chapter by chapter instead.
 
 ///

--- a/docs/en/docs/how-to/index.md
+++ b/docs/en/docs/how-to/index.md
@@ -8,6 +8,6 @@ If something seems interesting and useful to your project, go ahead and check it
 
 /// tip
 
-If you want to **learn FastAPI** in a structured way (recommended), go and read the [Tutorial - User Guide](../tutorial/index.md){target=_blank} chapter by chapter instead.
+If you want to **learn FastAPI** in a structured way (recommended), go and read the [Tutorial - User Guide](../tutorial/index.md) chapter by chapter instead.
 
 ///

--- a/docs/en/docs/how-to/migrate-from-pydantic-v1-to-pydantic-v2.md
+++ b/docs/en/docs/how-to/migrate-from-pydantic-v1-to-pydantic-v2.md
@@ -22,7 +22,7 @@ If you have an old FastAPI app with Pydantic v1, here I'll show you how to migra
 
 ## Official Guide { #official-guide }
 
-Pydantic has an official [Migration Guide](https://docs.pydantic.dev/latest/migration/){target=_blank} from v1 to v2.
+Pydantic has an official [Migration Guide](https://docs.pydantic.dev/latest/migration/) from v1 to v2.
 
 It also includes what has changed, how validations are now more correct and strict, possible caveats, etc.
 
@@ -30,7 +30,7 @@ You can read it to understand better what has changed.
 
 ## Tests { #tests }
 
-Make sure you have [tests](../tutorial/testing.md){target=_blank} for your app and you run them on continuous integration (CI).
+Make sure you have [tests](../tutorial/testing.md) for your app and you run them on continuous integration (CI).
 
 This way, you can do the upgrade and make sure everything is still working as expected.
 
@@ -38,7 +38,7 @@ This way, you can do the upgrade and make sure everything is still working as ex
 
 In many cases, when you use regular Pydantic models without customizations, you will be able to automate most of the process of migrating from Pydantic v1 to Pydantic v2.
 
-You can use [`bump-pydantic`](https://github.com/pydantic/bump-pydantic){target=_blank} from the same Pydantic team.
+You can use [`bump-pydantic`](https://github.com/pydantic/bump-pydantic) from the same Pydantic team.
 
 This tool will help you to automatically change most of the code that needs to be changed.
 

--- a/docs/en/docs/how-to/migrate-from-pydantic-v1-to-pydantic-v2.md
+++ b/docs/en/docs/how-to/migrate-from-pydantic-v1-to-pydantic-v2.md
@@ -22,7 +22,7 @@ If you have an old FastAPI app with Pydantic v1, here I'll show you how to migra
 
 ## Official Guide { #official-guide }
 
-Pydantic has an official <a href="https://docs.pydantic.dev/latest/migration/" class="external-link" target="_blank">Migration Guide</a> from v1 to v2.
+Pydantic has an official [Migration Guide](https://docs.pydantic.dev/latest/migration/){target=_blank} from v1 to v2.
 
 It also includes what has changed, how validations are now more correct and strict, possible caveats, etc.
 
@@ -30,7 +30,7 @@ You can read it to understand better what has changed.
 
 ## Tests { #tests }
 
-Make sure you have [tests](../tutorial/testing.md){.internal-link target=_blank} for your app and you run them on continuous integration (CI).
+Make sure you have [tests](../tutorial/testing.md){target=_blank} for your app and you run them on continuous integration (CI).
 
 This way, you can do the upgrade and make sure everything is still working as expected.
 
@@ -38,7 +38,7 @@ This way, you can do the upgrade and make sure everything is still working as ex
 
 In many cases, when you use regular Pydantic models without customizations, you will be able to automate most of the process of migrating from Pydantic v1 to Pydantic v2.
 
-You can use <a href="https://github.com/pydantic/bump-pydantic" class="external-link" target="_blank">`bump-pydantic`</a> from the same Pydantic team.
+You can use [`bump-pydantic`](https://github.com/pydantic/bump-pydantic){target=_blank} from the same Pydantic team.
 
 This tool will help you to automatically change most of the code that needs to be changed.
 

--- a/docs/en/docs/how-to/testing-database.md
+++ b/docs/en/docs/how-to/testing-database.md
@@ -1,7 +1,7 @@
 # Testing a Database { #testing-a-database }
 
-You can study about databases, SQL, and SQLModel in the <a href="https://sqlmodel.tiangolo.com/" class="external-link" target="_blank">SQLModel docs</a>. 🤓
+You can study about databases, SQL, and SQLModel in the [SQLModel docs](https://sqlmodel.tiangolo.com/){target=_blank}. 🤓
 
-There's a mini <a href="https://sqlmodel.tiangolo.com/tutorial/fastapi/" class="external-link" target="_blank">tutorial on using SQLModel with FastAPI</a>. ✨
+There's a mini [tutorial on using SQLModel with FastAPI](https://sqlmodel.tiangolo.com/tutorial/fastapi/){target=_blank}. ✨
 
-That tutorial includes a section about <a href="https://sqlmodel.tiangolo.com/tutorial/fastapi/tests/" class="external-link" target="_blank">testing SQL databases</a>. 😎
+That tutorial includes a section about [testing SQL databases](https://sqlmodel.tiangolo.com/tutorial/fastapi/tests/){target=_blank}. 😎

--- a/docs/en/docs/how-to/testing-database.md
+++ b/docs/en/docs/how-to/testing-database.md
@@ -1,7 +1,7 @@
 # Testing a Database { #testing-a-database }
 
-You can study about databases, SQL, and SQLModel in the [SQLModel docs](https://sqlmodel.tiangolo.com/){target=_blank}. 🤓
+You can study about databases, SQL, and SQLModel in the [SQLModel docs](https://sqlmodel.tiangolo.com/). 🤓
 
-There's a mini [tutorial on using SQLModel with FastAPI](https://sqlmodel.tiangolo.com/tutorial/fastapi/){target=_blank}. ✨
+There's a mini [tutorial on using SQLModel with FastAPI](https://sqlmodel.tiangolo.com/tutorial/fastapi/). ✨
 
-That tutorial includes a section about [testing SQL databases](https://sqlmodel.tiangolo.com/tutorial/fastapi/tests/){target=_blank}. 😎
+That tutorial includes a section about [testing SQL databases](https://sqlmodel.tiangolo.com/tutorial/fastapi/tests/). 😎

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -44,7 +44,7 @@ The key features are:
 * **Easy**: Designed to be easy to use and learn. Less time reading docs.
 * **Short**: Minimize code duplication. Multiple features from each parameter declaration. Fewer bugs.
 * **Robust**: Get production-ready code. With automatic interactive documentation.
-* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> (previously known as Swagger) and <a href="https://json-schema.org/" class="external-link" target="_blank">JSON Schema</a>.
+* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: <a href="https://github.com/OAI/OpenAPI-Specification" target="_blank">OpenAPI</a> (previously known as Swagger) and <a href="https://json-schema.org/" target="_blank">JSON Schema</a>.
 
 <small>* estimation based on tests conducted by an internal development team, building production applications.</small>
 
@@ -69,7 +69,7 @@ The key features are:
 
 <!-- /sponsors -->
 
-<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" class="external-link" target="_blank">Other sponsors</a>
+<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" target="_blank">Other sponsors</a>
 
 ## Opinions { #opinions }
 
@@ -119,7 +119,7 @@ The key features are:
 
 ## FastAPI mini documentary { #fastapi-mini-documentary }
 
-There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" class="external-link" target="_blank">FastAPI mini documentary</a> released at the end of 2025, you can watch it online:
+There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank">FastAPI mini documentary</a> released at the end of 2025, you can watch it online:
 
 <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
 
@@ -127,7 +127,7 @@ There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" class="external-
 
 <a href="https://typer.tiangolo.com" target="_blank"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" style="width: 20%;"></a>
 
-If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out <a href="https://typer.tiangolo.com/" class="external-link" target="_blank">**Typer**</a>.
+If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out <a href="https://typer.tiangolo.com/" target="_blank">**Typer**</a>.
 
 **Typer** is FastAPI's little sibling. And it's intended to be the **FastAPI of CLIs**. ⌨️ 🚀
 
@@ -135,12 +135,12 @@ If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be 
 
 FastAPI stands on the shoulders of giants:
 
-* <a href="https://www.starlette.dev/" class="external-link" target="_blank">Starlette</a> for the web parts.
-* <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> for the data parts.
+* <a href="https://www.starlette.dev/" target="_blank">Starlette</a> for the web parts.
+* <a href="https://docs.pydantic.dev/" target="_blank">Pydantic</a> for the data parts.
 
 ## Installation { #installation }
 
-Create and activate a <a href="https://fastapi.tiangolo.com/virtual-environments/" class="external-link" target="_blank">virtual environment</a> and then install FastAPI:
+Create and activate a <a href="https://fastapi.tiangolo.com/virtual-environments/" target="_blank">virtual environment</a> and then install FastAPI:
 
 <div class="termy">
 
@@ -237,7 +237,7 @@ INFO:     Application startup complete.
 <details markdown="1">
 <summary>About the command <code>fastapi dev main.py</code>...</summary>
 
-The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using <a href="https://www.uvicorn.dev" class="external-link" target="_blank">Uvicorn</a>.
+The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using <a href="https://www.uvicorn.dev" target="_blank">Uvicorn</a>.
 
 By default, `fastapi dev` will start with auto-reload enabled for local development.
 
@@ -247,7 +247,7 @@ You can read more about it in the <a href="https://fastapi.tiangolo.com/fastapi-
 
 ### Check it { #check-it }
 
-Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" class="external-link" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.
+Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.
 
 You will see the JSON response as:
 
@@ -264,17 +264,17 @@ You already created an API that:
 
 ### Interactive API docs { #interactive-api-docs }
 
-Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
 
-You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" target="_blank">Swagger UI</a>):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ### Alternative API docs { #alternative-api-docs }
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
 
-You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
+You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" target="_blank">ReDoc</a>):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -316,7 +316,7 @@ The `fastapi dev` server should reload automatically.
 
 ### Interactive API docs upgrade { #interactive-api-docs-upgrade }
 
-Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
 
 * The interactive API documentation will be automatically updated, including the new body:
 
@@ -332,7 +332,7 @@ Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_bl
 
 ### Alternative API docs upgrade { #alternative-api-docs-upgrade }
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
 
 * The alternative documentation will also reflect the new query parameter and body:
 
@@ -442,7 +442,7 @@ For a more complete example including more features, see the <a href="https://fa
 * A very powerful and easy to use **<dfn title="also known as components, resources, providers, services, injectables">Dependency Injection</dfn>** system.
 * Security and authentication, including support for **OAuth2** with **JWT tokens** and **HTTP Basic** auth.
 * More advanced (but equally easy) techniques for declaring **deeply nested JSON models** (thanks to Pydantic).
-* **GraphQL** integration with <a href="https://strawberry.rocks" class="external-link" target="_blank">Strawberry</a> and other libraries.
+* **GraphQL** integration with <a href="https://strawberry.rocks" target="_blank">Strawberry</a> and other libraries.
 * Many extra features (thanks to Starlette) as:
     * **WebSockets**
     * extremely easy tests based on HTTPX and `pytest`
@@ -452,7 +452,7 @@ For a more complete example including more features, see the <a href="https://fa
 
 ### Deploy your app (optional) { #deploy-your-app-optional }
 
-You can optionally deploy your FastAPI app to <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>, go and join the waiting list if you haven't. 🚀
+You can optionally deploy your FastAPI app to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>, go and join the waiting list if you haven't. 🚀
 
 If you already have a **FastAPI Cloud** account (we invited you from the waiting list 😉), you can deploy your application with one command.
 
@@ -488,7 +488,7 @@ That's it! Now you can access your app at that URL. ✨
 
 #### About FastAPI Cloud { #about-fastapi-cloud }
 
-**<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
+**<a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 
@@ -504,9 +504,9 @@ Follow your cloud provider's guides to deploy FastAPI apps with them. 🤓
 
 ## Performance { #performance }
 
-Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" class="external-link" target="_blank">one of the fastest Python frameworks available</a>, only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
+Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" target="_blank">one of the fastest Python frameworks available</a>, only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
 
-To understand more about it, see the section <a href="https://fastapi.tiangolo.com/benchmarks/" class="internal-link" target="_blank">Benchmarks</a>.
+To understand more about it, see the section <a href="https://fastapi.tiangolo.com/benchmarks/" target="_blank">Benchmarks</a>.
 
 ## Dependencies { #dependencies }
 
@@ -530,7 +530,7 @@ Used by FastAPI:
 
 * <a href="https://www.uvicorn.dev" target="_blank"><code>uvicorn</code></a> - for the server that loads and serves your application. This includes `uvicorn[standard]`, which includes some dependencies (e.g. `uvloop`) needed for high performance serving.
 * `fastapi-cli[standard]` - to provide the `fastapi` command.
-    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>.
+    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>.
 
 ### Without `standard` Dependencies { #without-standard-dependencies }
 

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -11,25 +11,25 @@
     <em>FastAPI framework, high performance, easy to learn, fast to code, ready for production</em>
 </p>
 <p align="center">
-<a href="https://github.com/fastapi/fastapi/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster" target="_blank">
+<a href="https://github.com/fastapi/fastapi/actions?query=workflow%3ATest+event%3Apush+branch%3Amaster">
     <img src="https://github.com/fastapi/fastapi/actions/workflows/test.yml/badge.svg?event=push&branch=master" alt="Test">
 </a>
-<a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi" target="_blank">
+<a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/fastapi">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/fastapi.svg" alt="Coverage">
 </a>
-<a href="https://pypi.org/project/fastapi" target="_blank">
+<a href="https://pypi.org/project/fastapi">
     <img src="https://img.shields.io/pypi/v/fastapi?color=%2334D058&label=pypi%20package" alt="Package version">
 </a>
-<a href="https://pypi.org/project/fastapi" target="_blank">
+<a href="https://pypi.org/project/fastapi">
     <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
 </a>
 </p>
 
 ---
 
-**Documentation**: <a href="https://fastapi.tiangolo.com" target="_blank">https://fastapi.tiangolo.com</a>
+**Documentation**: [https://fastapi.tiangolo.com](https://fastapi.tiangolo.com)
 
-**Source Code**: <a href="https://github.com/fastapi/fastapi" target="_blank">https://github.com/fastapi/fastapi</a>
+**Source Code**: [https://github.com/fastapi/fastapi](https://github.com/fastapi/fastapi)
 
 ---
 
@@ -44,7 +44,7 @@ The key features are:
 * **Easy**: Designed to be easy to use and learn. Less time reading docs.
 * **Short**: Minimize code duplication. Multiple features from each parameter declaration. Fewer bugs.
 * **Robust**: Get production-ready code. With automatic interactive documentation.
-* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: <a href="https://github.com/OAI/OpenAPI-Specification" target="_blank">OpenAPI</a> (previously known as Swagger) and <a href="https://json-schema.org/" target="_blank">JSON Schema</a>.
+* **Standards-based**: Based on (and fully compatible with) the open standards for APIs: [OpenAPI](https://github.com/OAI/OpenAPI-Specification) (previously known as Swagger) and [JSON Schema](https://json-schema.org/).
 
 <small>* estimation based on tests conducted by an internal development team, building production applications.</small>
 
@@ -55,51 +55,51 @@ The key features are:
 ### Keystone Sponsor { #keystone-sponsor }
 
 {% for sponsor in sponsors.keystone -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+<a href="{{ sponsor.url }}" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
 {% endfor -%}
 
 ### Gold and Silver Sponsors { #gold-and-silver-sponsors }
 
 {% for sponsor in sponsors.gold -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+<a href="{{ sponsor.url }}" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
 {% endfor -%}
 {%- for sponsor in sponsors.silver -%}
-<a href="{{ sponsor.url }}" target="_blank" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
+<a href="{{ sponsor.url }}" title="{{ sponsor.title }}"><img src="{{ sponsor.img }}" style="border-radius:15px"></a>
 {% endfor %}
 
 <!-- /sponsors -->
 
-<a href="https://fastapi.tiangolo.com/fastapi-people/#sponsors" target="_blank">Other sponsors</a>
+[Other sponsors](https://fastapi.tiangolo.com/fastapi-people/#sponsors)
 
 ## Opinions { #opinions }
 
 "_[...] I'm using **FastAPI** a ton these days. [...] I'm actually planning to use it for all of my team's **ML services at Microsoft**. Some of them are getting integrated into the core **Windows** product and some **Office** products._"
 
-<div style="text-align: right; margin-right: 10%;">Kabir Khan - <strong>Microsoft</strong> <a href="https://github.com/fastapi/fastapi/pull/26" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Kabir Khan - <strong>Microsoft</strong> <a href="https://github.com/fastapi/fastapi/pull/26"><small>(ref)</small></a></div>
 
 ---
 
 "_We adopted the **FastAPI** library to spawn a **REST** server that can be queried to obtain **predictions**. [for Ludwig]_"
 
-<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/"><small>(ref)</small></a></div>
 
 ---
 
 "_**Netflix** is pleased to announce the open-source release of our **crisis management** orchestration framework: **Dispatch**! [built with **FastAPI**]_"
 
-<div style="text-align: right; margin-right: 10%;">Kevin Glisson, Marc Vilanova, Forest Monsen - <strong>Netflix</strong> <a href="https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Kevin Glisson, Marc Vilanova, Forest Monsen - <strong>Netflix</strong> <a href="https://netflixtechblog.com/introducing-dispatch-da4b8a2a8072"><small>(ref)</small></a></div>
 
 ---
 
 "_I’m over the moon excited about **FastAPI**. It’s so fun!_"
 
-<div style="text-align: right; margin-right: 10%;">Brian Okken - <strong><a href="https://pythonbytes.fm/episodes/show/123/time-to-right-the-py-wrongs?time_in_sec=855" target="_blank">Python Bytes</a> podcast host</strong> <a href="https://x.com/brianokken/status/1112220079972728832" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Brian Okken - <strong>[Python Bytes](https://pythonbytes.fm/episodes/show/123/time-to-right-the-py-wrongs?time_in_sec=855) podcast host</strong> <a href="https://x.com/brianokken/status/1112220079972728832"><small>(ref)</small></a></div>
 
 ---
 
 "_Honestly, what you've built looks super solid and polished. In many ways, it's what I wanted **Hug** to be - it's really inspiring to see someone build that._"
 
-<div style="text-align: right; margin-right: 10%;">Timothy Crosley - <strong><a href="https://github.com/hugapi/hug" target="_blank">Hug</a> creator</strong> <a href="https://news.ycombinator.com/item?id=19455465" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Timothy Crosley - <strong>[Hug](https://github.com/hugapi/hug) creator</strong> <a href="https://news.ycombinator.com/item?id=19455465"><small>(ref)</small></a></div>
 
 ---
 
@@ -107,27 +107,27 @@ The key features are:
 
 "_We've switched over to **FastAPI** for our **APIs** [...] I think you'll like it [...]_"
 
-<div style="text-align: right; margin-right: 10%;">Ines Montani - Matthew Honnibal - <strong><a href="https://explosion.ai" target="_blank">Explosion AI</a> founders - <a href="https://spacy.io" target="_blank">spaCy</a> creators</strong> <a href="https://x.com/_inesmontani/status/1144173225322143744" target="_blank"><small>(ref)</small></a> - <a href="https://x.com/honnibal/status/1144031421859655680" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Ines Montani - Matthew Honnibal - <strong>[Explosion AI](https://explosion.ai) founders - [spaCy](https://spacy.io) creators</strong> <a href="https://x.com/_inesmontani/status/1144173225322143744"><small>(ref)</small></a> - <a href="https://x.com/honnibal/status/1144031421859655680"><small>(ref)</small></a></div>
 
 ---
 
 "_If anyone is looking to build a production Python API, I would highly recommend **FastAPI**. It is **beautifully designed**, **simple to use** and **highly scalable**, it has become a **key component** in our API first development strategy and is driving many automations and services such as our Virtual TAC Engineer._"
 
-<div style="text-align: right; margin-right: 10%;">Deon Pillsbury - <strong>Cisco</strong> <a href="https://www.linkedin.com/posts/deonpillsbury_cisco-cx-python-activity-6963242628536487936-trAp/" target="_blank"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Deon Pillsbury - <strong>Cisco</strong> <a href="https://www.linkedin.com/posts/deonpillsbury_cisco-cx-python-activity-6963242628536487936-trAp/"><small>(ref)</small></a></div>
 
 ---
 
 ## FastAPI mini documentary { #fastapi-mini-documentary }
 
-There's a <a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank">FastAPI mini documentary</a> released at the end of 2025, you can watch it online:
+There's a [FastAPI mini documentary](https://www.youtube.com/watch?v=mpR8ngthqiE) released at the end of 2025, you can watch it online:
 
-<a href="https://www.youtube.com/watch?v=mpR8ngthqiE" target="_blank"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
+<a href="https://www.youtube.com/watch?v=mpR8ngthqiE"><img src="https://fastapi.tiangolo.com/img/fastapi-documentary.jpg" alt="FastAPI Mini Documentary"></a>
 
 ## **Typer**, the FastAPI of CLIs { #typer-the-fastapi-of-clis }
 
-<a href="https://typer.tiangolo.com" target="_blank"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" style="width: 20%;"></a>
+<a href="https://typer.tiangolo.com"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" style="width: 20%;"></a>
 
-If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out <a href="https://typer.tiangolo.com/" target="_blank">**Typer**</a>.
+If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be used in the terminal instead of a web API, check out [**Typer**](https://typer.tiangolo.com/).
 
 **Typer** is FastAPI's little sibling. And it's intended to be the **FastAPI of CLIs**. ⌨️ 🚀
 
@@ -135,12 +135,12 @@ If you are building a <abbr title="Command Line Interface">CLI</abbr> app to be 
 
 FastAPI stands on the shoulders of giants:
 
-* <a href="https://www.starlette.dev/" target="_blank">Starlette</a> for the web parts.
-* <a href="https://docs.pydantic.dev/" target="_blank">Pydantic</a> for the data parts.
+* [Starlette](https://www.starlette.dev/) for the web parts.
+* [Pydantic](https://docs.pydantic.dev/) for the data parts.
 
 ## Installation { #installation }
 
-Create and activate a <a href="https://fastapi.tiangolo.com/virtual-environments/" target="_blank">virtual environment</a> and then install FastAPI:
+Create and activate a [virtual environment](https://fastapi.tiangolo.com/virtual-environments/) and then install FastAPI:
 
 <div class="termy">
 
@@ -199,7 +199,7 @@ async def read_item(item_id: int, q: str | None = None):
 
 **Note**:
 
-If you don't know, check the _"In a hurry?"_ section about <a href="https://fastapi.tiangolo.com/async/#in-a-hurry" target="_blank">`async` and `await` in the docs</a>.
+If you don't know, check the _"In a hurry?"_ section about [`async` and `await` in the docs](https://fastapi.tiangolo.com/async/#in-a-hurry).
 
 </details>
 
@@ -237,17 +237,17 @@ INFO:     Application startup complete.
 <details markdown="1">
 <summary>About the command <code>fastapi dev main.py</code>...</summary>
 
-The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using <a href="https://www.uvicorn.dev" target="_blank">Uvicorn</a>.
+The command `fastapi dev` reads your `main.py` file, detects the **FastAPI** app in it, and starts a server using [Uvicorn](https://www.uvicorn.dev).
 
 By default, `fastapi dev` will start with auto-reload enabled for local development.
 
-You can read more about it in the <a href="https://fastapi.tiangolo.com/fastapi-cli/" target="_blank">FastAPI CLI docs</a>.
+You can read more about it in the [FastAPI CLI docs](https://fastapi.tiangolo.com/fastapi-cli/).
 
 </details>
 
 ### Check it { #check-it }
 
-Open your browser at <a href="http://127.0.0.1:8000/items/5?q=somequery" target="_blank">http://127.0.0.1:8000/items/5?q=somequery</a>.
+Open your browser at [http://127.0.0.1:8000/items/5?q=somequery](http://127.0.0.1:8000/items/5?q=somequery).
 
 You will see the JSON response as:
 
@@ -264,17 +264,17 @@ You already created an API that:
 
 ### Interactive API docs { #interactive-api-docs }
 
-Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
-You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" target="_blank">Swagger UI</a>):
+You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui)):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ### Alternative API docs { #alternative-api-docs }
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc).
 
-You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" target="_blank">ReDoc</a>):
+You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc)):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -316,7 +316,7 @@ The `fastapi dev` server should reload automatically.
 
 ### Interactive API docs upgrade { #interactive-api-docs-upgrade }
 
-Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 * The interactive API documentation will be automatically updated, including the new body:
 
@@ -332,7 +332,7 @@ Now go to <a href="http://127.0.0.1:8000/docs" target="_blank">http://127.0.0.1:
 
 ### Alternative API docs upgrade { #alternative-api-docs-upgrade }
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc).
 
 * The alternative documentation will also reflect the new query parameter and body:
 
@@ -442,7 +442,7 @@ For a more complete example including more features, see the <a href="https://fa
 * A very powerful and easy to use **<dfn title="also known as components, resources, providers, services, injectables">Dependency Injection</dfn>** system.
 * Security and authentication, including support for **OAuth2** with **JWT tokens** and **HTTP Basic** auth.
 * More advanced (but equally easy) techniques for declaring **deeply nested JSON models** (thanks to Pydantic).
-* **GraphQL** integration with <a href="https://strawberry.rocks" target="_blank">Strawberry</a> and other libraries.
+* **GraphQL** integration with [Strawberry](https://strawberry.rocks) and other libraries.
 * Many extra features (thanks to Starlette) as:
     * **WebSockets**
     * extremely easy tests based on HTTPX and `pytest`
@@ -452,7 +452,7 @@ For a more complete example including more features, see the <a href="https://fa
 
 ### Deploy your app (optional) { #deploy-your-app-optional }
 
-You can optionally deploy your FastAPI app to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>, go and join the waiting list if you haven't. 🚀
+You can optionally deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com), go and join the waiting list if you haven't. 🚀
 
 If you already have a **FastAPI Cloud** account (we invited you from the waiting list 😉), you can deploy your application with one command.
 
@@ -488,7 +488,7 @@ That's it! Now you can access your app at that URL. ✨
 
 #### About FastAPI Cloud { #about-fastapi-cloud }
 
-**<a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com)** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 
@@ -504,9 +504,9 @@ Follow your cloud provider's guides to deploy FastAPI apps with them. 🤓
 
 ## Performance { #performance }
 
-Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as <a href="https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7" target="_blank">one of the fastest Python frameworks available</a>, only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
+Independent TechEmpower benchmarks show **FastAPI** applications running under Uvicorn as [one of the fastest Python frameworks available](https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7), only below Starlette and Uvicorn themselves (used internally by FastAPI). (*)
 
-To understand more about it, see the section <a href="https://fastapi.tiangolo.com/benchmarks/" target="_blank">Benchmarks</a>.
+To understand more about it, see the section [Benchmarks](https://fastapi.tiangolo.com/benchmarks/).
 
 ## Dependencies { #dependencies }
 
@@ -518,19 +518,19 @@ When you install FastAPI with `pip install "fastapi[standard]"` it comes with th
 
 Used by Pydantic:
 
-* <a href="https://github.com/JoshData/python-email-validator" target="_blank"><code>email-validator</code></a> - for email validation.
+* [`email-validator`](https://github.com/JoshData/python-email-validator) - for email validation.
 
 Used by Starlette:
 
-* <a href="https://www.python-httpx.org" target="_blank"><code>httpx</code></a> - Required if you want to use the `TestClient`.
-* <a href="https://jinja.palletsprojects.com" target="_blank"><code>jinja2</code></a> - Required if you want to use the default template configuration.
-* <a href="https://github.com/Kludex/python-multipart" target="_blank"><code>python-multipart</code></a> - Required if you want to support form <dfn title="converting the string that comes from an HTTP request into Python data">"parsing"</dfn>, with `request.form()`.
+* [`httpx`](https://www.python-httpx.org) - Required if you want to use the `TestClient`.
+* [`jinja2`](https://jinja.palletsprojects.com) - Required if you want to use the default template configuration.
+* [`python-multipart`](https://github.com/Kludex/python-multipart) - Required if you want to support form <dfn title="converting the string that comes from an HTTP request into Python data">"parsing"</dfn>, with `request.form()`.
 
 Used by FastAPI:
 
-* <a href="https://www.uvicorn.dev" target="_blank"><code>uvicorn</code></a> - for the server that loads and serves your application. This includes `uvicorn[standard]`, which includes some dependencies (e.g. `uvloop`) needed for high performance serving.
+* [`uvicorn`](https://www.uvicorn.dev) - for the server that loads and serves your application. This includes `uvicorn[standard]`, which includes some dependencies (e.g. `uvloop`) needed for high performance serving.
 * `fastapi-cli[standard]` - to provide the `fastapi` command.
-    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to <a href="https://fastapicloud.com" target="_blank">FastAPI Cloud</a>.
+    * This includes `fastapi-cloud-cli`, which allows you to deploy your FastAPI application to [FastAPI Cloud](https://fastapicloud.com).
 
 ### Without `standard` Dependencies { #without-standard-dependencies }
 
@@ -546,13 +546,13 @@ There are some additional dependencies you might want to install.
 
 Additional optional Pydantic dependencies:
 
-* <a href="https://docs.pydantic.dev/latest/usage/pydantic_settings/" target="_blank"><code>pydantic-settings</code></a> - for settings management.
-* <a href="https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/" target="_blank"><code>pydantic-extra-types</code></a> - for extra types to be used with Pydantic.
+* [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
+* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
 
 Additional optional FastAPI dependencies:
 
-* <a href="https://github.com/ijl/orjson" target="_blank"><code>orjson</code></a> - Required if you want to use `ORJSONResponse`.
-* <a href="https://github.com/esnme/ultrajson" target="_blank"><code>ujson</code></a> - Required if you want to use `UJSONResponse`.
+* [`orjson`](https://github.com/ijl/orjson) - Required if you want to use `ORJSONResponse`.
+* [`ujson`](https://github.com/esnme/ultrajson) - Required if you want to use `UJSONResponse`.
 
 ## License { #license }
 

--- a/docs/en/docs/management-tasks.md
+++ b/docs/en/docs/management-tasks.md
@@ -1,6 +1,6 @@
 # Repository Management Tasks
 
-These are the tasks that can be performed to manage the FastAPI repository by [team members](./fastapi-people.md#team){target=_blank}.
+These are the tasks that can be performed to manage the FastAPI repository by [team members](./fastapi-people.md#team).
 
 /// tip
 
@@ -8,9 +8,9 @@ This section is useful only to a handful of people, team members with permission
 
 ///
 
-...so, you are a [team member of FastAPI](./fastapi-people.md#team){target=_blank}? Wow, you are so cool! 😎
+...so, you are a [team member of FastAPI](./fastapi-people.md#team)? Wow, you are so cool! 😎
 
-You can help with everything on [Help FastAPI - Get Help](./help-fastapi.md){target=_blank} the same ways as external contributors. But additionally, there are some tasks that only you (as part of the team) can perform.
+You can help with everything on [Help FastAPI - Get Help](./help-fastapi.md) the same ways as external contributors. But additionally, there are some tasks that only you (as part of the team) can perform.
 
 Here are the general instructions for the tasks you can perform.
 
@@ -40,7 +40,7 @@ For conversations that are more difficult, for example to reject a PR, you can a
 
 ## Edit PR Titles
 
-* Edit the PR title to start with an emoji from [gitmoji](https://gitmoji.dev/){target=_blank}.
+* Edit the PR title to start with an emoji from [gitmoji](https://gitmoji.dev/).
     * Use the emoji character, not the GitHub code. So, use `🐛` instead of `:bug:`. This is so that it shows up correctly outside of GitHub, for example in the release notes.
     * For translations use the `🌐` emoji ("globe with meridians").
 * Start the title with a verb. For example `Add`, `Refactor`, `Fix`, etc. This way the title will say the action that the PR does. Like `Add support for teleporting`, instead of `Teleporting wasn't working, so this PR fixes it`.
@@ -53,15 +53,15 @@ For conversations that are more difficult, for example to reject a PR, you can a
 🌐 Add Spanish translation for `docs/es/docs/teleporting.md`
 ```
 
-Once the PR is merged, a GitHub Action ([latest-changes](https://github.com/tiangolo/latest-changes){target=_blank}) will use the PR title to update the latest changes automatically.
+Once the PR is merged, a GitHub Action ([latest-changes](https://github.com/tiangolo/latest-changes)) will use the PR title to update the latest changes automatically.
 
 So, having a nice PR title will not only look nice in GitHub, but also in the release notes. 📝
 
 ## Add Labels to PRs
 
-The same GitHub Action [latest-changes](https://github.com/tiangolo/latest-changes){target=_blank} uses one label in the PR to decide the section in the release notes to put this PR in.
+The same GitHub Action [latest-changes](https://github.com/tiangolo/latest-changes) uses one label in the PR to decide the section in the release notes to put this PR in.
 
-Make sure you use a supported label from the [latest-changes list of labels](https://github.com/tiangolo/latest-changes#using-labels){target=_blank}:
+Make sure you use a supported label from the [latest-changes list of labels](https://github.com/tiangolo/latest-changes#using-labels):
 
 * `breaking`: Breaking Changes
     * Existing code will break if they update the version without changing their code. This rarely happens, so this label is not frequently used.
@@ -108,7 +108,7 @@ This way, we can notice when there are new translations ready, because they have
 
 Translations are generated automatically with LLMs and scripts.
 
-There's one GitHub Action that can be manually run to add or update translations for a language: [`translate.yml`](https://github.com/fastapi/fastapi/actions/workflows/translate.yml){target=_blank}.
+There's one GitHub Action that can be manually run to add or update translations for a language: [`translate.yml`](https://github.com/fastapi/fastapi/actions/workflows/translate.yml).
 
 For these language translation PRs, confirm that:
 
@@ -140,7 +140,7 @@ For these language translation PRs, confirm that:
 
 ## FastAPI People PRs
 
-Every month, a GitHub Action updates the FastAPI People data. Those PRs look like this one: [👥 Update FastAPI People](https://github.com/fastapi/fastapi/pull/11669){target=_blank}.
+Every month, a GitHub Action updates the FastAPI People data. Those PRs look like this one: [👥 Update FastAPI People](https://github.com/fastapi/fastapi/pull/11669).
 
 If the tests are passing, you can merge it right away.
 
@@ -155,4 +155,4 @@ Dependabot will create PRs to update dependencies for several things, and those 
 
 When a question in GitHub Discussions has been answered, mark the answer by clicking "Mark as answer".
 
-You can filter discussions by [`Questions` that are `Unanswered`](https://github.com/tiangolo/fastapi/discussions/categories/questions?discussions_q=category:Questions+is:open+is:unanswered){target=_blank}.
+You can filter discussions by [`Questions` that are `Unanswered`](https://github.com/tiangolo/fastapi/discussions/categories/questions?discussions_q=category:Questions+is:open+is:unanswered).

--- a/docs/en/docs/management-tasks.md
+++ b/docs/en/docs/management-tasks.md
@@ -1,6 +1,6 @@
 # Repository Management Tasks
 
-These are the tasks that can be performed to manage the FastAPI repository by [team members](./fastapi-people.md#team){.internal-link target=_blank}.
+These are the tasks that can be performed to manage the FastAPI repository by [team members](./fastapi-people.md#team){target=_blank}.
 
 /// tip
 
@@ -8,9 +8,9 @@ This section is useful only to a handful of people, team members with permission
 
 ///
 
-...so, you are a [team member of FastAPI](./fastapi-people.md#team){.internal-link target=_blank}? Wow, you are so cool! 😎
+...so, you are a [team member of FastAPI](./fastapi-people.md#team){target=_blank}? Wow, you are so cool! 😎
 
-You can help with everything on [Help FastAPI - Get Help](./help-fastapi.md){.internal-link target=_blank} the same ways as external contributors. But additionally, there are some tasks that only you (as part of the team) can perform.
+You can help with everything on [Help FastAPI - Get Help](./help-fastapi.md){target=_blank} the same ways as external contributors. But additionally, there are some tasks that only you (as part of the team) can perform.
 
 Here are the general instructions for the tasks you can perform.
 
@@ -40,7 +40,7 @@ For conversations that are more difficult, for example to reject a PR, you can a
 
 ## Edit PR Titles
 
-* Edit the PR title to start with an emoji from <a href="https://gitmoji.dev/" class="external-link" target="_blank">gitmoji</a>.
+* Edit the PR title to start with an emoji from [gitmoji](https://gitmoji.dev/){target=_blank}.
     * Use the emoji character, not the GitHub code. So, use `🐛` instead of `:bug:`. This is so that it shows up correctly outside of GitHub, for example in the release notes.
     * For translations use the `🌐` emoji ("globe with meridians").
 * Start the title with a verb. For example `Add`, `Refactor`, `Fix`, etc. This way the title will say the action that the PR does. Like `Add support for teleporting`, instead of `Teleporting wasn't working, so this PR fixes it`.
@@ -53,15 +53,15 @@ For conversations that are more difficult, for example to reject a PR, you can a
 🌐 Add Spanish translation for `docs/es/docs/teleporting.md`
 ```
 
-Once the PR is merged, a GitHub Action (<a href="https://github.com/tiangolo/latest-changes" class="external-link" target="_blank">latest-changes</a>) will use the PR title to update the latest changes automatically.
+Once the PR is merged, a GitHub Action ([latest-changes](https://github.com/tiangolo/latest-changes){target=_blank}) will use the PR title to update the latest changes automatically.
 
 So, having a nice PR title will not only look nice in GitHub, but also in the release notes. 📝
 
 ## Add Labels to PRs
 
-The same GitHub Action <a href="https://github.com/tiangolo/latest-changes" class="external-link" target="_blank">latest-changes</a> uses one label in the PR to decide the section in the release notes to put this PR in.
+The same GitHub Action [latest-changes](https://github.com/tiangolo/latest-changes){target=_blank} uses one label in the PR to decide the section in the release notes to put this PR in.
 
-Make sure you use a supported label from the <a href="https://github.com/tiangolo/latest-changes#using-labels" class="external-link" target="_blank">latest-changes list of labels</a>:
+Make sure you use a supported label from the [latest-changes list of labels](https://github.com/tiangolo/latest-changes#using-labels){target=_blank}:
 
 * `breaking`: Breaking Changes
     * Existing code will break if they update the version without changing their code. This rarely happens, so this label is not frequently used.
@@ -108,7 +108,7 @@ This way, we can notice when there are new translations ready, because they have
 
 Translations are generated automatically with LLMs and scripts.
 
-There's one GitHub Action that can be manually run to add or update translations for a language: <a href="https://github.com/fastapi/fastapi/actions/workflows/translate.yml" class="external-link" target="_blank">`translate.yml`</a>.
+There's one GitHub Action that can be manually run to add or update translations for a language: [`translate.yml`](https://github.com/fastapi/fastapi/actions/workflows/translate.yml){target=_blank}.
 
 For these language translation PRs, confirm that:
 
@@ -140,7 +140,7 @@ For these language translation PRs, confirm that:
 
 ## FastAPI People PRs
 
-Every month, a GitHub Action updates the FastAPI People data. Those PRs look like this one: <a href="https://github.com/fastapi/fastapi/pull/11669" class="external-link" target="_blank">👥 Update FastAPI People</a>.
+Every month, a GitHub Action updates the FastAPI People data. Those PRs look like this one: [👥 Update FastAPI People](https://github.com/fastapi/fastapi/pull/11669){target=_blank}.
 
 If the tests are passing, you can merge it right away.
 
@@ -155,4 +155,4 @@ Dependabot will create PRs to update dependencies for several things, and those 
 
 When a question in GitHub Discussions has been answered, mark the answer by clicking "Mark as answer".
 
-You can filter discussions by <a href="https://github.com/tiangolo/fastapi/discussions/categories/questions?discussions_q=category:Questions+is:open+is:unanswered" class="external-link" target="_blank">`Questions` that are `Unanswered`</a>.
+You can filter discussions by [`Questions` that are `Unanswered`](https://github.com/tiangolo/fastapi/discussions/categories/questions?discussions_q=category:Questions+is:open+is:unanswered){target=_blank}.

--- a/docs/en/docs/management.md
+++ b/docs/en/docs/management.md
@@ -4,15 +4,15 @@ Here's a short description of how the FastAPI repository is managed and maintain
 
 ## Owner
 
-I, <a href="https://github.com/tiangolo" target="_blank">@tiangolo</a>, am the creator and owner of the FastAPI repository. 🤓
+I, [@tiangolo](https://github.com/tiangolo), am the creator and owner of the FastAPI repository. 🤓
 
-I normally give the final review to each PR before merging them. I make the final decisions on the project, I'm the <a href="https://en.wikipedia.org/wiki/Benevolent_dictator_for_life" target="_blank"><abbr title="Benevolent Dictator For Life">BDFL</abbr></a>. 😅
+I normally give the final review to each PR before merging them. I make the final decisions on the project, I'm the [<abbr title="Benevolent Dictator For Life">BDFL</abbr>](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life). 😅
 
 ## Team
 
 There's a team of people that help manage and maintain the project. 😎
 
-They have different levels of permissions and [specific instructions](./management-tasks.md){target=_blank}.
+They have different levels of permissions and [specific instructions](./management-tasks.md).
 
 Some of the tasks they can perform include:
 
@@ -22,13 +22,13 @@ Some of the tasks they can perform include:
 * Mark answers in GitHub Discussions questions, etc.
 * Merge some specific types of PRs.
 
-You can see the current team members in [FastAPI People - Team](./fastapi-people.md#team){target=_blank}.
+You can see the current team members in [FastAPI People - Team](./fastapi-people.md#team).
 
 Joining the team is by invitation only, and I could update or remove permissions, instructions, or membership.
 
 ## FastAPI Experts
 
-The people that help others the most in GitHub Discussions can become [**FastAPI Experts**](./fastapi-people.md#fastapi-experts){target=_blank}.
+The people that help others the most in GitHub Discussions can become [**FastAPI Experts**](./fastapi-people.md#fastapi-experts).
 
 This is normally the best way to contribute to the project.
 
@@ -36,4 +36,4 @@ This is normally the best way to contribute to the project.
 
 External contributions are very welcome and appreciated, including answering questions, submitting PRs, etc. 🙇‍♂️
 
-There are many ways to [help maintain FastAPI](./help-fastapi.md#help-maintain-fastapi){target=_blank}.
+There are many ways to [help maintain FastAPI](./help-fastapi.md#help-maintain-fastapi).

--- a/docs/en/docs/management.md
+++ b/docs/en/docs/management.md
@@ -6,13 +6,13 @@ Here's a short description of how the FastAPI repository is managed and maintain
 
 I, <a href="https://github.com/tiangolo" target="_blank">@tiangolo</a>, am the creator and owner of the FastAPI repository. 🤓
 
-I normally give the final review to each PR before merging them. I make the final decisions on the project, I'm the <a href="https://en.wikipedia.org/wiki/Benevolent_dictator_for_life" class="external-link" target="_blank"><abbr title="Benevolent Dictator For Life">BDFL</abbr></a>. 😅
+I normally give the final review to each PR before merging them. I make the final decisions on the project, I'm the <a href="https://en.wikipedia.org/wiki/Benevolent_dictator_for_life" target="_blank"><abbr title="Benevolent Dictator For Life">BDFL</abbr></a>. 😅
 
 ## Team
 
 There's a team of people that help manage and maintain the project. 😎
 
-They have different levels of permissions and [specific instructions](./management-tasks.md){.internal-link target=_blank}.
+They have different levels of permissions and [specific instructions](./management-tasks.md){target=_blank}.
 
 Some of the tasks they can perform include:
 
@@ -22,13 +22,13 @@ Some of the tasks they can perform include:
 * Mark answers in GitHub Discussions questions, etc.
 * Merge some specific types of PRs.
 
-You can see the current team members in [FastAPI People - Team](./fastapi-people.md#team){.internal-link target=_blank}.
+You can see the current team members in [FastAPI People - Team](./fastapi-people.md#team){target=_blank}.
 
 Joining the team is by invitation only, and I could update or remove permissions, instructions, or membership.
 
 ## FastAPI Experts
 
-The people that help others the most in GitHub Discussions can become [**FastAPI Experts**](./fastapi-people.md#fastapi-experts){.internal-link target=_blank}.
+The people that help others the most in GitHub Discussions can become [**FastAPI Experts**](./fastapi-people.md#fastapi-experts){target=_blank}.
 
 This is normally the best way to contribute to the project.
 
@@ -36,4 +36,4 @@ This is normally the best way to contribute to the project.
 
 External contributions are very welcome and appreciated, including answering questions, submitting PRs, etc. 🙇‍♂️
 
-There are many ways to [help maintain FastAPI](./help-fastapi.md#help-maintain-fastapi){.internal-link target=_blank}.
+There are many ways to [help maintain FastAPI](./help-fastapi.md#help-maintain-fastapi){target=_blank}.

--- a/docs/en/docs/project-generation.md
+++ b/docs/en/docs/project-generation.md
@@ -4,7 +4,7 @@ Templates, while typically come with a specific setup, are designed to be flexib
 
 You can use this template to get started, as it includes a lot of the initial set up, security, database and some API endpoints already done for you.
 
-GitHub Repository: [Full Stack FastAPI Template](https://github.com/tiangolo/full-stack-fastapi-template){target=_blank}
+GitHub Repository: [Full Stack FastAPI Template](https://github.com/tiangolo/full-stack-fastapi-template)
 
 ## Full Stack FastAPI Template - Technology Stack and Features { #full-stack-fastapi-template-technology-stack-and-features }
 

--- a/docs/en/docs/project-generation.md
+++ b/docs/en/docs/project-generation.md
@@ -4,7 +4,7 @@ Templates, while typically come with a specific setup, are designed to be flexib
 
 You can use this template to get started, as it includes a lot of the initial set up, security, database and some API endpoints already done for you.
 
-GitHub Repository: <a href="https://github.com/tiangolo/full-stack-fastapi-template" class="external-link" target="_blank">Full Stack FastAPI Template</a>
+GitHub Repository: [Full Stack FastAPI Template](https://github.com/tiangolo/full-stack-fastapi-template){target=_blank}
 
 ## Full Stack FastAPI Template - Technology Stack and Features { #full-stack-fastapi-template-technology-stack-and-features }
 

--- a/docs/en/docs/python-types.md
+++ b/docs/en/docs/python-types.md
@@ -269,7 +269,7 @@ It doesn't mean "`one_person` is the **class** called `Person`".
 
 ## Pydantic models { #pydantic-models }
 
-<a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> is a Python library to perform data validation.
+[Pydantic](https://docs.pydantic.dev/){target=_blank} is a Python library to perform data validation.
 
 You declare the "shape" of the data as classes with attributes.
 
@@ -285,13 +285,13 @@ An example from the official Pydantic docs:
 
 /// info
 
-To learn more about <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic, check its docs</a>.
+To learn more about [Pydantic, check its docs](https://docs.pydantic.dev/){target=_blank}.
 
 ///
 
 **FastAPI** is all based on Pydantic.
 
-You will see a lot more of all this in practice in the [Tutorial - User Guide](tutorial/index.md){.internal-link target=_blank}.
+You will see a lot more of all this in practice in the [Tutorial - User Guide](tutorial/index.md){target=_blank}.
 
 ## Type Hints with Metadata Annotations { #type-hints-with-metadata-annotations }
 
@@ -337,12 +337,12 @@ With **FastAPI** you declare parameters with type hints and you get:
 * **Document** the API using OpenAPI:
     * which is then used by the automatic interactive documentation user interfaces.
 
-This might all sound abstract. Don't worry. You'll see all this in action in the [Tutorial - User Guide](tutorial/index.md){.internal-link target=_blank}.
+This might all sound abstract. Don't worry. You'll see all this in action in the [Tutorial - User Guide](tutorial/index.md){target=_blank}.
 
 The important thing is that by using standard Python types, in a single place (instead of adding more classes, decorators, etc), **FastAPI** will do a lot of the work for you.
 
 /// info
 
-If you already went through all the tutorial and came back to see more about types, a good resource is <a href="https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html" class="external-link" target="_blank">the "cheat sheet" from `mypy`</a>.
+If you already went through all the tutorial and came back to see more about types, a good resource is [the "cheat sheet" from `mypy`](https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html){target=_blank}.
 
 ///

--- a/docs/en/docs/python-types.md
+++ b/docs/en/docs/python-types.md
@@ -269,7 +269,7 @@ It doesn't mean "`one_person` is the **class** called `Person`".
 
 ## Pydantic models { #pydantic-models }
 
-[Pydantic](https://docs.pydantic.dev/){target=_blank} is a Python library to perform data validation.
+[Pydantic](https://docs.pydantic.dev/) is a Python library to perform data validation.
 
 You declare the "shape" of the data as classes with attributes.
 
@@ -285,13 +285,13 @@ An example from the official Pydantic docs:
 
 /// info
 
-To learn more about [Pydantic, check its docs](https://docs.pydantic.dev/){target=_blank}.
+To learn more about [Pydantic, check its docs](https://docs.pydantic.dev/).
 
 ///
 
 **FastAPI** is all based on Pydantic.
 
-You will see a lot more of all this in practice in the [Tutorial - User Guide](tutorial/index.md){target=_blank}.
+You will see a lot more of all this in practice in the [Tutorial - User Guide](tutorial/index.md).
 
 ## Type Hints with Metadata Annotations { #type-hints-with-metadata-annotations }
 
@@ -337,12 +337,12 @@ With **FastAPI** you declare parameters with type hints and you get:
 * **Document** the API using OpenAPI:
     * which is then used by the automatic interactive documentation user interfaces.
 
-This might all sound abstract. Don't worry. You'll see all this in action in the [Tutorial - User Guide](tutorial/index.md){target=_blank}.
+This might all sound abstract. Don't worry. You'll see all this in action in the [Tutorial - User Guide](tutorial/index.md).
 
 The important thing is that by using standard Python types, in a single place (instead of adding more classes, decorators, etc), **FastAPI** will do a lot of the work for you.
 
 /// info
 
-If you already went through all the tutorial and came back to see more about types, a good resource is [the "cheat sheet" from `mypy`](https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html){target=_blank}.
+If you already went through all the tutorial and came back to see more about types, a good resource is [the "cheat sheet" from `mypy`](https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html).
 
 ///

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -3587,8 +3587,8 @@ There are **tests for both Pydantic v1 and v2**, and test **coverage** is kept a
 * The attribute `schema_extra` for the internal class `Config` has been replaced by the key `json_schema_extra` in the new `model_config` dict.
     * You can read more about it in the docs for [Declare Request Example Data](https://fastapi.tiangolo.com/tutorial/schema-extra-example/).
 * When you install `"fastapi[all]"` it now also includes:
-    * <a href="https://docs.pydantic.dev/latest/usage/pydantic_settings/" target="_blank"><code>pydantic-settings</code></a> - for settings management.
-    * <a href="https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/" target="_blank"><code>pydantic-extra-types</code></a> - for extra types to be used with Pydantic.
+    * [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
+    * [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
 * Now Pydantic Settings is an additional optional package (included in `"fastapi[all]"`). To use settings you should now import `from pydantic_settings import BaseSettings` instead of importing from `pydantic` directly.
     * You can read more about it in the docs for [Settings and Environment Variables](https://fastapi.tiangolo.com/advanced/settings/).
 
@@ -5547,7 +5547,7 @@ Note: all the previous parameters are still there, so it's still possible to dec
 * PR [#2434](https://github.com/tiangolo/fastapi/pull/2434) (above) includes new or updated docs:
     * [Advanced User Guide - OpenAPI Callbacks](https://fastapi.tiangolo.com/advanced/openapi-callbacks/).
     * [Tutorial - Bigger Applications](https://fastapi.tiangolo.com/tutorial/bigger-applications/).
-    * [Tutorial - Dependencies - Dependencies in path operation decorators](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/){target=_blank}.
+    * [Tutorial - Dependencies - Dependencies in path operation decorators](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/).
     * [Tutorial - Dependencies - Global Dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/global-dependencies/).
 
 * 📝 Add FastAPI monitoring blog post to External Links. PR [#2324](https://github.com/tiangolo/fastapi/pull/2324) by [@louisguitton](https://github.com/louisguitton).
@@ -6675,7 +6675,7 @@ Note: all the previous parameters are still there, so it's still possible to dec
 
 * Update [section about error handling](https://fastapi.tiangolo.com/tutorial/handling-errors/) with more information and make relation with Starlette error handling utilities more explicit. PR [#41](https://github.com/tiangolo/fastapi/pull/41).
 
-* Add <a href="" target="_blank">Development - Contributing section to the docs</a>. PR [#42](https://github.com/tiangolo/fastapi/pull/42).
+* Add [Development - Contributing section to the docs](). PR [#42](https://github.com/tiangolo/fastapi/pull/42).
 
 ## 0.5.0 (2019-02-16)
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -3609,10 +3609,10 @@ There are **tests for both Pydantic v1 and v2**, and test **coverage** is kept a
 ### Features
 
 * ✨ Add support for OpenAPI 3.1.0. PR [#9770](https://github.com/tiangolo/fastapi/pull/9770) by [@tiangolo](https://github.com/tiangolo).
-    * New support for documenting **webhooks**, read the new docs here: <a href="https://fastapi.tiangolo.com/advanced/openapi-webhooks/" class="external-link" target="_blank">Advanced User Guide: OpenAPI Webhooks</a>.
+    * New support for documenting **webhooks**, read the new docs here: [Advanced User Guide: OpenAPI Webhooks](https://fastapi.tiangolo.com/advanced/openapi-webhooks/).
     * Upgrade OpenAPI 3.1.0, this uses JSON Schema 2020-12.
     * Upgrade Swagger UI to version 5.x.x, that supports OpenAPI 3.1.0.
-    * Updated `examples` field in `Query()`, `Cookie()`, `Body()`, etc. based on the latest JSON Schema and OpenAPI. Now it takes a list of examples and they are included directly in the JSON Schema, not outside. Read more about it (including the historical technical details) in the updated docs: <a href="https://fastapi.tiangolo.com/tutorial/schema-extra-example/" class="external-link" target="_blank">Tutorial: Declare Request Example Data</a>.
+    * Updated `examples` field in `Query()`, `Cookie()`, `Body()`, etc. based on the latest JSON Schema and OpenAPI. Now it takes a list of examples and they are included directly in the JSON Schema, not outside. Read more about it (including the historical technical details) in the updated docs: [Tutorial: Declare Request Example Data](https://fastapi.tiangolo.com/tutorial/schema-extra-example/).
 
 * ✨ Add support for `deque` objects and children in `jsonable_encoder`. PR [#9433](https://github.com/tiangolo/fastapi/pull/9433) by [@cranium](https://github.com/cranium).
 
@@ -5545,10 +5545,10 @@ Note: all the previous parameters are still there, so it's still possible to dec
 ### Docs
 
 * PR [#2434](https://github.com/tiangolo/fastapi/pull/2434) (above) includes new or updated docs:
-    * <a href="https://fastapi.tiangolo.com/advanced/openapi-callbacks/" class="external-link" target="_blank">Advanced User Guide - OpenAPI Callbacks</a>.
-    * <a href="https://fastapi.tiangolo.com/tutorial/bigger-applications/" class="external-link" target="_blank">Tutorial - Bigger Applications</a>.
-    * <a href="https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/" class="external-link" target="_blank">Tutorial - Dependencies - Dependencies in path operation decorators</a>.
-    * <a href="https://fastapi.tiangolo.com/tutorial/dependencies/global-dependencies/" class="external-link" target="_blank">Tutorial - Dependencies - Global Dependencies</a>.
+    * [Advanced User Guide - OpenAPI Callbacks](https://fastapi.tiangolo.com/advanced/openapi-callbacks/).
+    * [Tutorial - Bigger Applications](https://fastapi.tiangolo.com/tutorial/bigger-applications/).
+    * [Tutorial - Dependencies - Dependencies in path operation decorators](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/){target=_blank}.
+    * [Tutorial - Dependencies - Global Dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/global-dependencies/).
 
 * 📝 Add FastAPI monitoring blog post to External Links. PR [#2324](https://github.com/tiangolo/fastapi/pull/2324) by [@louisguitton](https://github.com/louisguitton).
 * ✏️ Fix typo in Deta tutorial. PR [#2320](https://github.com/tiangolo/fastapi/pull/2320) by [@tiangolo](https://github.com/tiangolo).

--- a/docs/en/docs/tutorial/background-tasks.md
+++ b/docs/en/docs/tutorial/background-tasks.md
@@ -63,7 +63,7 @@ And then another background task generated at the *path operation function* will
 
 ## Technical Details { #technical-details }
 
-The class `BackgroundTasks` comes directly from [`starlette.background`](https://www.starlette.dev/background/){target=_blank}.
+The class `BackgroundTasks` comes directly from [`starlette.background`](https://www.starlette.dev/background/).
 
 It is imported/included directly into FastAPI so that you can import it from `fastapi` and avoid accidentally importing the alternative `BackgroundTask` (without the `s` at the end) from `starlette.background`.
 
@@ -71,11 +71,11 @@ By only using `BackgroundTasks` (and not `BackgroundTask`), it's then possible t
 
 It's still possible to use `BackgroundTask` alone in FastAPI, but you have to create the object in your code and return a Starlette `Response` including it.
 
-You can see more details in [Starlette's official docs for Background Tasks](https://www.starlette.dev/background/){target=_blank}.
+You can see more details in [Starlette's official docs for Background Tasks](https://www.starlette.dev/background/).
 
 ## Caveat { #caveat }
 
-If you need to perform heavy background computation and you don't necessarily need it to be run by the same process (for example, you don't need to share memory, variables, etc), you might benefit from using other bigger tools like [Celery](https://docs.celeryq.dev){target=_blank}.
+If you need to perform heavy background computation and you don't necessarily need it to be run by the same process (for example, you don't need to share memory, variables, etc), you might benefit from using other bigger tools like [Celery](https://docs.celeryq.dev).
 
 They tend to require more complex configurations, a message/job queue manager, like RabbitMQ or Redis, but they allow you to run background tasks in multiple processes, and especially, in multiple servers.
 

--- a/docs/en/docs/tutorial/background-tasks.md
+++ b/docs/en/docs/tutorial/background-tasks.md
@@ -63,7 +63,7 @@ And then another background task generated at the *path operation function* will
 
 ## Technical Details { #technical-details }
 
-The class `BackgroundTasks` comes directly from <a href="https://www.starlette.dev/background/" class="external-link" target="_blank">`starlette.background`</a>.
+The class `BackgroundTasks` comes directly from [`starlette.background`](https://www.starlette.dev/background/){target=_blank}.
 
 It is imported/included directly into FastAPI so that you can import it from `fastapi` and avoid accidentally importing the alternative `BackgroundTask` (without the `s` at the end) from `starlette.background`.
 
@@ -71,11 +71,11 @@ By only using `BackgroundTasks` (and not `BackgroundTask`), it's then possible t
 
 It's still possible to use `BackgroundTask` alone in FastAPI, but you have to create the object in your code and return a Starlette `Response` including it.
 
-You can see more details in <a href="https://www.starlette.dev/background/" class="external-link" target="_blank">Starlette's official docs for Background Tasks</a>.
+You can see more details in [Starlette's official docs for Background Tasks](https://www.starlette.dev/background/){target=_blank}.
 
 ## Caveat { #caveat }
 
-If you need to perform heavy background computation and you don't necessarily need it to be run by the same process (for example, you don't need to share memory, variables, etc), you might benefit from using other bigger tools like <a href="https://docs.celeryq.dev" class="external-link" target="_blank">Celery</a>.
+If you need to perform heavy background computation and you don't necessarily need it to be run by the same process (for example, you don't need to share memory, variables, etc), you might benefit from using other bigger tools like [Celery](https://docs.celeryq.dev){target=_blank}.
 
 They tend to require more complex configurations, a message/job queue manager, like RabbitMQ or Redis, but they allow you to run background tasks in multiple processes, and especially, in multiple servers.
 

--- a/docs/en/docs/tutorial/bigger-applications.md
+++ b/docs/en/docs/tutorial/bigger-applications.md
@@ -123,7 +123,7 @@ We will now use a simple dependency to read a custom `X-Token` header:
 
 We are using an invented header to simplify this example.
 
-But in real cases you will get better results using the integrated [Security utilities](security/index.md){.internal-link target=_blank}.
+But in real cases you will get better results using the integrated [Security utilities](security/index.md){target=_blank}.
 
 ///
 
@@ -169,7 +169,7 @@ And we can add a list of `dependencies` that will be added to all the *path oper
 
 /// tip
 
-Note that, much like [dependencies in *path operation decorators*](dependencies/dependencies-in-path-operation-decorators.md){.internal-link target=_blank}, no value will be passed to your *path operation function*.
+Note that, much like [dependencies in *path operation decorators*](dependencies/dependencies-in-path-operation-decorators.md){target=_blank}, no value will be passed to your *path operation function*.
 
 ///
 
@@ -185,8 +185,8 @@ The end result is that the item paths are now:
 * All of them will include the predefined `responses`.
 * All these *path operations* will have the list of `dependencies` evaluated/executed before them.
     * If you also declare dependencies in a specific *path operation*, **they will be executed too**.
-    * The router dependencies are executed first, then the [`dependencies` in the decorator](dependencies/dependencies-in-path-operation-decorators.md){.internal-link target=_blank}, and then the normal parameter dependencies.
-    * You can also add [`Security` dependencies with `scopes`](../advanced/security/oauth2-scopes.md){.internal-link target=_blank}.
+    * The router dependencies are executed first, then the [`dependencies` in the decorator](dependencies/dependencies-in-path-operation-decorators.md){target=_blank}, and then the normal parameter dependencies.
+    * You can also add [`Security` dependencies with `scopes`](../advanced/security/oauth2-scopes.md){target=_blank}.
 
 /// tip
 
@@ -303,7 +303,7 @@ And as most of your logic will now live in its own specific module, the main fil
 
 You import and create a `FastAPI` class as normally.
 
-And we can even declare [global dependencies](dependencies/global-dependencies.md){.internal-link target=_blank} that will be combined with the dependencies for each `APIRouter`:
+And we can even declare [global dependencies](dependencies/global-dependencies.md){target=_blank} that will be combined with the dependencies for each `APIRouter`:
 
 {* ../../docs_src/bigger_applications/app_an_py310/main.py hl[1,3,7] title["app/main.py"] *}
 
@@ -353,7 +353,7 @@ The second version is an "absolute import":
 from app.routers import items, users
 ```
 
-To learn more about Python Packages and Modules, read <a href="https://docs.python.org/3/tutorial/modules.html" class="external-link" target="_blank">the official Python documentation about Modules</a>.
+To learn more about Python Packages and Modules, read [the official Python documentation about Modules](https://docs.python.org/3/tutorial/modules.html){target=_blank}.
 
 ///
 
@@ -479,7 +479,7 @@ $ fastapi dev app/main.py
 
 </div>
 
-And open the docs at <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+And open the docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
 You will see the automatic API docs, including the paths from all the submodules, using the correct paths (and prefixes) and the correct tags:
 

--- a/docs/en/docs/tutorial/bigger-applications.md
+++ b/docs/en/docs/tutorial/bigger-applications.md
@@ -123,7 +123,7 @@ We will now use a simple dependency to read a custom `X-Token` header:
 
 We are using an invented header to simplify this example.
 
-But in real cases you will get better results using the integrated [Security utilities](security/index.md){target=_blank}.
+But in real cases you will get better results using the integrated [Security utilities](security/index.md).
 
 ///
 
@@ -169,7 +169,7 @@ And we can add a list of `dependencies` that will be added to all the *path oper
 
 /// tip
 
-Note that, much like [dependencies in *path operation decorators*](dependencies/dependencies-in-path-operation-decorators.md){target=_blank}, no value will be passed to your *path operation function*.
+Note that, much like [dependencies in *path operation decorators*](dependencies/dependencies-in-path-operation-decorators.md), no value will be passed to your *path operation function*.
 
 ///
 
@@ -185,8 +185,8 @@ The end result is that the item paths are now:
 * All of them will include the predefined `responses`.
 * All these *path operations* will have the list of `dependencies` evaluated/executed before them.
     * If you also declare dependencies in a specific *path operation*, **they will be executed too**.
-    * The router dependencies are executed first, then the [`dependencies` in the decorator](dependencies/dependencies-in-path-operation-decorators.md){target=_blank}, and then the normal parameter dependencies.
-    * You can also add [`Security` dependencies with `scopes`](../advanced/security/oauth2-scopes.md){target=_blank}.
+    * The router dependencies are executed first, then the [`dependencies` in the decorator](dependencies/dependencies-in-path-operation-decorators.md), and then the normal parameter dependencies.
+    * You can also add [`Security` dependencies with `scopes`](../advanced/security/oauth2-scopes.md).
 
 /// tip
 
@@ -303,7 +303,7 @@ And as most of your logic will now live in its own specific module, the main fil
 
 You import and create a `FastAPI` class as normally.
 
-And we can even declare [global dependencies](dependencies/global-dependencies.md){target=_blank} that will be combined with the dependencies for each `APIRouter`:
+And we can even declare [global dependencies](dependencies/global-dependencies.md) that will be combined with the dependencies for each `APIRouter`:
 
 {* ../../docs_src/bigger_applications/app_an_py310/main.py hl[1,3,7] title["app/main.py"] *}
 
@@ -353,7 +353,7 @@ The second version is an "absolute import":
 from app.routers import items, users
 ```
 
-To learn more about Python Packages and Modules, read [the official Python documentation about Modules](https://docs.python.org/3/tutorial/modules.html){target=_blank}.
+To learn more about Python Packages and Modules, read [the official Python documentation about Modules](https://docs.python.org/3/tutorial/modules.html).
 
 ///
 
@@ -479,7 +479,7 @@ $ fastapi dev app/main.py
 
 </div>
 
-And open the docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+And open the docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 You will see the automatic API docs, including the paths from all the submodules, using the correct paths (and prefixes) and the correct tags:
 

--- a/docs/en/docs/tutorial/body-nested-models.md
+++ b/docs/en/docs/tutorial/body-nested-models.md
@@ -96,7 +96,7 @@ Again, doing just that declaration, with **FastAPI** you get:
 
 Apart from normal singular types like `str`, `int`, `float`, etc. you can use more complex singular types that inherit from `str`.
 
-To see all the options you have, checkout <a href="https://docs.pydantic.dev/latest/concepts/types/" class="external-link" target="_blank">Pydantic's Type Overview</a>. You will see some examples in the next chapter.
+To see all the options you have, checkout [Pydantic's Type Overview](https://docs.pydantic.dev/latest/concepts/types/){target=_blank}. You will see some examples in the next chapter.
 
 For example, as in the `Image` model we have a `url` field, we can declare it to be an instance of Pydantic's `HttpUrl` instead of a `str`:
 

--- a/docs/en/docs/tutorial/body-nested-models.md
+++ b/docs/en/docs/tutorial/body-nested-models.md
@@ -96,7 +96,7 @@ Again, doing just that declaration, with **FastAPI** you get:
 
 Apart from normal singular types like `str`, `int`, `float`, etc. you can use more complex singular types that inherit from `str`.
 
-To see all the options you have, checkout [Pydantic's Type Overview](https://docs.pydantic.dev/latest/concepts/types/){target=_blank}. You will see some examples in the next chapter.
+To see all the options you have, checkout [Pydantic's Type Overview](https://docs.pydantic.dev/latest/concepts/types/). You will see some examples in the next chapter.
 
 For example, as in the `Image` model we have a `url` field, we can declare it to be an instance of Pydantic's `HttpUrl` instead of a `str`:
 

--- a/docs/en/docs/tutorial/body-updates.md
+++ b/docs/en/docs/tutorial/body-updates.md
@@ -2,7 +2,7 @@
 
 ## Update replacing with `PUT` { #update-replacing-with-put }
 
-To update an item you can use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT" class="external-link" target="_blank">HTTP `PUT`</a> operation.
+To update an item you can use the [HTTP `PUT`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT){target=_blank} operation.
 
 You can use the `jsonable_encoder` to convert the input data to data that can be stored as JSON (e.g. with a NoSQL database). For example, converting `datetime` to `str`.
 
@@ -28,7 +28,7 @@ And the data would be saved with that "new" `tax` of `10.5`.
 
 ## Partial updates with `PATCH` { #partial-updates-with-patch }
 
-You can also use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH" class="external-link" target="_blank">HTTP `PATCH`</a> operation to *partially* update data.
+You can also use the [HTTP `PATCH`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH){target=_blank} operation to *partially* update data.
 
 This means that you can send only the data that you want to update, leaving the rest intact.
 
@@ -95,6 +95,6 @@ Notice that the input model is still validated.
 
 So, if you want to receive partial updates that can omit all the attributes, you need to have a model with all the attributes marked as optional (with default values or `None`).
 
-To distinguish from the models with all optional values for **updates** and models with required values for **creation**, you can use the ideas described in [Extra Models](extra-models.md){.internal-link target=_blank}.
+To distinguish from the models with all optional values for **updates** and models with required values for **creation**, you can use the ideas described in [Extra Models](extra-models.md){target=_blank}.
 
 ///

--- a/docs/en/docs/tutorial/body-updates.md
+++ b/docs/en/docs/tutorial/body-updates.md
@@ -2,7 +2,7 @@
 
 ## Update replacing with `PUT` { #update-replacing-with-put }
 
-To update an item you can use the [HTTP `PUT`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT){target=_blank} operation.
+To update an item you can use the [HTTP `PUT`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT) operation.
 
 You can use the `jsonable_encoder` to convert the input data to data that can be stored as JSON (e.g. with a NoSQL database). For example, converting `datetime` to `str`.
 
@@ -28,7 +28,7 @@ And the data would be saved with that "new" `tax` of `10.5`.
 
 ## Partial updates with `PATCH` { #partial-updates-with-patch }
 
-You can also use the [HTTP `PATCH`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH){target=_blank} operation to *partially* update data.
+You can also use the [HTTP `PATCH`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) operation to *partially* update data.
 
 This means that you can send only the data that you want to update, leaving the rest intact.
 
@@ -95,6 +95,6 @@ Notice that the input model is still validated.
 
 So, if you want to receive partial updates that can omit all the attributes, you need to have a model with all the attributes marked as optional (with default values or `None`).
 
-To distinguish from the models with all optional values for **updates** and models with required values for **creation**, you can use the ideas described in [Extra Models](extra-models.md){target=_blank}.
+To distinguish from the models with all optional values for **updates** and models with required values for **creation**, you can use the ideas described in [Extra Models](extra-models.md).
 
 ///

--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -6,7 +6,7 @@ A **request** body is data sent by the client to your API. A **response** body i
 
 Your API almost always has to send a **response** body. But clients don't necessarily need to send **request bodies** all the time, sometimes they only request a path, maybe with some query parameters, but don't send a body.
 
-To declare a **request** body, you use <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a> models with all their power and benefits.
+To declare a **request** body, you use [Pydantic](https://docs.pydantic.dev/){target=_blank} models with all their power and benefits.
 
 /// info
 
@@ -73,7 +73,7 @@ With just that Python type declaration, **FastAPI** will:
     * If the data is invalid, it will return a nice and clear error, indicating exactly where and what was the incorrect data.
 * Give you the received data in the parameter `item`.
     * As you declared it in the function to be of type `Item`, you will also have all the editor support (completion, etc) for all of the attributes and their types.
-* Generate <a href="https://json-schema.org" class="external-link" target="_blank">JSON Schema</a> definitions for your model, you can also use them anywhere else you like if it makes sense for your project.
+* Generate [JSON Schema](https://json-schema.org){target=_blank} definitions for your model, you can also use them anywhere else you like if it makes sense for your project.
 * Those schemas will be part of the generated OpenAPI schema, and used by the automatic documentation <abbr title="User Interfaces">UIs</abbr>.
 
 ## Automatic docs { #automatic-docs }
@@ -102,15 +102,15 @@ And it was thoroughly tested at the design phase, before any implementation, to 
 
 There were even some changes to Pydantic itself to support this.
 
-The previous screenshots were taken with <a href="https://code.visualstudio.com" class="external-link" target="_blank">Visual Studio Code</a>.
+The previous screenshots were taken with [Visual Studio Code](https://code.visualstudio.com){target=_blank}.
 
-But you would get the same editor support with <a href="https://www.jetbrains.com/pycharm/" class="external-link" target="_blank">PyCharm</a> and most of the other Python editors:
+But you would get the same editor support with [PyCharm](https://www.jetbrains.com/pycharm/){target=_blank} and most of the other Python editors:
 
 <img src="/img/tutorial/body/image05.png">
 
 /// tip
 
-If you use <a href="https://www.jetbrains.com/pycharm/" class="external-link" target="_blank">PyCharm</a> as your editor, you can use the <a href="https://github.com/koxudaxi/pydantic-pycharm-plugin/" class="external-link" target="_blank">Pydantic PyCharm Plugin</a>.
+If you use [PyCharm](https://www.jetbrains.com/pycharm/){target=_blank} as your editor, you can use the [Pydantic PyCharm Plugin](https://github.com/koxudaxi/pydantic-pycharm-plugin/){target=_blank}.
 
 It improves editor support for Pydantic models, with:
 
@@ -163,4 +163,4 @@ But adding the type annotations will allow your editor to give you better suppor
 
 ## Without Pydantic { #without-pydantic }
 
-If you don't want to use Pydantic models, you can also use **Body** parameters. See the docs for [Body - Multiple Parameters: Singular values in body](body-multiple-params.md#singular-values-in-body){.internal-link target=_blank}.
+If you don't want to use Pydantic models, you can also use **Body** parameters. See the docs for [Body - Multiple Parameters: Singular values in body](body-multiple-params.md#singular-values-in-body){target=_blank}.

--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -6,7 +6,7 @@ A **request** body is data sent by the client to your API. A **response** body i
 
 Your API almost always has to send a **response** body. But clients don't necessarily need to send **request bodies** all the time, sometimes they only request a path, maybe with some query parameters, but don't send a body.
 
-To declare a **request** body, you use [Pydantic](https://docs.pydantic.dev/){target=_blank} models with all their power and benefits.
+To declare a **request** body, you use [Pydantic](https://docs.pydantic.dev/) models with all their power and benefits.
 
 /// info
 
@@ -73,7 +73,7 @@ With just that Python type declaration, **FastAPI** will:
     * If the data is invalid, it will return a nice and clear error, indicating exactly where and what was the incorrect data.
 * Give you the received data in the parameter `item`.
     * As you declared it in the function to be of type `Item`, you will also have all the editor support (completion, etc) for all of the attributes and their types.
-* Generate [JSON Schema](https://json-schema.org){target=_blank} definitions for your model, you can also use them anywhere else you like if it makes sense for your project.
+* Generate [JSON Schema](https://json-schema.org) definitions for your model, you can also use them anywhere else you like if it makes sense for your project.
 * Those schemas will be part of the generated OpenAPI schema, and used by the automatic documentation <abbr title="User Interfaces">UIs</abbr>.
 
 ## Automatic docs { #automatic-docs }
@@ -102,15 +102,15 @@ And it was thoroughly tested at the design phase, before any implementation, to 
 
 There were even some changes to Pydantic itself to support this.
 
-The previous screenshots were taken with [Visual Studio Code](https://code.visualstudio.com){target=_blank}.
+The previous screenshots were taken with [Visual Studio Code](https://code.visualstudio.com).
 
-But you would get the same editor support with [PyCharm](https://www.jetbrains.com/pycharm/){target=_blank} and most of the other Python editors:
+But you would get the same editor support with [PyCharm](https://www.jetbrains.com/pycharm/) and most of the other Python editors:
 
 <img src="/img/tutorial/body/image05.png">
 
 /// tip
 
-If you use [PyCharm](https://www.jetbrains.com/pycharm/){target=_blank} as your editor, you can use the [Pydantic PyCharm Plugin](https://github.com/koxudaxi/pydantic-pycharm-plugin/){target=_blank}.
+If you use [PyCharm](https://www.jetbrains.com/pycharm/) as your editor, you can use the [Pydantic PyCharm Plugin](https://github.com/koxudaxi/pydantic-pycharm-plugin/).
 
 It improves editor support for Pydantic models, with:
 
@@ -163,4 +163,4 @@ But adding the type annotations will allow your editor to give you better suppor
 
 ## Without Pydantic { #without-pydantic }
 
-If you don't want to use Pydantic models, you can also use **Body** parameters. See the docs for [Body - Multiple Parameters: Singular values in body](body-multiple-params.md#singular-values-in-body){target=_blank}.
+If you don't want to use Pydantic models, you can also use **Body** parameters. See the docs for [Body - Multiple Parameters: Singular values in body](body-multiple-params.md#singular-values-in-body).

--- a/docs/en/docs/tutorial/cors.md
+++ b/docs/en/docs/tutorial/cors.md
@@ -1,6 +1,6 @@
 # CORS (Cross-Origin Resource Sharing) { #cors-cross-origin-resource-sharing }
 
-[CORS or "Cross-Origin Resource Sharing"](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){target=_blank} refers to the situations when a frontend running in a browser has JavaScript code that communicates with a backend, and the backend is in a different "origin" than the frontend.
+[CORS or "Cross-Origin Resource Sharing"](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) refers to the situations when a frontend running in a browser has JavaScript code that communicates with a backend, and the backend is in a different "origin" than the frontend.
 
 ## Origin { #origin }
 
@@ -56,10 +56,10 @@ The following arguments are supported:
 * `allow_origins` - A list of origins that should be permitted to make cross-origin requests. E.g. `['https://example.org', 'https://www.example.org']`. You can use `['*']` to allow any origin.
 * `allow_origin_regex` - A regex string to match against origins that should be permitted to make cross-origin requests. e.g. `'https://.*\.example\.org'`.
 * `allow_methods` - A list of HTTP methods that should be allowed for cross-origin requests. Defaults to `['GET']`. You can use `['*']` to allow all standard methods.
-* `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for [simple CORS requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests){target=_blank}.
+* `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for [simple CORS requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests).
 * `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`.
 
-    None of `allow_origins`, `allow_methods` and `allow_headers` can be set to `['*']` if `allow_credentials` is set to `True`. All of them must be [explicitly specified](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#credentialed_requests_and_wildcards){target=_blank}.
+    None of `allow_origins`, `allow_methods` and `allow_headers` can be set to `['*']` if `allow_credentials` is set to `True`. All of them must be [explicitly specified](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#credentialed_requests_and_wildcards).
 
 * `expose_headers` - Indicate any response headers that should be made accessible to the browser. Defaults to `[]`.
 * `max_age` - Sets a maximum time in seconds for browsers to cache CORS responses. Defaults to `600`.
@@ -78,7 +78,7 @@ Any request with an `Origin` header. In this case the middleware will pass the r
 
 ## More info { #more-info }
 
-For more info about <abbr title="Cross-Origin Resource Sharing">CORS</abbr>, check the [Mozilla CORS documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){target=_blank}.
+For more info about <abbr title="Cross-Origin Resource Sharing">CORS</abbr>, check the [Mozilla CORS documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
 
 /// note | Technical Details
 

--- a/docs/en/docs/tutorial/cors.md
+++ b/docs/en/docs/tutorial/cors.md
@@ -1,6 +1,6 @@
 # CORS (Cross-Origin Resource Sharing) { #cors-cross-origin-resource-sharing }
 
-<a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" class="external-link" target="_blank">CORS or "Cross-Origin Resource Sharing"</a> refers to the situations when a frontend running in a browser has JavaScript code that communicates with a backend, and the backend is in a different "origin" than the frontend.
+[CORS or "Cross-Origin Resource Sharing"](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){target=_blank} refers to the situations when a frontend running in a browser has JavaScript code that communicates with a backend, and the backend is in a different "origin" than the frontend.
 
 ## Origin { #origin }
 
@@ -56,10 +56,10 @@ The following arguments are supported:
 * `allow_origins` - A list of origins that should be permitted to make cross-origin requests. E.g. `['https://example.org', 'https://www.example.org']`. You can use `['*']` to allow any origin.
 * `allow_origin_regex` - A regex string to match against origins that should be permitted to make cross-origin requests. e.g. `'https://.*\.example\.org'`.
 * `allow_methods` - A list of HTTP methods that should be allowed for cross-origin requests. Defaults to `['GET']`. You can use `['*']` to allow all standard methods.
-* `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests" class="external-link" rel="noopener" target="_blank">simple CORS requests</a>.
+* `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for [simple CORS requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests){target=_blank}.
 * `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`.
 
-    None of `allow_origins`, `allow_methods` and `allow_headers` can be set to `['*']` if `allow_credentials` is set to `True`. All of them must be <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#credentialed_requests_and_wildcards" class="external-link" rel="noopener" target="_blank">explicitly specified</a>.
+    None of `allow_origins`, `allow_methods` and `allow_headers` can be set to `['*']` if `allow_credentials` is set to `True`. All of them must be [explicitly specified](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#credentialed_requests_and_wildcards){target=_blank}.
 
 * `expose_headers` - Indicate any response headers that should be made accessible to the browser. Defaults to `[]`.
 * `max_age` - Sets a maximum time in seconds for browsers to cache CORS responses. Defaults to `600`.
@@ -78,7 +78,7 @@ Any request with an `Origin` header. In this case the middleware will pass the r
 
 ## More info { #more-info }
 
-For more info about <abbr title="Cross-Origin Resource Sharing">CORS</abbr>, check the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" class="external-link" target="_blank">Mozilla CORS documentation</a>.
+For more info about <abbr title="Cross-Origin Resource Sharing">CORS</abbr>, check the [Mozilla CORS documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){target=_blank}.
 
 /// note | Technical Details
 

--- a/docs/en/docs/tutorial/debugging.md
+++ b/docs/en/docs/tutorial/debugging.md
@@ -74,7 +74,7 @@ will not be executed.
 
 /// info
 
-For more information, check <a href="https://docs.python.org/3/library/__main__.html" class="external-link" target="_blank">the official Python docs</a>.
+For more information, check [the official Python docs](https://docs.python.org/3/library/__main__.html){target=_blank}.
 
 ///
 

--- a/docs/en/docs/tutorial/debugging.md
+++ b/docs/en/docs/tutorial/debugging.md
@@ -74,7 +74,7 @@ will not be executed.
 
 /// info
 
-For more information, check [the official Python docs](https://docs.python.org/3/library/__main__.html){target=_blank}.
+For more information, check [the official Python docs](https://docs.python.org/3/library/__main__.html).
 
 ///
 

--- a/docs/en/docs/tutorial/dependencies/dependencies-in-path-operation-decorators.md
+++ b/docs/en/docs/tutorial/dependencies/dependencies-in-path-operation-decorators.md
@@ -32,7 +32,7 @@ It might also help avoid confusion for new developers that see an unused paramet
 
 In this example we use invented custom headers `X-Key` and `X-Token`.
 
-But in real cases, when implementing security, you would get more benefits from using the integrated [Security utilities (the next chapter)](../security/index.md){target=_blank}.
+But in real cases, when implementing security, you would get more benefits from using the integrated [Security utilities (the next chapter)](../security/index.md).
 
 ///
 
@@ -62,7 +62,7 @@ So, you can reuse a normal dependency (that returns a value) you already use som
 
 ## Dependencies for a group of *path operations* { #dependencies-for-a-group-of-path-operations }
 
-Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md){target=_blank}), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.
+Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md)), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.
 
 ## Global Dependencies { #global-dependencies }
 

--- a/docs/en/docs/tutorial/dependencies/dependencies-in-path-operation-decorators.md
+++ b/docs/en/docs/tutorial/dependencies/dependencies-in-path-operation-decorators.md
@@ -32,7 +32,7 @@ It might also help avoid confusion for new developers that see an unused paramet
 
 In this example we use invented custom headers `X-Key` and `X-Token`.
 
-But in real cases, when implementing security, you would get more benefits from using the integrated [Security utilities (the next chapter)](../security/index.md){.internal-link target=_blank}.
+But in real cases, when implementing security, you would get more benefits from using the integrated [Security utilities (the next chapter)](../security/index.md){target=_blank}.
 
 ///
 
@@ -62,7 +62,7 @@ So, you can reuse a normal dependency (that returns a value) you already use som
 
 ## Dependencies for a group of *path operations* { #dependencies-for-a-group-of-path-operations }
 
-Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md){.internal-link target=_blank}), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.
+Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md){target=_blank}), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.
 
 ## Global Dependencies { #global-dependencies }
 

--- a/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
+++ b/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
@@ -14,8 +14,8 @@ Make sure to use `yield` one single time per dependency.
 
 Any function that is valid to use with:
 
-* <a href="https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager" class="external-link" target="_blank">`@contextlib.contextmanager`</a> or
-* <a href="https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager" class="external-link" target="_blank">`@contextlib.asynccontextmanager`</a>
+* [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager){target=_blank} or
+* [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager){target=_blank}
 
 would be valid to use as a **FastAPI** dependency.
 
@@ -87,7 +87,7 @@ You can have any combinations of dependencies that you want.
 
 /// note | Technical Details
 
-This works thanks to Python's <a href="https://docs.python.org/3/library/contextlib.html" class="external-link" target="_blank">Context Managers</a>.
+This works thanks to Python's [Context Managers](https://docs.python.org/3/library/contextlib.html){target=_blank}.
 
 **FastAPI** uses them internally to achieve this.
 
@@ -111,7 +111,7 @@ But it's there for you if you need it. 🤓
 
 {* ../../docs_src/dependencies/tutorial008b_an_py310.py hl[18:22,31] *}
 
-If you want to catch exceptions and create a custom response based on that, create a [Custom Exception Handler](../handling-errors.md#install-custom-exception-handlers){.internal-link target=_blank}.
+If you want to catch exceptions and create a custom response based on that, create a [Custom Exception Handler](../handling-errors.md#install-custom-exception-handlers){target=_blank}.
 
 ## Dependencies with `yield` and `except` { #dependencies-with-yield-and-except }
 
@@ -233,14 +233,14 @@ participant operation as Path Operation
 
 Dependencies with `yield` have evolved over time to cover different use cases and fix some issues.
 
-If you want to see what has changed in different versions of FastAPI, you can read more about it in the advanced guide, in [Advanced Dependencies - Dependencies with `yield`, `HTTPException`, `except` and Background Tasks](../../advanced/advanced-dependencies.md#dependencies-with-yield-httpexception-except-and-background-tasks){.internal-link target=_blank}.
+If you want to see what has changed in different versions of FastAPI, you can read more about it in the advanced guide, in [Advanced Dependencies - Dependencies with `yield`, `HTTPException`, `except` and Background Tasks](../../advanced/advanced-dependencies.md#dependencies-with-yield-httpexception-except-and-background-tasks){target=_blank}.
 ## Context Managers { #context-managers }
 
 ### What are "Context Managers" { #what-are-context-managers }
 
 "Context Managers" are any of those Python objects that you can use in a `with` statement.
 
-For example, <a href="https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files" class="external-link" target="_blank">you can use `with` to read a file</a>:
+For example, [you can use `with` to read a file](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files){target=_blank}:
 
 ```Python
 with open("./somefile.txt") as f:
@@ -264,7 +264,7 @@ If you are just starting with **FastAPI** you might want to skip it for now.
 
 ///
 
-In Python, you can create Context Managers by <a href="https://docs.python.org/3/reference/datamodel.html#context-managers" class="external-link" target="_blank">creating a class with two methods: `__enter__()` and `__exit__()`</a>.
+In Python, you can create Context Managers by [creating a class with two methods: `__enter__()` and `__exit__()`](https://docs.python.org/3/reference/datamodel.html#context-managers){target=_blank}.
 
 You can also use them inside of **FastAPI** dependencies with `yield` by using
 `with` or `async with` statements inside of the dependency function:
@@ -275,8 +275,8 @@ You can also use them inside of **FastAPI** dependencies with `yield` by using
 
 Another way to create a context manager is with:
 
-* <a href="https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager" class="external-link" target="_blank">`@contextlib.contextmanager`</a> or
-* <a href="https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager" class="external-link" target="_blank">`@contextlib.asynccontextmanager`</a>
+* [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager){target=_blank} or
+* [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager){target=_blank}
 
 using them to decorate a function with a single `yield`.
 

--- a/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
+++ b/docs/en/docs/tutorial/dependencies/dependencies-with-yield.md
@@ -14,8 +14,8 @@ Make sure to use `yield` one single time per dependency.
 
 Any function that is valid to use with:
 
-* [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager){target=_blank} or
-* [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager){target=_blank}
+* [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager) or
+* [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager)
 
 would be valid to use as a **FastAPI** dependency.
 
@@ -87,7 +87,7 @@ You can have any combinations of dependencies that you want.
 
 /// note | Technical Details
 
-This works thanks to Python's [Context Managers](https://docs.python.org/3/library/contextlib.html){target=_blank}.
+This works thanks to Python's [Context Managers](https://docs.python.org/3/library/contextlib.html).
 
 **FastAPI** uses them internally to achieve this.
 
@@ -111,7 +111,7 @@ But it's there for you if you need it. 🤓
 
 {* ../../docs_src/dependencies/tutorial008b_an_py310.py hl[18:22,31] *}
 
-If you want to catch exceptions and create a custom response based on that, create a [Custom Exception Handler](../handling-errors.md#install-custom-exception-handlers){target=_blank}.
+If you want to catch exceptions and create a custom response based on that, create a [Custom Exception Handler](../handling-errors.md#install-custom-exception-handlers).
 
 ## Dependencies with `yield` and `except` { #dependencies-with-yield-and-except }
 
@@ -233,14 +233,14 @@ participant operation as Path Operation
 
 Dependencies with `yield` have evolved over time to cover different use cases and fix some issues.
 
-If you want to see what has changed in different versions of FastAPI, you can read more about it in the advanced guide, in [Advanced Dependencies - Dependencies with `yield`, `HTTPException`, `except` and Background Tasks](../../advanced/advanced-dependencies.md#dependencies-with-yield-httpexception-except-and-background-tasks){target=_blank}.
+If you want to see what has changed in different versions of FastAPI, you can read more about it in the advanced guide, in [Advanced Dependencies - Dependencies with `yield`, `HTTPException`, `except` and Background Tasks](../../advanced/advanced-dependencies.md#dependencies-with-yield-httpexception-except-and-background-tasks).
 ## Context Managers { #context-managers }
 
 ### What are "Context Managers" { #what-are-context-managers }
 
 "Context Managers" are any of those Python objects that you can use in a `with` statement.
 
-For example, [you can use `with` to read a file](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files){target=_blank}:
+For example, [you can use `with` to read a file](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files):
 
 ```Python
 with open("./somefile.txt") as f:
@@ -264,7 +264,7 @@ If you are just starting with **FastAPI** you might want to skip it for now.
 
 ///
 
-In Python, you can create Context Managers by [creating a class with two methods: `__enter__()` and `__exit__()`](https://docs.python.org/3/reference/datamodel.html#context-managers){target=_blank}.
+In Python, you can create Context Managers by [creating a class with two methods: `__enter__()` and `__exit__()`](https://docs.python.org/3/reference/datamodel.html#context-managers).
 
 You can also use them inside of **FastAPI** dependencies with `yield` by using
 `with` or `async with` statements inside of the dependency function:
@@ -275,8 +275,8 @@ You can also use them inside of **FastAPI** dependencies with `yield` by using
 
 Another way to create a context manager is with:
 
-* [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager){target=_blank} or
-* [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager){target=_blank}
+* [`@contextlib.contextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager) or
+* [`@contextlib.asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager)
 
 using them to decorate a function with a single `yield`.
 

--- a/docs/en/docs/tutorial/dependencies/global-dependencies.md
+++ b/docs/en/docs/tutorial/dependencies/global-dependencies.md
@@ -2,15 +2,15 @@
 
 For some types of applications you might want to add dependencies to the whole application.
 
-Similar to the way you can [add `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md){target=_blank}, you can add them to the `FastAPI` application.
+Similar to the way you can [add `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md), you can add them to the `FastAPI` application.
 
 In that case, they will be applied to all the *path operations* in the application:
 
 {* ../../docs_src/dependencies/tutorial012_an_py310.py hl[17] *}
 
 
-And all the ideas in the section about [adding `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md){target=_blank} still apply, but in this case, to all of the *path operations* in the app.
+And all the ideas in the section about [adding `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md) still apply, but in this case, to all of the *path operations* in the app.
 
 ## Dependencies for groups of *path operations* { #dependencies-for-groups-of-path-operations }
 
-Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md){target=_blank}), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.
+Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md)), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.

--- a/docs/en/docs/tutorial/dependencies/global-dependencies.md
+++ b/docs/en/docs/tutorial/dependencies/global-dependencies.md
@@ -2,15 +2,15 @@
 
 For some types of applications you might want to add dependencies to the whole application.
 
-Similar to the way you can [add `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md){.internal-link target=_blank}, you can add them to the `FastAPI` application.
+Similar to the way you can [add `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md){target=_blank}, you can add them to the `FastAPI` application.
 
 In that case, they will be applied to all the *path operations* in the application:
 
 {* ../../docs_src/dependencies/tutorial012_an_py310.py hl[17] *}
 
 
-And all the ideas in the section about [adding `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md){.internal-link target=_blank} still apply, but in this case, to all of the *path operations* in the app.
+And all the ideas in the section about [adding `dependencies` to the *path operation decorators*](dependencies-in-path-operation-decorators.md){target=_blank} still apply, but in this case, to all of the *path operations* in the app.
 
 ## Dependencies for groups of *path operations* { #dependencies-for-groups-of-path-operations }
 
-Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md){.internal-link target=_blank}), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.
+Later, when reading about how to structure bigger applications ([Bigger Applications - Multiple Files](../../tutorial/bigger-applications.md){target=_blank}), possibly with multiple files, you will learn how to declare a single `dependencies` parameter for a group of *path operations*.

--- a/docs/en/docs/tutorial/dependencies/index.md
+++ b/docs/en/docs/tutorial/dependencies/index.md
@@ -57,7 +57,7 @@ FastAPI added support for `Annotated` (and started recommending it) in version 0
 
 If you have an older version, you would get errors when trying to use `Annotated`.
 
-Make sure you [Upgrade the FastAPI version](../../deployment/versions.md#upgrading-the-fastapi-versions){target=_blank} to at least 0.95.1 before using `Annotated`.
+Make sure you [Upgrade the FastAPI version](../../deployment/versions.md#upgrading-the-fastapi-versions) to at least 0.95.1 before using `Annotated`.
 
 ///
 
@@ -152,7 +152,7 @@ It doesn't matter. **FastAPI** will know what to do.
 
 /// note
 
-If you don't know, check the [Async: *"In a hurry?"*](../../async.md#in-a-hurry){target=_blank} section about `async` and `await` in the docs.
+If you don't know, check the [Async: *"In a hurry?"*](../../async.md#in-a-hurry) section about `async` and `await` in the docs.
 
 ///
 

--- a/docs/en/docs/tutorial/dependencies/index.md
+++ b/docs/en/docs/tutorial/dependencies/index.md
@@ -57,7 +57,7 @@ FastAPI added support for `Annotated` (and started recommending it) in version 0
 
 If you have an older version, you would get errors when trying to use `Annotated`.
 
-Make sure you [Upgrade the FastAPI version](../../deployment/versions.md#upgrading-the-fastapi-versions){.internal-link target=_blank} to at least 0.95.1 before using `Annotated`.
+Make sure you [Upgrade the FastAPI version](../../deployment/versions.md#upgrading-the-fastapi-versions){target=_blank} to at least 0.95.1 before using `Annotated`.
 
 ///
 
@@ -152,7 +152,7 @@ It doesn't matter. **FastAPI** will know what to do.
 
 /// note
 
-If you don't know, check the [Async: *"In a hurry?"*](../../async.md#in-a-hurry){.internal-link target=_blank} section about `async` and `await` in the docs.
+If you don't know, check the [Async: *"In a hurry?"*](../../async.md#in-a-hurry){target=_blank} section about `async` and `await` in the docs.
 
 ///
 

--- a/docs/en/docs/tutorial/encoder.md
+++ b/docs/en/docs/tutorial/encoder.md
@@ -12,7 +12,7 @@ Let's imagine that you have a database `fake_db` that only receives JSON compati
 
 For example, it doesn't receive `datetime` objects, as those are not compatible with JSON.
 
-So, a `datetime` object would have to be converted to a `str` containing the data in [ISO format](https://en.wikipedia.org/wiki/ISO_8601){target=_blank}.
+So, a `datetime` object would have to be converted to a `str` containing the data in [ISO format](https://en.wikipedia.org/wiki/ISO_8601).
 
 The same way, this database wouldn't receive a Pydantic model (an object with attributes), only a `dict`.
 
@@ -24,7 +24,7 @@ It receives an object, like a Pydantic model, and returns a JSON compatible vers
 
 In this example, it would convert the Pydantic model to a `dict`, and the `datetime` to a `str`.
 
-The result of calling it is something that can be encoded with the Python standard [`json.dumps()`](https://docs.python.org/3/library/json.html#json.dumps){target=_blank}.
+The result of calling it is something that can be encoded with the Python standard [`json.dumps()`](https://docs.python.org/3/library/json.html#json.dumps).
 
 It doesn't return a large `str` containing the data in JSON format (as a string). It returns a Python standard data structure (e.g. a `dict`) with values and sub-values that are all compatible with JSON.
 

--- a/docs/en/docs/tutorial/encoder.md
+++ b/docs/en/docs/tutorial/encoder.md
@@ -12,7 +12,7 @@ Let's imagine that you have a database `fake_db` that only receives JSON compati
 
 For example, it doesn't receive `datetime` objects, as those are not compatible with JSON.
 
-So, a `datetime` object would have to be converted to a `str` containing the data in <a href="https://en.wikipedia.org/wiki/ISO_8601" class="external-link" target="_blank">ISO format</a>.
+So, a `datetime` object would have to be converted to a `str` containing the data in [ISO format](https://en.wikipedia.org/wiki/ISO_8601){target=_blank}.
 
 The same way, this database wouldn't receive a Pydantic model (an object with attributes), only a `dict`.
 
@@ -24,7 +24,7 @@ It receives an object, like a Pydantic model, and returns a JSON compatible vers
 
 In this example, it would convert the Pydantic model to a `dict`, and the `datetime` to a `str`.
 
-The result of calling it is something that can be encoded with the Python standard <a href="https://docs.python.org/3/library/json.html#json.dumps" class="external-link" target="_blank">`json.dumps()`</a>.
+The result of calling it is something that can be encoded with the Python standard [`json.dumps()`](https://docs.python.org/3/library/json.html#json.dumps){target=_blank}.
 
 It doesn't return a large `str` containing the data in JSON format (as a string). It returns a Python standard data structure (e.g. a `dict`) with values and sub-values that are all compatible with JSON.
 

--- a/docs/en/docs/tutorial/extra-data-types.md
+++ b/docs/en/docs/tutorial/extra-data-types.md
@@ -36,7 +36,7 @@ Here are some of the additional data types you can use:
 * `datetime.timedelta`:
     * A Python `datetime.timedelta`.
     * In requests and responses will be represented as a `float` of total seconds.
-    * Pydantic also allows representing it as a "ISO 8601 time diff encoding", [see the docs for more info](https://docs.pydantic.dev/latest/concepts/serialization/#custom-serializers){target=_blank}.
+    * Pydantic also allows representing it as a "ISO 8601 time diff encoding", [see the docs for more info](https://docs.pydantic.dev/latest/concepts/serialization/#custom-serializers).
 * `frozenset`:
     * In requests and responses, treated the same as a `set`:
         * In requests, a list will be read, eliminating duplicates and converting it to a `set`.
@@ -49,7 +49,7 @@ Here are some of the additional data types you can use:
 * `Decimal`:
     * Standard Python `Decimal`.
     * In requests and responses, handled the same as a `float`.
-* You can check all the valid Pydantic data types here: [Pydantic data types](https://docs.pydantic.dev/latest/usage/types/types/){target=_blank}.
+* You can check all the valid Pydantic data types here: [Pydantic data types](https://docs.pydantic.dev/latest/usage/types/types/).
 
 ## Example { #example }
 

--- a/docs/en/docs/tutorial/extra-data-types.md
+++ b/docs/en/docs/tutorial/extra-data-types.md
@@ -36,7 +36,7 @@ Here are some of the additional data types you can use:
 * `datetime.timedelta`:
     * A Python `datetime.timedelta`.
     * In requests and responses will be represented as a `float` of total seconds.
-    * Pydantic also allows representing it as a "ISO 8601 time diff encoding", <a href="https://docs.pydantic.dev/latest/concepts/serialization/#custom-serializers" class="external-link" target="_blank">see the docs for more info</a>.
+    * Pydantic also allows representing it as a "ISO 8601 time diff encoding", [see the docs for more info](https://docs.pydantic.dev/latest/concepts/serialization/#custom-serializers){target=_blank}.
 * `frozenset`:
     * In requests and responses, treated the same as a `set`:
         * In requests, a list will be read, eliminating duplicates and converting it to a `set`.
@@ -49,7 +49,7 @@ Here are some of the additional data types you can use:
 * `Decimal`:
     * Standard Python `Decimal`.
     * In requests and responses, handled the same as a `float`.
-* You can check all the valid Pydantic data types here: <a href="https://docs.pydantic.dev/latest/usage/types/types/" class="external-link" target="_blank">Pydantic data types</a>.
+* You can check all the valid Pydantic data types here: [Pydantic data types](https://docs.pydantic.dev/latest/usage/types/types/){target=_blank}.
 
 ## Example { #example }
 

--- a/docs/en/docs/tutorial/extra-models.md
+++ b/docs/en/docs/tutorial/extra-models.md
@@ -12,7 +12,7 @@ This is especially the case for user models, because:
 
 Never store user's plaintext passwords. Always store a "secure hash" that you can then verify.
 
-If you don't know, you will learn what a "password hash" is in the [security chapters](security/simple-oauth2.md#password-hashing){target=_blank}.
+If you don't know, you will learn what a "password hash" is in the [security chapters](security/simple-oauth2.md#password-hashing).
 
 ///
 
@@ -162,11 +162,11 @@ You can declare a response to be the `Union` of two or more types, that means, t
 
 It will be defined in OpenAPI with `anyOf`.
 
-To do that, use the standard Python type hint [`typing.Union`](https://docs.python.org/3/library/typing.html#typing.Union){target=_blank}:
+To do that, use the standard Python type hint [`typing.Union`](https://docs.python.org/3/library/typing.html#typing.Union):
 
 /// note
 
-When defining a [`Union`](https://docs.pydantic.dev/latest/concepts/types/#unions){target=_blank}, include the most specific type first, followed by the less specific type. In the example below, the more specific `PlaneItem` comes before `CarItem` in `Union[PlaneItem, CarItem]`.
+When defining a [`Union`](https://docs.pydantic.dev/latest/concepts/types/#unions), include the most specific type first, followed by the less specific type. In the example below, the more specific `PlaneItem` comes before `CarItem` in `Union[PlaneItem, CarItem]`.
 
 ///
 

--- a/docs/en/docs/tutorial/extra-models.md
+++ b/docs/en/docs/tutorial/extra-models.md
@@ -12,7 +12,7 @@ This is especially the case for user models, because:
 
 Never store user's plaintext passwords. Always store a "secure hash" that you can then verify.
 
-If you don't know, you will learn what a "password hash" is in the [security chapters](security/simple-oauth2.md#password-hashing){.internal-link target=_blank}.
+If you don't know, you will learn what a "password hash" is in the [security chapters](security/simple-oauth2.md#password-hashing){target=_blank}.
 
 ///
 
@@ -162,11 +162,11 @@ You can declare a response to be the `Union` of two or more types, that means, t
 
 It will be defined in OpenAPI with `anyOf`.
 
-To do that, use the standard Python type hint <a href="https://docs.python.org/3/library/typing.html#typing.Union" class="external-link" target="_blank">`typing.Union`</a>:
+To do that, use the standard Python type hint [`typing.Union`](https://docs.python.org/3/library/typing.html#typing.Union){target=_blank}:
 
 /// note
 
-When defining a <a href="https://docs.pydantic.dev/latest/concepts/types/#unions" class="external-link" target="_blank">`Union`</a>, include the most specific type first, followed by the less specific type. In the example below, the more specific `PlaneItem` comes before `CarItem` in `Union[PlaneItem, CarItem]`.
+When defining a [`Union`](https://docs.pydantic.dev/latest/concepts/types/#unions){target=_blank}, include the most specific type first, followed by the less specific type. In the example below, the more specific `PlaneItem` comes before `CarItem` in `Union[PlaneItem, CarItem]`.
 
 ///
 

--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -58,7 +58,7 @@ That line shows the URL where your app is being served on your local machine.
 
 ### Check it { #check-it }
 
-Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000){target=_blank}.
+Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
 You will see the JSON response as:
 
@@ -68,17 +68,17 @@ You will see the JSON response as:
 
 ### Interactive API docs { #interactive-api-docs }
 
-Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
-You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui){target=_blank}):
+You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui)):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ### Alternative API docs { #alternative-api-docs }
 
-And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc){target=_blank}.
+And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc).
 
-You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc){target=_blank}):
+You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc)):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -92,7 +92,7 @@ A "schema" is a definition or description of something. Not the code that implem
 
 #### API "schema" { #api-schema }
 
-In this case, [OpenAPI](https://github.com/OAI/OpenAPI-Specification){target=_blank} is a specification that dictates how to define a schema of your API.
+In this case, [OpenAPI](https://github.com/OAI/OpenAPI-Specification) is a specification that dictates how to define a schema of your API.
 
 This schema definition includes your API paths, the possible parameters they take, etc.
 
@@ -110,7 +110,7 @@ OpenAPI defines an API schema for your API. And that schema includes definitions
 
 If you are curious about how the raw OpenAPI schema looks like, FastAPI automatically generates a JSON (schema) with the descriptions of all your API.
 
-You can see it directly at: [http://127.0.0.1:8000/openapi.json](http://127.0.0.1:8000/openapi.json){target=_blank}.
+You can see it directly at: [http://127.0.0.1:8000/openapi.json](http://127.0.0.1:8000/openapi.json).
 
 It will show a JSON starting with something like:
 
@@ -145,7 +145,7 @@ You could also use it to generate code automatically, for clients that communica
 
 ### Deploy your app (optional) { #deploy-your-app-optional }
 
-You can optionally deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com){target=_blank}, go and join the waiting list if you haven't. 🚀
+You can optionally deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com), go and join the waiting list if you haven't. 🚀
 
 If you already have a **FastAPI Cloud** account (we invited you from the waiting list 😉), you can deploy your application with one command.
 
@@ -191,7 +191,7 @@ That's it! Now you can access your app at that URL. ✨
 
 `FastAPI` is a class that inherits directly from `Starlette`.
 
-You can use all the [Starlette](https://www.starlette.dev/){target=_blank} functionality with `FastAPI` too.
+You can use all the [Starlette](https://www.starlette.dev/) functionality with `FastAPI` too.
 
 ///
 
@@ -336,7 +336,7 @@ You could also define it as a normal function instead of `async def`:
 
 /// note
 
-If you don't know the difference, check the [Async: *"In a hurry?"*](../async.md#in-a-hurry){target=_blank}.
+If you don't know the difference, check the [Async: *"In a hurry?"*](../async.md#in-a-hurry).
 
 ///
 
@@ -352,11 +352,11 @@ There are many other objects and models that will be automatically converted to 
 
 ### Step 6: Deploy it { #step-6-deploy-it }
 
-Deploy your app to **[FastAPI Cloud](https://fastapicloud.com){target=_blank}** with one command: `fastapi deploy`. 🎉
+Deploy your app to **[FastAPI Cloud](https://fastapicloud.com)** with one command: `fastapi deploy`. 🎉
 
 #### About FastAPI Cloud { #about-fastapi-cloud }
 
-**[FastAPI Cloud](https://fastapicloud.com){target=_blank}** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com)** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 

--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -58,7 +58,7 @@ That line shows the URL where your app is being served on your local machine.
 
 ### Check it { #check-it }
 
-Open your browser at <a href="http://127.0.0.1:8000" class="external-link" target="_blank">http://127.0.0.1:8000</a>.
+Open your browser at [http://127.0.0.1:8000](http://127.0.0.1:8000){target=_blank}.
 
 You will see the JSON response as:
 
@@ -68,17 +68,17 @@ You will see the JSON response as:
 
 ### Interactive API docs { #interactive-api-docs }
 
-Now go to <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
-You will see the automatic interactive API documentation (provided by <a href="https://github.com/swagger-api/swagger-ui" class="external-link" target="_blank">Swagger UI</a>):
+You will see the automatic interactive API documentation (provided by [Swagger UI](https://github.com/swagger-api/swagger-ui){target=_blank}):
 
 ![Swagger UI](https://fastapi.tiangolo.com/img/index/index-01-swagger-ui-simple.png)
 
 ### Alternative API docs { #alternative-api-docs }
 
-And now, go to <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>.
+And now, go to [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc){target=_blank}.
 
-You will see the alternative automatic documentation (provided by <a href="https://github.com/Rebilly/ReDoc" class="external-link" target="_blank">ReDoc</a>):
+You will see the alternative automatic documentation (provided by [ReDoc](https://github.com/Rebilly/ReDoc){target=_blank}):
 
 ![ReDoc](https://fastapi.tiangolo.com/img/index/index-02-redoc-simple.png)
 
@@ -92,7 +92,7 @@ A "schema" is a definition or description of something. Not the code that implem
 
 #### API "schema" { #api-schema }
 
-In this case, <a href="https://github.com/OAI/OpenAPI-Specification" class="external-link" target="_blank">OpenAPI</a> is a specification that dictates how to define a schema of your API.
+In this case, [OpenAPI](https://github.com/OAI/OpenAPI-Specification){target=_blank} is a specification that dictates how to define a schema of your API.
 
 This schema definition includes your API paths, the possible parameters they take, etc.
 
@@ -110,7 +110,7 @@ OpenAPI defines an API schema for your API. And that schema includes definitions
 
 If you are curious about how the raw OpenAPI schema looks like, FastAPI automatically generates a JSON (schema) with the descriptions of all your API.
 
-You can see it directly at: <a href="http://127.0.0.1:8000/openapi.json" class="external-link" target="_blank">http://127.0.0.1:8000/openapi.json</a>.
+You can see it directly at: [http://127.0.0.1:8000/openapi.json](http://127.0.0.1:8000/openapi.json){target=_blank}.
 
 It will show a JSON starting with something like:
 
@@ -145,7 +145,7 @@ You could also use it to generate code automatically, for clients that communica
 
 ### Deploy your app (optional) { #deploy-your-app-optional }
 
-You can optionally deploy your FastAPI app to <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>, go and join the waiting list if you haven't. 🚀
+You can optionally deploy your FastAPI app to [FastAPI Cloud](https://fastapicloud.com){target=_blank}, go and join the waiting list if you haven't. 🚀
 
 If you already have a **FastAPI Cloud** account (we invited you from the waiting list 😉), you can deploy your application with one command.
 
@@ -191,7 +191,7 @@ That's it! Now you can access your app at that URL. ✨
 
 `FastAPI` is a class that inherits directly from `Starlette`.
 
-You can use all the <a href="https://www.starlette.dev/" class="external-link" target="_blank">Starlette</a> functionality with `FastAPI` too.
+You can use all the [Starlette](https://www.starlette.dev/){target=_blank} functionality with `FastAPI` too.
 
 ///
 
@@ -336,7 +336,7 @@ You could also define it as a normal function instead of `async def`:
 
 /// note
 
-If you don't know the difference, check the [Async: *"In a hurry?"*](../async.md#in-a-hurry){.internal-link target=_blank}.
+If you don't know the difference, check the [Async: *"In a hurry?"*](../async.md#in-a-hurry){target=_blank}.
 
 ///
 
@@ -352,11 +352,11 @@ There are many other objects and models that will be automatically converted to 
 
 ### Step 6: Deploy it { #step-6-deploy-it }
 
-Deploy your app to **<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** with one command: `fastapi deploy`. 🎉
+Deploy your app to **[FastAPI Cloud](https://fastapicloud.com){target=_blank}** with one command: `fastapi deploy`. 🎉
 
 #### About FastAPI Cloud { #about-fastapi-cloud }
 
-**<a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>** is built by the same author and team behind **FastAPI**.
+**[FastAPI Cloud](https://fastapicloud.com){target=_blank}** is built by the same author and team behind **FastAPI**.
 
 It streamlines the process of **building**, **deploying**, and **accessing** an API with minimal effort.
 

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -81,7 +81,7 @@ But in case you needed it for an advanced scenario, you can add custom headers:
 
 ## Install custom exception handlers { #install-custom-exception-handlers }
 
-You can add custom exception handlers with [the same exception utilities from Starlette](https://www.starlette.dev/exceptions/){target=_blank}.
+You can add custom exception handlers with [the same exception utilities from Starlette](https://www.starlette.dev/exceptions/).
 
 Let's say you have a custom exception `UnicornException` that you (or a library you use) might `raise`.
 

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -81,7 +81,7 @@ But in case you needed it for an advanced scenario, you can add custom headers:
 
 ## Install custom exception handlers { #install-custom-exception-handlers }
 
-You can add custom exception handlers with <a href="https://www.starlette.dev/exceptions/" class="external-link" target="_blank">the same exception utilities from Starlette</a>.
+You can add custom exception handlers with [the same exception utilities from Starlette](https://www.starlette.dev/exceptions/){target=_blank}.
 
 Let's say you have a custom exception `UnicornException` that you (or a library you use) might `raise`.
 

--- a/docs/en/docs/tutorial/index.md
+++ b/docs/en/docs/tutorial/index.md
@@ -62,7 +62,7 @@ Using it in your editor is what really shows you the benefits of FastAPI, seeing
 
 The first step is to install FastAPI.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then **install FastAPI**:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then **install FastAPI**:
 
 <div class="termy">
 
@@ -76,7 +76,7 @@ $ pip install "fastapi[standard]"
 
 /// note
 
-When you install with `pip install "fastapi[standard]"` it comes with some default optional standard dependencies, including `fastapi-cloud-cli`, which allows you to deploy to <a href="https://fastapicloud.com" class="external-link" target="_blank">FastAPI Cloud</a>.
+When you install with `pip install "fastapi[standard]"` it comes with some default optional standard dependencies, including `fastapi-cloud-cli`, which allows you to deploy to [FastAPI Cloud](https://fastapicloud.com){target=_blank}.
 
 If you don't want to have those optional dependencies, you can instead install `pip install fastapi`.
 
@@ -86,7 +86,7 @@ If you want to install the standard dependencies but without the `fastapi-cloud-
 
 /// tip
 
-FastAPI has an <a href="https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode" class="external-link" target="_blank">official extension for VS Code</a> (and Cursor), which provides a lot of features, including a path operation explorer, path operation search, CodeLens navigation in tests (jump to definition from tests), and FastAPI Cloud deployment and logs, all from your editor.
+FastAPI has an [official extension for VS Code](https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode){target=_blank} (and Cursor), which provides a lot of features, including a path operation explorer, path operation search, CodeLens navigation in tests (jump to definition from tests), and FastAPI Cloud deployment and logs, all from your editor.
 
 ///
 

--- a/docs/en/docs/tutorial/index.md
+++ b/docs/en/docs/tutorial/index.md
@@ -62,7 +62,7 @@ Using it in your editor is what really shows you the benefits of FastAPI, seeing
 
 The first step is to install FastAPI.
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then **install FastAPI**:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then **install FastAPI**:
 
 <div class="termy">
 
@@ -76,7 +76,7 @@ $ pip install "fastapi[standard]"
 
 /// note
 
-When you install with `pip install "fastapi[standard]"` it comes with some default optional standard dependencies, including `fastapi-cloud-cli`, which allows you to deploy to [FastAPI Cloud](https://fastapicloud.com){target=_blank}.
+When you install with `pip install "fastapi[standard]"` it comes with some default optional standard dependencies, including `fastapi-cloud-cli`, which allows you to deploy to [FastAPI Cloud](https://fastapicloud.com).
 
 If you don't want to have those optional dependencies, you can instead install `pip install fastapi`.
 
@@ -86,7 +86,7 @@ If you want to install the standard dependencies but without the `fastapi-cloud-
 
 /// tip
 
-FastAPI has an [official extension for VS Code](https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode){target=_blank} (and Cursor), which provides a lot of features, including a path operation explorer, path operation search, CodeLens navigation in tests (jump to definition from tests), and FastAPI Cloud deployment and logs, all from your editor.
+FastAPI has an [official extension for VS Code](https://marketplace.visualstudio.com/items?itemName=FastAPILabs.fastapi-vscode) (and Cursor), which provides a lot of features, including a path operation explorer, path operation search, CodeLens navigation in tests (jump to definition from tests), and FastAPI Cloud deployment and logs, all from your editor.
 
 ///
 

--- a/docs/en/docs/tutorial/metadata.md
+++ b/docs/en/docs/tutorial/metadata.md
@@ -14,7 +14,7 @@ You can set the following fields that are used in the OpenAPI specification and 
 | `version` | `string` | The version of the API. This is the version of your own application, not of OpenAPI. For example `2.5.0`. |
 | `terms_of_service` | `str` | A URL to the Terms of Service for the API. If provided, this has to be a URL. |
 | `contact` | `dict` | The contact information for the exposed API. It can contain several fields. <details><summary><code>contact</code> fields</summary><table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead><tbody><tr><td><code>name</code></td><td><code>str</code></td><td>The identifying name of the contact person/organization.</td></tr><tr><td><code>url</code></td><td><code>str</code></td><td>The URL pointing to the contact information. MUST be in the format of a URL.</td></tr><tr><td><code>email</code></td><td><code>str</code></td><td>The email address of the contact person/organization. MUST be in the format of an email address.</td></tr></tbody></table></details> |
-| `license_info` | `dict` | The license information for the exposed API. It can contain several fields. <details><summary><code>license_info</code> fields</summary><table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead><tbody><tr><td><code>name</code></td><td><code>str</code></td><td><strong>REQUIRED</strong> (if a <code>license_info</code> is set). The license name used for the API.</td></tr><tr><td><code>identifier</code></td><td><code>str</code></td><td>An [SPDX](https://spdx.org/licenses/){target=_blank} license expression for the API. The <code>identifier</code> field is mutually exclusive of the <code>url</code> field. <small>Available since OpenAPI 3.1.0, FastAPI 0.99.0.</small></td></tr><tr><td><code>url</code></td><td><code>str</code></td><td>A URL to the license used for the API. MUST be in the format of a URL.</td></tr></tbody></table></details> |
+| `license_info` | `dict` | The license information for the exposed API. It can contain several fields. <details><summary><code>license_info</code> fields</summary><table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead><tbody><tr><td><code>name</code></td><td><code>str</code></td><td><strong>REQUIRED</strong> (if a <code>license_info</code> is set). The license name used for the API.</td></tr><tr><td><code>identifier</code></td><td><code>str</code></td><td>An [SPDX](https://spdx.org/licenses/) license expression for the API. The <code>identifier</code> field is mutually exclusive of the <code>url</code> field. <small>Available since OpenAPI 3.1.0, FastAPI 0.99.0.</small></td></tr><tr><td><code>url</code></td><td><code>str</code></td><td>A URL to the license used for the API. MUST be in the format of a URL.</td></tr></tbody></table></details> |
 
 You can set them as follows:
 
@@ -76,7 +76,7 @@ Use the `tags` parameter with your *path operations* (and `APIRouter`s) to assig
 
 /// info
 
-Read more about tags in [Path Operation Configuration](path-operation-configuration.md#tags){target=_blank}.
+Read more about tags in [Path Operation Configuration](path-operation-configuration.md#tags).
 
 ///
 

--- a/docs/en/docs/tutorial/metadata.md
+++ b/docs/en/docs/tutorial/metadata.md
@@ -14,7 +14,7 @@ You can set the following fields that are used in the OpenAPI specification and 
 | `version` | `string` | The version of the API. This is the version of your own application, not of OpenAPI. For example `2.5.0`. |
 | `terms_of_service` | `str` | A URL to the Terms of Service for the API. If provided, this has to be a URL. |
 | `contact` | `dict` | The contact information for the exposed API. It can contain several fields. <details><summary><code>contact</code> fields</summary><table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead><tbody><tr><td><code>name</code></td><td><code>str</code></td><td>The identifying name of the contact person/organization.</td></tr><tr><td><code>url</code></td><td><code>str</code></td><td>The URL pointing to the contact information. MUST be in the format of a URL.</td></tr><tr><td><code>email</code></td><td><code>str</code></td><td>The email address of the contact person/organization. MUST be in the format of an email address.</td></tr></tbody></table></details> |
-| `license_info` | `dict` | The license information for the exposed API. It can contain several fields. <details><summary><code>license_info</code> fields</summary><table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead><tbody><tr><td><code>name</code></td><td><code>str</code></td><td><strong>REQUIRED</strong> (if a <code>license_info</code> is set). The license name used for the API.</td></tr><tr><td><code>identifier</code></td><td><code>str</code></td><td>An <a href="https://spdx.org/licenses/" class="external-link" target="_blank">SPDX</a> license expression for the API. The <code>identifier</code> field is mutually exclusive of the <code>url</code> field. <small>Available since OpenAPI 3.1.0, FastAPI 0.99.0.</small></td></tr><tr><td><code>url</code></td><td><code>str</code></td><td>A URL to the license used for the API. MUST be in the format of a URL.</td></tr></tbody></table></details> |
+| `license_info` | `dict` | The license information for the exposed API. It can contain several fields. <details><summary><code>license_info</code> fields</summary><table><thead><tr><th>Parameter</th><th>Type</th><th>Description</th></tr></thead><tbody><tr><td><code>name</code></td><td><code>str</code></td><td><strong>REQUIRED</strong> (if a <code>license_info</code> is set). The license name used for the API.</td></tr><tr><td><code>identifier</code></td><td><code>str</code></td><td>An [SPDX](https://spdx.org/licenses/){target=_blank} license expression for the API. The <code>identifier</code> field is mutually exclusive of the <code>url</code> field. <small>Available since OpenAPI 3.1.0, FastAPI 0.99.0.</small></td></tr><tr><td><code>url</code></td><td><code>str</code></td><td>A URL to the license used for the API. MUST be in the format of a URL.</td></tr></tbody></table></details> |
 
 You can set them as follows:
 
@@ -76,7 +76,7 @@ Use the `tags` parameter with your *path operations* (and `APIRouter`s) to assig
 
 /// info
 
-Read more about tags in [Path Operation Configuration](path-operation-configuration.md#tags){.internal-link target=_blank}.
+Read more about tags in [Path Operation Configuration](path-operation-configuration.md#tags){target=_blank}.
 
 ///
 

--- a/docs/en/docs/tutorial/middleware.md
+++ b/docs/en/docs/tutorial/middleware.md
@@ -15,7 +15,7 @@ A "middleware" is a function that works with every **request** before it is proc
 
 If you have dependencies with `yield`, the exit code will run *after* the middleware.
 
-If there were any background tasks (covered in the [Background Tasks](background-tasks.md){.internal-link target=_blank} section, you will see it later), they will run *after* all the middleware.
+If there were any background tasks (covered in the [Background Tasks](background-tasks.md){target=_blank} section, you will see it later), they will run *after* all the middleware.
 
 ///
 
@@ -35,9 +35,9 @@ The middleware function receives:
 
 /// tip
 
-Keep in mind that custom proprietary headers can be added <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers" class="external-link" target="_blank">using the `X-` prefix</a>.
+Keep in mind that custom proprietary headers can be added [using the `X-` prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers){target=_blank}.
 
-But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations ([CORS (Cross-Origin Resource Sharing)](cors.md){.internal-link target=_blank}) using the parameter `expose_headers` documented in <a href="https://www.starlette.dev/middleware/#corsmiddleware" class="external-link" target="_blank">Starlette's CORS docs</a>.
+But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations ([CORS (Cross-Origin Resource Sharing)](cors.md){target=_blank}) using the parameter `expose_headers` documented in [Starlette's CORS docs](https://www.starlette.dev/middleware/#corsmiddleware){target=_blank}.
 
 ///
 
@@ -61,7 +61,7 @@ For example, you could add a custom header `X-Process-Time` containing the time 
 
 /// tip
 
-Here we use <a href="https://docs.python.org/3/library/time.html#time.perf_counter" class="external-link" target="_blank">`time.perf_counter()`</a> instead of `time.time()` because it can be more precise for these use cases. 🤓
+Here we use [`time.perf_counter()`](https://docs.python.org/3/library/time.html#time.perf_counter){target=_blank} instead of `time.time()` because it can be more precise for these use cases. 🤓
 
 ///
 
@@ -90,6 +90,6 @@ This stacking behavior ensures that middlewares are executed in a predictable an
 
 ## Other middlewares { #other-middlewares }
 
-You can later read more about other middlewares in the [Advanced User Guide: Advanced Middleware](../advanced/middleware.md){.internal-link target=_blank}.
+You can later read more about other middlewares in the [Advanced User Guide: Advanced Middleware](../advanced/middleware.md){target=_blank}.
 
 You will read about how to handle <abbr title="Cross-Origin Resource Sharing">CORS</abbr> with a middleware in the next section.

--- a/docs/en/docs/tutorial/middleware.md
+++ b/docs/en/docs/tutorial/middleware.md
@@ -15,7 +15,7 @@ A "middleware" is a function that works with every **request** before it is proc
 
 If you have dependencies with `yield`, the exit code will run *after* the middleware.
 
-If there were any background tasks (covered in the [Background Tasks](background-tasks.md){target=_blank} section, you will see it later), they will run *after* all the middleware.
+If there were any background tasks (covered in the [Background Tasks](background-tasks.md) section, you will see it later), they will run *after* all the middleware.
 
 ///
 
@@ -35,9 +35,9 @@ The middleware function receives:
 
 /// tip
 
-Keep in mind that custom proprietary headers can be added [using the `X-` prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers){target=_blank}.
+Keep in mind that custom proprietary headers can be added [using the `X-` prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).
 
-But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations ([CORS (Cross-Origin Resource Sharing)](cors.md){target=_blank}) using the parameter `expose_headers` documented in [Starlette's CORS docs](https://www.starlette.dev/middleware/#corsmiddleware){target=_blank}.
+But if you have custom headers that you want a client in a browser to be able to see, you need to add them to your CORS configurations ([CORS (Cross-Origin Resource Sharing)](cors.md)) using the parameter `expose_headers` documented in [Starlette's CORS docs](https://www.starlette.dev/middleware/#corsmiddleware).
 
 ///
 
@@ -61,7 +61,7 @@ For example, you could add a custom header `X-Process-Time` containing the time 
 
 /// tip
 
-Here we use [`time.perf_counter()`](https://docs.python.org/3/library/time.html#time.perf_counter){target=_blank} instead of `time.time()` because it can be more precise for these use cases. 🤓
+Here we use [`time.perf_counter()`](https://docs.python.org/3/library/time.html#time.perf_counter) instead of `time.time()` because it can be more precise for these use cases. 🤓
 
 ///
 
@@ -90,6 +90,6 @@ This stacking behavior ensures that middlewares are executed in a predictable an
 
 ## Other middlewares { #other-middlewares }
 
-You can later read more about other middlewares in the [Advanced User Guide: Advanced Middleware](../advanced/middleware.md){target=_blank}.
+You can later read more about other middlewares in the [Advanced User Guide: Advanced Middleware](../advanced/middleware.md).
 
 You will read about how to handle <abbr title="Cross-Origin Resource Sharing">CORS</abbr> with a middleware in the next section.

--- a/docs/en/docs/tutorial/path-operation-configuration.md
+++ b/docs/en/docs/tutorial/path-operation-configuration.md
@@ -58,7 +58,7 @@ You can add a `summary` and `description`:
 
 As descriptions tend to be long and cover multiple lines, you can declare the *path operation* description in the function <dfn title="a multi-line string as the first expression inside a function (not assigned to any variable) used for documentation">docstring</dfn> and **FastAPI** will read it from there.
 
-You can write [Markdown](https://en.wikipedia.org/wiki/Markdown){target=_blank} in the docstring, it will be interpreted and displayed correctly (taking into account docstring indentation).
+You can write [Markdown](https://en.wikipedia.org/wiki/Markdown) in the docstring, it will be interpreted and displayed correctly (taking into account docstring indentation).
 
 {* ../../docs_src/path_operation_configuration/tutorial004_py310.py hl[17:25] *}
 

--- a/docs/en/docs/tutorial/path-operation-configuration.md
+++ b/docs/en/docs/tutorial/path-operation-configuration.md
@@ -58,7 +58,7 @@ You can add a `summary` and `description`:
 
 As descriptions tend to be long and cover multiple lines, you can declare the *path operation* description in the function <dfn title="a multi-line string as the first expression inside a function (not assigned to any variable) used for documentation">docstring</dfn> and **FastAPI** will read it from there.
 
-You can write <a href="https://en.wikipedia.org/wiki/Markdown" class="external-link" target="_blank">Markdown</a> in the docstring, it will be interpreted and displayed correctly (taking into account docstring indentation).
+You can write [Markdown](https://en.wikipedia.org/wiki/Markdown){target=_blank} in the docstring, it will be interpreted and displayed correctly (taking into account docstring indentation).
 
 {* ../../docs_src/path_operation_configuration/tutorial004_py310.py hl[17:25] *}
 

--- a/docs/en/docs/tutorial/path-params-numeric-validations.md
+++ b/docs/en/docs/tutorial/path-params-numeric-validations.md
@@ -14,7 +14,7 @@ FastAPI added support for `Annotated` (and started recommending it) in version 0
 
 If you have an older version, you would get errors when trying to use `Annotated`.
 
-Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions){.internal-link target=_blank} to at least 0.95.1 before using `Annotated`.
+Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions){target=_blank} to at least 0.95.1 before using `Annotated`.
 
 ///
 
@@ -122,7 +122,7 @@ And the same for <abbr title="less than"><code>lt</code></abbr>.
 
 ## Recap { #recap }
 
-With `Query`, `Path` (and others you haven't seen yet) you can declare metadata and string validations in the same ways as with [Query Parameters and String Validations](query-params-str-validations.md){.internal-link target=_blank}.
+With `Query`, `Path` (and others you haven't seen yet) you can declare metadata and string validations in the same ways as with [Query Parameters and String Validations](query-params-str-validations.md){target=_blank}.
 
 And you can also declare numeric validations:
 

--- a/docs/en/docs/tutorial/path-params-numeric-validations.md
+++ b/docs/en/docs/tutorial/path-params-numeric-validations.md
@@ -14,7 +14,7 @@ FastAPI added support for `Annotated` (and started recommending it) in version 0
 
 If you have an older version, you would get errors when trying to use `Annotated`.
 
-Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions){target=_blank} to at least 0.95.1 before using `Annotated`.
+Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions) to at least 0.95.1 before using `Annotated`.
 
 ///
 
@@ -122,7 +122,7 @@ And the same for <abbr title="less than"><code>lt</code></abbr>.
 
 ## Recap { #recap }
 
-With `Query`, `Path` (and others you haven't seen yet) you can declare metadata and string validations in the same ways as with [Query Parameters and String Validations](query-params-str-validations.md){target=_blank}.
+With `Query`, `Path` (and others you haven't seen yet) you can declare metadata and string validations in the same ways as with [Query Parameters and String Validations](query-params-str-validations.md).
 
 And you can also declare numeric validations:
 

--- a/docs/en/docs/tutorial/path-params.md
+++ b/docs/en/docs/tutorial/path-params.md
@@ -6,7 +6,7 @@ You can declare path "parameters" or "variables" with the same syntax used by Py
 
 The value of the path parameter `item_id` will be passed to your function as the argument `item_id`.
 
-So, if you run this example and go to [http://127.0.0.1:8000/items/foo](http://127.0.0.1:8000/items/foo){target=_blank}, you will see a response of:
+So, if you run this example and go to [http://127.0.0.1:8000/items/foo](http://127.0.0.1:8000/items/foo), you will see a response of:
 
 ```JSON
 {"item_id":"foo"}
@@ -28,7 +28,7 @@ This will give you editor support inside of your function, with error checks, co
 
 ## Data <dfn title="also known as: serialization, parsing, marshalling">conversion</dfn> { #data-conversion }
 
-If you run this example and open your browser at [http://127.0.0.1:8000/items/3](http://127.0.0.1:8000/items/3){target=_blank}, you will see a response of:
+If you run this example and open your browser at [http://127.0.0.1:8000/items/3](http://127.0.0.1:8000/items/3), you will see a response of:
 
 ```JSON
 {"item_id":3}
@@ -44,7 +44,7 @@ So, with that type declaration, **FastAPI** gives you automatic request <dfn tit
 
 ## Data validation { #data-validation }
 
-But if you go to the browser at [http://127.0.0.1:8000/items/foo](http://127.0.0.1:8000/items/foo){target=_blank}, you will see a nice HTTP error of:
+But if you go to the browser at [http://127.0.0.1:8000/items/foo](http://127.0.0.1:8000/items/foo), you will see a nice HTTP error of:
 
 ```JSON
 {
@@ -64,7 +64,7 @@ But if you go to the browser at [http://127.0.0.1:8000/items/foo](http://127.0.0
 
 because the path parameter `item_id` had a value of `"foo"`, which is not an `int`.
 
-The same error would appear if you provided a `float` instead of an `int`, as in: [http://127.0.0.1:8000/items/4.2](http://127.0.0.1:8000/items/4.2){target=_blank}
+The same error would appear if you provided a `float` instead of an `int`, as in: [http://127.0.0.1:8000/items/4.2](http://127.0.0.1:8000/items/4.2)
 
 /// check
 
@@ -78,7 +78,7 @@ This is incredibly helpful while developing and debugging code that interacts wi
 
 ## Documentation { #documentation }
 
-And when you open your browser at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}, you will see an automatic, interactive, API documentation like:
+And when you open your browser at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs), you will see an automatic, interactive, API documentation like:
 
 <img src="/img/tutorial/path-params/image01.png">
 
@@ -92,9 +92,9 @@ Notice that the path parameter is declared to be an integer.
 
 ## Standards-based benefits, alternative documentation { #standards-based-benefits-alternative-documentation }
 
-And because the generated schema is from the [OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md){target=_blank} standard, there are many compatible tools.
+And because the generated schema is from the [OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md) standard, there are many compatible tools.
 
-Because of this, **FastAPI** itself provides an alternative API documentation (using ReDoc), which you can access at [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc){target=_blank}:
+Because of this, **FastAPI** itself provides an alternative API documentation (using ReDoc), which you can access at [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc):
 
 <img src="/img/tutorial/path-params/image02.png">
 
@@ -102,7 +102,7 @@ The same way, there are many compatible tools. Including code generation tools f
 
 ## Pydantic { #pydantic }
 
-All the data validation is performed under the hood by [Pydantic](https://docs.pydantic.dev/){target=_blank}, so you get all the benefits from it. And you know you are in good hands.
+All the data validation is performed under the hood by [Pydantic](https://docs.pydantic.dev/), so you get all the benefits from it. And you know you are in good hands.
 
 You can use the same type declarations with `str`, `float`, `bool` and many other complex data types.
 

--- a/docs/en/docs/tutorial/path-params.md
+++ b/docs/en/docs/tutorial/path-params.md
@@ -6,7 +6,7 @@ You can declare path "parameters" or "variables" with the same syntax used by Py
 
 The value of the path parameter `item_id` will be passed to your function as the argument `item_id`.
 
-So, if you run this example and go to <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a>, you will see a response of:
+So, if you run this example and go to [http://127.0.0.1:8000/items/foo](http://127.0.0.1:8000/items/foo){target=_blank}, you will see a response of:
 
 ```JSON
 {"item_id":"foo"}
@@ -28,7 +28,7 @@ This will give you editor support inside of your function, with error checks, co
 
 ## Data <dfn title="also known as: serialization, parsing, marshalling">conversion</dfn> { #data-conversion }
 
-If you run this example and open your browser at <a href="http://127.0.0.1:8000/items/3" class="external-link" target="_blank">http://127.0.0.1:8000/items/3</a>, you will see a response of:
+If you run this example and open your browser at [http://127.0.0.1:8000/items/3](http://127.0.0.1:8000/items/3){target=_blank}, you will see a response of:
 
 ```JSON
 {"item_id":3}
@@ -44,7 +44,7 @@ So, with that type declaration, **FastAPI** gives you automatic request <dfn tit
 
 ## Data validation { #data-validation }
 
-But if you go to the browser at <a href="http://127.0.0.1:8000/items/foo" class="external-link" target="_blank">http://127.0.0.1:8000/items/foo</a>, you will see a nice HTTP error of:
+But if you go to the browser at [http://127.0.0.1:8000/items/foo](http://127.0.0.1:8000/items/foo){target=_blank}, you will see a nice HTTP error of:
 
 ```JSON
 {
@@ -64,7 +64,7 @@ But if you go to the browser at <a href="http://127.0.0.1:8000/items/foo" class=
 
 because the path parameter `item_id` had a value of `"foo"`, which is not an `int`.
 
-The same error would appear if you provided a `float` instead of an `int`, as in: <a href="http://127.0.0.1:8000/items/4.2" class="external-link" target="_blank">http://127.0.0.1:8000/items/4.2</a>
+The same error would appear if you provided a `float` instead of an `int`, as in: [http://127.0.0.1:8000/items/4.2](http://127.0.0.1:8000/items/4.2){target=_blank}
 
 /// check
 
@@ -78,7 +78,7 @@ This is incredibly helpful while developing and debugging code that interacts wi
 
 ## Documentation { #documentation }
 
-And when you open your browser at <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>, you will see an automatic, interactive, API documentation like:
+And when you open your browser at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}, you will see an automatic, interactive, API documentation like:
 
 <img src="/img/tutorial/path-params/image01.png">
 
@@ -92,9 +92,9 @@ Notice that the path parameter is declared to be an integer.
 
 ## Standards-based benefits, alternative documentation { #standards-based-benefits-alternative-documentation }
 
-And because the generated schema is from the <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md" class="external-link" target="_blank">OpenAPI</a> standard, there are many compatible tools.
+And because the generated schema is from the [OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md){target=_blank} standard, there are many compatible tools.
 
-Because of this, **FastAPI** itself provides an alternative API documentation (using ReDoc), which you can access at <a href="http://127.0.0.1:8000/redoc" class="external-link" target="_blank">http://127.0.0.1:8000/redoc</a>:
+Because of this, **FastAPI** itself provides an alternative API documentation (using ReDoc), which you can access at [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc){target=_blank}:
 
 <img src="/img/tutorial/path-params/image02.png">
 
@@ -102,7 +102,7 @@ The same way, there are many compatible tools. Including code generation tools f
 
 ## Pydantic { #pydantic }
 
-All the data validation is performed under the hood by <a href="https://docs.pydantic.dev/" class="external-link" target="_blank">Pydantic</a>, so you get all the benefits from it. And you know you are in good hands.
+All the data validation is performed under the hood by [Pydantic](https://docs.pydantic.dev/){target=_blank}, so you get all the benefits from it. And you know you are in good hands.
 
 You can use the same type declarations with `str`, `float`, `bool` and many other complex data types.
 

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -35,13 +35,13 @@ FastAPI added support for `Annotated` (and started recommending it) in version 0
 
 If you have an older version, you would get errors when trying to use `Annotated`.
 
-Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions){target=_blank} to at least 0.95.1 before using `Annotated`.
+Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions) to at least 0.95.1 before using `Annotated`.
 
 ///
 
 ## Use `Annotated` in the type for the `q` parameter { #use-annotated-in-the-type-for-the-q-parameter }
 
-Remember I told you before that `Annotated` can be used to add metadata to your parameters in the [Python Types Intro](../python-types.md#type-hints-with-metadata-annotations){target=_blank}?
+Remember I told you before that `Annotated` can be used to add metadata to your parameters in the [Python Types Intro](../python-types.md#type-hints-with-metadata-annotations)?
 
 Now it's the time to use it with FastAPI. 🚀
 
@@ -158,7 +158,7 @@ You could **call** that same function in **other places** without FastAPI, and i
 
 When you don't use `Annotated` and instead use the **(old) default value style**, if you call that function without FastAPI in **other places**, you have to **remember** to pass the arguments to the function for it to work correctly, otherwise the values will be different from what you expect (e.g. `QueryInfo` or something similar instead of `str`). And your editor won't complain, and Python won't complain running that function, only when the operations inside error out.
 
-Because `Annotated` can have more than one metadata annotation, you could now even use the same function with other tools, like [Typer](https://typer.tiangolo.com/){target=_blank}. 🚀
+Because `Annotated` can have more than one metadata annotation, you could now even use the same function with other tools, like [Typer](https://typer.tiangolo.com/). 🚀
 
 ## Add more validations { #add-more-validations }
 
@@ -370,11 +370,11 @@ There could be cases where you need to do some **custom validation** that can't 
 
 In those cases, you can use a **custom validator function** that is applied after the normal validation (e.g. after validating that the value is a `str`).
 
-You can achieve that using [Pydantic's `AfterValidator`](https://docs.pydantic.dev/latest/concepts/validators/#field-after-validator){target=_blank} inside of `Annotated`.
+You can achieve that using [Pydantic's `AfterValidator`](https://docs.pydantic.dev/latest/concepts/validators/#field-after-validator) inside of `Annotated`.
 
 /// tip
 
-Pydantic also has [`BeforeValidator`](https://docs.pydantic.dev/latest/concepts/validators/#field-before-validator){target=_blank} and others. 🤓
+Pydantic also has [`BeforeValidator`](https://docs.pydantic.dev/latest/concepts/validators/#field-before-validator) and others. 🤓
 
 ///
 

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -35,13 +35,13 @@ FastAPI added support for `Annotated` (and started recommending it) in version 0
 
 If you have an older version, you would get errors when trying to use `Annotated`.
 
-Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions){.internal-link target=_blank} to at least 0.95.1 before using `Annotated`.
+Make sure you [Upgrade the FastAPI version](../deployment/versions.md#upgrading-the-fastapi-versions){target=_blank} to at least 0.95.1 before using `Annotated`.
 
 ///
 
 ## Use `Annotated` in the type for the `q` parameter { #use-annotated-in-the-type-for-the-q-parameter }
 
-Remember I told you before that `Annotated` can be used to add metadata to your parameters in the [Python Types Intro](../python-types.md#type-hints-with-metadata-annotations){.internal-link target=_blank}?
+Remember I told you before that `Annotated` can be used to add metadata to your parameters in the [Python Types Intro](../python-types.md#type-hints-with-metadata-annotations){target=_blank}?
 
 Now it's the time to use it with FastAPI. 🚀
 
@@ -158,7 +158,7 @@ You could **call** that same function in **other places** without FastAPI, and i
 
 When you don't use `Annotated` and instead use the **(old) default value style**, if you call that function without FastAPI in **other places**, you have to **remember** to pass the arguments to the function for it to work correctly, otherwise the values will be different from what you expect (e.g. `QueryInfo` or something similar instead of `str`). And your editor won't complain, and Python won't complain running that function, only when the operations inside error out.
 
-Because `Annotated` can have more than one metadata annotation, you could now even use the same function with other tools, like <a href="https://typer.tiangolo.com/" class="external-link" target="_blank">Typer</a>. 🚀
+Because `Annotated` can have more than one metadata annotation, you could now even use the same function with other tools, like [Typer](https://typer.tiangolo.com/){target=_blank}. 🚀
 
 ## Add more validations { #add-more-validations }
 
@@ -370,11 +370,11 @@ There could be cases where you need to do some **custom validation** that can't 
 
 In those cases, you can use a **custom validator function** that is applied after the normal validation (e.g. after validating that the value is a `str`).
 
-You can achieve that using <a href="https://docs.pydantic.dev/latest/concepts/validators/#field-after-validator" class="external-link" target="_blank">Pydantic's `AfterValidator`</a> inside of `Annotated`.
+You can achieve that using [Pydantic's `AfterValidator`](https://docs.pydantic.dev/latest/concepts/validators/#field-after-validator){target=_blank} inside of `Annotated`.
 
 /// tip
 
-Pydantic also has <a href="https://docs.pydantic.dev/latest/concepts/validators/#field-before-validator" class="external-link" target="_blank">`BeforeValidator`</a> and others. 🤓
+Pydantic also has [`BeforeValidator`](https://docs.pydantic.dev/latest/concepts/validators/#field-before-validator){target=_blank} and others. 🤓
 
 ///
 

--- a/docs/en/docs/tutorial/query-params.md
+++ b/docs/en/docs/tutorial/query-params.md
@@ -183,6 +183,6 @@ In this case, there are 3 query parameters:
 
 /// tip
 
-You could also use `Enum`s the same way as with [Path Parameters](path-params.md#predefined-values){.internal-link target=_blank}.
+You could also use `Enum`s the same way as with [Path Parameters](path-params.md#predefined-values){target=_blank}.
 
 ///

--- a/docs/en/docs/tutorial/query-params.md
+++ b/docs/en/docs/tutorial/query-params.md
@@ -183,6 +183,6 @@ In this case, there are 3 query parameters:
 
 /// tip
 
-You could also use `Enum`s the same way as with [Path Parameters](path-params.md#predefined-values){target=_blank}.
+You could also use `Enum`s the same way as with [Path Parameters](path-params.md#predefined-values).
 
 ///

--- a/docs/en/docs/tutorial/request-files.md
+++ b/docs/en/docs/tutorial/request-files.md
@@ -4,9 +4,9 @@ You can define files to be uploaded by the client using `File`.
 
 /// info
 
-To receive uploaded files, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
+To receive uploaded files, first install [`python-multipart`](https://github.com/Kludex/python-multipart).
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart
@@ -63,8 +63,8 @@ Using `UploadFile` has several advantages over `bytes`:
     * A file stored in memory up to a maximum size limit, and after passing this limit it will be stored in disk.
 * This means that it will work well for large files like images, videos, large binaries, etc. without consuming all the memory.
 * You can get metadata from the uploaded file.
-* It has a [file-like](https://docs.python.org/3/glossary.html#term-file-like-object){target=_blank} `async` interface.
-* It exposes an actual Python [`SpooledTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile){target=_blank} object that you can pass directly to other libraries that expect a file-like object.
+* It has a [file-like](https://docs.python.org/3/glossary.html#term-file-like-object) `async` interface.
+* It exposes an actual Python [`SpooledTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile) object that you can pass directly to other libraries that expect a file-like object.
 
 ### `UploadFile` { #uploadfile }
 
@@ -72,7 +72,7 @@ Using `UploadFile` has several advantages over `bytes`:
 
 * `filename`: A `str` with the original file name that was uploaded (e.g. `myimage.jpg`).
 * `content_type`: A `str` with the content type (MIME type / media type) (e.g. `image/jpeg`).
-* `file`: A [`SpooledTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile){target=_blank} (a [file-like](https://docs.python.org/3/glossary.html#term-file-like-object){target=_blank} object). This is the actual Python file object that you can pass directly to other functions or libraries that expect a "file-like" object.
+* `file`: A [`SpooledTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile) (a [file-like](https://docs.python.org/3/glossary.html#term-file-like-object) object). This is the actual Python file object that you can pass directly to other functions or libraries that expect a "file-like" object.
 
 `UploadFile` has the following `async` methods. They all call the corresponding file methods underneath (using the internal `SpooledTemporaryFile`).
 
@@ -121,7 +121,7 @@ Data from forms is normally encoded using the "media type" `application/x-www-fo
 
 But when the form includes files, it is encoded as `multipart/form-data`. If you use `File`, **FastAPI** will know it has to get the files from the correct part of the body.
 
-If you want to read more about these encodings and form fields, head to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> web docs for <code>POST</code></a>.
+If you want to read more about these encodings and form fields, head to the [<abbr title="Mozilla Developer Network">MDN</abbr> web docs for `POST`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST).
 
 ///
 

--- a/docs/en/docs/tutorial/request-files.md
+++ b/docs/en/docs/tutorial/request-files.md
@@ -4,9 +4,9 @@ You can define files to be uploaded by the client using `File`.
 
 /// info
 
-To receive uploaded files, first install <a href="https://github.com/Kludex/python-multipart" class="external-link" target="_blank">`python-multipart`</a>.
+To receive uploaded files, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart
@@ -63,8 +63,8 @@ Using `UploadFile` has several advantages over `bytes`:
     * A file stored in memory up to a maximum size limit, and after passing this limit it will be stored in disk.
 * This means that it will work well for large files like images, videos, large binaries, etc. without consuming all the memory.
 * You can get metadata from the uploaded file.
-* It has a <a href="https://docs.python.org/3/glossary.html#term-file-like-object" class="external-link" target="_blank">file-like</a> `async` interface.
-* It exposes an actual Python <a href="https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile" class="external-link" target="_blank">`SpooledTemporaryFile`</a> object that you can pass directly to other libraries that expect a file-like object.
+* It has a [file-like](https://docs.python.org/3/glossary.html#term-file-like-object){target=_blank} `async` interface.
+* It exposes an actual Python [`SpooledTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile){target=_blank} object that you can pass directly to other libraries that expect a file-like object.
 
 ### `UploadFile` { #uploadfile }
 
@@ -72,7 +72,7 @@ Using `UploadFile` has several advantages over `bytes`:
 
 * `filename`: A `str` with the original file name that was uploaded (e.g. `myimage.jpg`).
 * `content_type`: A `str` with the content type (MIME type / media type) (e.g. `image/jpeg`).
-* `file`: A <a href="https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile" class="external-link" target="_blank">`SpooledTemporaryFile`</a> (a <a href="https://docs.python.org/3/glossary.html#term-file-like-object" class="external-link" target="_blank">file-like</a> object). This is the actual Python file object that you can pass directly to other functions or libraries that expect a "file-like" object.
+* `file`: A [`SpooledTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile){target=_blank} (a [file-like](https://docs.python.org/3/glossary.html#term-file-like-object){target=_blank} object). This is the actual Python file object that you can pass directly to other functions or libraries that expect a "file-like" object.
 
 `UploadFile` has the following `async` methods. They all call the corresponding file methods underneath (using the internal `SpooledTemporaryFile`).
 
@@ -121,7 +121,7 @@ Data from forms is normally encoded using the "media type" `application/x-www-fo
 
 But when the form includes files, it is encoded as `multipart/form-data`. If you use `File`, **FastAPI** will know it has to get the files from the correct part of the body.
 
-If you want to read more about these encodings and form fields, head to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST" class="external-link" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> web docs for <code>POST</code></a>.
+If you want to read more about these encodings and form fields, head to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> web docs for <code>POST</code></a>.
 
 ///
 

--- a/docs/en/docs/tutorial/request-form-models.md
+++ b/docs/en/docs/tutorial/request-form-models.md
@@ -4,9 +4,9 @@ You can use **Pydantic models** to declare **form fields** in FastAPI.
 
 /// info
 
-To use forms, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
+To use forms, first install [`python-multipart`](https://github.com/Kludex/python-multipart).
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart

--- a/docs/en/docs/tutorial/request-form-models.md
+++ b/docs/en/docs/tutorial/request-form-models.md
@@ -4,9 +4,9 @@ You can use **Pydantic models** to declare **form fields** in FastAPI.
 
 /// info
 
-To use forms, first install <a href="https://github.com/Kludex/python-multipart" class="external-link" target="_blank">`python-multipart`</a>.
+To use forms, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart

--- a/docs/en/docs/tutorial/request-forms-and-files.md
+++ b/docs/en/docs/tutorial/request-forms-and-files.md
@@ -4,9 +4,9 @@ You can define files and form fields at the same time using `File` and `Form`.
 
 /// info
 
-To receive uploaded files and/or form data, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
+To receive uploaded files and/or form data, first install [`python-multipart`](https://github.com/Kludex/python-multipart).
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart

--- a/docs/en/docs/tutorial/request-forms-and-files.md
+++ b/docs/en/docs/tutorial/request-forms-and-files.md
@@ -4,9 +4,9 @@ You can define files and form fields at the same time using `File` and `Form`.
 
 /// info
 
-To receive uploaded files and/or form data, first install <a href="https://github.com/Kludex/python-multipart" class="external-link" target="_blank">`python-multipart`</a>.
+To receive uploaded files and/or form data, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart

--- a/docs/en/docs/tutorial/request-forms.md
+++ b/docs/en/docs/tutorial/request-forms.md
@@ -4,9 +4,9 @@ When you need to receive form fields instead of JSON, you can use `Form`.
 
 /// info
 
-To use forms, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
+To use forms, first install [`python-multipart`](https://github.com/Kludex/python-multipart).
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart
@@ -56,7 +56,7 @@ Data from forms is normally encoded using the "media type" `application/x-www-fo
 
 But when the form includes files, it is encoded as `multipart/form-data`. You'll read about handling files in the next chapter.
 
-If you want to read more about these encodings and form fields, head to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> web docs for <code>POST</code></a>.
+If you want to read more about these encodings and form fields, head to the [<abbr title="Mozilla Developer Network">MDN</abbr> web docs for `POST`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST).
 
 ///
 

--- a/docs/en/docs/tutorial/request-forms.md
+++ b/docs/en/docs/tutorial/request-forms.md
@@ -4,9 +4,9 @@ When you need to receive form fields instead of JSON, you can use `Form`.
 
 /// info
 
-To use forms, first install <a href="https://github.com/Kludex/python-multipart" class="external-link" target="_blank">`python-multipart`</a>.
+To use forms, first install [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank}.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
 
 ```console
 $ pip install python-multipart
@@ -56,7 +56,7 @@ Data from forms is normally encoded using the "media type" `application/x-www-fo
 
 But when the form includes files, it is encoded as `multipart/form-data`. You'll read about handling files in the next chapter.
 
-If you want to read more about these encodings and form fields, head to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST" class="external-link" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> web docs for <code>POST</code></a>.
+If you want to read more about these encodings and form fields, head to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> web docs for <code>POST</code></a>.
 
 ///
 

--- a/docs/en/docs/tutorial/response-model.md
+++ b/docs/en/docs/tutorial/response-model.md
@@ -74,9 +74,9 @@ Here we are declaring a `UserIn` model, it will contain a plaintext password:
 
 /// info
 
-To use `EmailStr`, first install <a href="https://github.com/JoshData/python-email-validator" class="external-link" target="_blank">`email-validator`</a>.
+To use `EmailStr`, first install [`email-validator`](https://github.com/JoshData/python-email-validator){target=_blank}.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
 
 ```console
 $ pip install email-validator
@@ -182,7 +182,7 @@ There might be cases where you return something that is not a valid Pydantic fie
 
 ### Return a Response Directly { #return-a-response-directly }
 
-The most common case would be [returning a Response directly as explained later in the advanced docs](../advanced/response-directly.md){.internal-link target=_blank}.
+The most common case would be [returning a Response directly as explained later in the advanced docs](../advanced/response-directly.md){target=_blank}.
 
 {* ../../docs_src/response_model/tutorial003_02_py310.py hl[8,10:11] *}
 
@@ -258,7 +258,7 @@ You can also use:
 * `response_model_exclude_defaults=True`
 * `response_model_exclude_none=True`
 
-as described in <a href="https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict" class="external-link" target="_blank">the Pydantic docs</a> for `exclude_defaults` and `exclude_none`.
+as described in [the Pydantic docs](https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict){target=_blank} for `exclude_defaults` and `exclude_none`.
 
 ///
 

--- a/docs/en/docs/tutorial/response-model.md
+++ b/docs/en/docs/tutorial/response-model.md
@@ -74,9 +74,9 @@ Here we are declaring a `UserIn` model, it will contain a plaintext password:
 
 /// info
 
-To use `EmailStr`, first install [`email-validator`](https://github.com/JoshData/python-email-validator){target=_blank}.
+To use `EmailStr`, first install [`email-validator`](https://github.com/JoshData/python-email-validator).
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then install it, for example:
 
 ```console
 $ pip install email-validator
@@ -182,7 +182,7 @@ There might be cases where you return something that is not a valid Pydantic fie
 
 ### Return a Response Directly { #return-a-response-directly }
 
-The most common case would be [returning a Response directly as explained later in the advanced docs](../advanced/response-directly.md){target=_blank}.
+The most common case would be [returning a Response directly as explained later in the advanced docs](../advanced/response-directly.md).
 
 {* ../../docs_src/response_model/tutorial003_02_py310.py hl[8,10:11] *}
 
@@ -258,7 +258,7 @@ You can also use:
 * `response_model_exclude_defaults=True`
 * `response_model_exclude_none=True`
 
-as described in [the Pydantic docs](https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict){target=_blank} for `exclude_defaults` and `exclude_none`.
+as described in [the Pydantic docs](https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict) for `exclude_defaults` and `exclude_none`.
 
 ///
 

--- a/docs/en/docs/tutorial/response-status-code.md
+++ b/docs/en/docs/tutorial/response-status-code.md
@@ -20,7 +20,7 @@ The `status_code` parameter receives a number with the HTTP status code.
 
 /// info
 
-`status_code` can alternatively also receive an `IntEnum`, such as Python's <a href="https://docs.python.org/3/library/http.html#http.HTTPStatus" class="external-link" target="_blank">`http.HTTPStatus`</a>.
+`status_code` can alternatively also receive an `IntEnum`, such as Python's [`http.HTTPStatus`](https://docs.python.org/3/library/http.html#http.HTTPStatus){target=_blank}.
 
 ///
 
@@ -66,7 +66,7 @@ In short:
 
 /// tip
 
-To know more about each status code and which code is for what, check the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status" class="external-link" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> documentation about HTTP status codes</a>.
+To know more about each status code and which code is for what, check the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> documentation about HTTP status codes</a>.
 
 ///
 
@@ -98,4 +98,4 @@ You could also use `from starlette import status`.
 
 ## Changing the default { #changing-the-default }
 
-Later, in the [Advanced User Guide](../advanced/response-change-status-code.md){.internal-link target=_blank}, you will see how to return a different status code than the default you are declaring here.
+Later, in the [Advanced User Guide](../advanced/response-change-status-code.md){target=_blank}, you will see how to return a different status code than the default you are declaring here.

--- a/docs/en/docs/tutorial/response-status-code.md
+++ b/docs/en/docs/tutorial/response-status-code.md
@@ -20,7 +20,7 @@ The `status_code` parameter receives a number with the HTTP status code.
 
 /// info
 
-`status_code` can alternatively also receive an `IntEnum`, such as Python's [`http.HTTPStatus`](https://docs.python.org/3/library/http.html#http.HTTPStatus){target=_blank}.
+`status_code` can alternatively also receive an `IntEnum`, such as Python's [`http.HTTPStatus`](https://docs.python.org/3/library/http.html#http.HTTPStatus).
 
 ///
 
@@ -66,7 +66,7 @@ In short:
 
 /// tip
 
-To know more about each status code and which code is for what, check the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status" target="_blank"><abbr title="Mozilla Developer Network">MDN</abbr> documentation about HTTP status codes</a>.
+To know more about each status code and which code is for what, check the [<abbr title="Mozilla Developer Network">MDN</abbr> documentation about HTTP status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
 
 ///
 
@@ -98,4 +98,4 @@ You could also use `from starlette import status`.
 
 ## Changing the default { #changing-the-default }
 
-Later, in the [Advanced User Guide](../advanced/response-change-status-code.md){target=_blank}, you will see how to return a different status code than the default you are declaring here.
+Later, in the [Advanced User Guide](../advanced/response-change-status-code.md), you will see how to return a different status code than the default you are declaring here.

--- a/docs/en/docs/tutorial/schema-extra-example.md
+++ b/docs/en/docs/tutorial/schema-extra-example.md
@@ -12,7 +12,7 @@ You can declare `examples` for a Pydantic model that will be added to the genera
 
 That extra info will be added as-is to the output **JSON Schema** for that model, and it will be used in the API docs.
 
-You can use the attribute `model_config` that takes a `dict` as described in <a href="https://docs.pydantic.dev/latest/api/config/" class="external-link" target="_blank">Pydantic's docs: Configuration</a>.
+You can use the attribute `model_config` that takes a `dict` as described in [Pydantic's docs: Configuration](https://docs.pydantic.dev/latest/api/config/){target=_blank}.
 
 You can set `"json_schema_extra"` with a `dict` containing any additional data you would like to show up in the generated JSON Schema, including `examples`.
 
@@ -145,12 +145,12 @@ JSON Schema didn't have `examples`, so OpenAPI added its own `example` field to 
 
 OpenAPI also added `example` and `examples` fields to other parts of the specification:
 
-* <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object" class="external-link" target="_blank">`Parameter Object` (in the specification)</a> that was used by FastAPI's:
+* [`Parameter Object` (in the specification)](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object){target=_blank} that was used by FastAPI's:
     * `Path()`
     * `Query()`
     * `Header()`
     * `Cookie()`
-* <a href="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object" class="external-link" target="_blank">`Request Body Object`, in the field `content`, on the `Media Type Object` (in the specification)</a> that was used by FastAPI's:
+* [`Request Body Object`, in the field `content`, on the `Media Type Object` (in the specification)](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object){target=_blank} that was used by FastAPI's:
     * `Body()`
     * `File()`
     * `Form()`
@@ -163,7 +163,7 @@ This old OpenAPI-specific `examples` parameter is now `openapi_examples` since F
 
 ### JSON Schema's `examples` field { #json-schemas-examples-field }
 
-But then JSON Schema added an <a href="https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.5" class="external-link" target="_blank">`examples`</a> field to a new version of the specification.
+But then JSON Schema added an [`examples`](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.5){target=_blank} field to a new version of the specification.
 
 And then the new OpenAPI 3.1.0 was based on the latest version (JSON Schema 2020-12) that included this new field `examples`.
 

--- a/docs/en/docs/tutorial/schema-extra-example.md
+++ b/docs/en/docs/tutorial/schema-extra-example.md
@@ -12,7 +12,7 @@ You can declare `examples` for a Pydantic model that will be added to the genera
 
 That extra info will be added as-is to the output **JSON Schema** for that model, and it will be used in the API docs.
 
-You can use the attribute `model_config` that takes a `dict` as described in [Pydantic's docs: Configuration](https://docs.pydantic.dev/latest/api/config/){target=_blank}.
+You can use the attribute `model_config` that takes a `dict` as described in [Pydantic's docs: Configuration](https://docs.pydantic.dev/latest/api/config/).
 
 You can set `"json_schema_extra"` with a `dict` containing any additional data you would like to show up in the generated JSON Schema, including `examples`.
 
@@ -145,12 +145,12 @@ JSON Schema didn't have `examples`, so OpenAPI added its own `example` field to 
 
 OpenAPI also added `example` and `examples` fields to other parts of the specification:
 
-* [`Parameter Object` (in the specification)](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object){target=_blank} that was used by FastAPI's:
+* [`Parameter Object` (in the specification)](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object) that was used by FastAPI's:
     * `Path()`
     * `Query()`
     * `Header()`
     * `Cookie()`
-* [`Request Body Object`, in the field `content`, on the `Media Type Object` (in the specification)](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object){target=_blank} that was used by FastAPI's:
+* [`Request Body Object`, in the field `content`, on the `Media Type Object` (in the specification)](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object) that was used by FastAPI's:
     * `Body()`
     * `File()`
     * `Form()`
@@ -163,7 +163,7 @@ This old OpenAPI-specific `examples` parameter is now `openapi_examples` since F
 
 ### JSON Schema's `examples` field { #json-schemas-examples-field }
 
-But then JSON Schema added an [`examples`](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.5){target=_blank} field to a new version of the specification.
+But then JSON Schema added an [`examples`](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.5) field to a new version of the specification.
 
 And then the new OpenAPI 3.1.0 was based on the latest version (JSON Schema 2020-12) that included this new field `examples`.
 

--- a/docs/en/docs/tutorial/security/first-steps.md
+++ b/docs/en/docs/tutorial/security/first-steps.md
@@ -26,11 +26,11 @@ Copy the example in a file `main.py`:
 
 /// info
 
-The [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank} package is automatically installed with **FastAPI** when you run the `pip install "fastapi[standard]"` command.
+The [`python-multipart`](https://github.com/Kludex/python-multipart) package is automatically installed with **FastAPI** when you run the `pip install "fastapi[standard]"` command.
 
 However, if you use the `pip install fastapi` command, the `python-multipart` package is not included by default.
 
-To install it manually, make sure you create a [virtual environment](../../virtual-environments.md){target=_blank}, activate it, and then install it with:
+To install it manually, make sure you create a [virtual environment](../../virtual-environments.md), activate it, and then install it with:
 
 ```console
 $ pip install python-multipart
@@ -54,7 +54,7 @@ $ fastapi dev main.py
 
 ## Check it { #check-it }
 
-Go to the interactive docs at: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+Go to the interactive docs at: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 You will see something like this:
 
@@ -140,7 +140,7 @@ Here `tokenUrl="token"` refers to a relative URL `token` that we haven't created
 
 Because we are using a relative URL, if your API was located at `https://example.com/`, then it would refer to `https://example.com/token`. But if your API was located at `https://example.com/api/v1/`, then it would refer to `https://example.com/api/v1/token`.
 
-Using a relative URL is important to make sure your application keeps working even in an advanced use case like [Behind a Proxy](../../advanced/behind-a-proxy.md){target=_blank}.
+Using a relative URL is important to make sure your application keeps working even in an advanced use case like [Behind a Proxy](../../advanced/behind-a-proxy.md).
 
 ///
 

--- a/docs/en/docs/tutorial/security/first-steps.md
+++ b/docs/en/docs/tutorial/security/first-steps.md
@@ -26,11 +26,11 @@ Copy the example in a file `main.py`:
 
 /// info
 
-The <a href="https://github.com/Kludex/python-multipart" class="external-link" target="_blank">`python-multipart`</a> package is automatically installed with **FastAPI** when you run the `pip install "fastapi[standard]"` command.
+The [`python-multipart`](https://github.com/Kludex/python-multipart){target=_blank} package is automatically installed with **FastAPI** when you run the `pip install "fastapi[standard]"` command.
 
 However, if you use the `pip install fastapi` command, the `python-multipart` package is not included by default.
 
-To install it manually, make sure you create a [virtual environment](../../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it with:
+To install it manually, make sure you create a [virtual environment](../../virtual-environments.md){target=_blank}, activate it, and then install it with:
 
 ```console
 $ pip install python-multipart
@@ -54,7 +54,7 @@ $ fastapi dev main.py
 
 ## Check it { #check-it }
 
-Go to the interactive docs at: <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Go to the interactive docs at: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
 You will see something like this:
 
@@ -140,7 +140,7 @@ Here `tokenUrl="token"` refers to a relative URL `token` that we haven't created
 
 Because we are using a relative URL, if your API was located at `https://example.com/`, then it would refer to `https://example.com/token`. But if your API was located at `https://example.com/api/v1/`, then it would refer to `https://example.com/api/v1/token`.
 
-Using a relative URL is important to make sure your application keeps working even in an advanced use case like [Behind a Proxy](../../advanced/behind-a-proxy.md){.internal-link target=_blank}.
+Using a relative URL is important to make sure your application keeps working even in an advanced use case like [Behind a Proxy](../../advanced/behind-a-proxy.md){target=_blank}.
 
 ///
 

--- a/docs/en/docs/tutorial/security/oauth2-jwt.md
+++ b/docs/en/docs/tutorial/security/oauth2-jwt.md
@@ -24,13 +24,13 @@ That way, you can create a token with an expiration of, let's say, 1 week. And t
 
 After a week, the token will be expired and the user will not be authorized and will have to sign in again to get a new token. And if the user (or a third party) tried to modify the token to change the expiration, you would be able to discover it, because the signatures would not match.
 
-If you want to play with JWT tokens and see how they work, check <a href="https://jwt.io/" class="external-link" target="_blank">https://jwt.io</a>.
+If you want to play with JWT tokens and see how they work, check [https://jwt.io](https://jwt.io/){target=_blank}.
 
 ## Install `PyJWT` { #install-pyjwt }
 
 We need to install `PyJWT` to generate and verify the JWT tokens in Python.
 
-Make sure you create a [virtual environment](../../virtual-environments.md){.internal-link target=_blank}, activate it, and then install `pyjwt`:
+Make sure you create a [virtual environment](../../virtual-environments.md){target=_blank}, activate it, and then install `pyjwt`:
 
 <div class="termy">
 
@@ -46,7 +46,7 @@ $ pip install pyjwt
 
 If you are planning to use digital signature algorithms like RSA or ECDSA, you should install the cryptography library dependency `pyjwt[crypto]`.
 
-You can read more about it in the <a href="https://pyjwt.readthedocs.io/en/latest/installation.html" class="external-link" target="_blank">PyJWT Installation docs</a>.
+You can read more about it in the [PyJWT Installation docs](https://pyjwt.readthedocs.io/en/latest/installation.html){target=_blank}.
 
 ///
 
@@ -72,7 +72,7 @@ It supports many secure hashing algorithms and utilities to work with them.
 
 The recommended algorithm is "Argon2".
 
-Make sure you create a [virtual environment](../../virtual-environments.md){.internal-link target=_blank}, activate it, and then install pwdlib with Argon2:
+Make sure you create a [virtual environment](../../virtual-environments.md){target=_blank}, activate it, and then install pwdlib with Argon2:
 
 <div class="termy">
 
@@ -200,7 +200,7 @@ The important thing to keep in mind is that the `sub` key should have a unique i
 
 ## Check it { #check-it }
 
-Run the server and go to the docs: <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Run the server and go to the docs: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
 You'll see the user interface like:
 

--- a/docs/en/docs/tutorial/security/oauth2-jwt.md
+++ b/docs/en/docs/tutorial/security/oauth2-jwt.md
@@ -24,13 +24,13 @@ That way, you can create a token with an expiration of, let's say, 1 week. And t
 
 After a week, the token will be expired and the user will not be authorized and will have to sign in again to get a new token. And if the user (or a third party) tried to modify the token to change the expiration, you would be able to discover it, because the signatures would not match.
 
-If you want to play with JWT tokens and see how they work, check [https://jwt.io](https://jwt.io/){target=_blank}.
+If you want to play with JWT tokens and see how they work, check [https://jwt.io](https://jwt.io/).
 
 ## Install `PyJWT` { #install-pyjwt }
 
 We need to install `PyJWT` to generate and verify the JWT tokens in Python.
 
-Make sure you create a [virtual environment](../../virtual-environments.md){target=_blank}, activate it, and then install `pyjwt`:
+Make sure you create a [virtual environment](../../virtual-environments.md), activate it, and then install `pyjwt`:
 
 <div class="termy">
 
@@ -46,7 +46,7 @@ $ pip install pyjwt
 
 If you are planning to use digital signature algorithms like RSA or ECDSA, you should install the cryptography library dependency `pyjwt[crypto]`.
 
-You can read more about it in the [PyJWT Installation docs](https://pyjwt.readthedocs.io/en/latest/installation.html){target=_blank}.
+You can read more about it in the [PyJWT Installation docs](https://pyjwt.readthedocs.io/en/latest/installation.html).
 
 ///
 
@@ -72,7 +72,7 @@ It supports many secure hashing algorithms and utilities to work with them.
 
 The recommended algorithm is "Argon2".
 
-Make sure you create a [virtual environment](../../virtual-environments.md){target=_blank}, activate it, and then install pwdlib with Argon2:
+Make sure you create a [virtual environment](../../virtual-environments.md), activate it, and then install pwdlib with Argon2:
 
 <div class="termy">
 
@@ -200,7 +200,7 @@ The important thing to keep in mind is that the `sub` key should have a unique i
 
 ## Check it { #check-it }
 
-Run the server and go to the docs: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+Run the server and go to the docs: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 You'll see the user interface like:
 

--- a/docs/en/docs/tutorial/security/simple-oauth2.md
+++ b/docs/en/docs/tutorial/security/simple-oauth2.md
@@ -146,7 +146,7 @@ UserInDB(
 
 /// info
 
-For a more complete explanation of `**user_dict` check back in [the documentation for **Extra Models**](../extra-models.md#about-user-in-dict){target=_blank}.
+For a more complete explanation of `**user_dict` check back in [the documentation for **Extra Models**](../extra-models.md#about-user-in-dict).
 
 ///
 
@@ -216,7 +216,7 @@ That's the benefit of standards...
 
 ## See it in action { #see-it-in-action }
 
-Open the interactive docs: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
+Open the interactive docs: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 ### Authenticate { #authenticate }
 

--- a/docs/en/docs/tutorial/security/simple-oauth2.md
+++ b/docs/en/docs/tutorial/security/simple-oauth2.md
@@ -146,7 +146,7 @@ UserInDB(
 
 /// info
 
-For a more complete explanation of `**user_dict` check back in [the documentation for **Extra Models**](../extra-models.md#about-user-in-dict){.internal-link target=_blank}.
+For a more complete explanation of `**user_dict` check back in [the documentation for **Extra Models**](../extra-models.md#about-user-in-dict){target=_blank}.
 
 ///
 
@@ -216,7 +216,7 @@ That's the benefit of standards...
 
 ## See it in action { #see-it-in-action }
 
-Open the interactive docs: <a href="http://127.0.0.1:8000/docs" class="external-link" target="_blank">http://127.0.0.1:8000/docs</a>.
+Open the interactive docs: [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs){target=_blank}.
 
 ### Authenticate { #authenticate }
 

--- a/docs/en/docs/tutorial/server-sent-events.md
+++ b/docs/en/docs/tutorial/server-sent-events.md
@@ -2,7 +2,7 @@
 
 You can stream data to the client using **Server-Sent Events** (SSE).
 
-This is similar to [Stream JSON Lines](stream-json-lines.md){target=_blank}, but uses the `text/event-stream` format, which is supported natively by browsers with the [`EventSource` API](https://developer.mozilla.org/en-US/docs/Web/API/EventSource){target=_blank}.
+This is similar to [Stream JSON Lines](stream-json-lines.md), but uses the `text/event-stream` format, which is supported natively by browsers with the [`EventSource` API](https://developer.mozilla.org/en-US/docs/Web/API/EventSource).
 
 /// info
 
@@ -29,7 +29,7 @@ SSE is commonly used for AI chat streaming, live notifications, logs and observa
 
 /// tip
 
-If you want to stream binary data, for example video or audio, check the advanced guide: [Stream Data](../advanced/stream-data.md){target=_blank}.
+If you want to stream binary data, for example video or audio, check the advanced guide: [Stream Data](../advanced/stream-data.md).
 
 ///
 
@@ -65,7 +65,7 @@ As in this case the function is not async, the right return type would be `Itera
 
 ### No Return Type { #no-return-type }
 
-You can also omit the return type. FastAPI will use the [`jsonable_encoder`](./encoder.md){target=_blank} to convert the data and send it.
+You can also omit the return type. FastAPI will use the [`jsonable_encoder`](./encoder.md) to convert the data and send it.
 
 {* ../../docs_src/server_sent_events/tutorial001_py310.py ln[34:37] hl[35] *}
 
@@ -105,7 +105,7 @@ You can read it as a header parameter and use it to resume the stream from where
 
 SSE works with **any HTTP method**, not just `GET`.
 
-This is useful for protocols like [MCP](https://modelcontextprotocol.io){target=_blank} that stream SSE over `POST`:
+This is useful for protocols like [MCP](https://modelcontextprotocol.io) that stream SSE over `POST`:
 
 {* ../../docs_src/server_sent_events/tutorial005_py310.py hl[14] *}
 
@@ -113,7 +113,7 @@ This is useful for protocols like [MCP](https://modelcontextprotocol.io){target=
 
 FastAPI implements some SSE best practices out of the box.
 
-* Send a **"keep alive" `ping` comment** every 15 seconds when there hasn't been any message, to prevent some proxies from closing the connection, as suggested in the [HTML specification: Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes){target=_blank}.
+* Send a **"keep alive" `ping` comment** every 15 seconds when there hasn't been any message, to prevent some proxies from closing the connection, as suggested in the [HTML specification: Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes).
 * Set the `Cache-Control: no-cache` header to **prevent caching** of the stream.
 * Set a special header `X-Accel-Buffering: no` to **prevent buffering** in some proxies like Nginx.
 

--- a/docs/en/docs/tutorial/server-sent-events.md
+++ b/docs/en/docs/tutorial/server-sent-events.md
@@ -2,7 +2,7 @@
 
 You can stream data to the client using **Server-Sent Events** (SSE).
 
-This is similar to [Stream JSON Lines](stream-json-lines.md){.internal-link target=_blank}, but uses the `text/event-stream` format, which is supported natively by browsers with the <a href="https://developer.mozilla.org/en-US/docs/Web/API/EventSource" class="external-link" target="_blank">`EventSource` API</a>.
+This is similar to [Stream JSON Lines](stream-json-lines.md){target=_blank}, but uses the `text/event-stream` format, which is supported natively by browsers with the [`EventSource` API](https://developer.mozilla.org/en-US/docs/Web/API/EventSource){target=_blank}.
 
 /// info
 
@@ -29,7 +29,7 @@ SSE is commonly used for AI chat streaming, live notifications, logs and observa
 
 /// tip
 
-If you want to stream binary data, for example video or audio, check the advanced guide: [Stream Data](../advanced/stream-data.md){.internal-link target=_blank}.
+If you want to stream binary data, for example video or audio, check the advanced guide: [Stream Data](../advanced/stream-data.md){target=_blank}.
 
 ///
 
@@ -65,7 +65,7 @@ As in this case the function is not async, the right return type would be `Itera
 
 ### No Return Type { #no-return-type }
 
-You can also omit the return type. FastAPI will use the [`jsonable_encoder`](./encoder.md){.internal-link target=_blank} to convert the data and send it.
+You can also omit the return type. FastAPI will use the [`jsonable_encoder`](./encoder.md){target=_blank} to convert the data and send it.
 
 {* ../../docs_src/server_sent_events/tutorial001_py310.py ln[34:37] hl[35] *}
 
@@ -105,7 +105,7 @@ You can read it as a header parameter and use it to resume the stream from where
 
 SSE works with **any HTTP method**, not just `GET`.
 
-This is useful for protocols like <a href="https://modelcontextprotocol.io" class="external-link" target="_blank">MCP</a> that stream SSE over `POST`:
+This is useful for protocols like [MCP](https://modelcontextprotocol.io){target=_blank} that stream SSE over `POST`:
 
 {* ../../docs_src/server_sent_events/tutorial005_py310.py hl[14] *}
 
@@ -113,7 +113,7 @@ This is useful for protocols like <a href="https://modelcontextprotocol.io" clas
 
 FastAPI implements some SSE best practices out of the box.
 
-* Send a **"keep alive" `ping` comment** every 15 seconds when there hasn't been any message, to prevent some proxies from closing the connection, as suggested in the <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes" class="external-link" target="_blank">HTML specification: Server-Sent Events</a>.
+* Send a **"keep alive" `ping` comment** every 15 seconds when there hasn't been any message, to prevent some proxies from closing the connection, as suggested in the [HTML specification: Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes){target=_blank}.
 * Set the `Cache-Control: no-cache` header to **prevent caching** of the stream.
 * Set a special header `X-Accel-Buffering: no` to **prevent buffering** in some proxies like Nginx.
 

--- a/docs/en/docs/tutorial/sql-databases.md
+++ b/docs/en/docs/tutorial/sql-databases.md
@@ -2,9 +2,9 @@
 
 **FastAPI** doesn't require you to use a SQL (relational) database. But you can use **any database** that you want.
 
-Here we'll see an example using <a href="https://sqlmodel.tiangolo.com/" class="external-link" target="_blank">SQLModel</a>.
+Here we'll see an example using [SQLModel](https://sqlmodel.tiangolo.com/){target=_blank}.
 
-**SQLModel** is built on top of <a href="https://www.sqlalchemy.org/" class="external-link" target="_blank">SQLAlchemy</a> and Pydantic. It was made by the same author of **FastAPI** to be the perfect match for FastAPI applications that need to use **SQL databases**.
+**SQLModel** is built on top of [SQLAlchemy](https://www.sqlalchemy.org/){target=_blank} and Pydantic. It was made by the same author of **FastAPI** to be the perfect match for FastAPI applications that need to use **SQL databases**.
 
 /// tip
 
@@ -26,15 +26,15 @@ Later, for your production application, you might want to use a database server 
 
 /// tip
 
-There is an official project generator with **FastAPI** and **PostgreSQL** including a frontend and more tools: <a href="https://github.com/fastapi/full-stack-fastapi-template" class="external-link" target="_blank">https://github.com/fastapi/full-stack-fastapi-template</a>
+There is an official project generator with **FastAPI** and **PostgreSQL** including a frontend and more tools: [https://github.com/fastapi/full-stack-fastapi-template](https://github.com/fastapi/full-stack-fastapi-template){target=_blank}
 
 ///
 
-This is a very simple and short tutorial, if you want to learn about databases in general, about SQL, or more advanced features, go to the <a href="https://sqlmodel.tiangolo.com/" class="external-link" target="_blank">SQLModel docs</a>.
+This is a very simple and short tutorial, if you want to learn about databases in general, about SQL, or more advanced features, go to the [SQLModel docs](https://sqlmodel.tiangolo.com/){target=_blank}.
 
 ## Install `SQLModel` { #install-sqlmodel }
 
-First, make sure you create your [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install `sqlmodel`:
+First, make sure you create your [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install `sqlmodel`:
 
 <div class="termy">
 
@@ -65,7 +65,7 @@ There are a few differences:
 
 * `Field(primary_key=True)` tells SQLModel that the `id` is the **primary key** in the SQL database (you can learn more about SQL primary keys in the SQLModel docs).
 
-    **Note:** We use `int | None` for the primary key field so that in Python code we can *create an object without an `id`* (`id=None`), assuming the database will *generate it when saving*. SQLModel understands that the database will provide the `id` and *defines the column as a non-null `INTEGER`* in the database schema. See <a href="https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#primary-key-id" class="external-link" target="_blank">SQLModel docs on primary keys</a> for details.
+    **Note:** We use `int | None` for the primary key field so that in Python code we can *create an object without an `id`* (`id=None`), assuming the database will *generate it when saving*. SQLModel understands that the database will provide the `id` and *defines the column as a non-null `INTEGER`* in the database schema. See [SQLModel docs on primary keys](https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#primary-key-id){target=_blank} for details.
 
 * `Field(index=True)` tells SQLModel that it should create a **SQL index** for this column, that would allow faster lookups in the database when reading data filtered by this column.
 
@@ -111,7 +111,7 @@ For production you would probably use a migration script that runs before you st
 
 /// tip
 
-SQLModel will have migration utilities wrapping Alembic, but for now, you can use <a href="https://alembic.sqlalchemy.org/en/latest/" class="external-link" target="_blank">Alembic</a> directly.
+SQLModel will have migration utilities wrapping Alembic, but for now, you can use [Alembic](https://alembic.sqlalchemy.org/en/latest/){target=_blank} directly.
 
 ///
 
@@ -352,6 +352,6 @@ If you go to the `/docs` API UI, you will see that it is now updated, and it won
 
 ## Recap { #recap }
 
-You can use <a href="https://sqlmodel.tiangolo.com/" class="external-link" target="_blank">**SQLModel**</a> to interact with a SQL database and simplify the code with *data models*  and *table models*.
+You can use [**SQLModel**](https://sqlmodel.tiangolo.com/){target=_blank} to interact with a SQL database and simplify the code with *data models*  and *table models*.
 
-You can learn a lot more at the **SQLModel** docs, there's a longer mini <a href="https://sqlmodel.tiangolo.com/tutorial/fastapi/" class="external-link" target="_blank">tutorial on using SQLModel with **FastAPI**</a>. 🚀
+You can learn a lot more at the **SQLModel** docs, there's a longer mini [tutorial on using SQLModel with **FastAPI**](https://sqlmodel.tiangolo.com/tutorial/fastapi/){target=_blank}. 🚀

--- a/docs/en/docs/tutorial/sql-databases.md
+++ b/docs/en/docs/tutorial/sql-databases.md
@@ -2,9 +2,9 @@
 
 **FastAPI** doesn't require you to use a SQL (relational) database. But you can use **any database** that you want.
 
-Here we'll see an example using [SQLModel](https://sqlmodel.tiangolo.com/){target=_blank}.
+Here we'll see an example using [SQLModel](https://sqlmodel.tiangolo.com/).
 
-**SQLModel** is built on top of [SQLAlchemy](https://www.sqlalchemy.org/){target=_blank} and Pydantic. It was made by the same author of **FastAPI** to be the perfect match for FastAPI applications that need to use **SQL databases**.
+**SQLModel** is built on top of [SQLAlchemy](https://www.sqlalchemy.org/) and Pydantic. It was made by the same author of **FastAPI** to be the perfect match for FastAPI applications that need to use **SQL databases**.
 
 /// tip
 
@@ -26,15 +26,15 @@ Later, for your production application, you might want to use a database server 
 
 /// tip
 
-There is an official project generator with **FastAPI** and **PostgreSQL** including a frontend and more tools: [https://github.com/fastapi/full-stack-fastapi-template](https://github.com/fastapi/full-stack-fastapi-template){target=_blank}
+There is an official project generator with **FastAPI** and **PostgreSQL** including a frontend and more tools: [https://github.com/fastapi/full-stack-fastapi-template](https://github.com/fastapi/full-stack-fastapi-template)
 
 ///
 
-This is a very simple and short tutorial, if you want to learn about databases in general, about SQL, or more advanced features, go to the [SQLModel docs](https://sqlmodel.tiangolo.com/){target=_blank}.
+This is a very simple and short tutorial, if you want to learn about databases in general, about SQL, or more advanced features, go to the [SQLModel docs](https://sqlmodel.tiangolo.com/).
 
 ## Install `SQLModel` { #install-sqlmodel }
 
-First, make sure you create your [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install `sqlmodel`:
+First, make sure you create your [virtual environment](../virtual-environments.md), activate it, and then install `sqlmodel`:
 
 <div class="termy">
 
@@ -65,7 +65,7 @@ There are a few differences:
 
 * `Field(primary_key=True)` tells SQLModel that the `id` is the **primary key** in the SQL database (you can learn more about SQL primary keys in the SQLModel docs).
 
-    **Note:** We use `int | None` for the primary key field so that in Python code we can *create an object without an `id`* (`id=None`), assuming the database will *generate it when saving*. SQLModel understands that the database will provide the `id` and *defines the column as a non-null `INTEGER`* in the database schema. See [SQLModel docs on primary keys](https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#primary-key-id){target=_blank} for details.
+    **Note:** We use `int | None` for the primary key field so that in Python code we can *create an object without an `id`* (`id=None`), assuming the database will *generate it when saving*. SQLModel understands that the database will provide the `id` and *defines the column as a non-null `INTEGER`* in the database schema. See [SQLModel docs on primary keys](https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#primary-key-id) for details.
 
 * `Field(index=True)` tells SQLModel that it should create a **SQL index** for this column, that would allow faster lookups in the database when reading data filtered by this column.
 
@@ -111,7 +111,7 @@ For production you would probably use a migration script that runs before you st
 
 /// tip
 
-SQLModel will have migration utilities wrapping Alembic, but for now, you can use [Alembic](https://alembic.sqlalchemy.org/en/latest/){target=_blank} directly.
+SQLModel will have migration utilities wrapping Alembic, but for now, you can use [Alembic](https://alembic.sqlalchemy.org/en/latest/) directly.
 
 ///
 
@@ -352,6 +352,6 @@ If you go to the `/docs` API UI, you will see that it is now updated, and it won
 
 ## Recap { #recap }
 
-You can use [**SQLModel**](https://sqlmodel.tiangolo.com/){target=_blank} to interact with a SQL database and simplify the code with *data models*  and *table models*.
+You can use [**SQLModel**](https://sqlmodel.tiangolo.com/) to interact with a SQL database and simplify the code with *data models*  and *table models*.
 
-You can learn a lot more at the **SQLModel** docs, there's a longer mini [tutorial on using SQLModel with **FastAPI**](https://sqlmodel.tiangolo.com/tutorial/fastapi/){target=_blank}. 🚀
+You can learn a lot more at the **SQLModel** docs, there's a longer mini [tutorial on using SQLModel with **FastAPI**](https://sqlmodel.tiangolo.com/tutorial/fastapi/). 🚀

--- a/docs/en/docs/tutorial/static-files.md
+++ b/docs/en/docs/tutorial/static-files.md
@@ -23,7 +23,7 @@ You could also use `from starlette.staticfiles import StaticFiles`.
 
 This is different from using an `APIRouter` as a mounted application is completely independent. The OpenAPI and docs from your main application won't include anything from the mounted application, etc.
 
-You can read more about this in the [Advanced User Guide](../advanced/index.md){.internal-link target=_blank}.
+You can read more about this in the [Advanced User Guide](../advanced/index.md){target=_blank}.
 
 ## Details { #details }
 
@@ -37,4 +37,4 @@ All these parameters can be different than "`static`", adjust them with the need
 
 ## More info { #more-info }
 
-For more details and options check <a href="https://www.starlette.dev/staticfiles/" class="external-link" target="_blank">Starlette's docs about Static Files</a>.
+For more details and options check [Starlette's docs about Static Files](https://www.starlette.dev/staticfiles/){target=_blank}.

--- a/docs/en/docs/tutorial/static-files.md
+++ b/docs/en/docs/tutorial/static-files.md
@@ -23,7 +23,7 @@ You could also use `from starlette.staticfiles import StaticFiles`.
 
 This is different from using an `APIRouter` as a mounted application is completely independent. The OpenAPI and docs from your main application won't include anything from the mounted application, etc.
 
-You can read more about this in the [Advanced User Guide](../advanced/index.md){target=_blank}.
+You can read more about this in the [Advanced User Guide](../advanced/index.md).
 
 ## Details { #details }
 
@@ -37,4 +37,4 @@ All these parameters can be different than "`static`", adjust them with the need
 
 ## More info { #more-info }
 
-For more details and options check [Starlette's docs about Static Files](https://www.starlette.dev/staticfiles/){target=_blank}.
+For more details and options check [Starlette's docs about Static Files](https://www.starlette.dev/staticfiles/).

--- a/docs/en/docs/tutorial/stream-json-lines.md
+++ b/docs/en/docs/tutorial/stream-json-lines.md
@@ -102,10 +102,10 @@ As in this case the function is not async, the right return type would be `Itera
 
 ### No Return Type { #no-return-type }
 
-You can also omit the return type. FastAPI will then use the [`jsonable_encoder`](./encoder.md){target=_blank} to convert the data to something that can be serialized to JSON and then send it as JSON Lines.
+You can also omit the return type. FastAPI will then use the [`jsonable_encoder`](./encoder.md) to convert the data to something that can be serialized to JSON and then send it as JSON Lines.
 
 {* ../../docs_src/stream_json_lines/tutorial001_py310.py ln[33:36] hl[34] *}
 
 ## Server-Sent Events (SSE) { #server-sent-events-sse }
 
-FastAPI also has first-class support for Server-Sent Events (SSE), which are quite similar but with a couple of extra details. You can learn about them in the next chapter: [Server-Sent Events (SSE)](server-sent-events.md){target=_blank}. 🤓
+FastAPI also has first-class support for Server-Sent Events (SSE), which are quite similar but with a couple of extra details. You can learn about them in the next chapter: [Server-Sent Events (SSE)](server-sent-events.md). 🤓

--- a/docs/en/docs/tutorial/stream-json-lines.md
+++ b/docs/en/docs/tutorial/stream-json-lines.md
@@ -102,10 +102,10 @@ As in this case the function is not async, the right return type would be `Itera
 
 ### No Return Type { #no-return-type }
 
-You can also omit the return type. FastAPI will then use the [`jsonable_encoder`](./encoder.md){.internal-link target=_blank} to convert the data to something that can be serialized to JSON and then send it as JSON Lines.
+You can also omit the return type. FastAPI will then use the [`jsonable_encoder`](./encoder.md){target=_blank} to convert the data to something that can be serialized to JSON and then send it as JSON Lines.
 
 {* ../../docs_src/stream_json_lines/tutorial001_py310.py ln[33:36] hl[34] *}
 
 ## Server-Sent Events (SSE) { #server-sent-events-sse }
 
-FastAPI also has first-class support for Server-Sent Events (SSE), which are quite similar but with a couple of extra details. You can learn about them in the next chapter: [Server-Sent Events (SSE)](server-sent-events.md){.internal-link target=_blank}. 🤓
+FastAPI also has first-class support for Server-Sent Events (SSE), which are quite similar but with a couple of extra details. You can learn about them in the next chapter: [Server-Sent Events (SSE)](server-sent-events.md){target=_blank}. 🤓

--- a/docs/en/docs/tutorial/testing.md
+++ b/docs/en/docs/tutorial/testing.md
@@ -1,18 +1,18 @@
 # Testing { #testing }
 
-Thanks to <a href="https://www.starlette.dev/testclient/" class="external-link" target="_blank">Starlette</a>, testing **FastAPI** applications is easy and enjoyable.
+Thanks to [Starlette](https://www.starlette.dev/testclient/){target=_blank}, testing **FastAPI** applications is easy and enjoyable.
 
-It is based on <a href="https://www.python-httpx.org" class="external-link" target="_blank">HTTPX</a>, which in turn is designed based on Requests, so it's very familiar and intuitive.
+It is based on [HTTPX](https://www.python-httpx.org){target=_blank}, which in turn is designed based on Requests, so it's very familiar and intuitive.
 
-With it, you can use <a href="https://docs.pytest.org/" class="external-link" target="_blank">pytest</a> directly with **FastAPI**.
+With it, you can use [pytest](https://docs.pytest.org/){target=_blank} directly with **FastAPI**.
 
 ## Using `TestClient` { #using-testclient }
 
 /// info
 
-To use `TestClient`, first install <a href="https://www.python-httpx.org" class="external-link" target="_blank">`httpx`</a>.
+To use `TestClient`, first install [`httpx`](https://www.python-httpx.org){target=_blank}.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
 
 ```console
 $ pip install httpx
@@ -52,7 +52,7 @@ You could also use `from starlette.testclient import TestClient`.
 
 /// tip
 
-If you want to call `async` functions in your tests apart from sending requests to your FastAPI application (e.g. asynchronous database functions), have a look at the [Async Tests](../advanced/async-tests.md){.internal-link target=_blank} in the advanced tutorial.
+If you want to call `async` functions in your tests apart from sending requests to your FastAPI application (e.g. asynchronous database functions), have a look at the [Async Tests](../advanced/async-tests.md){target=_blank} in the advanced tutorial.
 
 ///
 
@@ -64,7 +64,7 @@ And your **FastAPI** application might also be composed of several files/modules
 
 ### **FastAPI** app file { #fastapi-app-file }
 
-Let's say you have a file structure as described in [Bigger Applications](bigger-applications.md){.internal-link target=_blank}:
+Let's say you have a file structure as described in [Bigger Applications](bigger-applications.md){target=_blank}:
 
 ```
 .
@@ -142,13 +142,13 @@ E.g.:
 * To pass *headers*, use a `dict` in the `headers` parameter.
 * For *cookies*, a `dict` in the `cookies` parameter.
 
-For more information about how to pass data to the backend (using `httpx` or the `TestClient`) check the <a href="https://www.python-httpx.org" class="external-link" target="_blank">HTTPX documentation</a>.
+For more information about how to pass data to the backend (using `httpx` or the `TestClient`) check the [HTTPX documentation](https://www.python-httpx.org){target=_blank}.
 
 /// info
 
 Note that the `TestClient` receives data that can be converted to JSON, not Pydantic models.
 
-If you have a Pydantic model in your test and you want to send its data to the application during testing, you can use the `jsonable_encoder` described in [JSON Compatible Encoder](encoder.md){.internal-link target=_blank}.
+If you have a Pydantic model in your test and you want to send its data to the application during testing, you can use the `jsonable_encoder` described in [JSON Compatible Encoder](encoder.md){target=_blank}.
 
 ///
 
@@ -156,7 +156,7 @@ If you have a Pydantic model in your test and you want to send its data to the a
 
 After that, you just need to install `pytest`.
 
-Make sure you create a [virtual environment](../virtual-environments.md){.internal-link target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
 
 <div class="termy">
 

--- a/docs/en/docs/tutorial/testing.md
+++ b/docs/en/docs/tutorial/testing.md
@@ -1,18 +1,18 @@
 # Testing { #testing }
 
-Thanks to [Starlette](https://www.starlette.dev/testclient/){target=_blank}, testing **FastAPI** applications is easy and enjoyable.
+Thanks to [Starlette](https://www.starlette.dev/testclient/), testing **FastAPI** applications is easy and enjoyable.
 
-It is based on [HTTPX](https://www.python-httpx.org){target=_blank}, which in turn is designed based on Requests, so it's very familiar and intuitive.
+It is based on [HTTPX](https://www.python-httpx.org), which in turn is designed based on Requests, so it's very familiar and intuitive.
 
-With it, you can use [pytest](https://docs.pytest.org/){target=_blank} directly with **FastAPI**.
+With it, you can use [pytest](https://docs.pytest.org/) directly with **FastAPI**.
 
 ## Using `TestClient` { #using-testclient }
 
 /// info
 
-To use `TestClient`, first install [`httpx`](https://www.python-httpx.org){target=_blank}.
+To use `TestClient`, first install [`httpx`](https://www.python-httpx.org).
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then install it, for example:
 
 ```console
 $ pip install httpx
@@ -52,7 +52,7 @@ You could also use `from starlette.testclient import TestClient`.
 
 /// tip
 
-If you want to call `async` functions in your tests apart from sending requests to your FastAPI application (e.g. asynchronous database functions), have a look at the [Async Tests](../advanced/async-tests.md){target=_blank} in the advanced tutorial.
+If you want to call `async` functions in your tests apart from sending requests to your FastAPI application (e.g. asynchronous database functions), have a look at the [Async Tests](../advanced/async-tests.md) in the advanced tutorial.
 
 ///
 
@@ -64,7 +64,7 @@ And your **FastAPI** application might also be composed of several files/modules
 
 ### **FastAPI** app file { #fastapi-app-file }
 
-Let's say you have a file structure as described in [Bigger Applications](bigger-applications.md){target=_blank}:
+Let's say you have a file structure as described in [Bigger Applications](bigger-applications.md):
 
 ```
 .
@@ -142,13 +142,13 @@ E.g.:
 * To pass *headers*, use a `dict` in the `headers` parameter.
 * For *cookies*, a `dict` in the `cookies` parameter.
 
-For more information about how to pass data to the backend (using `httpx` or the `TestClient`) check the [HTTPX documentation](https://www.python-httpx.org){target=_blank}.
+For more information about how to pass data to the backend (using `httpx` or the `TestClient`) check the [HTTPX documentation](https://www.python-httpx.org).
 
 /// info
 
 Note that the `TestClient` receives data that can be converted to JSON, not Pydantic models.
 
-If you have a Pydantic model in your test and you want to send its data to the application during testing, you can use the `jsonable_encoder` described in [JSON Compatible Encoder](encoder.md){target=_blank}.
+If you have a Pydantic model in your test and you want to send its data to the application during testing, you can use the `jsonable_encoder` described in [JSON Compatible Encoder](encoder.md).
 
 ///
 
@@ -156,7 +156,7 @@ If you have a Pydantic model in your test and you want to send its data to the a
 
 After that, you just need to install `pytest`.
 
-Make sure you create a [virtual environment](../virtual-environments.md){target=_blank}, activate it, and then install it, for example:
+Make sure you create a [virtual environment](../virtual-environments.md), activate it, and then install it, for example:
 
 <div class="termy">
 

--- a/docs/en/docs/virtual-environments.md
+++ b/docs/en/docs/virtual-environments.md
@@ -22,7 +22,7 @@ A **virtual environment** is a directory with some files in it.
 
 This page will teach you how to use **virtual environments** and how they work.
 
-If you are ready to adopt a **tool that manages everything** for you (including installing Python), try <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">uv</a>.
+If you are ready to adopt a **tool that manages everything** for you (including installing Python), try [uv](https://github.com/astral-sh/uv){target=_blank}.
 
 ///
 
@@ -86,7 +86,7 @@ $ python -m venv .venv
 
 //// tab | `uv`
 
-If you have <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">`uv`</a> installed, you can use it to create a virtual environment.
+If you have [`uv`](https://github.com/astral-sh/uv){target=_blank} installed, you can use it to create a virtual environment.
 
 <div class="termy">
 
@@ -150,7 +150,7 @@ $ .venv\Scripts\Activate.ps1
 
 //// tab | Windows Bash
 
-Or if you use Bash for Windows (e.g. <a href="https://gitforwindows.org/" class="external-link" target="_blank">Git Bash</a>):
+Or if you use Bash for Windows (e.g. [Git Bash](https://gitforwindows.org/){target=_blank}):
 
 <div class="termy">
 
@@ -216,7 +216,7 @@ If it shows the `python` binary at `.venv\Scripts\python`, inside of your projec
 
 /// tip
 
-If you use <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">`uv`</a> you would use it to install things instead of `pip`, so you don't need to upgrade `pip`. 😎
+If you use [`uv`](https://github.com/astral-sh/uv){target=_blank} you would use it to install things instead of `pip`, so you don't need to upgrade `pip`. 😎
 
 ///
 
@@ -268,7 +268,7 @@ If you are using **Git** (you should), add a `.gitignore` file to exclude everyt
 
 /// tip
 
-If you used <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">`uv`</a> to create the virtual environment, it already did this for you, you can skip this step. 😎
+If you used [`uv`](https://github.com/astral-sh/uv){target=_blank} to create the virtual environment, it already did this for you, you can skip this step. 😎
 
 ///
 
@@ -340,7 +340,7 @@ $ pip install "fastapi[standard]"
 
 //// tab | `uv`
 
-If you have <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">`uv`</a>:
+If you have [`uv`](https://github.com/astral-sh/uv){target=_blank}:
 
 <div class="termy">
 
@@ -372,7 +372,7 @@ $ pip install -r requirements.txt
 
 //// tab | `uv`
 
-If you have <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">`uv`</a>:
+If you have [`uv`](https://github.com/astral-sh/uv){target=_blank}:
 
 <div class="termy">
 
@@ -416,8 +416,8 @@ You would probably use an editor, make sure you configure it to use the same vir
 
 For example:
 
-* <a href="https://code.visualstudio.com/docs/python/environments#_select-and-activate-an-environment" class="external-link" target="_blank">VS Code</a>
-* <a href="https://www.jetbrains.com/help/pycharm/creating-virtual-environment.html" class="external-link" target="_blank">PyCharm</a>
+* [VS Code](https://code.visualstudio.com/docs/python/environments#_select-and-activate-an-environment){target=_blank}
+* [PyCharm](https://www.jetbrains.com/help/pycharm/creating-virtual-environment.html){target=_blank}
 
 /// tip
 
@@ -455,7 +455,7 @@ Continue reading. 👇🤓
 
 ## Why Virtual Environments { #why-virtual-environments }
 
-To work with FastAPI you need to install <a href="https://www.python.org/" class="external-link" target="_blank">Python</a>.
+To work with FastAPI you need to install [Python](https://www.python.org/){target=_blank}.
 
 After that, you would need to **install** FastAPI and any other **packages** you want to use.
 
@@ -564,7 +564,7 @@ $ pip install "fastapi[standard]"
 
 </div>
 
-That will download a compressed file with the FastAPI code, normally from <a href="https://pypi.org/project/fastapi/" class="external-link" target="_blank">PyPI</a>.
+That will download a compressed file with the FastAPI code, normally from [PyPI](https://pypi.org/project/fastapi/){target=_blank}.
 
 It will also **download** files for other packages that FastAPI depends on.
 
@@ -627,7 +627,7 @@ $ .venv\Scripts\Activate.ps1
 
 //// tab | Windows Bash
 
-Or if you use Bash for Windows (e.g. <a href="https://gitforwindows.org/" class="external-link" target="_blank">Git Bash</a>):
+Or if you use Bash for Windows (e.g. [Git Bash](https://gitforwindows.org/){target=_blank}):
 
 <div class="termy">
 
@@ -639,13 +639,13 @@ $ source .venv/Scripts/activate
 
 ////
 
-That command will create or modify some [environment variables](environment-variables.md){.internal-link target=_blank} that will be available for the next commands.
+That command will create or modify some [environment variables](environment-variables.md){target=_blank} that will be available for the next commands.
 
 One of those variables is the `PATH` variable.
 
 /// tip
 
-You can learn more about the `PATH` environment variable in the [Environment Variables](environment-variables.md#path-environment-variable){.internal-link target=_blank} section.
+You can learn more about the `PATH` environment variable in the [Environment Variables](environment-variables.md#path-environment-variable){target=_blank} section.
 
 ///
 
@@ -846,7 +846,7 @@ This is a simple guide to get you started and teach you how everything works **u
 
 There are many **alternatives** to managing virtual environments, package dependencies (requirements), projects.
 
-Once you are ready and want to use a tool to **manage the entire project**, packages dependencies, virtual environments, etc. I would suggest you try <a href="https://github.com/astral-sh/uv" class="external-link" target="_blank">uv</a>.
+Once you are ready and want to use a tool to **manage the entire project**, packages dependencies, virtual environments, etc. I would suggest you try [uv](https://github.com/astral-sh/uv){target=_blank}.
 
 `uv` can do a lot of things, it can:
 

--- a/docs/en/docs/virtual-environments.md
+++ b/docs/en/docs/virtual-environments.md
@@ -22,7 +22,7 @@ A **virtual environment** is a directory with some files in it.
 
 This page will teach you how to use **virtual environments** and how they work.
 
-If you are ready to adopt a **tool that manages everything** for you (including installing Python), try [uv](https://github.com/astral-sh/uv){target=_blank}.
+If you are ready to adopt a **tool that manages everything** for you (including installing Python), try [uv](https://github.com/astral-sh/uv).
 
 ///
 
@@ -86,7 +86,7 @@ $ python -m venv .venv
 
 //// tab | `uv`
 
-If you have [`uv`](https://github.com/astral-sh/uv){target=_blank} installed, you can use it to create a virtual environment.
+If you have [`uv`](https://github.com/astral-sh/uv) installed, you can use it to create a virtual environment.
 
 <div class="termy">
 
@@ -150,7 +150,7 @@ $ .venv\Scripts\Activate.ps1
 
 //// tab | Windows Bash
 
-Or if you use Bash for Windows (e.g. [Git Bash](https://gitforwindows.org/){target=_blank}):
+Or if you use Bash for Windows (e.g. [Git Bash](https://gitforwindows.org/)):
 
 <div class="termy">
 
@@ -216,7 +216,7 @@ If it shows the `python` binary at `.venv\Scripts\python`, inside of your projec
 
 /// tip
 
-If you use [`uv`](https://github.com/astral-sh/uv){target=_blank} you would use it to install things instead of `pip`, so you don't need to upgrade `pip`. 😎
+If you use [`uv`](https://github.com/astral-sh/uv) you would use it to install things instead of `pip`, so you don't need to upgrade `pip`. 😎
 
 ///
 
@@ -268,7 +268,7 @@ If you are using **Git** (you should), add a `.gitignore` file to exclude everyt
 
 /// tip
 
-If you used [`uv`](https://github.com/astral-sh/uv){target=_blank} to create the virtual environment, it already did this for you, you can skip this step. 😎
+If you used [`uv`](https://github.com/astral-sh/uv) to create the virtual environment, it already did this for you, you can skip this step. 😎
 
 ///
 
@@ -340,7 +340,7 @@ $ pip install "fastapi[standard]"
 
 //// tab | `uv`
 
-If you have [`uv`](https://github.com/astral-sh/uv){target=_blank}:
+If you have [`uv`](https://github.com/astral-sh/uv):
 
 <div class="termy">
 
@@ -372,7 +372,7 @@ $ pip install -r requirements.txt
 
 //// tab | `uv`
 
-If you have [`uv`](https://github.com/astral-sh/uv){target=_blank}:
+If you have [`uv`](https://github.com/astral-sh/uv):
 
 <div class="termy">
 
@@ -416,8 +416,8 @@ You would probably use an editor, make sure you configure it to use the same vir
 
 For example:
 
-* [VS Code](https://code.visualstudio.com/docs/python/environments#_select-and-activate-an-environment){target=_blank}
-* [PyCharm](https://www.jetbrains.com/help/pycharm/creating-virtual-environment.html){target=_blank}
+* [VS Code](https://code.visualstudio.com/docs/python/environments#_select-and-activate-an-environment)
+* [PyCharm](https://www.jetbrains.com/help/pycharm/creating-virtual-environment.html)
 
 /// tip
 
@@ -455,7 +455,7 @@ Continue reading. 👇🤓
 
 ## Why Virtual Environments { #why-virtual-environments }
 
-To work with FastAPI you need to install [Python](https://www.python.org/){target=_blank}.
+To work with FastAPI you need to install [Python](https://www.python.org/).
 
 After that, you would need to **install** FastAPI and any other **packages** you want to use.
 
@@ -564,7 +564,7 @@ $ pip install "fastapi[standard]"
 
 </div>
 
-That will download a compressed file with the FastAPI code, normally from [PyPI](https://pypi.org/project/fastapi/){target=_blank}.
+That will download a compressed file with the FastAPI code, normally from [PyPI](https://pypi.org/project/fastapi/).
 
 It will also **download** files for other packages that FastAPI depends on.
 
@@ -627,7 +627,7 @@ $ .venv\Scripts\Activate.ps1
 
 //// tab | Windows Bash
 
-Or if you use Bash for Windows (e.g. [Git Bash](https://gitforwindows.org/){target=_blank}):
+Or if you use Bash for Windows (e.g. [Git Bash](https://gitforwindows.org/)):
 
 <div class="termy">
 
@@ -639,13 +639,13 @@ $ source .venv/Scripts/activate
 
 ////
 
-That command will create or modify some [environment variables](environment-variables.md){target=_blank} that will be available for the next commands.
+That command will create or modify some [environment variables](environment-variables.md) that will be available for the next commands.
 
 One of those variables is the `PATH` variable.
 
 /// tip
 
-You can learn more about the `PATH` environment variable in the [Environment Variables](environment-variables.md#path-environment-variable){target=_blank} section.
+You can learn more about the `PATH` environment variable in the [Environment Variables](environment-variables.md#path-environment-variable) section.
 
 ///
 
@@ -846,7 +846,7 @@ This is a simple guide to get you started and teach you how everything works **u
 
 There are many **alternatives** to managing virtual environments, package dependencies (requirements), projects.
 
-Once you are ready and want to use a tool to **manage the entire project**, packages dependencies, virtual environments, etc. I would suggest you try [uv](https://github.com/astral-sh/uv){target=_blank}.
+Once you are ready and want to use a tool to **manage the entire project**, packages dependencies, virtual environments, etc. I would suggest you try [uv](https://github.com/astral-sh/uv).
 
 `uv` can do a lot of things, it can:
 


### PR DESCRIPTION
📝 Update links in docs to no longer use the classes external-link and internal-link, remove `target=_blank`, which is now added automatically by JS, and move from HTML to Markdown syntax (as now it no longer needs anything from HTML).

The migration was done automatically with this script, generated with Claude Opus 4.6, the results were reviewed by (human) hand one by one.

```Python
#!/usr/bin/env python3
"""
Remove .external-link and .internal-link classes and target=_blank from docs,
converting HTML <a> tags to Markdown links where possible.

Handles these patterns:

1. HTML external/internal links (simple text content):
   <a href="URL" class="external-link" target="_blank">Text</a>
   → [Text](URL)

2. HTML links with <strong> content:
   <a href="URL" class="external-link" target="_blank"><strong>Text</strong></a>
   → [**Text**](URL)

3. HTML links with <code> content:
   <a href="URL" class="external-link" target="_blank"><code>text</code></a>
   → [`text`](URL)

4. HTML links with <abbr> (converted, abbr kept inline):
   <a href="URL" class="external-link" target="_blank"><abbr title="T">Text</abbr></a>
   → [<abbr title="T">Text</abbr>](URL)

5. HTML links with mixed <abbr> + <code>/<strong> (converted):
   <a href="URL" class="external-link" target="_blank"><abbr>X</abbr> docs for <code>POST</code></a>
   → [<abbr>X</abbr> docs for `POST`](URL)

6. Markdown attr_list (.internal-link or .external-link and target=_blank removed):
   [Text](URL){.internal-link target=_blank}
   → [Text](URL)

7. HTML <a> tags without link classes but with target="_blank" (class stripped, target removed):
   <a href="URL" target="_blank">Text</a>
   → [Text](URL)

8. Markdown attr_list with only target=_blank (removed):
   [Text](URL){target=_blank}
   → [Text](URL)
"""

import re
import sys
from pathlib import Path


def convert_html_link_to_markdown(match: str) -> str:
    """Convert <a> tag to markdown link, stripping class and target."""
    # Extract href
    href_m = re.search(r'href="([^"]*)"', match)
    if not href_m:
        return match
    href = href_m.group(1)

    # Extract inner content (between > and </a>)
    content_m = re.search(r'>(.+?)</a>\s*$', match, re.DOTALL)
    if not content_m:
        return match
    content = content_m.group(1).strip()

    # Convert inline HTML to markdown equivalents
    # Convert <strong>text</strong> → **text**
    content = re.sub(r'<strong>(.*?)</strong>', r'**\1**', content)
    # Convert <code>text</code> → `text`
    content = re.sub(r'<code>(.*?)</code>', r'`\1`', content)
    # Convert <em>text</em> → *text*
    content = re.sub(r'<em>(.*?)</em>', r'*\1*', content)

    # If there's still HTML other than <abbr> in the content, keep as HTML
    # but remove class and target attributes
    content_without_abbr = re.sub(r'<abbr\s[^>]*>.*?</abbr>', '', content)
    if '<' in content_without_abbr:
        result = re.sub(r'\s*class="(?:external|internal)-link"', '', match)
        result = re.sub(r'\s*target="[^"]*"', '', result)
        return result

    return f"[{content}]({href})"


def process_file(filepath: Path, dry_run: bool = False) -> tuple[int, list[str]]:
    """Process a single file. Returns (change_count, list of changes)."""
    text = filepath.read_text(encoding="utf-8")
    original = text
    changes: list[str] = []

    # Pattern 1: HTML <a> tags with class="external-link" or class="internal-link"
    # Handles attributes in any order
    html_class_pattern = re.compile(
        r'<a\s+'
        r'(?=[^>]*class="(?:external|internal)-link")'  # must have the class
        r'[^>]*?'                                        # other attrs before href
        r'href="[^"]*"'                                  # href
        r'[^>]*?'                                        # other attrs
        r'>'                                             # end of opening tag
        r'.+?'                                           # content
        r'</a>',                                         # closing tag
        re.DOTALL,
    )

    def replace_html_class(m: re.Match) -> str:
        result = convert_html_link_to_markdown(m.group(0))
        if result != m.group(0):
            changes.append(f"  HTML class → MD: {m.group(0)[:80]}...")
        return result

    text = html_class_pattern.sub(replace_html_class, text)

    # Pattern 2: HTML <a> tags with target="_blank" but no link class
    # (these may have been left by previous runs or were never classed)
    html_target_pattern = re.compile(
        r'<a\s+'
        r'(?=[^>]*target="_blank")'                      # must have target=_blank
        r'(?![^>]*class=")'                              # must NOT have a class attr
        r'[^>]*?'                                        # other attrs before href
        r'href="[^"]*"'                                  # href
        r'[^>]*?'                                        # other attrs
        r'>'                                             # end of opening tag
        r'.+?'                                           # content
        r'</a>',                                         # closing tag
        re.DOTALL,
    )

    def replace_html_target(m: re.Match) -> str:
        result = convert_html_link_to_markdown(m.group(0))
        if result != m.group(0):
            changes.append(f"  HTML target → MD: {m.group(0)[:80]}...")
        return result

    text = html_target_pattern.sub(replace_html_target, text)

    # Pattern 3: Markdown attr_list with .external-link or .internal-link
    # [Text](URL){.internal-link target=_blank}  →  [Text](URL)
    # [Text](URL){.external-link target=_blank}  →  [Text](URL)
    md_class_pattern = re.compile(
        r'(\[[^\]]+\]\([^)]+\))'     # [text](url)
        r'\{'                         # {
        r'\.(?:external|internal)-link'  # .external-link or .internal-link
        r'\s*'                        # optional space
        r'([^}]*?)'                   # remaining attrs (e.g. target=_blank)
        r'\}'                         # }
    )

    def replace_md_class(m: re.Match) -> str:
        link_part = m.group(1)
        remaining_attrs = m.group(2).strip()
        # Remove target=_blank from remaining attrs
        remaining_attrs = re.sub(r'target=_blank\s*', '', remaining_attrs).strip()
        if remaining_attrs:
            result = f"{link_part}{{{remaining_attrs}}}"
        else:
            result = link_part
        changes.append(f"  MD class attr: {m.group(0)[:80]}...")
        return result

    text = md_class_pattern.sub(replace_md_class, text)

    # Pattern 4: Markdown attr_list with only target=_blank (no class)
    # [Text](URL){target=_blank}  →  [Text](URL)
    md_target_pattern = re.compile(
        r'(\[[^\]]+\]\([^)]+\))'     # [text](url)
        r'\{target=_blank\}'          # {target=_blank}
    )

    def replace_md_target(m: re.Match) -> str:
        changes.append(f"  MD target attr: {m.group(0)[:80]}...")
        return m.group(1)

    text = md_target_pattern.sub(replace_md_target, text)

    if text != original:
        if not dry_run:
            filepath.write_text(text, encoding="utf-8")
        return len(changes), changes
    return 0, []


def main() -> None:
    dry_run = "--dry-run" in sys.argv
    docs_dir = Path("docs/en/docs")

    if not docs_dir.exists():
        print(f"Error: {docs_dir} not found. Run from the repo root.")
        sys.exit(1)

    total_changes = 0
    files_changed = 0

    for md_file in sorted(docs_dir.rglob("*.md")):
        count, changes = process_file(md_file, dry_run=dry_run)
        if count:
            files_changed += 1
            total_changes += count
            print(f"{md_file} ({count} changes)")
            for c in changes:
                print(c)

    mode = "DRY RUN" if dry_run else "APPLIED"
    print(f"\n{mode}: {total_changes} changes across {files_changed} files")


if __name__ == "__main__":
    main()
```