### PR TITLE
Fix deterministic method suffix in generated operation IDs

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -96,7 +96,7 @@ def generate_unique_id(route: "APIRoute") -> str:
     operation_id = f"{route.name}{route.path_format}"
     operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    operation_id = f"{operation_id}_{sorted(route.methods)[0].lower()}"
     return operation_id
 
 

--- a/tests/test_generate_unique_id_function.py
+++ b/tests/test_generate_unique_id_function.py
@@ -3,6 +3,7 @@ import warnings
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
+from fastapi.utils import generate_unique_id
 from inline_snapshot import snapshot
 from pydantic import BaseModel
 
@@ -1697,3 +1698,19 @@ def test_warn_duplicate_operation_id():
         ]
         assert len(duplicate_warnings) > 0
         assert "Duplicate Operation ID" in str(duplicate_warnings[0].message)
+
+
+def test_generate_unique_id_with_multiple_methods_is_deterministic():
+    app = FastAPI()
+
+    @app.api_route("/items", methods=["POST", "DELETE"])
+    def items():
+        return {}  # pragma: nocover
+
+    route = next(
+        route
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.path == "/items"
+    )
+
+    assert generate_unique_id(route) == "items_items_delete"


### PR DESCRIPTION
## Summary
- make `generate_unique_id()` pick the HTTP method suffix deterministically
- replace `list(route.methods)[0]` (set iteration order) with `sorted(route.methods)[0]`
- add a regression test for routes declared with multiple methods

## Why
`route.methods` is a set, so selecting the first element by list conversion can vary by runtime hash seed. This can produce unstable operation IDs for multi-method routes and increase the chance of surprising schema diffs/warnings.

## Changes
- `fastapi/utils.py`
  - use `sorted(route.methods)[0].lower()` when composing the default unique ID
- `tests/test_generate_unique_id_function.py`
  - add `test_generate_unique_id_with_multiple_methods_is_deterministic`

## Testing
- Added regression test.
- I couldn't run the test suite in this environment because `pytest` is not installed on the runner image.
