### PR TITLE
🔨 Add pre-commit hook to ensure latest release header has date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,3 +78,10 @@ repos:
         name: fix translations
         entry: uv run ./scripts/translation_fixer.py fix-pages
         files: ^docs/(?!en/).*/docs/.*\.md$
+
+      - id: add-release-date
+        language: unsupported
+        name: add date to latest release header
+        entry: uv run python scripts/add_latest_release_date.py
+        files: ^docs/en/docs/release-notes\.md$
+        pass_filenames: false

--- a/scripts/add_latest_release_date.py
+++ b/scripts/add_latest_release_date.py
@@ -1,0 +1,40 @@
+"""Check release-notes.md and add today's date to the latest release header if missing."""
+
+import re
+import sys
+from datetime import date
+
+RELEASE_NOTES_FILE = "docs/en/docs/release-notes.md"
+RELEASE_HEADER_PATTERN = re.compile(r"^## (\d+\.\d+\.\d+)\s*(\(.*\))?\s*$")
+
+
+def main() -> None:
+    with open(RELEASE_NOTES_FILE) as f:
+        lines = f.readlines()
+
+    for i, line in enumerate(lines):
+        match = RELEASE_HEADER_PATTERN.match(line)
+        if not match:
+            continue
+
+        version = match.group(1)
+        date_part = match.group(2)
+
+        if date_part:
+            print(f"Latest release {version} already has a date: {date_part}")
+            sys.exit(0)
+
+        today = date.today().isoformat()
+        lines[i] = f"## {version} ({today})\n"
+        print(f"Added date: {version} ({today})")
+
+        with open(RELEASE_NOTES_FILE, "w") as f:
+            f.writelines(lines)
+        sys.exit(0)
+
+    print("No release header found")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add pre-commit hook to ensure latest release header in `release-notes.md` has date.

Checked locally