### PR TITLE
docs: fix duplicate words in security module docstrings

### DIFF
--- a/fastapi/security/http.py
+++ b/fastapi/security/http.py
@@ -321,7 +321,7 @@ class HTTPDigest(HTTPBase):
     HTTP Digest authentication.
 
     **Warning**: this is only a stub to connect the components with OpenAPI in FastAPI,
-    but it doesn't implement the full Digest scheme, you would need to to subclass it
+    but it doesn't implement the full Digest scheme, you would need to subclass it
     and implement it in your code.
 
     Ref: https://datatracker.ietf.org/doc/html/rfc7616

--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -53,7 +53,7 @@ class OAuth2PasswordRequestForm:
     You could have custom internal logic to separate it by colon characters (`:`) or
     similar, and get the two parts `items` and `read`. Many applications do that to
     group and organize permissions, you could do it as well in your application, just
-    know that that it is application specific, it's not part of the specification.
+    know that it is application specific, it's not part of the specification.
     """
 
     def __init__(
@@ -207,7 +207,7 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
     You could have custom internal logic to separate it by colon characters (`:`) or
     similar, and get the two parts `items` and `read`. Many applications do that to
     group and organize permissions, you could do it as well in your application, just
-    know that that it is application specific, it's not part of the specification.
+    know that it is application specific, it's not part of the specification.
 
 
     grant_type: the OAuth2 spec says it is required and MUST be the fixed string "password".

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -15,7 +15,7 @@ class OpenIdConnect(SecurityBase):
 
     **Warning**: this is only a stub to connect the components with OpenAPI in FastAPI,
     but it doesn't implement the full OpenIdConnect scheme, for example, it doesn't use
-    the OpenIDConnect URL. You would need to to subclass it and implement it in your
+    the OpenIDConnect URL. You would need to subclass it and implement it in your
     code.
     """
 


### PR DESCRIPTION
## Summary

Fix typos with repeated/duplicate words in docstrings across the security module:

- `fastapi/security/http.py` (HTTPDigest): "you would need to **to** subclass it" → "you would need to subclass it"
- `fastapi/security/open_id_connect_url.py` (OpenIdConnect): "You would need to **to** subclass it" → "You would need to subclass it"
- `fastapi/security/oauth2.py` (OAuth2PasswordRequestForm): "know that **that** it is application specific" → "know that it is application specific"
- `fastapi/security/oauth2.py` (OAuth2PasswordRequestFormStrict): same duplicate "that that" fix

## Type of change

- [x] Documentation update (docstring typo fixes)
- [ ] Bug fix
- [ ] New feature