### PR TITLE
Fix deprecated=False override precedence for included routes

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1394,7 +1394,7 @@ class APIRouter(routing.Router):
             description=description,
             response_description=response_description,
             responses=combined_responses,
-            deprecated=deprecated or self.deprecated,
+            deprecated=self.deprecated if deprecated is None else deprecated,
             methods=methods,
             operation_id=operation_id,
             response_model_include=response_model_include,
@@ -1770,7 +1770,11 @@ class APIRouter(routing.Router):
                     description=route.description,
                     response_description=route.response_description,
                     responses=combined_responses,
-                    deprecated=route.deprecated or deprecated or self.deprecated,
+                    deprecated=(
+                        route.deprecated
+                        if route.deprecated is not None
+                        else self.deprecated if deprecated is None else deprecated
+                    ),
                     methods=route.methods,
                     operation_id=route.operation_id,
                     response_model_include=route.response_model_include,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1773,7 +1773,9 @@ class APIRouter(routing.Router):
                     deprecated=(
                         route.deprecated
                         if route.deprecated is not None
-                        else self.deprecated if deprecated is None else deprecated
+                        else self.deprecated
+                        if deprecated is None
+                        else deprecated
                     ),
                     methods=route.methods,
                     operation_id=route.operation_id,

--- a/tests/test_include_router_defaults_overrides.py
+++ b/tests/test_include_router_defaults_overrides.py
@@ -7302,3 +7302,18 @@ def test_openapi():
             },
         }
     )
+
+
+def test_route_deprecated_false_overrides_parent_deprecated_true():
+    child_router = APIRouter()
+
+    @child_router.get("/child", deprecated=False)
+    async def read_child():
+        return {"ok": True}
+
+    override_app = FastAPI(deprecated=True)
+    override_app.include_router(child_router)
+
+    schema = override_app.openapi()
+
+    assert "deprecated" not in schema["paths"]["/child"]["get"]


### PR DESCRIPTION
## Summary

Fix `deprecated` precedence when including routers so an explicit `deprecated=False`
on a route is not overridden by a parent app or router with `deprecated=True`.

This aligns behavior with expected precedence: route-level configuration should
override parent settings.

---

## Repro

```python
from fastapi import FastAPI, APIRouter

child = APIRouter()

@child.get("/x", deprecated=False)
def x():
    return {"ok": True}

app = FastAPI(deprecated=True)
app.include_router(child)

assert "deprecated" not in app.openapi()["paths"]["/x"]["get"]
```
---
## Changes

Preserve explicit non-None deprecated values when merging route, router, and app settings

Add a regression test for deprecated=False overriding parent deprecated=True
