### PR TITLE
Upgrade Starlette to `>=0.48.0`

### DIFF
--- a/docs_src/handling_errors/tutorial005_py310.py
+++ b/docs_src/handling_errors/tutorial005_py310.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -10,7 +10,7 @@ app = FastAPI()
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     return JSONResponse(
-        status_code=422,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
     )
 

--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -5,7 +5,7 @@ from fastapi.websockets import WebSocket
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
-from starlette.status import WS_1008_POLICY_VIOLATION
+from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT, WS_1008_POLICY_VIOLATION
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
@@ -21,7 +21,7 @@ async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
     return JSONResponse(
-        status_code=422,
+        status_code=HTTP_422_UNPROCESSABLE_CONTENT,
         content={"detail": jsonable_encoder(exc.errors())},
     )
 

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -38,6 +38,7 @@ from fastapi.utils import (
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute
+from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 
 validation_error_definition = {
     "title": "ValidationError",
@@ -451,7 +452,7 @@ def get_openapi_path(
                     )
                     deep_dict_update(openapi_response, process_response)
                     openapi_response["description"] = description
-            http422 = "422"
+            http422 = str(HTTP_422_UNPROCESSABLE_CONTENT)
             all_route_params = get_flat_params(route.dependant)
             if (all_route_params or route.body_field) and not any(
                 status in operation["responses"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.46.0",
+    "starlette>=0.48.0",
     "pydantic>=2.7.0",
     "typing-extensions>=4.8.0",
     "typing-inspection>=0.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'standard'", specifier = ">=0.0.18" },
     { name = "python-multipart", marker = "extra == 'standard-no-fastapi-cloud-cli'", specifier = ">=0.0.18" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=5.3.1" },
-    { name = "starlette", specifier = ">=0.46.0" },
+    { name = "starlette", specifier = ">=0.48.0" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
     { name = "typing-inspection", specifier = ">=0.4.2" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'all'", specifier = ">=0.12.0" },


### PR DESCRIPTION
## Summary
Starlette had a breaking change in 0.48.0 where the it removed the deprecated `status.HTTP_422_UNPROCESSABLE_ENTITY`.

In https://github.com/fastapi/fastapi/pull/14077, FastAPI internally transitioned to use literal `422` and widened the version range to `>=0.40.0,<0.49.0`. This broke builds for users using the constant from fastapi.status.

I had raised this issue in https://github.com/fastapi/fastapi/discussions/14812. From the response I received I felt it was more important to support Starlette versions `0.40.0` to `0.48.0`. I fixed builds at my end my just pinning the starlette in my project.

Recently in https://github.com/fastapi/fastapi/pull/15022 the minimum Starlette version got increased to `0.46.0`. If there are no other practical issues, I believe it is a nice time to increase the minimum version to `0.48.0` and get rid of this issue.