### PR TITLE
Fix mounting sub-applications under APIRouter

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1499,6 +1499,18 @@ class APIRouter(routing.Router):
         )
         self.routes.append(route)
 
+    def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:
+        """
+        Mount a sub-application at the given path.
+
+        Overrides `Router.mount` so that the router's own prefix is applied,
+        matching the behaviour of `add_api_route`.  The stored route path will
+        be `self.prefix + path`, which is then further prefixed by any
+        `prefix` argument passed to `include_router` when this router is
+        included into another router or application.
+        """
+        super().mount(self.prefix + path, app=app, name=name)
+
     def websocket(
         self,
         path: Annotated[
@@ -1794,6 +1806,8 @@ class APIRouter(routing.Router):
                         self.strict_content_type,
                     ),
                 )
+            elif isinstance(route, routing.Mount):
+                self.mount(prefix + route.path, route.app, route.name)
             elif isinstance(route, routing.Route):
                 methods = list(route.methods or [])
                 self.add_route(

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,0 +1,139 @@
+"""
+Tests for issue #10180: mounting sub-applications under APIRouter.
+
+Sub-apps mounted on an APIRouter (with a prefix) must be reachable via the
+combined prefix + mount-path after include_router().
+"""
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+
+def make_sub_app() -> FastAPI:
+    sub = FastAPI()
+
+    @sub.get("/sub")
+    def read_sub():
+        return {"message": "Hello World from sub API"}
+
+    return sub
+
+
+# ---------------------------------------------------------------------------
+# Router prefix baked into APIRouter(prefix=...) itself
+# ---------------------------------------------------------------------------
+
+
+def test_router_prefix_mount_routing():
+    """Request to /api/subapi/sub must return 200 (issue #10180 exact repro)."""
+    router = APIRouter(prefix="/api")
+
+    @router.get("/app")
+    def read_app():
+        return {"message": "Hello World from main app"}
+
+    router.mount("/subapi", make_sub_app())
+
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+    assert client.get("/api/app").status_code == 200
+    assert client.get("/api/subapi/sub").status_code == 200
+    assert client.get("/api/subapi/sub").json() == {
+        "message": "Hello World from sub API"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prefix supplied via include_router(prefix=...)
+# ---------------------------------------------------------------------------
+
+
+def test_include_router_prefix_mount_routing():
+    """Prefix from include_router() is applied to mounted sub-apps."""
+    router = APIRouter()
+    router.mount("/subapi", make_sub_app())
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    client = TestClient(app)
+    assert client.get("/api/subapi/sub").status_code == 200
+    assert client.get("/api/subapi/sub").json() == {
+        "message": "Hello World from sub API"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Combination: both router prefix AND include_router prefix
+# ---------------------------------------------------------------------------
+
+
+def test_combined_prefix_mount_routing():
+    """Router prefix and include_router prefix are both applied to mounts."""
+    router = APIRouter(prefix="/api")
+    router.mount("/subapi", make_sub_app())
+
+    app = FastAPI()
+    app.include_router(router, prefix="/v1")
+
+    client = TestClient(app)
+    assert client.get("/v1/api/subapi/sub").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Nested routers
+# ---------------------------------------------------------------------------
+
+
+def test_nested_router_mount_routing():
+    """Mounts survive two levels of include_router nesting."""
+    inner = APIRouter(prefix="/inner")
+    inner.mount("/subapi", make_sub_app())
+
+    outer = APIRouter(prefix="/outer")
+    outer.include_router(inner)
+
+    app = FastAPI()
+    app.include_router(outer)
+
+    client = TestClient(app)
+    assert client.get("/outer/inner/subapi/sub").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Sub-app openapi.json is reachable at the correct path
+# ---------------------------------------------------------------------------
+
+
+def test_router_prefix_mount_openapi():
+    """Sub-app's OpenAPI spec is accessible at the combined prefix path."""
+    router = APIRouter(prefix="/api")
+    router.mount("/subapi", make_sub_app())
+
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+    response = client.get("/api/subapi/openapi.json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["openapi"] == "3.1.0"
+    assert "/sub" in data["paths"]
+    # root_path is reflected in the servers list
+    assert any("/api/subapi" in s["url"] for s in data.get("servers", []))
+
+
+# ---------------------------------------------------------------------------
+# Mounts directly on FastAPI app are unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_direct_app_mount_unaffected():
+    """Existing behaviour: mounting directly on FastAPI still works."""
+    app = FastAPI()
+    app.mount("/subapi", make_sub_app())
+
+    client = TestClient(app)
+    assert client.get("/subapi/sub").status_code == 200


### PR DESCRIPTION
## Summary

Closes #10180

Sub-apps mounted on an `APIRouter` were silently dropped when the router was included into a `FastAPI` app, causing every request to the mounted path to return `404`.

```python
app = FastAPI()
api_router = APIRouter(prefix="/api")
api_router.mount("/subapi", subapi)
app.include_router(api_router)

# Before this fix:
client.get("/api/subapi/sub")  # → 404

# After this fix:
client.get("/api/subapi/sub")  # → 200 ✓
```

## Root cause

Two missing pieces:

1. **`APIRouter` had no `mount()` override.** All other route-registration methods (`add_api_route`, `add_api_websocket_route`, …) prepend `self.prefix` to the path before storing the route. `mount()` was inherited from Starlette's `Router` and stored the path as-is, so the router's own prefix was never applied to mounted sub-apps.

2. **`include_router()` ignored `routing.Mount` routes.** The loop inside `include_router` handled `APIRoute`, `Route`, `APIWebSocketRoute`, and `WebSocketRoute` — but had no branch for `Mount`, so mounted sub-apps were silently skipped.

## Changes

- `fastapi/routing.py` — add `APIRouter.mount()` override that prepends `self.prefix` (mirrors `add_api_route`) and add a `routing.Mount` branch in `include_router` that forwards the mount with `prefix + route.path`.
- `tests/test_router_mount.py` — 6 tests covering: exact issue repro, `include_router(prefix=…)`, combined prefixes, nested routers, sub-app OpenAPI reachability, and existing direct-mount behaviour.

## Prefix composition

Both prefix sources compose correctly and consistently with ordinary endpoints:

| Source | Route path stored | Final path |
|---|---|---|
| `APIRouter(prefix="/api").get("/x")` | `/api/x` | `include_prefix + /api/x` |
| `APIRouter(prefix="/api").mount("/sub", …)` | `/api/sub` | `include_prefix + /api/sub` |
| `include_router(router, prefix="/v1")` | as above | `/v1/api/sub` |

## Test plan

- [x] 6 new tests all pass
- [x] All existing routing/WS tests pass (`test_include_route`, `test_router_events`, `test_ws_router`, `test_empty_router`, `test_router_prefix_with_template`)
- [x] Direct `FastAPI.mount()` behaviour is unaffected