### PR TITLE
🐛 Fix multipart version comparison

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -91,12 +91,26 @@ multipart_incorrect_install_error = (
 )
 
 
+def _version_str_to_tuple(version: str) -> tuple[int, ...]:
+    version_tuple = []
+    for part in version.split("."):
+        numeric_prefix = ""
+        for char in part:
+            if not char.isdigit():
+                break
+            numeric_prefix += char
+        if not numeric_prefix:
+            break
+        version_tuple.append(int(numeric_prefix))
+    return tuple(version_tuple)
+
+
 def ensure_multipart_is_installed() -> None:
     try:
         from python_multipart import __version__
 
         # Import an attribute that can be mocked/deleted in testing
-        assert __version__ > "0.0.12"
+        assert _version_str_to_tuple(__version__) > (0, 0, 12)
     except (ImportError, AssertionError):
         try:
             # __version__ is available in both multiparts, and can be mocked

--- a/tests/test_dependencies_utils.py
+++ b/tests/test_dependencies_utils.py
@@ -1,4 +1,11 @@
-from fastapi.dependencies.utils import get_typed_annotation
+from fastapi.dependencies.utils import _version_str_to_tuple, get_typed_annotation
+
+
+def test_version_str_to_tuple():
+    assert _version_str_to_tuple("0.0.12") == (0, 0, 12)
+    assert _version_str_to_tuple("0.0.100") == (0, 0, 100)
+    assert _version_str_to_tuple("1.2.3a1") == (1, 2, 3)
+    assert _version_str_to_tuple("") == ()
 
 
 def test_get_typed_annotation():

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.dependencies.utils import (
+    _version_str_to_tuple,
     multipart_incorrect_install_error,
     multipart_not_installed_error,
 )
@@ -147,3 +148,21 @@ def test_old_multipart_installed(monkeypatch):
         @app.post("/")
         async def root(username: str = Form()):
             return username  # pragma: nocover
+
+
+def test_new_multipart_version_without_multipart_alias(monkeypatch):
+    monkeypatch.setattr("python_multipart.__version__", "0.0.100")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        app = FastAPI()
+
+        @app.post("/")
+        async def root(username: str = Form()):
+            return username  # pragma: nocover
+
+
+def test_version_str_to_tuple():
+    assert _version_str_to_tuple("0.0.12") == (0, 0, 12)
+    assert _version_str_to_tuple("0.0.100") == (0, 0, 100)
+    assert _version_str_to_tuple("1.2.3a1") == (1, 2, 3)
+    assert _version_str_to_tuple("") == ()

--- a/tests/test_multipart_installation.py
+++ b/tests/test_multipart_installation.py
@@ -3,7 +3,6 @@ import warnings
 import pytest
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.dependencies.utils import (
-    _version_str_to_tuple,
     multipart_incorrect_install_error,
     multipart_not_installed_error,
 )
@@ -154,15 +153,9 @@ def test_new_multipart_version_without_multipart_alias(monkeypatch):
     monkeypatch.setattr("python_multipart.__version__", "0.0.100")
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
+        monkeypatch.delattr("multipart.__version__", raising=False)
         app = FastAPI()
 
         @app.post("/")
         async def root(username: str = Form()):
             return username  # pragma: nocover
-
-
-def test_version_str_to_tuple():
-    assert _version_str_to_tuple("0.0.12") == (0, 0, 12)
-    assert _version_str_to_tuple("0.0.100") == (0, 0, 100)
-    assert _version_str_to_tuple("1.2.3a1") == (1, 2, 3)
-    assert _version_str_to_tuple("") == ()


### PR DESCRIPTION
This fixes the multipart version check used for form and file handling.

The code was comparing version strings directly, which means a version like 0.0.100 could be treated as older than 0.0.12. That can make a valid python-multipart installation look broken.

This change parses the version into numeric parts before comparing it. I also added tests to cover the regression and the helper used for parsing.