### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 <a href="https://pypi.org/project/fastapi">
     <img src="https://img.shields.io/pypi/pyversions/fastapi.svg?color=%2334D058" alt="Supported Python versions">
 </a>
+    <a href="https://gitcgr.com/fastapi/fastapi">
+      <img src="https://gitcgr.com/badge/fastapi/fastapi.svg" alt="gitcgr" />
+    </a>
 </p>
 
 ---


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/fastapi/fastapi.svg)](https://gitcgr.com/fastapi/fastapi)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).