### PR TITLE
Fix duplicate operationId for routes with multiple HTTP methods

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -1,6 +1,7 @@
 import copy
 import http.client
 import inspect
+import re
 import warnings
 from collections.abc import Sequence
 from typing import Any, Literal, cast
@@ -242,7 +243,16 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
+    if route.operation_id:
+        operation_id = route.operation_id
+    elif route.methods and len(route.methods) > 1:
+        # generate_unique_id only uses the first method of the set, which causes
+        # duplicate operationIds when a route is registered with multiple methods.
+        # Build a per-method unique ID using the same pattern as generate_unique_id.
+        base = re.sub(r"\W", "_", f"{route.name}{route.path_format}")
+        operation_id = f"{base}_{method.lower()}"
+    else:
+        operation_id = route.unique_id
     if operation_id in operation_ids:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"

--- a/tests/test_generate_unique_id_function.py
+++ b/tests/test_generate_unique_id_function.py
@@ -1697,3 +1697,29 @@ def test_warn_duplicate_operation_id():
         ]
         assert len(duplicate_warnings) > 0
         assert "Duplicate Operation ID" in str(duplicate_warnings[0].message)
+
+
+def test_no_duplicate_operation_id_for_multi_method_route():
+    app = FastAPI()
+    router = APIRouter()
+    router.add_api_route("/items/", lambda: [], methods=["POST", "DELETE"], name="items")
+    app.include_router(router)
+
+    client = TestClient(app)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        response = client.get("/openapi.json")
+        duplicate_warnings = [
+            warning
+            for warning in w
+            if issubclass(warning.category, UserWarning)
+            and "Duplicate Operation ID" in str(warning.message)
+        ]
+        assert len(duplicate_warnings) == 0
+
+    paths = response.json()["paths"]
+    post_op_id = paths["/items/"]["post"]["operationId"]
+    delete_op_id = paths["/items/"]["delete"]["operationId"]
+    assert post_op_id != delete_op_id
+    assert post_op_id.endswith("_post")
+    assert delete_op_id.endswith("_delete")

--- a/tests/test_generate_unique_id_function.py
+++ b/tests/test_generate_unique_id_function.py
@@ -1702,7 +1702,9 @@ def test_warn_duplicate_operation_id():
 def test_no_duplicate_operation_id_for_multi_method_route():
     app = FastAPI()
     router = APIRouter()
-    router.add_api_route("/items/", lambda: [], methods=["POST", "DELETE"], name="items")
+    router.add_api_route(
+        "/items/", lambda: [], methods=["POST", "DELETE"], name="items"
+    )
     app.include_router(router)
 
     client = TestClient(app)


### PR DESCRIPTION
## Description

When a route is registered with multiple HTTP methods:

```python
router.add_api_route("/items/", endpoint, methods=["POST", "DELETE"])
```
FastAPI generates the same operationId for all methods and emits a UserWarning: Duplicate Operation ID. This breaks OpenAPI clients and auto-generated SDKs.

Root cause: generate_unique_id() only takes the first method from the set (list(route.methods)[0]), so all methods on the same route share the same unique_id.

Fix: In get_openapi_operation_metadata() — which already receives the current method as a parameter — detect multi-method routes and build a per-method operationId using the same pattern as generate_unique_id.

Result:

POST /things/ → create_or_delete_things_things__post
DELETE /things/ → create_or_delete_things_things__delete
No duplicate warnings ✓
Fixes #13175