### PR TITLE
Fix `PydanticUserError` when a generic `BaseModel` with `Json[T]` field is specialized with `SerializeAsAny[SomeModel]`

### DIFF
--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -379,14 +379,28 @@ def create_body_model(
     return BodyModel
 
 
+def _needs_no_config(type_: Any) -> bool:
+    """Return True if TypeAdapter must not receive config= for this type.
+
+    Pydantic raises PydanticUserError when config= is passed to TypeAdapter and
+    the resolved type (or its inner type) is a BaseModel, dataclass, or TypedDict.
+    We therefore suppress config= not only for bare BaseModel/dataclass types but
+    also for Annotated wrappers whose first argument is such a type — this covers
+    Json[BaseModel], Json[SerializeAsAny[BaseModel]], and plain
+    Annotated[BaseModel, ...] forms.
+    """
+    if lenient_issubclass(type_, (BaseModel, dict)) or is_dataclass(type_):
+        return True
+    if get_origin(type_) is Annotated:
+        return _needs_no_config(get_args(type_)[0])
+    return False
+
+
 def get_model_fields(model: type[BaseModel]) -> list[ModelField]:
     model_fields: list[ModelField] = []
     for name, field_info in model.model_fields.items():
         type_ = field_info.annotation
-        if lenient_issubclass(type_, (BaseModel, dict)) or is_dataclass(type_):
-            model_config = None
-        else:
-            model_config = model.model_config
+        model_config = None if _needs_no_config(type_) else model.model_config
         model_fields.append(
             ModelField(
                 field_info=field_info,

--- a/tests/test_json_field_serialize_as_any.py
+++ b/tests/test_json_field_serialize_as_any.py
@@ -1,0 +1,66 @@
+"""
+Regression tests for:
+  PydanticUserError when a generic BaseModel with a Json[T] field is
+  specialized with SerializeAsAny[SomeModel].
+
+  fastapi/_compat/v2.py: get_model_fields() must suppress config= for
+  Annotated-wrapped types whose inner type is a BaseModel / dataclass,
+  not only for bare BaseModel types.
+"""
+
+from typing import Generic, TypeVar
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Json, SerializeAsAny
+
+T = TypeVar("T")
+
+
+class Inner(BaseModel):
+    value: str
+
+
+class Source(BaseModel, Generic[T]):
+    payload: Json[T]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_schema_generation_serialize_as_any_does_not_raise():
+    """app.openapi() must not raise PydanticUserError for Source[SerializeAsAny[Inner]].
+
+    Previously raised:
+      pydantic.errors.PydanticUserError: Cannot use `config` when the type
+      is a BaseModel, dataclass or TypedDict.
+
+    Root cause: get_model_fields() in fastapi/_compat/v2.py did not unwrap
+    Annotated before checking if config= should be suppressed, so
+    Json[Annotated[Inner, SerializeAsAny]] slipped through and TypeAdapter
+    received config= illegally.
+    """
+    app = FastAPI()
+
+    @app.get("/search")
+    def search() -> Source[SerializeAsAny[Inner]]:  # pragma: no cover
+        ...
+
+    schema = app.openapi()
+    assert schema is not None
+    # The route must appear in the generated schema.
+    assert "/search" in schema["paths"]
+
+
+def test_openapi_schema_generation_plain_inner_unaffected():
+    """Baseline: Source[Inner] (no SerializeAsAny) must continue to work."""
+    app = FastAPI()
+
+    @app.get("/search")
+    def search() -> Source[Inner]:  # pragma: no cover
+        ...
+
+    schema = app.openapi()
+    assert schema is not None
+    assert "/search" in schema["paths"]


### PR DESCRIPTION

## Summary

`get_model_fields()` in `fastapi/_compat/v2.py` was passing `model.model_config`
to `TypeAdapter` for fields whose annotation is `Json[SerializeAsAny[SomeModel]]`.
Pydantic 2.12 tightened its validation and now raises `PydanticUserError` in this
case, crashing `app.openapi()`.

## Root Cause

`get_model_fields()` decided whether to suppress `config=` by checking:

```python
if lenient_issubclass(type_, (BaseModel, dict)) or is_dataclass(type_):
    model_config = None
else:
    model_config = model.model_config   # forwarded to TypeAdapter
```

Pydantic raises `PydanticUserError` when `config=` is passed to `TypeAdapter`
whose resolved type is a `BaseModel`, dataclass, or `TypedDict`.

When `Source[SerializeAsAny[Inner]]` is resolved, the field annotation becomes
`Json[SerializeAsAny[Inner]]`.  
At runtime `Json[X]` expands to `Annotated[X, Json]` and `SerializeAsAny[X]`
expands to `Annotated[X, SerializeAsAny()]`, so the full type is
`Annotated[Annotated[Inner, SerializeAsAny()], Json]`. `lenient_issubclass`
returns `False` for this (it is not a bare `BaseModel`, dataclass, or
`TypedDict`), so `model_config` was forwarded to `TypeAdapter` — which Pydantic
2.12 now rejects.

`Source[Inner]` (without `SerializeAsAny`) did not crash because in that case
`field_info.annotation` resolves to `Inner` itself (a bare `BaseModel` subclass),
so `lenient_issubclass` returns `True` and `model_config` is already suppressed
before `TypeAdapter` is ever called. The `SerializeAsAny` wrapper is what
prevented this guard from triggering: the annotation becomes
`Json[SerializeAsAny[Inner]]` rather than `Inner`, and `lenient_issubclass`
returns `False` for that composite type.

## Changes

**`fastapi/_compat/v2.py`**

Extracted a `_needs_no_config()` helper that recursively unwraps `Annotated`
before checking the inner type:

```python
def _needs_no_config(type_: Any) -> bool:
    if lenient_issubclass(type_, (BaseModel, dict)) or is_dataclass(type_):
        return True
    if get_origin(type_) is Annotated:
        return _needs_no_config(get_args(type_)[0])
    return False
```

Because `Json[X]` is itself `Annotated[X, Json]` at runtime, and
`SerializeAsAny[X]` is `Annotated[X, SerializeAsAny()]`, the recursive
`Annotated`-unwrapping branch covers all affected forms (two levels of
recursion are needed for the `SerializeAsAny` case):

- `Annotated[BaseModel subclass, ...]`
- `Json[BaseModel subclass]` → `Annotated[BaseModel subclass, Json]`
- `Json[SerializeAsAny[BaseModel subclass]]`
  → `Annotated[SerializeAsAny[BaseModel subclass], Json]`
  → `Annotated[Annotated[BaseModel subclass, SerializeAsAny()], Json]`
  → unwraps twice to reach `BaseModel subclass`

**`tests/test_json_field_serialize_as_any.py`** (new)

Two tests:
- `test_openapi_schema_generation_serialize_as_any_does_not_raise` — regression for the reported crash
- `test_openapi_schema_generation_plain_inner_unaffected` — baseline to confirm `Source[Inner]` continues to work



## PoC

```poc.py
# /// script
# requires-python = ">=3.11"
# dependencies = [
#   "fastapi==0.135.3",
#   "pydantic==2.12.5",
# ]
# ///
"""
PoC: FastAPI 0.135.3 + Pydantic 2.12 — OpenAPI schema generation crash

The guard in `get_model_fields()` (fastapi/_compat/v2.py) checks whether the
field annotation is directly a BaseModel / dict / dataclass to decide whether
to pass `config=` to TypeAdapter:

    type_ = field_info.annotation
    if lenient_issubclass(type_, (BaseModel, dict)) or is_dataclass(type_):
        model_config = None
    else:
        model_config = model.model_config   # ← forwarded to TypeAdapter

Pydantic 2.12 raises PydanticUserError when `config=` is passed to TypeAdapter
and the *resolved* inner type is a BaseModel / dataclass / TypedDict.

The guard correctly handles:
  - Source[Inner]               → type_ = Json[Inner]        → lenient_issubclass fails
                                  BUT TypeAdapter(Json[Inner], config=...) is also OK
                                  because Json[Inner] does not resolve to a bare BaseModel

The guard misses:
  - Source[SerializeAsAny[Inner]]
      type_ = Json[Annotated[Inner, SerializeAsAny]]
      lenient_issubclass fails (not a BaseModel)
      → TypeAdapter(Json[Annotated[Inner, SerializeAsAny]], config=ConfigDict())
      → Pydantic 2.12 rejects this: the inner Annotated[BaseModel, SerializeAsAny]
        is treated as a BaseModel-equivalent and config= is forbidden

Root cause: `Annotated[BaseModel subclass, SerializeAsAny]` is not caught by
`lenient_issubclass(..., BaseModel)`, so when it is further wrapped in Json[...]
the guard is bypassed and config= is passed through to TypeAdapter.

Run
---
    uv run poc.py
"""

from typing import Generic, TypeVar

import fastapi
from fastapi import FastAPI
from pydantic import BaseModel, Json, SerializeAsAny

T = TypeVar("T")

app = FastAPI()


class Inner(BaseModel):
    value: str


class Source(BaseModel, Generic[T]):
    payload: Json[T]


@app.get("/trigger")
def trigger() -> Source[SerializeAsAny[Inner]]: ...


if __name__ == "__main__":
    from typing import Generic as _Generic, TypeVar as _TypeVar

    from pydantic import BaseModel as _BaseModel, Json as _Json, SerializeAsAny as _SerializeAsAny

    _T = _TypeVar("_T")

    class _Inner(_BaseModel):
        value: str

    class _Source(_BaseModel, _Generic[_T]):
        payload: _Json[_T]

    def _try(label: str, fn):
        try:
            fn()
            print(f"OK : {label}")
        except Exception as e:
            print(f"NG : {label}")
            print(f"     {type(e).__name__}: {e}\n")

    ok_app = fastapi.FastAPI()

    @ok_app.get("/ok")
    def _ok() -> _Source[_Inner]: ...

    ng_app = fastapi.FastAPI()

    @ng_app.get("/ng")
    def _ng() -> _Source[_SerializeAsAny[_Inner]]: ...

    _try("Source[Inner]                  (no SerializeAsAny — should pass)", ok_app.openapi)
    _try("Source[SerializeAsAny[Inner]]  (SerializeAsAny wraps T — crashes)", ng_app.openapi)
```