### PR TITLE
fix: replace innerHTML with safe DOM methods in termynal.js

### DIFF
--- a/docs/en/docs/js/termynal.js
+++ b/docs/en/docs/js/termynal.js
@@ -222,10 +222,18 @@ class Termynal {
      */
     lineDataToElements(lineData) {
         return lineData.map(line => {
-            let div = document.createElement('div');
-            div.innerHTML = `<span ${this._attributes(line)}>${line.value || ''}</span>`;
-
-            return div.firstElementChild;
+            const span = document.createElement('span');
+            for (let prop in line) {
+                if (prop === 'class') {
+                    span.className = line[prop];
+                } else if (prop === 'type') {
+                    span.setAttribute(this.pfx, line[prop]);
+                } else if (prop !== 'value') {
+                    span.setAttribute(`${this.pfx}-${prop}`, line[prop]);
+                }
+            }
+            span.textContent = line.value || '';
+            return span;
         });
     }
 


### PR DESCRIPTION
Resubmit of security fix for termynal.js DOM injection via innerHTML. See discussion on PR #15381 for full attack scenario details.