### PR TITLE
docs: add Pandas DataFrame serialization guidance to encoder.md

### DIFF
--- a/docs/en/docs/tutorial/encoder.md
+++ b/docs/en/docs/tutorial/encoder.md
@@ -33,3 +33,70 @@ It doesn't return a large `str` containing the data in JSON format (as a string)
 `jsonable_encoder` is actually used by **FastAPI** internally to convert data. But it is useful in many other scenarios.
 
 ///
+
+## Working with Pandas DataFrames { #working-with-pandas-dataframes }
+
+**Pandas** is commonly used in FastAPI applications for data science, analytics APIs, and ML inference backends. However, returning data from a Pandas DataFrame requires care — Pandas uses **NumPy types** internally (`numpy.int64`, `numpy.float64`, `numpy.nan`, `pandas.NaT`), which are **not natively JSON serializable**.
+
+Calling `.to_dict(orient="records")` on a DataFrame returns a list of dicts where numeric columns are still NumPy types, not standard Python `int` or `float`. This causes a `TypeError` at runtime:
+
+```
+TypeError: Object of type int64 is not JSON serializable
+```
+
+Additionally, `numpy.nan` and `pandas.NaT` are not valid JSON values and will cause serialization errors or malformed output.
+
+### Safe Pattern: Use `jsonable_encoder` { #safe-pattern-use-jsonable-encoder }
+
+Wrap the result of `.to_dict()` with `jsonable_encoder()` to safely convert all NumPy types to JSON-compatible Python types, and convert `NaT`/`nan` to `null`:
+
+```python
+from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
+import pandas as pd
+
+app = FastAPI()
+
+
+@app.get("/encounters")
+def get_encounters():
+    df = pd.read_csv("healthcare_data.csv")
+
+    # ❌ May raise TypeError — numpy.int64 / numpy.float64 / NaN not JSON serializable
+    # return df.to_dict(orient="records")
+
+    # ✅ jsonable_encoder converts numpy types and NaT/NaN -> null
+    return jsonable_encoder(df.to_dict(orient="records"))
+```
+
+### Alternative: Pandas Native JSON Serialization { #alternative-pandas-native-json-serialization }
+
+Pandas has its own JSON serializer that handles NumPy types and dates natively. Use `df.to_json()` with `json.loads()` to produce a clean Python list:
+
+```python
+import json
+from fastapi import FastAPI
+import pandas as pd
+
+app = FastAPI()
+
+
+@app.get("/encounters")
+def get_encounters():
+    df = pd.read_csv("healthcare_data.csv")
+
+    # ✅ Pandas handles numpy types + datetime columns with ISO format
+    return json.loads(df.to_json(orient="records", date_format="iso"))
+```
+
+/// tip
+
+Use the `date_format="iso"` parameter with `df.to_json()` to ensure datetime columns are serialized as ISO 8601 strings (e.g., `"2024-01-15T00:00:00"`), consistent with how `jsonable_encoder` handles Python `datetime` objects.
+
+///
+
+/// note
+
+Both approaches produce `null` for missing values (`NaN`, `NaT`), which is the correct JSON representation for missing data.
+
+///


### PR DESCRIPTION
## Summary

Closes #15085

Adds a new section **"Working with Pandas DataFrames"** to `docs/en/docs/tutorial/encoder.md`.

## Problem

Pandas is one of the most common data sources in FastAPI backends (ML APIs, analytics, data pipelines). However, the existing `encoder.md` doc only covers Pydantic models and Python `datetime` — it says nothing about Pandas DataFrames.

When developers call `df.to_dict(orient="records")` and return the result directly, they hit:

```
TypeError: Object of type int64 is not JSON serializable
```

This happens because Pandas uses NumPy types internally (`numpy.int64`, `numpy.float64`, `numpy.nan`, `pandas.NaT`) which are not JSON-serializable by default. This is a very common gotcha with no existing docs coverage.

## Changes

Added two safe patterns to `encoder.md`:

1. **`jsonable_encoder(df.to_dict(orient="records"))`** — wraps the dict output so FastAPI converts numpy types + NaT/NaN → null
2. **`json.loads(df.to_json(orient="records", date_format="iso"))`** — uses pandas native serializer, handles all numpy types natively

Both approaches are shown with a practical healthcare analytics API example (the real-world context where this was discovered).

## Checklist

- [x] Added new section `## Working with Pandas DataFrames` to `encoder.md`
- [x] Showed ❌ broken pattern and ✅ two safe alternatives
- [x] Added `/// tip` note on `date_format="iso"` for datetime consistency
- [x] Added `/// note` on NaN/NaT → null behavior
- [x] Doc-only change, no code changes
