### PR TITLE
Fix get_path_param_names to strip path converters

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -41,7 +41,7 @@ def is_body_allowed_for_status_code(status_code: int | str | None) -> bool:
 
 
 def get_path_param_names(path: str) -> set[str]:
-    return set(re.findall("{(.*?)}", path))
+    return set(re.findall("{([^:}]+)", path))
 
 
 _invalid_args_message = (


### PR DESCRIPTION
## Summary

Fixes #14883

`get_path_param_names()` uses regex `{(.*?)}` which captures `param:path` instead of `param` when OpenAPI path converters are used. This causes implicit path params to be incorrectly classified as query params.

## Fix

Change regex from `{(.*?)}` to `{([^:}]+)}` to stop at the colon separator.

## Example

```python
# Before: get_path_param_names("/files/{file_path:path}") → {"file_path:path"}
# After:  get_path_param_names("/files/{file_path:path}") → {"file_path"}
```