### PR TITLE
⬆ Bump ujson minimum to >=5.12.0 and orjson to >=3.9.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,9 +150,9 @@ docs-tests = [
     "httpx >=0.23.0,<1.0.0",
     "ruff >=0.14.14",
     # For UJSONResponse
-    "ujson >=5.8.0",
+    "ujson >=5.12.0",
     # For ORJSONResponse
-    "orjson >=3.9.3",
+    "orjson >=3.9.15",
 ]
 github-actions = [
     "httpx >=0.27.0,<1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ dev = [
     { name = "mkdocs-redirects", specifier = ">=1.2.1,<1.3.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.1" },
     { name = "mypy", specifier = ">=1.14.1" },
-    { name = "orjson", specifier = ">=3.9.3" },
+    { name = "orjson", specifier = ">=3.9.15" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "playwright", specifier = ">=1.57.0" },
     { name = "prek", specifier = ">=0.2.22" },
@@ -1309,7 +1309,7 @@ dev = [
     { name = "typer", specifier = ">=0.21.1" },
     { name = "types-orjson", specifier = ">=3.6.2" },
     { name = "types-ujson", specifier = ">=5.10.0.20240515" },
-    { name = "ujson", specifier = ">=5.8.0" },
+    { name = "ujson", specifier = ">=5.12.0" },
 ]
 docs = [
     { name = "black", specifier = ">=25.1.0" },
@@ -1325,19 +1325,19 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.7.0" },
     { name = "mkdocs-redirects", specifier = ">=1.2.1,<1.3.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.1" },
-    { name = "orjson", specifier = ">=3.9.3" },
+    { name = "orjson", specifier = ">=3.9.15" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "python-slugify", specifier = ">=8.0.4" },
     { name = "pyyaml", specifier = ">=5.3.1,<7.0.0" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "typer", specifier = ">=0.21.1" },
-    { name = "ujson", specifier = ">=5.8.0" },
+    { name = "ujson", specifier = ">=5.12.0" },
 ]
 docs-tests = [
     { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
-    { name = "orjson", specifier = ">=3.9.3" },
+    { name = "orjson", specifier = ">=3.9.15" },
     { name = "ruff", specifier = ">=0.14.14" },
-    { name = "ujson", specifier = ">=5.8.0" },
+    { name = "ujson", specifier = ">=5.12.0" },
 ]
 github-actions = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
@@ -1356,7 +1356,7 @@ tests = [
     { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
     { name = "inline-snapshot", specifier = ">=0.21.1" },
     { name = "mypy", specifier = ">=1.14.1" },
-    { name = "orjson", specifier = ">=3.9.3" },
+    { name = "orjson", specifier = ">=3.9.15" },
     { name = "pwdlib", extras = ["argon2"], specifier = ">=0.2.1" },
     { name = "pyjwt", specifier = ">=2.9.0" },
     { name = "pytest", specifier = ">=9.0.0" },
@@ -1372,7 +1372,7 @@ tests = [
     { name = "ty", specifier = ">=0.0.9" },
     { name = "types-orjson", specifier = ">=3.6.2" },
     { name = "types-ujson", specifier = ">=5.10.0.20240515" },
-    { name = "ujson", specifier = ">=5.8.0" },
+    { name = "ujson", specifier = ">=5.12.0" },
 ]
 translations = [
     { name = "gitpython", specifier = ">=3.1.46" },


### PR DESCRIPTION
Bumps minimum version constraints for ujson and orjson in the docs-tests dependency group.

### ujson >=5.8.0 → >=5.12.0

The old minimum allows versions with known vulnerabilities:

- **CVE-2026-32875** (CVSS 7.5): integer overflow in `ujson.dumps()` when indent * depth exceeds INT32_MAX, causing segfault or infinite loop
- **CVE-2026-32874** (CVSS 7.5): memory leak when parsing large integers outside [-2^63, 2^64-1], enabling OOM via repeated requests

Both fixed in ujson 5.12.0.

### orjson >=3.9.3 → >=3.9.15

The old minimum allows versions with:

- **CVE-2024-27454** (CVSS 7.5): `orjson.loads()` does not limit recursion depth for deeply nested JSON, allowing stack overflow crashes

Fixed in orjson 3.9.15.

### Impact

These are test/docs dependencies, not shipped to end users. But anyone who clones the repo and runs `uv sync` could resolve to a vulnerable version. This can affects contributors running tests locally and CI runners processing PRs.