### PR TITLE
Fix/client disconnect as parsing error

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -78,7 +78,7 @@ from starlette._utils import is_async_callable
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
-from starlette.requests import Request
+from starlette.requests import ClientDisconnect, Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import (
     BaseRoute,
@@ -441,6 +441,8 @@ def get_request_handler(
             raise validation_error from e
         except HTTPException:
             # If a middleware raises an HTTPException, it should be raised again
+            raise
+        except ClientDisconnect:
             raise
         except Exception as e:
             http_error = HTTPException(

--- a/tests/test_client_disconnect.py
+++ b/tests/test_client_disconnect.py
@@ -1,0 +1,113 @@
+"""
+Test that ClientDisconnect during request body reading is not
+misreported as HTTP 400 "There was an error parsing the body".
+
+Ref: https://github.com/fastapi/fastapi/issues/XXXXX
+"""
+
+import pytest
+from starlette.requests import ClientDisconnect
+
+from fastapi import Body, FastAPI, Form
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.anyio
+
+app = FastAPI()
+
+
+@app.post("/json")
+async def json_endpoint(data: dict = Body(...)):
+    return data
+
+
+@app.post("/form")
+async def form_endpoint(field: str = Form(...)):
+    return {"field": field}
+
+
+def _make_scope(path: str) -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 8000),
+    }
+
+
+async def test_client_disconnect_json_body():
+    """ClientDisconnect during JSON body reading must not become HTTP 400."""
+    messages = [
+        {"type": "http.request", "body": b'{"incomplete": ', "more_body": True},
+        {"type": "http.disconnect"},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    scope = _make_scope("/json")
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+
+    # Ensure no HTTP 400 response was sent
+    for msg in sent:
+        if msg.get("type") == "http.response.start":
+            assert msg.get("status") != 400, (
+                "ClientDisconnect should not produce HTTP 400"
+            )
+
+
+async def test_client_disconnect_form_body():
+    """ClientDisconnect during form body reading must not become HTTP 400."""
+    messages = [
+        {
+            "type": "http.request",
+            "body": b"field=partial",
+            "more_body": True,
+        },
+        {"type": "http.disconnect"},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    scope = _make_scope("/form")
+    scope["headers"] = [
+        (b"content-type", b"application/x-www-form-urlencoded"),
+    ]
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+
+    for msg in sent:
+        if msg.get("type") == "http.response.start":
+            assert msg.get("status") != 400, (
+                "ClientDisconnect should not produce HTTP 400"
+            )
+
+
+def test_body_parse_error_still_returns_400():
+    """Generic body parse errors must still produce HTTP 400."""
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post(
+        "/json",
+        content=b"not valid json",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 422

--- a/tests/test_client_disconnect.py
+++ b/tests/test_client_disconnect.py
@@ -6,10 +6,9 @@ Ref: https://github.com/fastapi/fastapi/issues/XXXXX
 """
 
 import pytest
-from starlette.requests import ClientDisconnect
-
 from fastapi import Body, FastAPI, Form
 from fastapi.testclient import TestClient
+from starlette.requests import ClientDisconnect
 
 pytestmark = pytest.mark.anyio
 


### PR DESCRIPTION
## Summary

When a client disconnects while FastAPI is reading the request body, Starlette raises `ClientDisconnect`. The broad `except Exception` handler in `fastapi/routing.py` catches it and converts it into `HTTPException(400, "There was an error parsing the body")`, which is misleading — a client disconnect is not a body parsing error.

This adds `except ClientDisconnect: raise` before the catch-all so the exception propagates correctly instead of being misclassified.

Closes #15312

## The Problem

In `fastapi/routing.py`, the body reading try/except block handles:
- `json.JSONDecodeError` → 422 (correct)
- `HTTPException` → re-raised (correct)
- `Exception` (catch-all) → **HTTP 400 "There was an error parsing the body"**

Since `ClientDisconnect` inherits from `Exception`, it gets caught by the catch-all and misreported as a parsing error. This causes:
- False HTTP 400 responses even when the request body is perfectly valid
- Polluted error monitoring with fake parsing errors
- Difficult production debugging (we spent hours tracing this)

## Real-World Scenario

Running FastAPI behind Gunicorn with `UvicornWorker` and `--max-requests` for worker recycling. When a worker is recycled mid-request, `receive()` returns `http.disconnect`, Starlette raises `ClientDisconnect`, and the client receives a false 400 parsing error.

## Research

Investigated how other major frameworks handle this:

| Framework | Behavior |
|---|---|
| **Django (ASGI)** | Raises `RequestAborted`, silently returns with no response |
| **Go net/http** | Cancels request context, stops processing |
| **Spring Boot** | `ClientAbortException` suppressed, logged at DEBUG |
| **Nginx** | Logs non-standard 499, no response sent |
| **<ASP.NET> Core** | `OperationCanceledException`, no default handler |

**Consensus**: Client disconnect is not a client error (400) nor a server error (500). It's an operational condition that should propagate, not be masked as a parsing error.

## Changes

- **`fastapi/routing.py`**: Added `ClientDisconnect` import and `except ClientDisconnect: raise` before the catch-all (2 lines)
- **`tests/test_client_disconnect.py`**: Regression tests

## Test Plan

- [x] `test_client_disconnect_json_body` — verifies `ClientDisconnect` during JSON body reading is not converted to HTTP 400
- [x] `test_client_disconnect_form_body` — same for form data
- [x] `test_body_parse_error_still_returns_400` — ensures genuine parse errors still return the correct status
