### PR TITLE
📝 Clarify that HTTP query params cannot be Python None

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -222,11 +222,17 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 ### Required, can be `None` { #required-can-be-none }
 
-You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
+You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send the parameter, but the value can be `None` in your Python code if the client sends no value for it.
 
 To do that, you can declare that `None` is a valid type but simply do not declare a default value:
 
 {* ../../docs_src/query_params_str_validations/tutorial006c_an_py310.py hl[9] *}
+
+/// note
+
+HTTP query parameters are always strings when sent by clients over the network. There is no way for a client to explicitly send a Python `None` as a query parameter — the parameter is either present as a string or absent entirely. The `None` in the type annotation tells FastAPI (and Python) that the value is allowed to be `None` at the Python level, but if the parameter is required (no default value), FastAPI will return a validation error when the client omits it.
+
+///
 
 ## Query parameter list / multiple values { #query-parameter-list-multiple-values }
 


### PR DESCRIPTION
## Description

Adds a clarifying note to the "Required, can be None" section explaining 
that HTTP query parameters are always transmitted as strings. Clients 
cannot explicitly send a Python `None` value — parameters are either 
present as strings or absent.

This addresses the confusion described in #12419 where the current 
wording implies clients can transmit `None`, which is not how HTTP works.

## Changes

- Improved the description sentence to be more precise  
- Added a note block explaining the HTTP vs Python typing distinction