### PR TITLE
💄 Fix code blocks in reference docs overflowing table width

### DIFF
--- a/docs/en/docs/css/custom.css
+++ b/docs/en/docs/css/custom.css
@@ -254,6 +254,12 @@ Inspired by Termynal's CSS tricks with modifications
           box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
 }
 
+.doc-param-details .highlight {
+  overflow-x: auto;
+  width: 0;
+  min-width: 100%;
+}
+
 .md-typeset dfn {
   border-bottom: .05rem dotted var(--md-default-fg-color--light);
   cursor: help;

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -279,6 +279,7 @@ markdown_extensions:
   pymdownx.caret: null
   pymdownx.highlight:
     line_spans: __span
+    linenums_style: pymdownx-inline
   pymdownx.inlinehilite: null
   pymdownx.keys: null
   pymdownx.mark: null


### PR DESCRIPTION
There is currently an issue in FastAPI Reference docs (reported in [this discussion](https://github.com/fastapi/fastapi/discussions/15082)): if parameter description contains code block with long lines, it will extend the column width and part of the text will become hidden:

See: https://fastapi.tiangolo.com/reference/fastapi/#fastapi.FastAPI--example

<details><summary>See screenshot (before fix)</summary>

<img width="805" height="949" alt="image" src="https://github.com/user-attachments/assets/6a1a4ce5-27de-4bb6-b91c-abdb9d5e705b" />

</details>


---

Together with Claude Code figured out a solution that looks quite simple and reasonable.
```css
.doc-param-details .highlight {
  overflow-x: auto;
  width: 0;
  min-width: 100%;
}
```

Claude Code explained it this way:
* `width: 0` - tells the table layout algorithm that `.highlight` needs zero width, so the `<td>` doesn't expand
* `min-width: 100%` - once the table has calculated column widths, `.highlight` fills the available space
* `overflow-x: auto` - adds a horizontal scrollbar when code is wider than the column

---

**After fix,** text fits the column width. If there are long lines in code block, you can use horizontal scroll bar to read them:

See (after fix): https://9541300a.fastapitiangolo.pages.dev/reference/fastapi/#fastapi.FastAPI--example

<details><summary>See screenshot (after fix)</summary>

<img width="853" height="1141" alt="image" src="https://github.com/user-attachments/assets/66806518-7595-4694-8bf8-65b9176e0a3a" />

</details>

## Bonus - fix displaying line numbers in API Reference docs (when run with `LINENUMS=true`)

Also fixed annoying bug - when you run docs live locally, it's run with `LINENUMS=true`. But line numbers layout is broken for API Reference docs:

<details><summary>See screenshot (line numbers before fix)</summary>

<img width="808" height="365" alt="image" src="https://github.com/user-attachments/assets/2900c89d-1afa-4c5c-845d-e9c4fae54d2a" />

</details>

By-default line numbers are added using table. And if this table is placed inside another table (table of parameters in API reference docs), it breaks styles..

There is an alternative approach as described in [docs](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#+pymdownx.highlight.linenums_style) - use `linenums_style: pymdownx-inline`.

This way line numbers are displayed correctly:

<details><summary>See screenshot (line numbers after fix)</summary>

<img width="795" height="283" alt="image" src="https://github.com/user-attachments/assets/02c9975d-4a17-4a80-9e90-3463d0f7356f" />


</details>