### PR TITLE
docs: replace "dependant" with "dependent" in heading

### DIFF
--- a/docs/en/docs/tutorial/dependencies/index.md
+++ b/docs/en/docs/tutorial/dependencies/index.md
@@ -65,7 +65,7 @@ Make sure you [Upgrade the FastAPI version](../../deployment/versions.md#upgradi
 
 {* ../../docs_src/dependencies/tutorial001_an_py310.py hl[3] *}
 
-### Declare the dependency, in the "dependant" { #declare-the-dependency-in-the-dependant }
+### Declare the dependency, in the "dependent" { #declare-the-dependency-in-the-dependent }
 
 The same way you use `Body`, `Query`, etc. with your *path operation function* parameters, use `Depends` with a new parameter:
 


### PR DESCRIPTION
## Summary
- Replace `dependant` with `dependent` in a section heading in `docs/en/docs/tutorial/dependencies/index.md`.

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- Followed the contributing guidance from `CONTRIBUTING.md` and the FastAPI docs.
- Single-file, docs-only correction.

## Validation
- Not run; docs-only wording change.