### PR TITLE
🔨 Tweak translation workflow and translation fixer tool

### DIFF
--- a/scripts/doc_parsing_utils.py
+++ b/scripts/doc_parsing_utils.py
@@ -17,7 +17,7 @@ MARKDOWN_LINK_RE = re.compile(
     r"(?P<url>[^)\s]+)"  # url (no spaces and `)`)
     r'(?:\s+["\'](?P<title>.*?)["\'])?'  # optional title in "" or ''
     r"\)"
-    r"(?:\s*\{(?P<attrs>[^}]*)\})?"  # optional attributes in {}
+    r"(?:\{(?P<attrs>[^}]*)\})?"  # optional attributes in {}
 )
 
 HTML_LINK_RE = re.compile(r"<a\s+[^>]*>.*?</a>")

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -142,7 +142,6 @@ def translate_page(
             continue  # Retry if not reached max attempts
     else:  # Max retry attempts reached
         print(f"Translation failed for {out_path} after {MAX_ATTEMPTS} attempts")
-        raise typer.Exit(code=1)
 
     print(f"Saving translation to {out_path}")
     out_path.write_text(out_content, encoding="utf-8", newline="\n")


### PR DESCRIPTION
This PR includes 2 fixes:

**1. Don't fail if translation doesn't pass validation (just save it and continue with next page)**

When translation script fails to translate page after 3 attempts (results fails to pass validation), it currently causes the workflow to fail. So, we are missing all data processed by that moment..
We can actually just skip it and fix this page later manually.

**2. Forbid whitespace before attributes in markdown link pattern**

```
## [title](https://example.com) { #permalink }
```

The line above currently mathches two patterns: header permalink and markdown link with parameters.

This causes problems - translation fixer tool treats it as link and removes whitespace, then it fails with "Number of permalinks doesn't match.."

Updated pattern of markdown link to not allow that whitespace