### PR TITLE
fix: preserve mounted sub-applications when including APIRouter

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1575,6 +1575,9 @@ class APIRouter(routing.Router):
 
         return decorator
 
+    def mount(self, path: str, app: ASGIApp, name: str | None = None) -> None:
+        super().mount(self.prefix + path, app=app, name=name)
+
     def include_router(
         self,
         router: Annotated["APIRouter", Doc("The `APIRouter` to include.")],
@@ -1803,6 +1806,8 @@ class APIRouter(routing.Router):
                     include_in_schema=route.include_in_schema,
                     name=route.name,
                 )
+            elif isinstance(route, routing.Mount):
+                self.mount(prefix + route.path, route.app, name=route.name)
             elif isinstance(route, APIWebSocketRoute):
                 current_dependencies = []
                 if dependencies:

--- a/tests/test_router_mount.py
+++ b/tests/test_router_mount.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+
+def test_mount_subapp_under_router_prefix() -> None:
+    app = FastAPI()
+    api_router = APIRouter(prefix="/api")
+
+    @api_router.get("/ping")
+    def ping() -> dict[str, str]:
+        return {"message": "pong"}
+
+    sub_app = FastAPI()
+
+    @sub_app.get("/sub")
+    def read_sub() -> dict[str, str]:
+        return {"message": "Hello World from sub API"}
+
+    api_router.mount("/subapi", sub_app)
+    app.include_router(api_router)
+
+    client = TestClient(app)
+
+    response = client.get("/api/ping")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "pong"}
+
+    mounted_response = client.get("/api/subapi/sub")
+    assert mounted_response.status_code == 200, mounted_response.text
+    assert mounted_response.json() == {"message": "Hello World from sub API"}
+
+
+def test_mount_starlette_route_under_router_prefix() -> None:
+    app = FastAPI()
+    router = APIRouter(prefix="/v1")
+
+    def plain_asgi_app(scope, receive, send):
+        response = JSONResponse({"ok": True})
+        return response(scope, receive, send)
+
+    router.mount("/internal", plain_asgi_app, name="internal")
+    app.include_router(router, prefix="/api")
+
+    client = TestClient(app)
+    response = client.get("/api/v1/internal")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"ok": True}


### PR DESCRIPTION
## Summary
Fixes #10180.

`APIRouter.mount()` currently stores `Mount` routes, but `APIRouter.include_router()` only copies `APIRoute`, `Route`, and websocket routes.
As a result, mounted sub-applications are silently dropped when the router is included.

This PR:
- adds an `APIRouter.mount()` override that applies `self.prefix` (matching `add_api_route` behavior)
- teaches `APIRouter.include_router()` to propagate `routing.Mount` routes
- adds regression tests for mounting both a FastAPI sub-app and a plain ASGI app under nested router prefixes

## Repro before
A mounted route like `/api/subapi/sub` returns 404 after `app.include_router(api_router)`.

## Behavior after
Mounted sub-app routes are reachable under the expected combined prefix path.

## Tests
Added `tests/test_router_mount.py` with coverage for:
- `APIRouter(prefix=...)` + `router.mount(...)` + `app.include_router(router)`
- nested include prefix handling (`app.include_router(router, prefix=...)`)
