### PR TITLE
fix: treat empty bearer token as missing credentials in OAuth2 helpers

### DIFF
--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -536,7 +536,7 @@ class OAuth2PasswordBearer(OAuth2):
     async def __call__(self, request: Request) -> str | None:
         authorization = request.headers.get("Authorization")
         scheme, param = get_authorization_scheme_param(authorization)
-        if not authorization or scheme.lower() != "bearer":
+        if not authorization or scheme.lower() != "bearer" or not param:
             if self.auto_error:
                 raise self.make_not_authenticated_error()
             else:
@@ -642,7 +642,7 @@ class OAuth2AuthorizationCodeBearer(OAuth2):
     async def __call__(self, request: Request) -> str | None:
         authorization = request.headers.get("Authorization")
         scheme, param = get_authorization_scheme_param(authorization)
-        if not authorization or scheme.lower() != "bearer":
+        if not authorization or scheme.lower() != "bearer" or not param:
             if self.auto_error:
                 raise self.make_not_authenticated_error()
             else:

--- a/tests/test_security_oauth2_authorization_code_bearer.py
+++ b/tests/test_security_oauth2_authorization_code_bearer.py
@@ -30,6 +30,12 @@ def test_incorrect_token():
     assert response.json() == {"detail": "Not authenticated"}
 
 
+def test_empty_bearer_token():
+    response = client.get("/items", headers={"Authorization": "Bearer "})
+    assert response.status_code == 401, response.text
+    assert response.json() == {"detail": "Not authenticated"}
+
+
 def test_token():
     response = client.get("/items", headers={"Authorization": "Bearer testtoken"})
     assert response.status_code == 200, response.text

--- a/tests/test_security_oauth2_password_bearer_optional.py
+++ b/tests/test_security_oauth2_password_bearer_optional.py
@@ -36,6 +36,12 @@ def test_incorrect_token():
     assert response.json() == {"msg": "Create an account first"}
 
 
+def test_empty_bearer_token():
+    response = client.get("/items", headers={"Authorization": "Bearer "})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"msg": "Create an account first"}
+
+
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text


### PR DESCRIPTION
## Summary

`OAuth2PasswordBearer` and `OAuth2AuthorizationCodeBearer` accept `Authorization: Bearer ` (empty token) and return `""` instead of triggering the `auto_error` path.

Fixes the issue raised in https://github.com/fastapi/fastapi/discussions/15192.

## Root Cause

`get_authorization_scheme_param("Bearer ")` returns `("Bearer", "")`. Both `__call__` methods only checked that the scheme was `"bearer"` — never that the credential string was non-empty.

## Fix

Add `not param` to the guard condition in both `OAuth2PasswordBearer.__call__` and `OAuth2AuthorizationCodeBearer.__call__`:

```python
# before
if not authorization or scheme.lower() != "bearer":

# after
if not authorization or scheme.lower() != "bearer" or not param:
```

## Spec Reference

RFC 6750 Section 2.1 defines the grammar as `credentials = "Bearer" 1*SP b64token` where `b64token = 1*(...)` — at least one character required. An empty credential is syntactically malformed and should be treated the same as missing credentials.

## Behavior

| Request | `auto_error=True` | `auto_error=False` |
|---|---|---|
| No `Authorization` header | 401 | `None` |
| `Authorization: Bearer ` (before) | 200, `token=""` | `""` |
| `Authorization: Bearer ` (after) | 401 | `None` |
| `Authorization: Bearer validtoken` | 200 | `"validtoken"` |

## Tests

- `test_empty_bearer_token` in `test_security_oauth2_password_bearer_optional.py` (`auto_error=False` → `None`)
- `test_empty_bearer_token` in `test_security_oauth2_authorization_code_bearer.py` (`auto_error=True` → 401)