### PR TITLE
fix: resolve ForwardRef inside Annotated in get_typed_annotation

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -245,9 +245,22 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
 def get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
     if isinstance(annotation, str):
         annotation = ForwardRef(annotation)
-        annotation = evaluate_forwardref(annotation, globalns, globalns)
+    if isinstance(annotation, ForwardRef):
+        annotation = evaluate_forwardref(annotation, globalns, globalns)  # ty: ignore[deprecated]
         if annotation is type(None):
             return None
+    # Resolve any ForwardRef inside the first argument of Annotated.
+    # Python automatically wraps string args in ForwardRef, e.g.:
+    #   Annotated["Potato", Depends(get_potato)]
+    # becomes Annotated[ForwardRef("Potato"), Depends(get_potato)] at runtime.
+    # Without this, FastAPI never sees the resolved type and treats the
+    # parameter as Any, producing an incorrect OpenAPI schema.
+    if get_origin(annotation) is Annotated:
+        args = get_args(annotation)
+        first_arg = args[0]
+        if isinstance(first_arg, (str, ForwardRef)):
+            resolved_first = get_typed_annotation(first_arg, globalns)
+            annotation = Annotated[tuple([resolved_first] + list(args[1:]))]
     return annotation
 
 


### PR DESCRIPTION
## Problem

Using a string literal as the first argument of `Annotated` causes FastAPI to treat the parameter as `Any`, producing an incorrect OpenAPI schema.

This affects two related cases:

**Case 1 — explicit string in `Annotated`:**
```python
@app.post('/')
async def endpoint(potato: Annotated["Potato", Depends(get_potato)]):
    ...
```
Python automatically creates `Annotated[ForwardRef("Potato"), Depends(get_potato)]`. Because `get_typed_annotation` only resolved the annotation itself (if it was a top-level string), the `ForwardRef` inside `Annotated` was never resolved.

**Case 2 — `from __future__ import annotations` with `Annotated`:**
```python
from __future__ import annotations

@app.post('/')
async def endpoint(potato: Annotated[Potato, Depends(get_potato)]):
    ...
```
With PEP 563, annotations are stored as strings. `inspect.signature(call, eval_str=True)` raises `NameError` (if `Potato` is defined later in the module), FastAPI falls back to the raw string, `evaluate_forwardref` produces `Annotated[ForwardRef("Potato"), Depends(...)]` — and the same unresolved ForwardRef problem occurs.

**Result in both cases:** `potato` appears as a plain query parameter with type `any` in the OpenAPI schema instead of being recognised as a dependency injection.

Closes #13056

## Fix

Two small changes to `get_typed_annotation`:

1. **Handle `ForwardRef` inputs directly** (not just `str`):
   ```python
   if isinstance(annotation, str):
       annotation = ForwardRef(annotation)
   if isinstance(annotation, ForwardRef):   # was: inside the `if str` branch
       annotation = evaluate_forwardref(...)
   ```

2. **Recursively resolve `ForwardRef` inside `Annotated`'s first argument:**
   ```python
   if get_origin(annotation) is Annotated:
       args = get_args(annotation)
       first_arg = args[0]
       if isinstance(first_arg, (str, ForwardRef)):
           resolved_first = get_typed_annotation(first_arg, globalns)
           annotation = Annotated[tuple([resolved_first] + list(args[1:]))]
   ```

All needed imports (`Annotated`, `ForwardRef`, `get_args`, `get_origin`) were already present.

> **Note:** When `Potato` is defined *after* the route decorator in a `from __future__ import annotations` module, the ForwardRef still cannot be resolved at decorator time since Python executes the module top-to-bottom. A full fix for that pattern requires deferred/lazy annotation evaluation — tracked separately. This PR fixes the cases where the referenced type IS available at the time the route is registered.