### PR TITLE
Fix mounting sub-applications under APIRouter with prefix support

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1499,6 +1499,9 @@ class APIRouter(routing.Router):
         )
         self.routes.append(route)
 
+    def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:
+        super().mount(self.prefix + path, app=app, name=name)
+
     def websocket(
         self,
         path: Annotated[
@@ -1803,6 +1806,8 @@ class APIRouter(routing.Router):
                     include_in_schema=route.include_in_schema,
                     name=route.name,
                 )
+            elif isinstance(route, routing.Mount):
+                self.mount(prefix + route.path, route.app, route.name)
             elif isinstance(route, APIWebSocketRoute):
                 current_dependencies = []
                 if dependencies:

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from inline_snapshot import snapshot
+
+
+def get_sub_app() -> FastAPI:
+    sub_app = FastAPI()
+
+    @sub_app.get("/sub")
+    def read_sub():
+        return {"message": "Hello World from sub API"}
+
+    return sub_app
+
+
+def test_mount_sub_application_with_router_prefix():
+    router = APIRouter(prefix="/api")
+    router.mount("/subapi", get_sub_app())
+
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+    response = client.get("/api/subapi/sub")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "Hello World from sub API"}
+
+
+def test_mount_sub_application_with_include_router_prefix():
+    router = APIRouter()
+    router.mount("/subapi", get_sub_app())
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    client = TestClient(app)
+    response = client.get("/api/subapi/sub")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "Hello World from sub API"}
+
+
+def test_mount_sub_application_openapi_with_included_router():
+    router = APIRouter(prefix="/api")
+    router.mount("/subapi", get_sub_app())
+
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+    response = client.get("/api/subapi/openapi.json")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == snapshot(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/sub": {
+                    "get": {
+                        "summary": "Read Sub",
+                        "operationId": "read_sub_sub_get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            }
+                        },
+                    }
+                }
+            },
+            "servers": [{"url": "/api/subapi"}],
+        }
+    )


### PR DESCRIPTION
## Summary

Fix mounting sub-applications when they are registered on an `APIRouter` and then included into a FastAPI app.

Previously, mounted sub-applications were not preserved when using `include_router()`, causing requests like `/api/subapi/sub` to return `404 Not Found`. Additionally, router prefixes were not applied when mounting sub-applications via `APIRouter`.

This change ensures that mounted sub-applications behave consistently whether they are registered directly on the FastAPI app or through an APIRouter.

## Changes

* override `APIRouter.mount()` to correctly apply router prefixes to mounted sub-applications
* preserve mounted routes when routers are included using `include_router()`
* add regression tests covering:

  * router-level prefixes
  * `include_router(..., prefix=...)`
  * mounted sub-application routing and OpenAPI behavior

## Backward Compatibility

This change is backward compatible, as it only fixes previously inconsistent behavior without modifying existing explicit routing definitions.

## Verification

Tested with:

* `uv run pytest tests/test_router_mount.py`
* `uv run pytest tests/test_tutorial/test_sub_applications/test_tutorial001.py`
* `uv run pytest tests/test_include_route.py`

## Related

Fixes #10180
