### PR TITLE
fix typos: FastAPI capitalization and duplicate words

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -4541,7 +4541,7 @@ You hopefully updated to a supported version of Python a while ago. If you haven
 * ✏ Reword and clarify text in tutorial `docs/en/docs/tutorial/body-nested-models.md`. PR [#5169](https://github.com/tiangolo/fastapi/pull/5169) by [@papb](https://github.com/papb).
 * ✏ Fix minor typo in `docs/en/docs/features.md`. PR [#5206](https://github.com/tiangolo/fastapi/pull/5206) by [@OtherBarry](https://github.com/OtherBarry).
 * ✏ Fix minor typos in `docs/en/docs/async.md`. PR [#5125](https://github.com/tiangolo/fastapi/pull/5125) by [@Ksenofanex](https://github.com/Ksenofanex).
-* 📝 Add external link to docs: "Fastapi, Docker(Docker compose) and Postgres". PR [#5033](https://github.com/tiangolo/fastapi/pull/5033) by [@krishnardt](https://github.com/krishnardt).
+* 📝 Add external link to docs: "FastAPI, Docker(Docker compose) and Postgres". PR [#5033](https://github.com/tiangolo/fastapi/pull/5033) by [@krishnardt](https://github.com/krishnardt).
 * 📝 Simplify example for docs for Additional Responses, remove unnecessary `else`. PR [#4693](https://github.com/tiangolo/fastapi/pull/4693) by [@adriangb](https://github.com/adriangb).
 * 📝 Update docs, compare enums with identity instead of equality. PR [#4905](https://github.com/tiangolo/fastapi/pull/4905) by [@MicaelJarniac](https://github.com/MicaelJarniac).
 * ✏ Fix typo in `docs/en/docs/python-types.md`. PR [#4886](https://github.com/tiangolo/fastapi/pull/4886) by [@MicaelJarniac](https://github.com/MicaelJarniac).
@@ -5959,7 +5959,7 @@ Note: all the previous parameters are still there, so it's still possible to dec
 
 * Allow enums to allow them to have their own schemas in OpenAPI. To support [pydantic/pydantic#1432](https://github.com/pydantic/pydantic/pull/1432) in FastAPI. PR [#1461](https://github.com/tiangolo/fastapi/pull/1461).
 * Add links for funding through [GitHub sponsors](https://github.com/sponsors/tiangolo). PR [#1425](https://github.com/tiangolo/fastapi/pull/1425).
-* Update issue template for for questions. PR [#1344](https://github.com/tiangolo/fastapi/pull/1344) by [@retnikt](https://github.com/retnikt).
+* Update issue template for questions. PR [#1344](https://github.com/tiangolo/fastapi/pull/1344) by [@retnikt](https://github.com/retnikt).
 * Update warning about storing passwords in docs. PR [#1336](https://github.com/tiangolo/fastapi/pull/1336) by [@skorokithakis](https://github.com/skorokithakis).
 * Fix typo. PR [#1326](https://github.com/tiangolo/fastapi/pull/1326) by [@chenl](https://github.com/chenl).
 * Add translation to Portuguese for [Alternatives, Inspiration and Comparisons - Alternativas, Inspiração e Comparações](https://fastapi.tiangolo.com/pt/alternatives/). PR [#1325](https://github.com/tiangolo/fastapi/pull/1325) by [@Serrones](https://github.com/Serrones).

--- a/docs/es/docs/alternatives.md
+++ b/docs/es/docs/alternatives.md
@@ -241,7 +241,7 @@ Generar el esquema OpenAPI automáticamente, desde el mismo código que define l
 
 Esto ni siquiera es Python, NestJS es un framework de JavaScript (TypeScript) NodeJS inspirado por Angular.
 
-Logra algo algo similar a lo que se puede hacer con Flask-apispec.
+Logra algo similar a lo que se puede hacer con Flask-apispec.
 
 Tiene un sistema de inyección de dependencias integrado, inspirado por Angular 2. Requiere pre-registrar los "inyectables" (como todos los otros sistemas de inyección de dependencias que conozco), por lo que añade a la verbosidad y repetición de código.
 

--- a/docs/pt/docs/advanced/async-tests.md
+++ b/docs/pt/docs/advanced/async-tests.md
@@ -34,7 +34,7 @@ O arquivo `main.py` teria:
 
 {* ../../docs_src/async_tests/app_a_py310/main.py *}
 
-O arquivo `test_main.py` teria os testes para para o arquivo `main.py`, ele poderia ficar assim:
+O arquivo `test_main.py` teria os testes para o arquivo `main.py`, ele poderia ficar assim:
 
 {* ../../docs_src/async_tests/app_a_py310/test_main.py *}
 

--- a/tests/test_tutorial/test_custom_response/test_tutorial006b.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006b.py
@@ -22,7 +22,7 @@ def test_openapi_schema():
             "paths": {
                 "/fastapi": {
                     "get": {
-                        "summary": "Redirect FastAPI",
+                        "summary": "Redirect Fastapi",
                         "operationId": "redirect_fastapi_fastapi_get",
                         "responses": {"307": {"description": "Successful Response"}},
                     }

--- a/tests/test_tutorial/test_custom_response/test_tutorial006b.py
+++ b/tests/test_tutorial/test_custom_response/test_tutorial006b.py
@@ -22,7 +22,7 @@ def test_openapi_schema():
             "paths": {
                 "/fastapi": {
                     "get": {
-                        "summary": "Redirect Fastapi",
+                        "summary": "Redirect FastAPI",
                         "operationId": "redirect_fastapi_fastapi_get",
                         "responses": {"307": {"description": "Successful Response"}},
                     }


### PR DESCRIPTION
This PR fixes minor typos and improves wording consistency across documentation and tests.

Changes include:
- Fix repeated words in English and Portuguese docs
- Standardize "FastAPI" capitalization
- Minor wording corrections in Spanish docs

No functional changes.