### PR TITLE
Alternative to #12066 - fix deadlock with thread overflow using "overflow" threads

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,53 +1,63 @@
+import functools
 from collections.abc import AsyncGenerator, Callable, Iterable
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import ParamSpec, TypeVar
+from typing import Literal, ParamSpec, TypeVar
 
 import anyio.to_thread
 from anyio import CapacityLimiter
 from starlette.concurrency import (
-    iterate_in_threadpool as _starlette_iterate_in_threadpool,
-)
-from starlette.concurrency import run_in_threadpool as _starlette_run_in_threadpool
-from starlette.concurrency import (
-    run_until_first_complete as _starlette_run_until_first_complete,
+    _next,
+    _StopIteration,
+    run_until_first_complete,  # noqa
 )
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
-# The default threadpool in anyio is 40. This limiter keeps one thread
-# for teardown tasks in order to prevent deadlocks when there is a pool
-# of finite resources (e.g. database connections) which threads will block
-# on trying to acquire.
-# NOTE: we defer instantiation until runtime since we must support anyio's trio backend
+# A pair of limiters keep one thread for teardown tasks in order to prevent deadlocks
+# when there is a pool of finite resources (e.g. database connections) which threads will
+# block on trying to acquire.
+# NOTE: we cannot use anyio's default limiter, since other libraries will not respect the
+# anti-deadlock reserve and may use up all available threads - we maintain our own pool.
+_global_capacity_limiter: CapacityLimiter | None = None
 _anti_deadlock_capacity_limiter: CapacityLimiter | None = None
 
 
-def _get_anti_deadlock_capacity_limiter() -> CapacityLimiter:
-    global _anti_deadlock_capacity_limiter
-    if _anti_deadlock_capacity_limiter is None:
+def _get_capacity_limiter(kind: Literal["global", "anti_deadlock"]) -> CapacityLimiter:
+    global _global_capacity_limiter, _anti_deadlock_capacity_limiter
+    if _global_capacity_limiter is None:
         global_limit = anyio.to_thread.current_default_thread_limiter().total_tokens
+        _global_capacity_limiter = CapacityLimiter(global_limit)
         _anti_deadlock_capacity_limiter = CapacityLimiter(global_limit - 1)
-    return _anti_deadlock_capacity_limiter
+    return (
+        _anti_deadlock_capacity_limiter
+        if kind == "anti_deadlock"
+        else _global_capacity_limiter
+    )
 
 
+# These are vendored from starlette to allow setting our own thread limiter
 async def run_in_threadpool(
     func: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
 ) -> _T:
-    async with _get_anti_deadlock_capacity_limiter():
-        return await _starlette_run_in_threadpool(func, *args, **kwargs)
+    async with _get_capacity_limiter("anti_deadlock"):
+        func = functools.partial(func, *args, **kwargs)
+        return await anyio.to_thread.run_sync(
+            func, limiter=_get_capacity_limiter("global")
+        )
 
 
 async def iterate_in_threadpool(iterator: Iterable[_T]) -> AsyncGenerator[_T, None]:
-    async with _get_anti_deadlock_capacity_limiter():
-        async for item in _starlette_iterate_in_threadpool(iterator):
-            yield item
-
-
-async def run_until_first_complete(*args: tuple[Callable, dict]) -> None:  # type: ignore[type-arg]
-    async with _get_anti_deadlock_capacity_limiter():
-        return await _starlette_run_until_first_complete(*args)
+    async with _get_capacity_limiter("anti_deadlock"):
+        as_iterator = iter(iterator)
+        while True:
+            try:
+                yield await anyio.to_thread.run_sync(
+                    _next, as_iterator, limiter=_get_capacity_limiter("global")
+                )
+            except _StopIteration:
+                break
 
 
 # NOTE: a separate function is required only because mypy dislikes trying to add
@@ -60,7 +70,8 @@ async def _run_in_threadpool_with_overflow(
     Unless you know what you are doing you probably do not want to use this function.
     It has access to the entire thread pool, including the anti-deadlock reserve threads.
     """
-    return await _starlette_run_in_threadpool(func, *args, **kwargs)
+    func = functools.partial(func, *args, **kwargs)
+    return await anyio.to_thread.run_sync(func, limiter=_global_capacity_limiter)
 
 
 def set_thread_limit(limit: int = 40, anti_deadlock_reserve: int = 1) -> None:
@@ -82,8 +93,8 @@ def set_thread_limit(limit: int = 40, anti_deadlock_reserve: int = 1) -> None:
     if not 0 < anti_deadlock_reserve < limit - 1:
         raise ValueError("Anti deadlock reserve must be between 0 and limit - 1.")
 
-    anyio.to_thread.current_default_thread_limiter().total_tokens = limit
-    _get_anti_deadlock_capacity_limiter().total_tokens = limit - anti_deadlock_reserve
+    _get_capacity_limiter("global").total_tokens = limit
+    _get_capacity_limiter("anti_deadlock").total_tokens = limit - anti_deadlock_reserve
 
 
 @asynccontextmanager

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -94,20 +94,15 @@ async def contextmanager_in_threadpool(
     # can create race conditions/deadlocks if the context manager itself
     # has its own internal pool (e.g. a database connection pool)
     # to avoid this we let __exit__ run without a capacity limit
-    # since we're creating a new limiter for each call, any non-zero limit
-    # works (1 is arbitrary)
-    exit_limiter = CapacityLimiter(1)
     try:
         yield await run_in_threadpool(cm.__enter__)
     except Exception as e:
         ok = bool(
-            await anyio.to_thread.run_sync(
-                cm.__exit__, type(e), e, e.__traceback__, limiter=exit_limiter
+            await _run_in_threadpool_with_overflow(
+                cm.__exit__, type(e), e, e.__traceback__
             )
         )
         if not ok:
             raise e
     else:
-        await anyio.to_thread.run_sync(
-            cm.__exit__, None, None, None, limiter=exit_limiter
-        )
+        await _run_in_threadpool_with_overflow(cm.__exit__, None, None, None)

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -63,6 +63,29 @@ async def _run_in_threadpool_with_overflow(
     return await _starlette_run_in_threadpool(func, *args, **kwargs)
 
 
+def set_thread_limit(limit: int = 40, anti_deadlock_reserve: int = 1) -> None:
+    """
+    Set the maximum number of threads that can be used by the thread pool.
+
+    This is a global setting that affects all calls to `run_in_threadpool` and
+    `iterate_in_threadpool`.
+    """
+    if not isinstance(limit, int):
+        raise TypeError("Thread limit must be an integer.")
+
+    if not isinstance(anti_deadlock_reserve, int):
+        raise TypeError("Anti deadlock reserve must be an integer.")
+
+    if limit < 2:
+        raise ValueError("Thread limit must be at least 2.")
+
+    if not 0 < anti_deadlock_reserve < limit - 1:
+        raise ValueError("Anti deadlock reserve must be between 0 and limit - 1.")
+
+    anyio.to_thread.current_default_thread_limiter().total_tokens = limit
+    _get_anti_deadlock_capacity_limiter().total_tokens = limit - anti_deadlock_reserve
+
+
 @asynccontextmanager
 async def contextmanager_in_threadpool(
     cm: AbstractContextManager[_T],

--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,17 +1,66 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable, Iterable
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import ParamSpec, TypeVar
 
 import anyio.to_thread
 from anyio import CapacityLimiter
-from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
-from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa
-from starlette.concurrency import (  # noqa
-    run_until_first_complete as run_until_first_complete,
+from starlette.concurrency import (
+    iterate_in_threadpool as _starlette_iterate_in_threadpool,
+)
+from starlette.concurrency import run_in_threadpool as _starlette_run_in_threadpool
+from starlette.concurrency import (
+    run_until_first_complete as _starlette_run_until_first_complete,
 )
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
+
+# The default threadpool in anyio is 40. This limiter keeps one thread
+# for teardown tasks in order to prevent deadlocks when there is a pool
+# of finite resources (e.g. database connections) which threads will block
+# on trying to acquire.
+# NOTE: we defer instantiation until runtime since we must support anyio's trio backend
+_anti_deadlock_capacity_limiter: CapacityLimiter | None = None
+
+
+def _get_anti_deadlock_capacity_limiter() -> CapacityLimiter:
+    global _anti_deadlock_capacity_limiter
+    if _anti_deadlock_capacity_limiter is None:
+        global_limit = anyio.to_thread.current_default_thread_limiter().total_tokens
+        _anti_deadlock_capacity_limiter = CapacityLimiter(global_limit - 1)
+    return _anti_deadlock_capacity_limiter
+
+
+async def run_in_threadpool(
+    func: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
+) -> _T:
+    async with _get_anti_deadlock_capacity_limiter():
+        return await _starlette_run_in_threadpool(func, *args, **kwargs)
+
+
+async def iterate_in_threadpool(iterator: Iterable[_T]) -> AsyncGenerator[_T, None]:
+    async with _get_anti_deadlock_capacity_limiter():
+        async for item in _starlette_iterate_in_threadpool(iterator):
+            yield item
+
+
+async def run_until_first_complete(*args: tuple[Callable, dict]) -> None:  # type: ignore[type-arg]
+    async with _get_anti_deadlock_capacity_limiter():
+        return await _starlette_run_until_first_complete(*args)
+
+
+# NOTE: a separate function is required only because mypy dislikes trying to add
+# a boolean flag along side the param spec
+async def _run_in_threadpool_with_overflow(
+    func: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
+) -> _T:
+    """Run a function in the thread pool, allowing it to use the overflow threads.
+
+    Unless you know what you are doing you probably do not want to use this function.
+    It has access to the entire thread pool, including the anti-deadlock reserve threads.
+    """
+    return await _starlette_run_in_threadpool(func, *args, **kwargs)
 
 
 @asynccontextmanager

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -53,6 +53,7 @@ from fastapi.background import BackgroundTasks
 from fastapi.concurrency import (
     asynccontextmanager,
     contextmanager_in_threadpool,
+    run_in_threadpool,
 )
 from fastapi.dependencies.models import Dependant
 from fastapi.exceptions import DependencyScopeError
@@ -63,7 +64,6 @@ from fastapi.utils import create_model_field, get_path_param_names
 from pydantic import BaseModel, Json
 from pydantic.fields import FieldInfo
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
-from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import (
     FormData,
     Headers,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -38,6 +38,11 @@ from fastapi._compat import (
     Undefined,
     lenient_issubclass,
 )
+from fastapi.concurrency import (
+    _run_in_threadpool_with_overflow,
+    iterate_in_threadpool,
+    run_in_threadpool,
+)
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import (
@@ -75,7 +80,6 @@ from fastapi.utils import (
 from starlette import routing
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import is_async_callable
-from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
@@ -292,7 +296,7 @@ async def serialize_response(
         if is_coroutine:
             value, errors = field.validate(response_content, {}, loc=("response",))
         else:
-            value, errors = await run_in_threadpool(
+            value, errors = await _run_in_threadpool_with_overflow(
                 field.validate, response_content, {}, loc=("response",)
             )
         if errors:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,5 +1,7 @@
 from collections.abc import Iterator
+from typing import Any
 
+import anyio
 import pytest
 from fastapi import concurrency
 
@@ -28,3 +30,37 @@ async def test_iterate_in_threadpool(_reset_capacity_limiter: None) -> None:
         result.append(item)
 
     assert result == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.parametrize(
+    "limit, anti_deadlock_reserve, error_kind",
+    [
+        ("not an int", 2, TypeError),
+        (10, "not an int", TypeError),
+        (1, 0, ValueError),
+        (10, 0, ValueError),
+        (10, 9, ValueError),
+    ],
+)
+def test_set_thread_limit_invalid_args(
+    limit: Any, anti_deadlock_reserve: Any, error_kind: type[Exception]
+) -> None:
+    with pytest.raises(error_kind):
+        concurrency.set_thread_limit(limit, anti_deadlock_reserve)
+
+
+@pytest.mark.anyio
+async def test_set_thread_limit(_reset_capacity_limiter: None) -> None:
+    original_total_tokens = (
+        anyio.to_thread.current_default_thread_limiter().total_tokens
+    )
+
+    try:
+        concurrency.set_thread_limit(10, anti_deadlock_reserve=2)
+        assert concurrency._anti_deadlock_capacity_limiter.total_tokens == 8
+        assert anyio.to_thread.current_default_thread_limiter().total_tokens == 10
+    finally:
+        # Restore original settings to avoid affecting other tests
+        anyio.to_thread.current_default_thread_limiter().total_tokens = (
+            original_total_tokens
+        )

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -10,8 +10,10 @@ from fastapi import concurrency
 def _reset_capacity_limiter() -> Iterator[None]:
     # Reset the capacity limiter before each test to ensure a clean slate
     concurrency._anti_deadlock_capacity_limiter = None
+    concurrency._global_capacity_limiter = None
     yield
     concurrency._anti_deadlock_capacity_limiter = None
+    concurrency._global_capacity_limiter = None
 
 
 @pytest.mark.anyio
@@ -51,16 +53,16 @@ def test_set_thread_limit_invalid_args(
 
 @pytest.mark.anyio
 async def test_set_thread_limit(_reset_capacity_limiter: None) -> None:
-    original_total_tokens = (
+    original_default_thread_limit = (
         anyio.to_thread.current_default_thread_limiter().total_tokens
     )
 
-    try:
-        concurrency.set_thread_limit(10, anti_deadlock_reserve=2)
-        assert concurrency._anti_deadlock_capacity_limiter.total_tokens == 8
-        assert anyio.to_thread.current_default_thread_limiter().total_tokens == 10
-    finally:
-        # Restore original settings to avoid affecting other tests
-        anyio.to_thread.current_default_thread_limiter().total_tokens = (
-            original_total_tokens
-        )
+    concurrency.set_thread_limit(10, anti_deadlock_reserve=2)
+    assert concurrency._anti_deadlock_capacity_limiter.total_tokens == 8
+    assert concurrency._global_capacity_limiter.total_tokens == 10
+
+    # default anyio token limiter not affected
+    assert (
+        anyio.to_thread.current_default_thread_limiter().total_tokens
+        == original_default_thread_limit
+    )

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,30 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi import concurrency
+
+
+@pytest.fixture
+def _reset_capacity_limiter() -> Iterator[None]:
+    # Reset the capacity limiter before each test to ensure a clean slate
+    concurrency._anti_deadlock_capacity_limiter = None
+    yield
+    concurrency._anti_deadlock_capacity_limiter = None
+
+
+@pytest.mark.anyio
+async def test_run_in_threadpool(_reset_capacity_limiter: None) -> None:
+    def blocking_function(x: int, y: int) -> int:
+        return x + y
+
+    result = await concurrency.run_in_threadpool(blocking_function, 1, y=2)
+    assert result == 3
+
+
+@pytest.mark.anyio
+async def test_iterate_in_threadpool(_reset_capacity_limiter: None) -> None:
+    result = []
+    async for item in concurrency.iterate_in_threadpool(range(5)):
+        result.append(item)
+
+    assert result == [0, 1, 2, 3, 4]

--- a/tests/test_depends_deadlock.py
+++ b/tests/test_depends_deadlock.py
@@ -1,0 +1,56 @@
+import asyncio
+import threading
+import time
+from collections.abc import Iterator
+
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+
+# Mutex, acting as our "connection pool" for a database for example
+mutex_pool = threading.Lock()
+
+
+# Simulate releaasing a pooled resource in the teardown of a Depends,
+# which in reality is usually a database connection or similar.
+def release_resource() -> Iterator[None]:
+    try:
+        time.sleep(0.001)
+        yield
+    finally:
+        time.sleep(0.001)
+        mutex_pool.release()
+
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    id: int
+
+
+# An endpoint that uses Depends for resource management and also includes
+# a response_model definition would previously deadlock in the validation
+# of the model and the cleanup of the Depends
+@app.get("/deadlock", response_model=Item)
+def get_deadlock(dep: None = Depends(release_resource)):
+    mutex_pool.acquire()
+    return Item(name="foo", id=1)
+
+
+# Fire off 100 requests in parallel(ish) in order to create contention
+# over the shared resource (simulating a fastapi server that interacts with
+# a database connection pool).
+def test_depends_deadlock():
+    async def make_request(client: AsyncClient):
+        await client.get("/deadlock")
+
+    async def run_requests():
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as aclient:
+            tasks = [make_request(aclient) for _ in range(100)]
+            await asyncio.gather(*tasks)
+
+    asyncio.run(run_requests())


### PR DESCRIPTION
This is an alternative to creating a separate CapacityLimiter to run critical-path tasks when the main threadpool is full. Mostly it exists since I'm not sure how to create a pull request on a pull request?

# what

This reserves 1 thread that can only be used by critical-path tasks. Those tasks are also free to use the rest of the threadpool, but at least one thread is reserved only for them.

To do this, it introduces more functions into `fastapi.concurrency` to replace the ones imported from starlette

- `run_in_threadpool`
- `iterate_in_threadpool`
- `run_until_first_complete`

together with a private method `_run_in_threadpool_with_overflow` that the critical functions can use.

We also added a `set_thread_limit` method, because it's now ineffective to directly modify the default thread limiter in anyio.

# how

This just limits the above functions using a separate limiter with capacity 1 less than the default global anyio limiter.

# why

see https://github.com/fastapi/fastapi/pull/12066

# limitations

~~It will still be possible for downstream users to deadlock the threadpool if they bypass the new CapacityLimiter - for instance by directly calling `anyio`'s threadpool primitives, instead of using the above functions in order to acquire resources.~~

In the end I used a dedicated global CapacityLimiter for fastapi to remove the possibility of 3rd party libraries (or downstream users) taking the extra thread we are reserving. That means that fastapi and other libraries will use different threadpools. That seems to be the only way to make the solution robust to other libraries "stealing" the final anti-deadlock thread