### PR TITLE
Add explanation for jsonable_encoder in reference docsAdd short explanation for jsonable_encoder in reference docs

### DIFF
--- a/docs/en/docs/reference/encoders.md
+++ b/docs/en/docs/reference/encoders.md
@@ -1,3 +1,5 @@
 # Encoders - `jsonable_encoder`
 
+`jsonable_encoder` converts Python objects such as Pydantic models into data types that can be easily encoded as JSON.
+
 ::: fastapi.encoders.jsonable_encoder


### PR DESCRIPTION
Added a short explanation for `jsonable_encoder` to improve clarity and consistency with other reference pages.