### PR TITLE
Reduce memory usage by `Dependant` by ~50%

### DIFF
--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -119,9 +119,7 @@ class Dependant:
             _impartial(dunder_call)
         ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call)):
             return True
-        dunder_unwrapped_call = getattr(
-            _unwrapped_call(self.call), "__call__", None
-        )  # noqa: B004
+        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
         if dunder_unwrapped_call is None:
             return False  # pragma: no cover
         if inspect.isgeneratorfunction(
@@ -147,9 +145,7 @@ class Dependant:
             _impartial(dunder_call)
         ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call)):
             return True
-        dunder_unwrapped_call = getattr(
-            _unwrapped_call(self.call), "__call__", None
-        )  # noqa: B004
+        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
         if dunder_unwrapped_call is None:
             return False  # pragma: no cover
         if inspect.isasyncgenfunction(
@@ -179,9 +175,7 @@ class Dependant:
             _unwrapped_call(dunder_call)
         ):
             return True
-        dunder_unwrapped_call = getattr(
-            _unwrapped_call(self.call), "__call__", None
-        )  # noqa: B004
+        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
         if dunder_unwrapped_call is None:
             return False  # pragma: no cover
         if iscoroutinefunction(

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -49,15 +49,20 @@ class Dependant:
     use_cache: bool = True
     path: str | None = None
     scope: Literal["function", "request"] | None = None
+    # Lazy cached fields
+    _oauth_scopes_cache: list[str] = field(default=None, init=False, repr=False)
 
-    @cached_property
+    @property
     def oauth_scopes(self) -> list[str]:
-        scopes = self.parent_oauth_scopes.copy() if self.parent_oauth_scopes else []
-        # This doesn't use a set to preserve order, just in case
-        for scope in self.own_oauth_scopes or []:
-            if scope not in scopes:
-                scopes.append(scope)
-        return scopes
+        if self._oauth_scopes_cache is None:
+            scopes = self.parent_oauth_scopes.copy() if self.parent_oauth_scopes else []
+            # This doesn't use a set to preserve order, just in case
+            for scope in self.own_oauth_scopes or []:
+                if scope not in scopes:
+                    scopes.append(scope)
+            self._oauth_scopes_cache = scopes
+
+        return self._oauth_scopes_cache
 
     @cached_property
     def cache_key(self) -> DependencyCacheKey:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -3,7 +3,7 @@ import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from fastapi._compat import ModelField
 from fastapi.security.base import SecurityBase
@@ -18,11 +18,11 @@ else:  # pragma: no cover
 def _unwrapped_call(call: Callable[..., Any] | None) -> Any:
     if call is None:
         return call  # pragma: no cover
-    unwrapped = inspect.unwrap(_impartial(call))
+    unwrapped = inspect.unwrap(cast(Callable[..., Any], _impartial(call)))
     return unwrapped
 
 
-def _impartial(func: Callable[..., Any]) -> Callable[..., Any]:
+def _impartial(func: Callable[..., Any] | None) -> Callable[..., Any] | None:
     while isinstance(func, partial):
         func = func.func
     return func

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -53,6 +53,7 @@ class Dependant:
     _oauth_scopes_cache: list[str] = field(default=None, init=False, repr=False)
     _cache_key_cache: DependencyCacheKey = field(default=None, init=False, repr=False)
     _uses_scopes_cache: bool = field(default=None, init=False, repr=False)
+    _is_security_scheme_cache: bool = field(default=False, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -97,15 +98,19 @@ class Dependant:
 
             if self._uses_scopes_cache is None:
                 self._uses_scopes_cache = False
-        
+
         return self._uses_scopes_cache
 
-    @cached_property
+    @property
     def _is_security_scheme(self) -> bool:
-        if self.call is None:
-            return False  # pragma: no cover
-        unwrapped = _unwrapped_call(self.call)
-        return isinstance(unwrapped, SecurityBase)
+        if self._is_security_scheme_cache is None:
+            if self.call is None:
+                self._is_security_scheme_cache = False  # pragma: no cover
+            else:
+                unwrapped = _unwrapped_call(self.call)
+                self._is_security_scheme_cache = isinstance(unwrapped, SecurityBase)
+
+        return self._is_security_scheme_cache
 
     # Mainly to get the type of SecurityBase, but it's the same self.call
     @cached_property

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -52,6 +52,7 @@ class Dependant:
     # Lazy cached fields
     _oauth_scopes_cache: list[str] = field(default=None, init=False, repr=False)
     _cache_key_cache: DependencyCacheKey = field(default=None, init=False, repr=False)
+    _uses_scopes_cache: bool = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -79,18 +80,25 @@ class Dependant:
 
         return self._cache_key_cache
 
-    @cached_property
+    @property
     def _uses_scopes(self) -> bool:
-        if self.own_oauth_scopes:
-            return True
-        if self.security_scopes_param_name is not None:
-            return True
-        if self._is_security_scheme:
-            return True
-        for sub_dep in self.dependencies:
-            if sub_dep._uses_scopes:
-                return True
-        return False
+        if self._uses_scopes_cache is None:
+            if self.own_oauth_scopes:
+                self._uses_scopes_cache = True
+            elif self.security_scopes_param_name is not None:
+                self._uses_scopes_cache = True
+            elif self._is_security_scheme:
+                self._uses_scopes_cache = True
+
+            for sub_dep in self.dependencies:
+                if sub_dep._uses_scopes:
+                    self._uses_scopes_cache = True
+                    break
+
+            if self._uses_scopes_cache is None:
+                self._uses_scopes_cache = False
+        
+        return self._uses_scopes_cache
 
     @cached_property
     def _is_security_scheme(self) -> bool:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -55,6 +55,7 @@ class Dependant:
     _uses_scopes_cache: bool = field(default=None, init=False, repr=False)
     _is_security_scheme_cache: bool = field(default=None, init=False, repr=False)
     _security_scheme_cache: SecurityBase = field(default=None, init=False, repr=False)
+    _security_dependencies_cache: list["Dependant"] = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -123,10 +124,13 @@ class Dependant:
 
         return self._security_scheme_cache
 
-    @cached_property
+    @property
     def _security_dependencies(self) -> list["Dependant"]:
-        security_deps = [dep for dep in self.dependencies if dep._is_security_scheme]
-        return security_deps
+        if self._security_dependencies_cache is None:
+            security_deps = [dep for dep in self.dependencies if dep._is_security_scheme]
+            self._security_dependencies_cache = security_deps
+
+        return self._security_dependencies_cache
 
     @cached_property
     def is_gen_callable(self) -> bool:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -174,9 +174,11 @@ class Dependant:
             if self._is_gen_callable_cache is not None:
                 return self._is_gen_callable_cache
 
-            dunder_unwrapped_call = getattr(
-                _unwrapped_call(self.call), "__call__", None
-            )  # noqa: B004
+            dunder_unwrapped_call = getattr(  # noqa: B004
+                _unwrapped_call(self.call),
+                "__call__",
+                None,
+            )
             if dunder_unwrapped_call is None:
                 self._is_gen_callable_cache = False  # pragma: no cover
             if inspect.isgeneratorfunction(
@@ -214,9 +216,9 @@ class Dependant:
             if self._is_async_gen_callable_cache is not None:
                 return self._is_async_gen_callable_cache
 
-            dunder_unwrapped_call = getattr(
+            dunder_unwrapped_call = getattr(  # noqa: B004
                 _unwrapped_call(self.call), "__call__", None
-            )  # noqa: B004
+            )
             if dunder_unwrapped_call is None:
                 self._is_async_gen_callable_cache = False  # pragma: no cover
             elif inspect.isasyncgenfunction(
@@ -258,9 +260,9 @@ class Dependant:
             if self._is_coroutine_callable_cache is not None:
                 return self._is_coroutine_callable_cache
 
-            dunder_unwrapped_call = getattr(
+            dunder_unwrapped_call = getattr(  # noqa: B004
                 _unwrapped_call(self.call), "__call__", None
-            )  # noqa: B004
+            )
             if dunder_unwrapped_call is None:
                 self._is_coroutine_callable_cache = False  # pragma: no cover
             elif iscoroutinefunction(

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -51,6 +51,7 @@ class Dependant:
     scope: Literal["function", "request"] | None = None
     # Lazy cached fields
     _oauth_scopes_cache: list[str] = field(default=None, init=False, repr=False)
+    _cache_key_cache: DependencyCacheKey = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -64,16 +65,19 @@ class Dependant:
 
         return self._oauth_scopes_cache
 
-    @cached_property
+    @property
     def cache_key(self) -> DependencyCacheKey:
-        scopes_for_cache = (
-            tuple(sorted(set(self.oauth_scopes or []))) if self._uses_scopes else ()
-        )
-        return (
-            self.call,
-            scopes_for_cache,
-            self.computed_scope or "",
-        )
+        if self._cache_key_cache is None:
+            scopes_for_cache = (
+                tuple(sorted(set(self.oauth_scopes or []))) if self._uses_scopes else ()
+            )
+            self._cache_key_cache = (
+                self.call,
+                scopes_for_cache,
+                self.computed_scope or "",
+            )
+
+        return self._cache_key_cache
 
     @cached_property
     def _uses_scopes(self) -> bool:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -54,6 +54,7 @@ class Dependant:
     _cache_key_cache: DependencyCacheKey = field(default=None, init=False, repr=False)
     _uses_scopes_cache: bool = field(default=None, init=False, repr=False)
     _is_security_scheme_cache: bool = field(default=False, init=False, repr=False)
+    _security_scheme_cache: SecurityBase = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -113,11 +114,14 @@ class Dependant:
         return self._is_security_scheme_cache
 
     # Mainly to get the type of SecurityBase, but it's the same self.call
-    @cached_property
+    @property
     def _security_scheme(self) -> SecurityBase:
-        unwrapped = _unwrapped_call(self.call)
-        assert isinstance(unwrapped, SecurityBase)
-        return unwrapped
+        if self._security_scheme_cache is None:
+            unwrapped = _unwrapped_call(self.call)
+            assert isinstance(unwrapped, SecurityBase)
+            self._security_scheme_cache = unwrapped
+
+        return self._security_scheme_cache
 
     @cached_property
     def _security_dependencies(self) -> list["Dependant"]:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -2,7 +2,7 @@ import inspect
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from functools import cached_property, partial
+from functools import partial
 from typing import Any, Literal
 
 from fastapi._compat import ModelField
@@ -51,14 +51,24 @@ class Dependant:
     scope: Literal["function", "request"] | None = None
     # Lazy cached fields
     _oauth_scopes_cache: list[str] | None = field(default=None, init=False, repr=False)
-    _cache_key_cache: DependencyCacheKey | None = field(default=None, init=False, repr=False)
+    _cache_key_cache: DependencyCacheKey | None = field(
+        default=None, init=False, repr=False
+    )
     _uses_scopes_cache: bool | None = field(default=None, init=False, repr=False)
     _is_security_scheme_cache: bool | None = field(default=None, init=False, repr=False)
-    _security_scheme_cache: SecurityBase | None = field(default=None, init=False, repr=False)
-    _security_dependencies_cache: list["Dependant"] | None = field(default=None, init=False, repr=False)
+    _security_scheme_cache: SecurityBase | None = field(
+        default=None, init=False, repr=False
+    )
+    _security_dependencies_cache: list["Dependant"] | None = field(
+        default=None, init=False, repr=False
+    )
     _is_gen_callable_cache: bool | None = field(default=None, init=False, repr=False)
-    _is_async_gen_callable_cache: bool | None = field(default=None, init=False, repr=False)
-    _is_coroutine_callable_cache: bool | None = field(default=None, init=False, repr=False)
+    _is_async_gen_callable_cache: bool | None = field(
+        default=None, init=False, repr=False
+    )
+    _is_coroutine_callable_cache: bool | None = field(
+        default=None, init=False, repr=False
+    )
     _computed_scope_cache: str | None = field(default=None, init=False, repr=False)
 
     @property
@@ -131,7 +141,9 @@ class Dependant:
     @property
     def _security_dependencies(self) -> list["Dependant"]:
         if self._security_dependencies_cache is None:
-            security_deps = [dep for dep in self.dependencies if dep._is_security_scheme]
+            security_deps = [
+                dep for dep in self.dependencies if dep._is_security_scheme
+            ]
             self._security_dependencies_cache = security_deps
 
         return self._security_dependencies_cache
@@ -162,7 +174,9 @@ class Dependant:
             if self._is_gen_callable_cache is not None:
                 return self._is_gen_callable_cache
 
-            dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+            dunder_unwrapped_call = getattr(
+                _unwrapped_call(self.call), "__call__", None
+            )  # noqa: B004
             if dunder_unwrapped_call is None:
                 self._is_gen_callable_cache = False  # pragma: no cover
             if inspect.isgeneratorfunction(
@@ -200,7 +214,9 @@ class Dependant:
             if self._is_async_gen_callable_cache is not None:
                 return self._is_async_gen_callable_cache
 
-            dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+            dunder_unwrapped_call = getattr(
+                _unwrapped_call(self.call), "__call__", None
+            )  # noqa: B004
             if dunder_unwrapped_call is None:
                 self._is_async_gen_callable_cache = False  # pragma: no cover
             elif inspect.isasyncgenfunction(
@@ -242,7 +258,9 @@ class Dependant:
             if self._is_coroutine_callable_cache is not None:
                 return self._is_coroutine_callable_cache
 
-            dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+            dunder_unwrapped_call = getattr(
+                _unwrapped_call(self.call), "__call__", None
+            )  # noqa: B004
             if dunder_unwrapped_call is None:
                 self._is_coroutine_callable_cache = False  # pragma: no cover
             elif iscoroutinefunction(

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -50,15 +50,15 @@ class Dependant:
     path: str | None = None
     scope: Literal["function", "request"] | None = None
     # Lazy cached fields
-    _oauth_scopes_cache: list[str] = field(default=None, init=False, repr=False)
-    _cache_key_cache: DependencyCacheKey = field(default=None, init=False, repr=False)
-    _uses_scopes_cache: bool = field(default=None, init=False, repr=False)
-    _is_security_scheme_cache: bool = field(default=None, init=False, repr=False)
-    _security_scheme_cache: SecurityBase = field(default=None, init=False, repr=False)
-    _security_dependencies_cache: list["Dependant"] = field(default=None, init=False, repr=False)
-    _is_gen_callable_cache: bool = field(default=None, init=False, repr=False)
-    _is_async_gen_callable_cache: bool = field(default=None, init=False, repr=False)
-    _is_coroutine_callable_cache: bool = field(default=None, init=False, repr=False)
+    _oauth_scopes_cache: list[str] | None = field(default=None, init=False, repr=False)
+    _cache_key_cache: DependencyCacheKey | None = field(default=None, init=False, repr=False)
+    _uses_scopes_cache: bool | None = field(default=None, init=False, repr=False)
+    _is_security_scheme_cache: bool | None = field(default=None, init=False, repr=False)
+    _security_scheme_cache: SecurityBase | None = field(default=None, init=False, repr=False)
+    _security_dependencies_cache: list["Dependant"] | None = field(default=None, init=False, repr=False)
+    _is_gen_callable_cache: bool | None = field(default=None, init=False, repr=False)
+    _is_async_gen_callable_cache: bool | None = field(default=None, init=False, repr=False)
+    _is_coroutine_callable_cache: bool | None = field(default=None, init=False, repr=False)
     _computed_scope_cache: str | None = field(default=None, init=False, repr=False)
 
     @property

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -58,6 +58,7 @@ class Dependant:
     _security_dependencies_cache: list["Dependant"] = field(default=None, init=False, repr=False)
     _is_gen_callable_cache: bool = field(default=None, init=False, repr=False)
     _is_async_gen_callable_cache: bool = field(default=None, init=False, repr=False)
+    _is_coroutine_callable_cache: bool = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -210,35 +211,47 @@ class Dependant:
 
         return self._is_async_gen_callable_cache
 
-    @cached_property
+    @property
     def is_coroutine_callable(self) -> bool:
-        if self.call is None:
-            return False  # pragma: no cover
-        if inspect.isroutine(_impartial(self.call)) and iscoroutinefunction(
-            _impartial(self.call)
-        ):
-            return True
-        if inspect.isroutine(_unwrapped_call(self.call)) and iscoroutinefunction(
-            _unwrapped_call(self.call)
-        ):
-            return True
-        if inspect.isclass(_unwrapped_call(self.call)):
-            return False
-        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
-        if dunder_call is None:
-            return False  # pragma: no cover
-        if iscoroutinefunction(_impartial(dunder_call)) or iscoroutinefunction(
-            _unwrapped_call(dunder_call)
-        ):
-            return True
-        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
-        if dunder_unwrapped_call is None:
-            return False  # pragma: no cover
-        if iscoroutinefunction(
-            _impartial(dunder_unwrapped_call)
-        ) or iscoroutinefunction(_unwrapped_call(dunder_unwrapped_call)):
-            return True
-        return False
+        if self._is_coroutine_callable_cache is None:
+            if self.call is None:
+                self._is_coroutine_callable_cache = False  # pragma: no cover
+            elif inspect.isroutine(_impartial(self.call)) and iscoroutinefunction(
+                _impartial(self.call)
+            ):
+                self._is_coroutine_callable_cache = True
+            elif inspect.isroutine(_unwrapped_call(self.call)) and iscoroutinefunction(
+                _unwrapped_call(self.call)
+            ):
+                self._is_coroutine_callable_cache = True
+            elif inspect.isclass(_unwrapped_call(self.call)):
+                self._is_coroutine_callable_cache = False
+
+            if self._is_coroutine_callable_cache is not None:
+                return self._is_coroutine_callable_cache
+
+            dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+            if dunder_call is None:
+                self._is_coroutine_callable_cache = False  # pragma: no cover
+            elif iscoroutinefunction(_impartial(dunder_call)) or iscoroutinefunction(
+                _unwrapped_call(dunder_call)
+            ):
+                self._is_coroutine_callable_cache = True
+
+            if self._is_coroutine_callable_cache is not None:
+                return self._is_coroutine_callable_cache
+
+            dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+            if dunder_unwrapped_call is None:
+                self._is_coroutine_callable_cache = False  # pragma: no cover
+            elif iscoroutinefunction(
+                _impartial(dunder_unwrapped_call)
+            ) or iscoroutinefunction(_unwrapped_call(dunder_unwrapped_call)):
+                self._is_coroutine_callable_cache = True
+            else:
+                self._is_coroutine_callable_cache = False
+        
+        return self._is_coroutine_callable_cache
 
     @cached_property
     def computed_scope(self) -> str | None:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -28,7 +28,7 @@ def _impartial(func: Callable[..., Any]) -> Callable[..., Any]:
     return func
 
 
-@dataclass
+@dataclass(slots=True)
 class Dependant:
     path_params: list[ModelField] = field(default_factory=list)
     query_params: list[ModelField] = field(default_factory=list)

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -57,6 +57,7 @@ class Dependant:
     _security_scheme_cache: SecurityBase = field(default=None, init=False, repr=False)
     _security_dependencies_cache: list["Dependant"] = field(default=None, init=False, repr=False)
     _is_gen_callable_cache: bool = field(default=None, init=False, repr=False)
+    _is_async_gen_callable_cache: bool = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -145,7 +146,6 @@ class Dependant:
             elif inspect.isclass(_unwrapped_call(self.call)):
                 self._is_gen_callable_cache = False
 
-            # optimization to exit early
             if self._is_gen_callable_cache is not None:
                 return self._is_gen_callable_cache
 
@@ -157,7 +157,6 @@ class Dependant:
             ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call)):
                 self._is_gen_callable_cache = True
 
-            # optimization to exit early
             if self._is_gen_callable_cache is not None:
                 return self._is_gen_callable_cache
 
@@ -170,34 +169,46 @@ class Dependant:
                 self._is_gen_callable_cache = True
             else:
                 self._is_gen_callable_cache = False
-        
+
         return self._is_gen_callable_cache
 
-    @cached_property
+    @property
     def is_async_gen_callable(self) -> bool:
-        if self.call is None:
-            return False  # pragma: no cover
-        if inspect.isasyncgenfunction(
-            _impartial(self.call)
-        ) or inspect.isasyncgenfunction(_unwrapped_call(self.call)):
-            return True
-        if inspect.isclass(_unwrapped_call(self.call)):
-            return False
-        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
-        if dunder_call is None:
-            return False  # pragma: no cover
-        if inspect.isasyncgenfunction(
-            _impartial(dunder_call)
-        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call)):
-            return True
-        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
-        if dunder_unwrapped_call is None:
-            return False  # pragma: no cover
-        if inspect.isasyncgenfunction(
-            _impartial(dunder_unwrapped_call)
-        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_unwrapped_call)):
-            return True
-        return False
+        if self._is_async_gen_callable_cache is None:
+            if self.call is None:
+                self._is_async_gen_callable_cache = False  # pragma: no cover
+            elif inspect.isasyncgenfunction(
+                _impartial(self.call)
+            ) or inspect.isasyncgenfunction(_unwrapped_call(self.call)):
+                self._is_async_gen_callable_cache = True
+            elif inspect.isclass(_unwrapped_call(self.call)):
+                self._is_async_gen_callable_cache = False
+
+            if self._is_async_gen_callable_cache is not None:
+                return self._is_async_gen_callable_cache
+
+            dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+            if dunder_call is None:
+                self._is_async_gen_callable_cache = False  # pragma: no cover
+            elif inspect.isasyncgenfunction(
+                _impartial(dunder_call)
+            ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call)):
+                self._is_async_gen_callable_cache = True
+
+            if self._is_async_gen_callable_cache is not None:
+                return self._is_async_gen_callable_cache
+
+            dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+            if dunder_unwrapped_call is None:
+                self._is_async_gen_callable_cache = False  # pragma: no cover
+            elif inspect.isasyncgenfunction(
+                _impartial(dunder_unwrapped_call)
+            ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_unwrapped_call)):
+                self._is_async_gen_callable_cache = True
+            else:
+                self._is_async_gen_callable_cache = False
+
+        return self._is_async_gen_callable_cache
 
     @cached_property
     def is_coroutine_callable(self) -> bool:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -56,6 +56,7 @@ class Dependant:
     _is_security_scheme_cache: bool = field(default=None, init=False, repr=False)
     _security_scheme_cache: SecurityBase = field(default=None, init=False, repr=False)
     _security_dependencies_cache: list["Dependant"] = field(default=None, init=False, repr=False)
+    _is_gen_callable_cache: bool = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -132,31 +133,45 @@ class Dependant:
 
         return self._security_dependencies_cache
 
-    @cached_property
+    @property
     def is_gen_callable(self) -> bool:
-        if self.call is None:
-            return False  # pragma: no cover
-        if inspect.isgeneratorfunction(
-            _impartial(self.call)
-        ) or inspect.isgeneratorfunction(_unwrapped_call(self.call)):
-            return True
-        if inspect.isclass(_unwrapped_call(self.call)):
-            return False
-        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
-        if dunder_call is None:
-            return False  # pragma: no cover
-        if inspect.isgeneratorfunction(
-            _impartial(dunder_call)
-        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call)):
-            return True
-        dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
-        if dunder_unwrapped_call is None:
-            return False  # pragma: no cover
-        if inspect.isgeneratorfunction(
-            _impartial(dunder_unwrapped_call)
-        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_unwrapped_call)):
-            return True
-        return False
+        if self._is_gen_callable_cache is None:
+            if self.call is None:
+                self._is_gen_callable_cache = False  # pragma: no cover
+            elif inspect.isgeneratorfunction(
+                _impartial(self.call)
+            ) or inspect.isgeneratorfunction(_unwrapped_call(self.call)):
+                self._is_gen_callable_cache = True
+            elif inspect.isclass(_unwrapped_call(self.call)):
+                self._is_gen_callable_cache = False
+
+            # optimization to exit early
+            if self._is_gen_callable_cache is not None:
+                return self._is_gen_callable_cache
+
+            dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+            if dunder_call is None:
+                self._is_gen_callable_cache = False  # pragma: no cover
+            elif inspect.isgeneratorfunction(
+                _impartial(dunder_call)
+            ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call)):
+                self._is_gen_callable_cache = True
+
+            # optimization to exit early
+            if self._is_gen_callable_cache is not None:
+                return self._is_gen_callable_cache
+
+            dunder_unwrapped_call = getattr(_unwrapped_call(self.call), "__call__", None)  # noqa: B004
+            if dunder_unwrapped_call is None:
+                self._is_gen_callable_cache = False  # pragma: no cover
+            if inspect.isgeneratorfunction(
+                _impartial(dunder_unwrapped_call)
+            ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_unwrapped_call)):
+                self._is_gen_callable_cache = True
+            else:
+                self._is_gen_callable_cache = False
+        
+        return self._is_gen_callable_cache
 
     @cached_property
     def is_async_gen_callable(self) -> bool:

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -53,7 +53,7 @@ class Dependant:
     _oauth_scopes_cache: list[str] = field(default=None, init=False, repr=False)
     _cache_key_cache: DependencyCacheKey = field(default=None, init=False, repr=False)
     _uses_scopes_cache: bool = field(default=None, init=False, repr=False)
-    _is_security_scheme_cache: bool = field(default=False, init=False, repr=False)
+    _is_security_scheme_cache: bool = field(default=None, init=False, repr=False)
     _security_scheme_cache: SecurityBase = field(default=None, init=False, repr=False)
 
     @property

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -59,6 +59,7 @@ class Dependant:
     _is_gen_callable_cache: bool = field(default=None, init=False, repr=False)
     _is_async_gen_callable_cache: bool = field(default=None, init=False, repr=False)
     _is_coroutine_callable_cache: bool = field(default=None, init=False, repr=False)
+    _computed_scope_cache: str | None = field(default=None, init=False, repr=False)
 
     @property
     def oauth_scopes(self) -> list[str]:
@@ -250,13 +251,17 @@ class Dependant:
                 self._is_coroutine_callable_cache = True
             else:
                 self._is_coroutine_callable_cache = False
-        
+
         return self._is_coroutine_callable_cache
 
-    @cached_property
+    @property
     def computed_scope(self) -> str | None:
-        if self.scope:
-            return self.scope
-        if self.is_gen_callable or self.is_async_gen_callable:
-            return "request"
-        return None
+        if self._computed_scope_cache is None:
+            if self.scope:
+                self._computed_scope_cache = self.scope
+            elif self.is_gen_callable or self.is_async_gen_callable:
+                self._computed_scope_cache = "request"
+            else:
+                self._computed_scope_cache = None
+
+        return self._computed_scope_cache

--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -49,6 +49,155 @@ class Dependant:
     use_cache: bool = True
     path: str | None = None
     scope: Literal["function", "request"] | None = None
+
+    @property
+    def _oauth_scopes(self) -> list[str]:
+        scopes = self.parent_oauth_scopes.copy() if self.parent_oauth_scopes else []
+        # This doesn't use a set to preserve order, just in case
+        for scope in self.own_oauth_scopes or []:
+            if scope not in scopes:
+                scopes.append(scope)
+        return scopes
+
+    @property
+    def _cache_key(self) -> DependencyCacheKey:
+        scopes_for_cache = (
+            tuple(sorted(set(self.oauth_scopes or []))) if self._uses_scopes else ()
+        )
+        return (
+            self.call,
+            scopes_for_cache,
+            self.computed_scope or "",
+        )
+
+    @property
+    def __uses_scopes(self) -> bool:
+        if self.own_oauth_scopes:
+            return True
+        if self.security_scopes_param_name is not None:
+            return True
+        if self._is_security_scheme:
+            return True
+        for sub_dep in self.dependencies:
+            if sub_dep._uses_scopes:
+                return True
+        return False
+
+    @property
+    def __is_security_scheme(self) -> bool:
+        if self.call is None:
+            return False  # pragma: no cover
+        unwrapped = _unwrapped_call(self.call)
+        return isinstance(unwrapped, SecurityBase)
+
+    # Mainly to get the type of SecurityBase, but it's the same self.call
+    @property
+    def __security_scheme(self) -> SecurityBase:
+        unwrapped = _unwrapped_call(self.call)
+        assert isinstance(unwrapped, SecurityBase)
+        return unwrapped
+
+    @property
+    def __security_dependencies(self) -> list["Dependant"]:
+        security_deps = [dep for dep in self.dependencies if dep._is_security_scheme]
+        return security_deps
+
+    @property
+    def _is_gen_callable(self) -> bool:
+        if self.call is None:
+            return False  # pragma: no cover
+        if inspect.isgeneratorfunction(
+            _impartial(self.call)
+        ) or inspect.isgeneratorfunction(_unwrapped_call(self.call)):
+            return True
+        if inspect.isclass(_unwrapped_call(self.call)):
+            return False
+        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+        if dunder_call is None:
+            return False  # pragma: no cover
+        if inspect.isgeneratorfunction(
+            _impartial(dunder_call)
+        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call)):
+            return True
+        dunder_unwrapped_call = getattr(
+            _unwrapped_call(self.call), "__call__", None
+        )  # noqa: B004
+        if dunder_unwrapped_call is None:
+            return False  # pragma: no cover
+        if inspect.isgeneratorfunction(
+            _impartial(dunder_unwrapped_call)
+        ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_unwrapped_call)):
+            return True
+        return False
+
+    @property
+    def _is_async_gen_callable(self) -> bool:
+        if self.call is None:
+            return False  # pragma: no cover
+        if inspect.isasyncgenfunction(
+            _impartial(self.call)
+        ) or inspect.isasyncgenfunction(_unwrapped_call(self.call)):
+            return True
+        if inspect.isclass(_unwrapped_call(self.call)):
+            return False
+        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+        if dunder_call is None:
+            return False  # pragma: no cover
+        if inspect.isasyncgenfunction(
+            _impartial(dunder_call)
+        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call)):
+            return True
+        dunder_unwrapped_call = getattr(
+            _unwrapped_call(self.call), "__call__", None
+        )  # noqa: B004
+        if dunder_unwrapped_call is None:
+            return False  # pragma: no cover
+        if inspect.isasyncgenfunction(
+            _impartial(dunder_unwrapped_call)
+        ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_unwrapped_call)):
+            return True
+        return False
+
+    @property
+    def _is_coroutine_callable(self) -> bool:
+        if self.call is None:
+            return False  # pragma: no cover
+        if inspect.isroutine(_impartial(self.call)) and iscoroutinefunction(
+            _impartial(self.call)
+        ):
+            return True
+        if inspect.isroutine(_unwrapped_call(self.call)) and iscoroutinefunction(
+            _unwrapped_call(self.call)
+        ):
+            return True
+        if inspect.isclass(_unwrapped_call(self.call)):
+            return False
+        dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
+        if dunder_call is None:
+            return False  # pragma: no cover
+        if iscoroutinefunction(_impartial(dunder_call)) or iscoroutinefunction(
+            _unwrapped_call(dunder_call)
+        ):
+            return True
+        dunder_unwrapped_call = getattr(
+            _unwrapped_call(self.call), "__call__", None
+        )  # noqa: B004
+        if dunder_unwrapped_call is None:
+            return False  # pragma: no cover
+        if iscoroutinefunction(
+            _impartial(dunder_unwrapped_call)
+        ) or iscoroutinefunction(_unwrapped_call(dunder_unwrapped_call)):
+            return True
+        return False
+
+    @property
+    def _computed_scope(self) -> str | None:
+        if self.scope:
+            return self.scope
+        if self.is_gen_callable or self.is_async_gen_callable:
+            return "request"
+        return None
+
     # Lazy cached fields
     _oauth_scopes_cache: list[str] | None = field(default=None, init=False, repr=False)
     _cache_key_cache: DependencyCacheKey | None = field(
@@ -74,214 +223,69 @@ class Dependant:
     @property
     def oauth_scopes(self) -> list[str]:
         if self._oauth_scopes_cache is None:
-            scopes = self.parent_oauth_scopes.copy() if self.parent_oauth_scopes else []
-            # This doesn't use a set to preserve order, just in case
-            for scope in self.own_oauth_scopes or []:
-                if scope not in scopes:
-                    scopes.append(scope)
-            self._oauth_scopes_cache = scopes
+            self._oauth_scopes_cache = self._oauth_scopes
 
         return self._oauth_scopes_cache
 
     @property
     def cache_key(self) -> DependencyCacheKey:
         if self._cache_key_cache is None:
-            scopes_for_cache = (
-                tuple(sorted(set(self.oauth_scopes or []))) if self._uses_scopes else ()
-            )
-            self._cache_key_cache = (
-                self.call,
-                scopes_for_cache,
-                self.computed_scope or "",
-            )
+            self._cache_key_cache = self._cache_key
 
         return self._cache_key_cache
 
     @property
     def _uses_scopes(self) -> bool:
         if self._uses_scopes_cache is None:
-            if self.own_oauth_scopes:
-                self._uses_scopes_cache = True
-            elif self.security_scopes_param_name is not None:
-                self._uses_scopes_cache = True
-            elif self._is_security_scheme:
-                self._uses_scopes_cache = True
-
-            for sub_dep in self.dependencies:
-                if sub_dep._uses_scopes:
-                    self._uses_scopes_cache = True
-                    break
-
-            if self._uses_scopes_cache is None:
-                self._uses_scopes_cache = False
+            self._uses_scopes_cache = self.__uses_scopes
 
         return self._uses_scopes_cache
 
     @property
     def _is_security_scheme(self) -> bool:
         if self._is_security_scheme_cache is None:
-            if self.call is None:
-                self._is_security_scheme_cache = False  # pragma: no cover
-            else:
-                unwrapped = _unwrapped_call(self.call)
-                self._is_security_scheme_cache = isinstance(unwrapped, SecurityBase)
+            self._is_security_scheme_cache = self.__is_security_scheme
 
         return self._is_security_scheme_cache
 
-    # Mainly to get the type of SecurityBase, but it's the same self.call
     @property
     def _security_scheme(self) -> SecurityBase:
         if self._security_scheme_cache is None:
-            unwrapped = _unwrapped_call(self.call)
-            assert isinstance(unwrapped, SecurityBase)
-            self._security_scheme_cache = unwrapped
+            self._security_scheme_cache = self.__security_scheme
 
         return self._security_scheme_cache
 
     @property
     def _security_dependencies(self) -> list["Dependant"]:
         if self._security_dependencies_cache is None:
-            security_deps = [
-                dep for dep in self.dependencies if dep._is_security_scheme
-            ]
-            self._security_dependencies_cache = security_deps
+            self._security_dependencies_cache = self.__security_dependencies
 
         return self._security_dependencies_cache
 
     @property
     def is_gen_callable(self) -> bool:
         if self._is_gen_callable_cache is None:
-            if self.call is None:
-                self._is_gen_callable_cache = False  # pragma: no cover
-            elif inspect.isgeneratorfunction(
-                _impartial(self.call)
-            ) or inspect.isgeneratorfunction(_unwrapped_call(self.call)):
-                self._is_gen_callable_cache = True
-            elif inspect.isclass(_unwrapped_call(self.call)):
-                self._is_gen_callable_cache = False
-
-            if self._is_gen_callable_cache is not None:
-                return self._is_gen_callable_cache
-
-            dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
-            if dunder_call is None:
-                self._is_gen_callable_cache = False  # pragma: no cover
-            elif inspect.isgeneratorfunction(
-                _impartial(dunder_call)
-            ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_call)):
-                self._is_gen_callable_cache = True
-
-            if self._is_gen_callable_cache is not None:
-                return self._is_gen_callable_cache
-
-            dunder_unwrapped_call = getattr(  # noqa: B004
-                _unwrapped_call(self.call),
-                "__call__",
-                None,
-            )
-            if dunder_unwrapped_call is None:
-                self._is_gen_callable_cache = False  # pragma: no cover
-            if inspect.isgeneratorfunction(
-                _impartial(dunder_unwrapped_call)
-            ) or inspect.isgeneratorfunction(_unwrapped_call(dunder_unwrapped_call)):
-                self._is_gen_callable_cache = True
-            else:
-                self._is_gen_callable_cache = False
+            self._is_gen_callable_cache = self._is_gen_callable
 
         return self._is_gen_callable_cache
 
     @property
     def is_async_gen_callable(self) -> bool:
         if self._is_async_gen_callable_cache is None:
-            if self.call is None:
-                self._is_async_gen_callable_cache = False  # pragma: no cover
-            elif inspect.isasyncgenfunction(
-                _impartial(self.call)
-            ) or inspect.isasyncgenfunction(_unwrapped_call(self.call)):
-                self._is_async_gen_callable_cache = True
-            elif inspect.isclass(_unwrapped_call(self.call)):
-                self._is_async_gen_callable_cache = False
-
-            if self._is_async_gen_callable_cache is not None:
-                return self._is_async_gen_callable_cache
-
-            dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
-            if dunder_call is None:
-                self._is_async_gen_callable_cache = False  # pragma: no cover
-            elif inspect.isasyncgenfunction(
-                _impartial(dunder_call)
-            ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_call)):
-                self._is_async_gen_callable_cache = True
-
-            if self._is_async_gen_callable_cache is not None:
-                return self._is_async_gen_callable_cache
-
-            dunder_unwrapped_call = getattr(  # noqa: B004
-                _unwrapped_call(self.call), "__call__", None
-            )
-            if dunder_unwrapped_call is None:
-                self._is_async_gen_callable_cache = False  # pragma: no cover
-            elif inspect.isasyncgenfunction(
-                _impartial(dunder_unwrapped_call)
-            ) or inspect.isasyncgenfunction(_unwrapped_call(dunder_unwrapped_call)):
-                self._is_async_gen_callable_cache = True
-            else:
-                self._is_async_gen_callable_cache = False
+            self._is_async_gen_callable_cache = self._is_async_gen_callable
 
         return self._is_async_gen_callable_cache
 
     @property
     def is_coroutine_callable(self) -> bool:
         if self._is_coroutine_callable_cache is None:
-            if self.call is None:
-                self._is_coroutine_callable_cache = False  # pragma: no cover
-            elif inspect.isroutine(_impartial(self.call)) and iscoroutinefunction(
-                _impartial(self.call)
-            ):
-                self._is_coroutine_callable_cache = True
-            elif inspect.isroutine(_unwrapped_call(self.call)) and iscoroutinefunction(
-                _unwrapped_call(self.call)
-            ):
-                self._is_coroutine_callable_cache = True
-            elif inspect.isclass(_unwrapped_call(self.call)):
-                self._is_coroutine_callable_cache = False
-
-            if self._is_coroutine_callable_cache is not None:
-                return self._is_coroutine_callable_cache
-
-            dunder_call = getattr(_impartial(self.call), "__call__", None)  # noqa: B004
-            if dunder_call is None:
-                self._is_coroutine_callable_cache = False  # pragma: no cover
-            elif iscoroutinefunction(_impartial(dunder_call)) or iscoroutinefunction(
-                _unwrapped_call(dunder_call)
-            ):
-                self._is_coroutine_callable_cache = True
-
-            if self._is_coroutine_callable_cache is not None:
-                return self._is_coroutine_callable_cache
-
-            dunder_unwrapped_call = getattr(  # noqa: B004
-                _unwrapped_call(self.call), "__call__", None
-            )
-            if dunder_unwrapped_call is None:
-                self._is_coroutine_callable_cache = False  # pragma: no cover
-            elif iscoroutinefunction(
-                _impartial(dunder_unwrapped_call)
-            ) or iscoroutinefunction(_unwrapped_call(dunder_unwrapped_call)):
-                self._is_coroutine_callable_cache = True
-            else:
-                self._is_coroutine_callable_cache = False
+            self._is_coroutine_callable_cache = self._is_coroutine_callable
 
         return self._is_coroutine_callable_cache
 
     @property
     def computed_scope(self) -> str | None:
         if self._computed_scope_cache is None:
-            if self.scope:
-                self._computed_scope_cache = self.scope
-            elif self.is_gen_callable or self.is_async_gen_callable:
-                self._computed_scope_cache = "request"
-            else:
-                self._computed_scope_cache = None
+            self._computed_scope_cache = self._computed_scope
 
         return self._computed_scope_cache


### PR DESCRIPTION
## Context

In https://github.com/fastapi/fastapi/discussions/14742, I reported a significant spike in memory usage when upgrading FastAPI from v0.120.4 to v0.121.x (and later versions).

My analysis traced the regression to [this refactor](https://github.com/fastapi/fastapi/pull/14262/files#diff-4d1d65ce33d5ef7383c87f7edeb3928bc0537016daba6d1a6b8b27a7af8f8aaaR46-R52), which replaced computed fields in `__post_init__` with [`functools.cached_property`](https://docs.python.org/3/library/functools.html#functools.cached_property).

## Root cause

The Python docs for [`functools.cached_property`](https://docs.python.org/3/library/functools.html#functools.cached_property) note:

> This decorator interferes with the operation of [[PEP 412](https://peps.python.org/pep-0412/)](https://peps.python.org/pep-0412/) key-sharing dictionaries. This means that instance dictionaries can take more space than usual.

While the worst of this was addressed in Python 3.12+ https://github.com/python/cpython/issues/101815, there is still an overhead: accessing `__dict__` on an instance forces creation of a full dictionary object rather than a compact `PyDictValues`, adding a `PyDictObject` (three fields) per instance. At scale, this adds up.

The exact quote from the cpython issue:
> It remains true that cached_property can cause instances to use slightly more memory, but the reason for this has changed (and the extra memory used will be significantly less.) The new reason is that any access of __dict__ on an instance will force creation of a real dictionary object for that instance, rather than just a PyDictValues. The keys remain shared in the created dict, though. So the added memory use is no longer "all the keys" but rather just "a PyDictObject" (which consists of only three fields.)

## Benchmarks

I wrote a script to measure memory usage across varying numbers of `Dependant` instances:

<details><summary>Benchmark script</summary>

```python
import gc
import tracemalloc
from fastapi.dependencies.models import Dependant

samples_tests = (
    200_000,
    100_000,
    50_000,
    1_000,
    500,
)

def measure(samples: int):
    gc.collect()
    tracemalloc.start()
    objs = [Dependant() for i in range(samples)]

    # Trigger all cached properties
    for o in objs:
        o.oauth_scopes
        o.cache_key
        o._uses_scopes
        o._is_security_scheme
        # o._security_scheme  # skipped: asserts a SecurityBase, not None
        o._security_dependencies
        o.is_gen_callable
        o.is_async_gen_callable
        o.is_coroutine_callable
        o.computed_scope

    current, peak = tracemalloc.get_traced_memory()
    tracemalloc.stop()
    return current, peak, objs  # keep objs alive until after measurement

for samples in samples_tests:
    cur, peak, _ = measure(samples)
    print(f"Samples: {samples} - current={cur/1e6:.1f} MB  peak={peak/1e6:.1f} MB")
```

</details>

**Before (current `master`, Python 3.13.12):**

```
Samples: 200000 - current=318.4 MB  peak=318.4 MB
Samples: 100000 - current=159.2 MB  peak=159.2 MB
Samples: 50000 - current=79.6 MB  peak=79.6 MB
Samples: 1000 - current=1.6 MB  peak=1.6 MB
Samples: 500 - current=0.8 MB  peak=0.8 MB
```

**After (this PR):**

```
Samples: 200000 - current=156.8 MB  peak=156.8 MB
Samples: 100000 - current=78.4 MB  peak=78.4 MB
Samples: 50000 - current=39.2 MB  peak=39.2 MB
Samples: 1000 - current=0.8 MB  peak=0.8 MB
Samples: 500 - current=0.4 MB  peak=0.4 MB
```

Memory usage is reduced by approximately **50%** across all cases.

## Approach

The key enabler for the memory reduction is the use of `__slots__`. However, `__slots__` is not compatible with `functools.cached_property`, so the caching strategy had to change.

I considered reverting to the previous `__post_init__` approach but decided against it for two reasons:

1. **No lazy initialization** — all computed fields would be evaluated eagerly on every `Dependant` instantiation, even if never accessed.
2. **Awkward dependency ordering** — several computed fields depend on each other, making `__post_init__` harder to maintain.

Instead, this PR introduces a different caching mechanism that preserves lazy evaluation while being compatible with `__slots__`.