### PR TITLE
Updated based on feedback to align with FastAPI's validation patterns.

### DIFF
--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -243,26 +243,29 @@ If you want to use the exception along with the same default exception handlers 
 
 In this example you are just printing the error with a very expressive message, but you get the idea. You can use the exception and then just reuse the default exception handlers.
 
-### Handling Validation for Path Parameters
+### Validating Path Parameters
 
-In real-world applications, you may need to validate input values beyond basic type checking.
+FastAPI allows you to validate path parameters using Pydantic validators, similar to query parameter validation.
 
-For example, ensuring that an ID is a positive number:
+For example, to ensure an ID follows a specific format:
 
 ```python
-from fastapi import FastAPI, HTTPException
+from typing import Annotated
+from fastapi import FastAPI
+from pydantic import AfterValidator
 
 app = FastAPI()
 
-@app.get("/users/{user_id}")
-def get_user(user_id: int):
-    if user_id <= 0:
-        raise HTTPException(
-            status_code=400,
-            detail="User ID must be a positive integer"
-        )
-    return {"user_id": user_id}
-```
-This ensures that invalid values are handled gracefully and provides clear feedback to API clients.
-You can also use validation libraries like Pydantic for more complex constraints.
+def check_valid_id(id: str) -> str:
+    if not id.startswith(("isbn-", "imdb-")):
+        raise ValueError('Invalid ID format, it must start with "isbn-" or "imdb-"')
+    return id
 
+ValidID = Annotated[str, AfterValidator(check_valid_id)]
+
+@app.get("/items/{item_id}")
+def read_item(item_id: ValidID):
+    return {"item_id": item_id}
+```
+This approach ensures validation happens before the request reaches your path operation function, 
+keeping your code clean and consistent.

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -242,3 +242,27 @@ If you want to use the exception along with the same default exception handlers 
 {* ../../docs_src/handling_errors/tutorial006_py310.py hl[2:5,15,21] *}
 
 In this example you are just printing the error with a very expressive message, but you get the idea. You can use the exception and then just reuse the default exception handlers.
+
+### Handling Validation for Path Parameters
+
+In real-world applications, you may need to validate input values beyond basic type checking.
+
+For example, ensuring that an ID is a positive number:
+
+```python
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI()
+
+@app.get("/users/{user_id}")
+def get_user(user_id: int):
+    if user_id <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="User ID must be a positive integer"
+        )
+    return {"user_id": user_id}
+```
+This ensures that invalid values are handled gracefully and provides clear feedback to API clients.
+You can also use validation libraries like Pydantic for more complex constraints.
+

--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -243,7 +243,7 @@ If you want to use the exception along with the same default exception handlers 
 
 In this example you are just printing the error with a very expressive message, but you get the idea. You can use the exception and then just reuse the default exception handlers.
 
-### Validating Path Parameters
+### Validating Path Parameters { #validating-path-parameters }
 
 FastAPI allows you to validate path parameters using Pydantic validators, similar to query parameter validation.
 
@@ -267,5 +267,5 @@ ValidID = Annotated[str, AfterValidator(check_valid_id)]
 def read_item(item_id: ValidID):
     return {"item_id": item_id}
 ```
-This approach ensures validation happens before the request reaches your path operation function, 
+This approach ensures validation happens before the request reaches your path operation function,
 keeping your code clean and consistent.


### PR DESCRIPTION
**Description**

Updated the example to demonstrate validation of path parameters using Pydantic's AfterValidator, aligning with FastAPI's recommended approach.

**Changes**

- Replaced manual validation with Annotated + AfterValidator
- Added example for validating structured ID formats

**Why**

This follows FastAPI's best practices and ensures validation occurs before entering the path operation function.

**Testing**

- Verified documentation locally using mkdocs serve