### PR TITLE
👷 Re-enable translation workflow run by cron in CI (twice a month)

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -2,7 +2,7 @@ name: Translate
 
 on:
   schedule:
-    - cron: "0 5 15 * *"  # Run at 05:00 on the 15 of every month
+    - cron: "0 5 1,15 * *"  # Run at 05:00 on the 1st and 15th of every month
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,8 +1,8 @@
 name: Translate
 
 on:
-  # schedule:
-  #   - cron: "0 5 15 * *"  # Run at 05:00 on the 15 of every month
+  schedule:
+    - cron: "0 5 15 * *"  # Run at 05:00 on the 15 of every month
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We disabled it while we were working on adding new languages (see https://github.com/fastapi/fastapi/pull/14613).
Now it's done and we can re-enable it