### PR TITLE
Add example for validating path parameters in error handling docs

### DIFF
--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -243,7 +243,7 @@ If you want to use the exception along with the same default exception handlers 
 
 In this example you are just printing the error with a very expressive message, but you get the idea. You can use the exception and then just reuse the default exception handlers.
 
-### Handling Validation for Path Parameters
+### Handling Validation for Path Parameters { #handling-validation-for-path-parameters }
 
 In real-world applications, you may need to validate input values beyond basic type checking.
 
@@ -265,4 +265,3 @@ def get_user(user_id: int):
 ```
 This ensures that invalid values are handled gracefully and provides clear feedback to API clients.
 You can also use validation libraries like Pydantic for more complex constraints.
-

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -242,3 +242,27 @@ If you want to use the exception along with the same default exception handlers 
 {* ../../docs_src/handling_errors/tutorial006_py310.py hl[2:5,15,21] *}
 
 In this example you are just printing the error with a very expressive message, but you get the idea. You can use the exception and then just reuse the default exception handlers.
+
+### Handling Validation for Path Parameters
+
+In real-world applications, you may need to validate input values beyond basic type checking.
+
+For example, ensuring that an ID is a positive number:
+
+```python
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI()
+
+@app.get("/users/{user_id}")
+def get_user(user_id: int):
+    if user_id <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="User ID must be a positive integer"
+        )
+    return {"user_id": user_id}
+```
+This ensures that invalid values are handled gracefully and provides clear feedback to API clients.
+You can also use validation libraries like Pydantic for more complex constraints.
+


### PR DESCRIPTION
## Description

Added a practical example demonstrating validation for path parameters using HTTPException.

## Changes

- Added example to validate that user_id is a positive integer
- Included explanation for handling invalid inputs gracefully

## Why

This helps developers understand how to implement custom validation logic beyond basic type checking.

## Testing

- Verified documentation locally using 'mkdocs serve'