### PR TITLE
docs: replace "re-using" with "reusing" in security tutorial

### DIFF
--- a/docs/en/docs/tutorial/security/get-current-user.md
+++ b/docs/en/docs/tutorial/security/get-current-user.md
@@ -88,7 +88,7 @@ And you can make it as complex as you want. And still, have it written only once
 
 But you can have thousands of endpoints (*path operations*) using the same security system.
 
-And all of them (or any portion of them that you want) can take advantage of re-using these dependencies or any other dependencies you create.
+And all of them (or any portion of them that you want) can take advantage of reusing these dependencies or any other dependencies you create.
 
 And all these thousands of *path operations* can be as small as 3 lines:
 


### PR DESCRIPTION
## Summary
- Replace `re-using` with `reusing` in `docs/en/docs/tutorial/security/get-current-user.md`.

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- Followed the contributing guidance from `CONTRIBUTING.md` and the FastAPI docs.
- Single-file, docs-only correction.

## Validation
- Not run; docs-only wording change.