### PR TITLE
🔨 Fix `commit_in_place` passed via env variable in `translate.yml` workflow

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -119,5 +119,5 @@ jobs:
           LANGUAGE: ${{ matrix.lang }}
           EN_PATH: ${{ github.event.inputs.en_path }}
           COMMAND: ${{ matrix.command }}
-          COMMIT_IN_PLACE: ${{ github.event.inputs.commit_in_place }}
+          COMMIT_IN_PLACE: ${{ github.event.inputs.commit_in_place == 'true' && 'true' || '' }}
           MAX: ${{ github.event.inputs.max }}


### PR DESCRIPTION
There seems to be a bug in `Click < 8.3.0` that the value of ENV variable is being interpreted incorrectly for bool flags (`"false"` becomes `True`).
This leads to our `translate.yml` workflow to fail with `Can't commit directly to master` (see https://github.com/fastapi/fastapi/actions/runs/23245751473/job/67573656641)

This bug has been fixed in latest versions of Click, but we can't upgrade due to another bug introduced in `Click 8.2.2` and still present in latest version (see https://github.com/fastapi/fastapi/pull/15057 and https://github.com/mkdocs/mkdocs/issues/4032).

I suggest we use a workaround until it has been solved - pass empty value instead of `"false"`.

I checked locally - it works.

---

Alternatively we can pass `commit_in_place` in command line instead of using ENV variable