### PR TITLE
Fix unstable operation IDs for multi-method routes

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -96,7 +96,7 @@ def generate_unique_id(route: "APIRoute") -> str:
     operation_id = f"{route.name}{route.path_format}"
     operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    operation_id = f"{operation_id}_{sorted(route.methods)[0].lower()}"
     return operation_id
 
 

--- a/tests/test_generate_unique_id_function.py
+++ b/tests/test_generate_unique_id_function.py
@@ -1,8 +1,10 @@
 import warnings
+from types import SimpleNamespace
 
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
+from fastapi.utils import generate_unique_id
 from inline_snapshot import snapshot
 from pydantic import BaseModel
 
@@ -27,6 +29,31 @@ class Item(BaseModel):
 class Message(BaseModel):
     title: str
     description: str
+
+
+class MethodsSet(set[str]):
+    def __init__(self, values: set[str], iteration_order: list[str]) -> None:
+        super().__init__(values)
+        self.iteration_order = iteration_order
+
+    def __iter__(self):
+        return iter(self.iteration_order)
+
+
+def test_generate_unique_id_with_multiple_methods_is_stable():
+    route_a = SimpleNamespace(
+        name="handler",
+        path_format="/items",
+        methods=MethodsSet({"POST", "DELETE"}, ["POST", "DELETE"]),
+    )
+    route_b = SimpleNamespace(
+        name="handler",
+        path_format="/items",
+        methods=MethodsSet({"POST", "DELETE"}, ["DELETE", "POST"]),
+    )
+
+    assert generate_unique_id(route_a) == "handler_items_delete"
+    assert generate_unique_id(route_a) == generate_unique_id(route_b)
 
 
 def test_top_level_generate_unique_id():


### PR DESCRIPTION

The current code picks the method from a set, so the generated ID can change depending on iteration order. That makes the schema unstable and can affect generated clients.

made  method selection deterministic by sorting the methods before building the ID. I also added a regression test to make sure the generated ID stays stable even if the method iteration order changes.