### PR TITLE
Added password format to Oauth2PasswordRequestFormStrict fields

### DIFF
--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -255,7 +255,7 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         ],
         password: Annotated[
             str,
-            Form(),
+            Form(json_schema_extra={"format": "password"}),
             Doc(
                 """
                 `password` string. The OAuth2 spec requires the exact field name
@@ -306,7 +306,7 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         ] = None,
         client_secret: Annotated[
             str | None,
-            Form(),
+            Form(json_schema_extra={"format": "password"}),
             Doc(
                 """
                 If there's a `client_password` (and a `client_id`), they can be sent

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -213,7 +213,11 @@ def test_openapi_schema():
                                 "type": "string",
                             },
                             "username": {"title": "Username", "type": "string"},
-                            "password": {"title": "Password", 'format': 'password', "type": "string"},
+                            "password": {
+                                "title": "Password",
+                                "format": "password",
+                                "type": "string",
+                            },
                             "scope": {
                                 "title": "Scope",
                                 "type": "string",
@@ -224,7 +228,9 @@ def test_openapi_schema():
                                 "anyOf": [{"type": "string"}, {"type": "null"}],
                             },
                             "client_secret": {
-                                "title": "Client Secret", 'format': 'password', "anyOf": [{"type": "string"}, {"type": "null"}],
+                                "title": "Client Secret",
+                                "format": "password",
+                                "anyOf": [{"type": "string"}, {"type": "null"}],
                             },
                         },
                     },

--- a/tests/test_security_oauth2.py
+++ b/tests/test_security_oauth2.py
@@ -213,7 +213,7 @@ def test_openapi_schema():
                                 "type": "string",
                             },
                             "username": {"title": "Username", "type": "string"},
-                            "password": {"title": "Password", "type": "string"},
+                            "password": {"title": "Password", 'format': 'password', "type": "string"},
                             "scope": {
                                 "title": "Scope",
                                 "type": "string",
@@ -224,8 +224,7 @@ def test_openapi_schema():
                                 "anyOf": [{"type": "string"}, {"type": "null"}],
                             },
                             "client_secret": {
-                                "title": "Client Secret",
-                                "anyOf": [{"type": "string"}, {"type": "null"}],
+                                "title": "Client Secret", 'format': 'password', "anyOf": [{"type": "string"}, {"type": "null"}],
                             },
                         },
                     },


### PR DESCRIPTION
When using OAuth2PasswordRequestFormStrict in the Swagger UI docs, the password and client_secret fields were showing as plain text input boxes instead of masked password fields. OAuth2PasswordRequestForm already had this fixed, but since OAuth2PasswordRequestFormStrict overrides __init__ separately, the fix never carried over. Added json_schema_extra={"format": "password"} to both fields to match the behavior of OAuth2PasswordRequestForm.