### PR TITLE
refactor: jsonable_encoder to remove redundant custom_encoder assignment

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -211,8 +211,7 @@ def jsonable_encoder(
     Read more about it in the
     [FastAPI docs for JSON Compatible Encoder](https://fastapi.tiangolo.com/tutorial/encoder/).
     """
-    custom_encoder = custom_encoder or {}
-    if custom_encoder:
+    if custom_encoder is not None:
         if type(obj) in custom_encoder:
             return custom_encoder[type(obj)](obj)
         else:


### PR DESCRIPTION
This refactor removes a redundant assignment of `custom_encoder` in `jsonable_encoder`.

Previously:

    custom_encoder = custom_encoder or {}
    if custom_encoder:

If `custom_encoder` is `None`, the first line converts it to `{}`, and the subsequent condition evaluates to `False`. The fallback assignment is therefore unnecessary.

This change simplifies the logic by checking `custom_encoder is not None` directly.

This PR is a refactor; please apply the refactor label.