### PR TITLE
Fix #12419: Update "Required, can be None" docs and fix example code

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -220,13 +220,19 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 {* ../../docs_src/query_params_str_validations/tutorial006_an_py310.py hl[9] *}
 
-### Required, can be `None` { #required-can-be-none }
+### Optional with `None` { #required-can-be-none }
 
-You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
+You can declare that a parameter is optional and can accept `None`, even when using `Query` for validations.
 
-To do that, you can declare that `None` is a valid type but simply do not declare a default value:
+To do that, you can declare that `None` is a valid type and use `None` as the default value:
 
 {* ../../docs_src/query_params_str_validations/tutorial006c_an_py310.py hl[9] *}
+
+/// tip
+
+This is the same as using `Query(None, min_length=3)`, the parameter is optional and will have a default value of `None`.
+
+///
 
 ## Query parameter list / multiple values { #query-parameter-list-multiple-values }
 

--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -220,7 +220,7 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 {* ../../docs_src/query_params_str_validations/tutorial006_an_py310.py hl[9] *}
 
-### Optional with `None` { #required-can-be-none }
+### Optional with `None` { #optional-with-none }
 
 You can declare that a parameter is optional and can accept `None`, even when using `Query` for validations.
 

--- a/docs_src/query_params_str_validations/tutorial006c_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial006c_an_py310.py
@@ -6,7 +6,7 @@ app = FastAPI()
 
 
 @app.get("/items/")
-async def read_items(q: Annotated[str | None, Query(min_length=3)]):
+async def read_items(q: Annotated[str | None, Query(min_length=3)] = None):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
         results.update({"q": q})

--- a/docs_src/query_params_str_validations/tutorial006c_py310.py
+++ b/docs_src/query_params_str_validations/tutorial006c_py310.py
@@ -4,7 +4,7 @@ app = FastAPI()
 
 
 @app.get("/items/")
-async def read_items(q: str | None = Query(min_length=3)):
+async def read_items(q: str | None = Query(min_length=3, default=None)):
     results = {"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}
     if q:
         results.update({"q": q})

--- a/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
+++ b/tests/test_tutorial/test_query_params_str_validations/test_tutorial006c.py
@@ -22,24 +22,18 @@ def get_client(request: pytest.FixtureRequest):
     return client
 
 
-@pytest.mark.xfail(
-    reason="Code example is not valid. See https://github.com/fastapi/fastapi/issues/12419"
-)
 def test_query_params_str_validations_no_query(client: TestClient):
     response = client.get("/items/")
     assert response.status_code == 200
-    assert response.json() == {  # pragma: no cover
+    assert response.json() == {
         "items": [{"item_id": "Foo"}, {"item_id": "Bar"}],
     }
 
 
-@pytest.mark.xfail(
-    reason="Code example is not valid. See https://github.com/fastapi/fastapi/issues/12419"
-)
 def test_query_params_str_validations_empty_str(client: TestClient):
     response = client.get("/items/?q=")
     assert response.status_code == 200
-    assert response.json() == {  # pragma: no cover
+    assert response.json() == {
         "items": [{"item_id": "Foo"}, {"item_id": "Bar"}],
     }
 
@@ -99,7 +93,7 @@ def test_openapi_schema(client: TestClient):
                         "operationId": "read_items_items__get",
                         "parameters": [
                             {
-                                "required": True,
+                                "required": False,
                                 "schema": {
                                     "anyOf": [
                                         {"type": "string", "minLength": 3},


### PR DESCRIPTION
## Summary

Fixes #12419.

The documentation section "Required, can be None" claimed that a query parameter without a default value can accept `None`, but this is misleading. In HTTP query parameters, you cannot send a literal `None` value, and omitting a required parameter results in a 422 validation error.

As noted by @Kludex in the issue, the documentation is wrong and the tests were marked as `xfail`.

## Changes

- **docs/en/docs/tutorial/query-params-str-validations.md**: Reworded section from "Required, can be `None`" to "Optional with `None`", clarified that using `= None` as default makes the parameter optional
- **docs_src/.../tutorial006c_an_py310.py**: Added `= None` default to make parameter truly optional
- **docs_src/.../tutorial006c_py310.py**: Added `default=None` to `Query()`
- **tests/.../test_tutorial006c.py**: Removed `xfail` markers, updated OpenAPI schema expectation from `required: True` to `required: False`

## Behavior after fix

| Request | Status | Response |
|---------|--------|----------|
| `GET /items/` | 200 | `{"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}` |
| `GET /items/?q=` | 200 | `{"items": [{"item_id": "Foo"}, {"item_id": "Bar"}]}` |
| `GET /items/?q=query` | 200 | `{"items": [...], "q": "query"}` |
| `GET /items/?q=fa` | 422 | Validation error (min_length=3) |

Note: Translations of this doc section will also need updating.