### PR TITLE
fix: include method in operation_id to prevent duplicates with multi-method routes

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -33,6 +33,7 @@ from fastapi.types import ModelNameMap
 from fastapi.utils import (
     deep_dict_update,
     generate_operation_id_for_path,
+    generate_unique_id,
     is_body_allowed_for_status_code,
 )
 from pydantic import BaseModel
@@ -242,7 +243,7 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
+    operation_id = route.operation_id or generate_unique_id(route, method=method)
     if operation_id in operation_ids:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -92,11 +92,17 @@ def generate_operation_id_for_path(
     return operation_id
 
 
-def generate_unique_id(route: "APIRoute") -> str:
+def generate_unique_id(route: "APIRoute", method: str | None = None) -> str:
     operation_id = f"{route.name}{route.path_format}"
     operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    if method:
+        # Include the specific method being generated
+        operation_id = f"{operation_id}_{method.lower()}"
+    else:
+        # When no specific method is provided, include all methods (for backwards compatibility)
+        methods_str = "_".join(sorted(m.lower() for m in route.methods))
+        operation_id = f"{operation_id}_{methods_str}"
     return operation_id
 
 

--- a/tests/test_duplicate_operation_id.py
+++ b/tests/test_duplicate_operation_id.py
@@ -1,4 +1,5 @@
 """Test for fix of issue #13175: duplicate operation IDs with multi-method routes"""
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -14,37 +15,37 @@ def test_no_duplicate_operation_ids_with_multiple_methods():
     client = TestClient(app)
     response = client.get("/openapi.json")
     assert response.status_code == 200
-    
+
     data = response.json()
-    
+
     # Check that all three methods exist in the OpenAPI schema
     paths = data.get("paths", {})
     items_path = paths.get("/items/", {})
-    
+
     assert "get" in items_path
     assert "post" in items_path
     assert "delete" in items_path
-    
+
     # Verify each method has a unique operation ID
     get_op_id = items_path["get"].get("operationId")
     post_op_id = items_path["post"].get("operationId")
     delete_op_id = items_path["delete"].get("operationId")
-    
+
     # All should exist
     assert get_op_id is not None
     assert post_op_id is not None
     assert delete_op_id is not None
-    
+
     # All should be different
     assert get_op_id != post_op_id
     assert get_op_id != delete_op_id
     assert post_op_id != delete_op_id
-    
+
     # Verify they follow the pattern: <name>_<path>_<method>
     assert "handle_items_items_" in get_op_id
     assert "handle_items_items_" in post_op_id
     assert "handle_items_items_" in delete_op_id
-    
+
     assert "_get" in get_op_id
     assert "_post" in post_op_id
     assert "_delete" in delete_op_id
@@ -53,4 +54,3 @@ def test_no_duplicate_operation_ids_with_multiple_methods():
 if __name__ == "__main__":
     test_no_duplicate_operation_ids_with_multiple_methods()
     print("✓ Test passed!")
-

--- a/tests/test_duplicate_operation_id.py
+++ b/tests/test_duplicate_operation_id.py
@@ -1,0 +1,56 @@
+"""Test for fix of issue #13175: duplicate operation IDs with multi-method routes"""
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_no_duplicate_operation_ids_with_multiple_methods():
+    """Test that routes with multiple methods generate unique operation IDs for each method."""
+    app = FastAPI()
+
+    @app.api_route("/items/", methods=["GET", "POST", "DELETE"])
+    def handle_items():
+        return {"message": "handled"}
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    
+    data = response.json()
+    
+    # Check that all three methods exist in the OpenAPI schema
+    paths = data.get("paths", {})
+    items_path = paths.get("/items/", {})
+    
+    assert "get" in items_path
+    assert "post" in items_path
+    assert "delete" in items_path
+    
+    # Verify each method has a unique operation ID
+    get_op_id = items_path["get"].get("operationId")
+    post_op_id = items_path["post"].get("operationId")
+    delete_op_id = items_path["delete"].get("operationId")
+    
+    # All should exist
+    assert get_op_id is not None
+    assert post_op_id is not None
+    assert delete_op_id is not None
+    
+    # All should be different
+    assert get_op_id != post_op_id
+    assert get_op_id != delete_op_id
+    assert post_op_id != delete_op_id
+    
+    # Verify they follow the pattern: <name>_<path>_<method>
+    assert "handle_items_items_" in get_op_id
+    assert "handle_items_items_" in post_op_id
+    assert "handle_items_items_" in delete_op_id
+    
+    assert "_get" in get_op_id
+    assert "_post" in post_op_id
+    assert "_delete" in delete_op_id
+
+
+if __name__ == "__main__":
+    test_no_duplicate_operation_ids_with_multiple_methods()
+    print("✓ Test passed!")
+


### PR DESCRIPTION
## Issue
This PR addresses issue #13175 - When a route is defined with multiple HTTP methods (e.g., methods=['POST', 'DELETE']), the operation_id generation was only using the first method name, causing all methods to get the same operation_id suffix. This resulted in duplicate operation IDs in the OpenAPI schema.

## Root Cause
The generate_unique_id() function in astapi/utils.py was using list(route.methods)[0] which always picks the first method. When OpenAPI generation iterates through each method to create separate operation entries, they all received the same operation_id.

## Solution
- Modified generate_unique_id() to accept an optional 'method' parameter
- When a specific method is provided, it includes that method in the operation_id
- Updated get_openapi_operation_metadata() to pass the method being generated
- Each HTTP method now gets its own unique operation_id

## Example
Before fix (both POST and DELETE get same ID):
\\\
POST /items/: handle_items_items__post
DELETE /items/: handle_items_items__post (DUPLICATE!)
\\\

After fix (each method gets unique ID):
\\\
POST /items/: handle_items_items__post
DELETE /items/: handle_items_items__delete
\\\

## Testing
Added comprehensive test in 	ests/test_duplicate_operation_id.py that verifies:
- Routes with multiple methods generate unique operation IDs
- Each method gets its own unique identifier
- Operation IDs follow the correct pattern