### PR TITLE
📝 Update .gitignore and add skipif decorator for fastapi-cli tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ log.txt
 Pipfile.lock
 env3.*
 env
+.env
+.venv
 docs_build
 site_build
 venv

--- a/tests/test_fastapi_cli.py
+++ b/tests/test_fastapi_cli.py
@@ -6,7 +6,13 @@ from unittest.mock import patch
 import fastapi.cli
 import pytest
 
+fastapi_cli_installed = pytest.mark.skipif(
+    fastapi.cli.cli_main is None,
+    reason="fastapi-cli is not installed",
+)
 
+
+@fastapi_cli_installed
 def test_fastapi_cli():
     result = subprocess.run(
         [


### PR DESCRIPTION
## Problem
`test_fastapi_cli` runs `fastapi dev non_existent_file.py` in subprocess and waits
"Path does not exist non_existent_file.py". But if `fastapi-cli` is not installed
(without the extra `[standard]`), the subprocess displays the installation message instead,
which causes the test to fail.

## Fix
Added a `pytest.mark.skipif` that skips `test_fastapi_cli` when `fastapi.cli.cli_main is None`.
The `test_fastapi_cli_not_installed` test already covers this case via mock, no coverage is lost.