### PR TITLE
Merge injected BackgroundTasks with Response.background

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -73,6 +73,7 @@ from fastapi.utils import (
     is_body_allowed_for_status_code,
 )
 from starlette import routing
+from starlette.background import BackgroundTasks
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import is_async_callable
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
@@ -679,6 +680,18 @@ def get_request_handler(
                 if isinstance(raw_response, Response):
                     if raw_response.background is None:
                         raw_response.background = solved_result.background_tasks
+                    elif solved_result.background_tasks is not None:
+                        # Merge injected BackgroundTasks with the Response's
+                        # own background task so neither set is lost.
+                        original = raw_response.background
+                        merged = BackgroundTasks(
+                            solved_result.background_tasks.tasks
+                        )
+                        if isinstance(original, BackgroundTasks):
+                            merged.tasks.extend(original.tasks)
+                        else:
+                            merged.tasks.append(original)
+                        raw_response.background = merged
                     response = raw_response
                 else:
                     response_args = _build_response_args(

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -73,9 +73,9 @@ from fastapi.utils import (
     is_body_allowed_for_status_code,
 )
 from starlette import routing
-from starlette.background import BackgroundTasks
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import is_async_callable
+from starlette.background import BackgroundTasks
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
@@ -684,9 +684,7 @@ def get_request_handler(
                         # Merge injected BackgroundTasks with the Response's
                         # own background task so neither set is lost.
                         original = raw_response.background
-                        merged = BackgroundTasks(
-                            solved_result.background_tasks.tasks
-                        )
+                        merged = BackgroundTasks(solved_result.background_tasks.tasks)
                         if isinstance(original, BackgroundTasks):
                             merged.tasks.extend(original.tasks)
                         else:

--- a/tests/test_background_tasks_merge.py
+++ b/tests/test_background_tasks_merge.py
@@ -1,0 +1,142 @@
+"""Tests for merging injected BackgroundTasks with Response.background.
+
+When a route uses both the injected ``BackgroundTasks`` dependency and returns
+a ``Response`` with its own ``background`` parameter, both sets of tasks should
+execute.  Previously, the Response's background task silently overwrote the
+injected tasks.
+
+See: https://github.com/fastapi/fastapi/issues/11215
+"""
+
+from fastapi import FastAPI, BackgroundTasks
+from fastapi.testclient import TestClient
+from starlette.background import BackgroundTask
+from starlette.background import BackgroundTasks as StarletteBackgroundTasks
+from starlette.responses import Response
+
+
+def test_injected_tasks_not_lost_when_response_has_background():
+    """Core bug: injected BackgroundTasks must not be discarded."""
+    results: list[str] = []
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(tasks: BackgroundTasks):
+        tasks.add_task(lambda: results.append("injected"))
+        return Response(
+            content="ok",
+            background=BackgroundTask(lambda: results.append("response")),
+        )
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "injected" in results
+    assert "response" in results
+
+
+def test_injected_tasks_run_before_response_tasks():
+    """Injected tasks should run first (dependency order), then response tasks."""
+    results: list[str] = []
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(tasks: BackgroundTasks):
+        tasks.add_task(lambda: results.append("first"))
+        return Response(
+            content="ok",
+            background=BackgroundTask(lambda: results.append("second")),
+        )
+
+    TestClient(app).get("/")
+    assert results == ["first", "second"]
+
+
+def test_multiple_injected_with_single_response_task():
+    results: list[str] = []
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(tasks: BackgroundTasks):
+        tasks.add_task(lambda: results.append("a"))
+        tasks.add_task(lambda: results.append("b"))
+        return Response(
+            content="ok",
+            background=BackgroundTask(lambda: results.append("c")),
+        )
+
+    TestClient(app).get("/")
+    assert results == ["a", "b", "c"]
+
+
+def test_injected_with_response_background_tasks():
+    """Response.background can also be a BackgroundTasks (not just single task)."""
+    results: list[str] = []
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(tasks: BackgroundTasks):
+        tasks.add_task(lambda: results.append("injected"))
+        bg = StarletteBackgroundTasks()
+        bg.add_task(lambda: results.append("resp1"))
+        bg.add_task(lambda: results.append("resp2"))
+        return Response(content="ok", background=bg)
+
+    TestClient(app).get("/")
+    assert results == ["injected", "resp1", "resp2"]
+
+
+def test_only_injected_tasks_still_works():
+    """No regression: injected tasks without Response.background still work."""
+    results: list[str] = []
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(tasks: BackgroundTasks):
+        tasks.add_task(lambda: results.append("only"))
+        return Response(content="ok")
+
+    TestClient(app).get("/")
+    assert results == ["only"]
+
+
+def test_only_response_background_still_works():
+    """No regression: Response.background without injected tasks still works."""
+    results: list[str] = []
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint():
+        return Response(
+            content="ok",
+            background=BackgroundTask(lambda: results.append("only")),
+        )
+
+    TestClient(app).get("/")
+    assert results == ["only"]
+
+
+def test_no_background_tasks_at_all():
+    """No regression: routes without any background tasks work normally."""
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint():
+        return Response(content="ok")
+
+    response = TestClient(app).get("/")
+    assert response.status_code == 200
+
+
+def test_normal_return_with_injected_tasks():
+    """No regression: non-Response returns with injected tasks still work."""
+    results: list[str] = []
+    app = FastAPI()
+
+    @app.get("/")
+    async def endpoint(tasks: BackgroundTasks):
+        tasks.add_task(lambda: results.append("normal"))
+        return {"ok": True}
+
+    TestClient(app).get("/")
+    assert results == ["normal"]

--- a/tests/test_background_tasks_merge.py
+++ b/tests/test_background_tasks_merge.py
@@ -8,7 +8,7 @@ injected tasks.
 See: https://github.com/fastapi/fastapi/issues/11215
 """
 
-from fastapi import FastAPI, BackgroundTasks
+from fastapi import BackgroundTasks, FastAPI
 from fastapi.testclient import TestClient
 from starlette.background import BackgroundTask
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks


### PR DESCRIPTION
## Summary

Closes #11215

When a route handler uses both the injected `BackgroundTasks` dependency **and** returns a `Response(background=BackgroundTask(...))`, the injected tasks were silently discarded. This was a known footgun [reported in 2024](https://github.com/fastapi/fastapi/issues/11215).

**Before:** Only the Response's background task runs; injected tasks are lost.
**After:** Both sets of tasks are merged — injected tasks run first, then the Response's tasks.

## Change

`fastapi/routing.py` lines 679-691: Instead of the simple conditional:

```python
if raw_response.background is None:
    raw_response.background = solved_result.background_tasks
```

Now merges both sources when both exist:

```python
elif solved_result.background_tasks is not None:
    merged = BackgroundTasks(solved_result.background_tasks.tasks)
    if isinstance(original, BackgroundTasks):
        merged.tasks.extend(original.tasks)
    else:
        merged.tasks.append(original)
    raw_response.background = merged
```

Handles both `BackgroundTask` (single) and `BackgroundTasks` (multiple) on the Response.

## Test plan

- [x] Injected tasks + Response background task — both execute
- [x] Execution order: injected first, then response tasks
- [x] Multiple injected + single response task
- [x] Injected + Response with `BackgroundTasks` (multiple)
- [x] Only injected tasks (no Response.background) — still works
- [x] Only Response.background (no injection) — still works
- [x] No background tasks at all — still works
- [x] Normal dict return with injected tasks — still works
- [x] Existing background_tasks tutorial tests pass
- [x] 51 regression tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)