### PR TITLE
fix: resolve ForwardRef in get_typed_annotation for Annotated+Depends (#13056)

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -245,6 +245,7 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
 def get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
     if isinstance(annotation, str):
         annotation = ForwardRef(annotation)
+    if isinstance(annotation, ForwardRef):
         annotation = evaluate_forwardref(annotation, globalns, globalns)  # ty: ignore[deprecated]
         if annotation is type(None):
             return None


### PR DESCRIPTION
## Summary
Fixes #13056

When using `from __future__ import annotations` with `Annotated[Potato, Depends(get_potato)]`, the annotation can reach `analyze_param` as a `ForwardRef` (e.g. when `inspect.signature` partially evaluates or in certain code paths). Previously `get_typed_annotation` only resolved string annotations; `ForwardRef` was returned as-is. This caused:
1. `Depends` to be missed (since `get_origin(ForwardRef)` is `None`)
2. The param to be incorrectly treated as a default Query param
3. `PydanticUserError` during OpenAPI schema generation (`TypeAdapter` with unresolved `ForwardRef`)

## Fix
Extend `get_typed_annotation` to also resolve `ForwardRef` annotations using `evaluate_forwardref` before returning.

## Root cause
`get_typed_annotation` only handled `str`; when the annotation was already a `ForwardRef`, it was returned unresolved, breaking downstream `Annotated` extraction and schema generation.

Made with [Cursor](https://cursor.com)