### PR TITLE
docs(readme): clarify production run command after fastapi dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ The command `fastapi dev` reads your `main.py` file automatically, detects the *
 
 By default, `fastapi dev` will start with auto-reload enabled for local development.
 
+When you are ready to run the same app without auto-reload for production, use `fastapi run`.
+
 You can read more about it in the [FastAPI CLI docs](https://fastapi.tiangolo.com/fastapi-cli/).
 
 </details>


### PR DESCRIPTION
## What changed

Clarified the README to distinguish between:

- `fastapi dev` = development mode with auto-reload
- `fastapi run` = production mode without reload

## Why

Many beginners accidentally deploy with `fastapi dev` in production, which enables auto-reload and is not suitable for live environments. This makes the distinction explicit.