### PR TITLE
📝 Fix duplicated words in docstrings

### DIFF
--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -321,7 +321,7 @@ class HTTPDigest(HTTPBase):
     HTTP Digest authentication.
 
     **Warning**: this is only a stub to connect the components with OpenAPI in FastAPI,
-    but it doesn't implement the full Digest scheme, you would need to to subclass it
+    but it doesn't implement the full Digest scheme, you would need to subclass it
     and implement it in your code.
 
     Ref: https://datatracker.ietf.org/doc/html/rfc7616

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -53,7 +53,7 @@ class OAuth2PasswordRequestForm:
     You could have custom internal logic to separate it by colon characters (`:`) or
     similar, and get the two parts `items` and `read`. Many applications do that to
     group and organize permissions, you could do it as well in your application, just
-    know that that it is application specific, it's not part of the specification.
+    know that it is application specific, it's not part of the specification.
     """
 
     def __init__(
@@ -207,7 +207,7 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
     You could have custom internal logic to separate it by colon characters (`:`) or
     similar, and get the two parts `items` and `read`. Many applications do that to
     group and organize permissions, you could do it as well in your application, just
-    know that that it is application specific, it's not part of the specification.
+    know that it is application specific, it's not part of the specification.
 
 
     grant_type: the OAuth2 spec says it is required and MUST be the fixed string "password".

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -15,7 +15,7 @@ class OpenIdConnect(SecurityBase):
 
     **Warning**: this is only a stub to connect the components with OpenAPI in FastAPI,
     but it doesn't implement the full OpenIdConnect scheme, for example, it doesn't use
-    the OpenIDConnect URL. You would need to to subclass it and implement it in your
+    the OpenIDConnect URL. You would need to subclass it and implement it in your
     code.
     """
 

--- a/tests/test_pydanticv2_dataclasses_uuid_stringified_annotations.py
+++ b/tests/test_pydanticv2_dataclasses_uuid_stringified_annotations.py
@@ -28,7 +28,7 @@ async def read_item():
         "id": uuid.uuid4(),
         "name": "Island In The Moon",
         "price": 12.99,
-        "description": "A place to be be playin' and havin' fun",
+        "description": "A place to be playin' and havin' fun",
         "tags": ["breater"],
     }
 
@@ -45,7 +45,7 @@ def test_annotations():
             "name": "Island In The Moon",
             "price": 12.99,
             "tags": ["breater"],
-            "description": "A place to be be playin' and havin' fun",
+            "description": "A place to be playin' and havin' fun",
             "tax": None,
         }
     )


### PR DESCRIPTION
## Summary
- Fix "to to" → "to" in `HTTPDigest` and `OpenIdConnect` class docstrings
- Fix "that that" → "that" in `OAuth2PasswordRequestForm` and `OAuth2PasswordRequestFormStrict` class docstrings
- Fix "be be" → "be" in test data string

## Files Changed
- `fastapi/security/http.py` — removed duplicated "to" in HTTPDigest docstring
- `fastapi/security/oauth2.py` — removed duplicated "that" in two docstrings
- `fastapi/security/open_id_connect_url.py` — removed duplicated "to" in OpenIdConnect docstring
- `tests/test_pydanticv2_dataclasses_uuid_stringified_annotations.py` — removed duplicated "be" in test data and assertion

## Test plan
- [x] `ruff check` passes on all changed files
- [x] `ruff format --check` passes on all changed files
- [x] `pytest tests/test_pydanticv2_dataclasses_uuid_stringified_annotations.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)