### PR TITLE
fix(dependencies): resolve forward ref in Annotated type_annotation

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -411,6 +411,11 @@ def analyze_param(
     if get_origin(use_annotation) is Annotated:
         annotated_args = get_args(annotation)
         type_annotation = annotated_args[0]
+        # Resolve forward reference in type_annotation
+        if isinstance(type_annotation, str):
+            # Try to resolve using endpoint's globalns
+            globalns = getattr(call, "__globals__", {})
+            type_annotation = get_typed_annotation(type_annotation, globalns)
         fastapi_annotations = [
             arg
             for arg in annotated_args[1:]

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -417,7 +417,7 @@ def analyze_param(
             globalns = getattr(call, "__globals__", {})
             type_annotation = get_typed_annotation(type_annotation, globalns)
         # Also handle ForwardRef object (not just string)
-        elif hasattr(type_annotation, '__forward_arg__'):
+        elif hasattr(type_annotation, "__forward_arg__"):
             globalns = getattr(call, "__globals__", {})
             type_annotation = get_typed_annotation(
                 ForwardRef(type_annotation.__forward_arg__),

--- a/fastapi/dependencies/utils.py.bak
+++ b/fastapi/dependencies/utils.py.bak
@@ -416,13 +416,6 @@ def analyze_param(
             # Try to resolve using endpoint's globalns
             globalns = getattr(call, "__globals__", {})
             type_annotation = get_typed_annotation(type_annotation, globalns)
-        # Also handle ForwardRef object (not just string)
-        elif hasattr(type_annotation, '__forward_arg__'):
-            globalns = getattr(call, "__globals__", {})
-            type_annotation = get_typed_annotation(
-                ForwardRef(type_annotation.__forward_arg__),
-                globalns,
-            )
         fastapi_annotations = [
             arg
             for arg in annotated_args[1:]


### PR DESCRIPTION
When using `from __future__ import annotations`, the type inside Annotated remains as a string (forward reference). This fixes issue #13056.

## Fix

In `analyze_param()`, when extracting type_annotation from Annotated, we now resolve forward references using `get_typed_annotation()` which calls `evaluate_forwardref()`.

## Test case

```python
from __future__ import annotations

from dataclasses import dataclass
from typing import Annotated

from fastapi import Depends, FastAPI

app = FastAPI()

def get_potato() -> Potato:
    return Potato(color='red', size=10)

@app.get('/')
async def read_root(potato: Annotated[Potato, Depends(get_potato)]):
    return {'Hello': 'World'}

@dataclass
class Potato:
    color: str
    size: int
```

Fixes: #13056