### PR TITLE
docs: replace "re-use" in query parameter models

### DIFF
--- a/docs/en/docs/tutorial/query-param-models.md
+++ b/docs/en/docs/tutorial/query-param-models.md
@@ -2,7 +2,7 @@
 
 If you have a group of **query parameters** that are related, you can create a **Pydantic model** to declare them.
 
-This would allow you to **re-use the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
+This would allow you to **reuse the model** in **multiple places** and also to declare validations and metadata for all the parameters at once. 😎
 
 /// note
 


### PR DESCRIPTION
## Summary
- Replace \"re-use\" with \"reuse\" in the query parameter models guide

## Related issue
- N/A (trivial docs-only wording fix)

## Guideline alignment
- Followed `CONTRIBUTING.md`, which points to the FastAPI contributing guide: https://fastapi.tiangolo.com/contributing/
- Keeps the change docs-only, single-file, and sentence-scoped

## Validation/testing
- Not run; docs-only wording change