### PR TITLE
refactor: Move type-only imports into TYPE_CHECKING blocks

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -3,7 +3,7 @@ import http.client
 import inspect
 import warnings
 from collections.abc import Sequence
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, TYPE_CHECKING
 
 from fastapi import routing
 from fastapi._compat import (
@@ -27,7 +27,6 @@ from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.openapi.constants import METHODS_WITH_BODY, REF_PREFIX
 from fastapi.openapi.models import OpenAPI
 from fastapi.params import Body, ParamTypes
-from fastapi.responses import Response
 from fastapi.sse import _SSE_EVENT_SCHEMA
 from fastapi.types import ModelNameMap
 from fastapi.utils import (
@@ -38,6 +37,9 @@ from fastapi.utils import (
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute
+
+if TYPE_CHECKING:
+    from fastapi.responses import Response
 
 validation_error_definition = {
     "title": "ValidationError",

--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -3,7 +3,7 @@ import http.client
 import inspect
 import warnings
 from collections.abc import Sequence
-from typing import Any, Literal, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from fastapi import routing
 from fastapi._compat import (

--- a/tests/test_dependency_contextmanager.py
+++ b/tests/test_dependency_contextmanager.py
@@ -2,8 +2,11 @@ import json
 
 import pytest
 from fastapi import BackgroundTasks, Depends, FastAPI
-from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi.responses import StreamingResponse
 
 app = FastAPI()
 state = {

--- a/tests/test_dependency_contextmanager.py
+++ b/tests/test_dependency_contextmanager.py
@@ -1,9 +1,9 @@
 import json
+from typing import TYPE_CHECKING
 
 import pytest
 from fastapi import BackgroundTasks, Depends, FastAPI
 from fastapi.testclient import TestClient
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from fastapi.responses import StreamingResponse

--- a/tests/test_route_scope.py
+++ b/tests/test_route_scope.py
@@ -1,7 +1,8 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.testclient import TestClient
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from fastapi.routing import APIRoute, APIWebSocketRoute

--- a/tests/test_route_scope.py
+++ b/tests/test_route_scope.py
@@ -1,7 +1,10 @@
 import pytest
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
-from fastapi.routing import APIRoute, APIWebSocketRoute
 from fastapi.testclient import TestClient
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi.routing import APIRoute, APIWebSocketRoute
 
 app = FastAPI()
 


### PR DESCRIPTION
## Description

Moves imports that are only used for type annotations into `TYPE_CHECKING` blocks to prevent unnecessary runtime imports and potential circular import issues.

## Changes
- `fastapi/openapi/utils.py`: Move `Response` import
- `tests/test_dependency_contextmanager.py`: Move `StreamingResponse` import  
- `tests/test_route_scope.py`: Move `APIRoute` import

## Detection
Found via: `ruff check . --select TC002`

## Benefits
- Reduces runtime import overhead
- Prevents potential circular import issues
- Improves type checking performance
- Follows Python typing best practices

## Testing
- ✅ Existing tests pass
- ✅ Type checking still works correctly
- ✅ No runtime behavior changes