### PR TITLE
📝 Fix: clarify 'Required, can be None' query parameter documentation

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -222,9 +222,15 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 ### Required, can be `None` { #required-can-be-none }
 
-You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
+You can declare that a parameter's type can be `None`, but that it's still **required** (it must be included in the request). This is useful when you want to require the parameter to be present, but allow the value to be `None`.
 
 To do that, you can declare that `None` is a valid type but simply do not declare a default value:
+
+/// info
+
+When the parameter is required (no default value), omitting it will result in a **422 Validation Error**. The `None` type is included so that the OpenAPI schema correctly represents the parameter as **nullable**, and it allows your code to handle a `None` value explicitly. However, note that there's no standard HTTP mechanism to send `None` as a query parameter value from a client.
+
+///
 
 {* ../../docs_src/query_params_str_validations/tutorial006c_an_py310.py hl[9] *}
 

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
@@ -22,25 +22,36 @@ def get_client(request: pytest.FixtureRequest):
     return client
 
 
-@pytest.mark.xfail(
-    reason="Code example is not valid. See https://github.com/fastapi/fastapi/issues/12419"
-)
 def test_query_params_str_validations_no_query(client: TestClient):
+    """When q is required (no default), omitting it returns 422."""
     response = client.get("/items/")
-    assert response.status_code == 200
-    assert response.json() == {  # pragma: no cover
-        "items": [{"item_id": "Foo"}, {"item_id": "Bar"}],
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "missing",
+                "loc": ["query", "q"],
+                "msg": "Field required",
+                "input": None,
+            }
+        ]
     }
 
 
-@pytest.mark.xfail(
-    reason="Code example is not valid. See https://github.com/fastapi/fastapi/issues/12419"
-)
 def test_query_params_str_validations_empty_str(client: TestClient):
+    """Empty string fails min_length validation."""
     response = client.get("/items/?q=")
-    assert response.status_code == 200
-    assert response.json() == {  # pragma: no cover
-        "items": [{"item_id": "Foo"}, {"item_id": "Bar"}],
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "string_too_short",
+                "loc": ["query", "q"],
+                "msg": "String should have at least 3 characters",
+                "input": "",
+                "ctx": {"min_length": 3},
+            }
+        ]
     }
 
 


### PR DESCRIPTION
## Summary

This PR fixes the misleading "Required, can be `None`" section in the query parameter documentation (issue #12419).

### Problem
The documentation stated:
> You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.

This is incorrect. When a query parameter is required (no default value), omitting it returns a **422 Validation Error**. There is no standard HTTP mechanism to pass `None` as a query parameter value.

### Changes
1. **Documentation** (`docs/en/docs/tutorial/query-params-str-validations.md`):
   - Rewrote the section to clarify that `None` in the type annotation means the OpenAPI schema marks the parameter as nullable
   - Added an info box explaining that omitting the parameter returns 422 and that the `None` type is for schema representation

2. **Tests** (`tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py`):
   - Removed `@pytest.mark.xfail` from `test_query_params_str_validations_no_query` and `test_query_params_str_validations_empty_str`
   - Updated assertions to verify the correct 422 behavior instead of expecting impossible 200 responses

### Related
- Closes #12419