### PR TITLE
🐛 fix deadlocks in depends by using a separate CapacityLimiter for teardown

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,7 +1,8 @@
-from collections.abc import AsyncGenerator
+import functools
+from collections.abc import AsyncGenerator, Callable
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import ParamSpec, TypeVar
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -11,31 +12,44 @@ from starlette.concurrency import (  # noqa
     run_until_first_complete as run_until_first_complete,
 )
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
+
+# Blocking __exit__ and other teardown operations from running can create race
+# conditions/deadlocks if the context manager itself has its own internal pool
+# (e.g. a database connection pool).
+# To avoid this maintain a separate limiter for teardown operations, so that the
+# operations acquiring resources can never block operations releasing resources.
+# NOTE: 5 is arbitrary, we would like more than 1 so that teardowns are not serialised.
+_teardown_limiter = CapacityLimiter(5)
 
 
 @asynccontextmanager
 async def contextmanager_in_threadpool(
     cm: AbstractContextManager[_T],
 ) -> AsyncGenerator[_T, None]:
-    # blocking __exit__ from running waiting on a free thread
-    # can create race conditions/deadlocks if the context manager itself
-    # has its own internal pool (e.g. a database connection pool)
-    # to avoid this we let __exit__ run without a capacity limit
-    # since we're creating a new limiter for each call, any non-zero limit
-    # works (1 is arbitrary)
-    exit_limiter = CapacityLimiter(1)
     try:
         yield await run_in_threadpool(cm.__enter__)
     except Exception as e:
         ok = bool(
-            await anyio.to_thread.run_sync(
-                cm.__exit__, type(e), e, e.__traceback__, limiter=exit_limiter
-            )
+            await run_in_teardown_threadpool(cm.__exit__, type(e), e, e.__traceback__)
         )
         if not ok:
             raise e
     else:
-        await anyio.to_thread.run_sync(
-            cm.__exit__, None, None, None, limiter=exit_limiter
-        )
+        await run_in_teardown_threadpool(cm.__exit__, None, None, None)
+
+
+async def run_in_teardown_threadpool(
+    func: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs
+) -> _T:
+    """Run a function in the separate teardown threadpool.
+
+    This will run the function in the teardown threadpool in order to avoid it
+    being blocked by other operations waiting to acquire resources.
+
+    Unless you know what you are doing, you probably don't want this function,
+    use run_in_threadpool instead.
+    """
+    func = functools.partial(func, *args, **kwargs)
+    return await anyio.to_thread.run_sync(func, limiter=_teardown_limiter)

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -38,6 +38,11 @@ from fastapi._compat import (
     Undefined,
     lenient_issubclass,
 )
+from fastapi.concurrency import (
+    iterate_in_threadpool,
+    run_in_teardown_threadpool,
+    run_in_threadpool,
+)
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import (
@@ -75,7 +80,6 @@ from fastapi.utils import (
 from starlette import routing
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import is_async_callable
-from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
@@ -292,7 +296,7 @@ async def serialize_response(
         if is_coroutine:
             value, errors = field.validate(response_content, {}, loc=("response",))
         else:
-            value, errors = await run_in_threadpool(
+            value, errors = await run_in_teardown_threadpool(
                 field.validate, response_content, {}, loc=("response",)
             )
         if errors:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -46,6 +46,11 @@ from fastapi._compat import (
     Undefined,
     lenient_issubclass,
 )
+from fastapi.concurrency import (
+    iterate_in_threadpool,
+    run_in_teardown_threadpool,
+    run_in_threadpool,
+)
 from fastapi.datastructures import Default, DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import (
@@ -83,7 +88,6 @@ from fastapi.utils import (
 from starlette import routing
 from starlette._exception_handler import wrap_app_handling_exceptions
 from starlette._utils import get_route_path, is_async_callable
-from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import URL, FormData, URLPath
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
@@ -308,7 +312,7 @@ async def serialize_response(
         if is_coroutine:
             value, errors = field.validate(response_content, {}, loc=("response",))
         else:
-            value, errors = await run_in_threadpool(
+            value, errors = await run_in_teardown_threadpool(
                 field.validate, response_content, {}, loc=("response",)
             )
         if errors:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,68 @@
+import contextlib
+import time
+from collections.abc import Iterator
+
+import anyio.to_thread
+import pytest
+from anyio import CapacityLimiter
+from fastapi import concurrency
+
+
+@pytest.fixture
+def reset_teardown_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the teardown limiter before/after tests to avoid interference
+    between different anyio backends."""
+    monkeypatch.setattr(concurrency, "_teardown_limiter", CapacityLimiter(5))
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("reset_teardown_limiter")
+async def test_run_in_teardown_threadpool() -> None:
+    def func(x: int, y: int) -> int:
+        return x + y
+
+    result = await concurrency.run_in_teardown_threadpool(func, 1, y=2)
+    assert result == 3
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("reset_teardown_limiter")
+async def test_contextmanager_in_threadpool() -> None:
+    @contextlib.contextmanager
+    def context_manager() -> Iterator[str]:
+        yield "entered"
+
+    async with concurrency.contextmanager_in_threadpool(context_manager()) as result:
+        assert result == "entered"
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("reset_teardown_limiter")
+async def test_competing_acquire_release() -> None:
+    """Check that the main threadpool does not block the teardown threadpool."""
+    pool_size = anyio.to_thread.current_default_thread_limiter().total_tokens
+    acquirable = False
+    acquired = []
+
+    def acquire() -> None:
+        while not acquirable:
+            time.sleep(0.001)
+        acquired.append(True)
+
+    def release() -> bool:
+        nonlocal acquirable
+        time.sleep(0.001)
+        acquirable = True
+        return acquirable
+
+    async with anyio.create_task_group() as tg:
+        for _ in range(pool_size):
+            tg.start_soon(concurrency.run_in_threadpool, acquire)
+
+        await anyio.sleep(0.001)
+
+        # The threadpool should now be full of threads waiting to acquire
+        # The release function should be able to run without being blocked by acquires
+        await concurrency.run_in_teardown_threadpool(release)
+
+    assert len(acquired) == pool_size

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -37,7 +37,6 @@ async def test_contextmanager_in_threadpool() -> None:
 
 
 @pytest.mark.anyio
-@pytest.mark.timeout(10, func_only=True)
 @pytest.mark.usefixtures("reset_teardown_limiter")
 async def test_competing_acquire_release() -> None:
     """Check that the main threadpool does not block the teardown threadpool."""
@@ -46,15 +45,19 @@ async def test_competing_acquire_release() -> None:
     acquired = []
 
     def acquire() -> None:
-        while not acquirable:
+        # We wait a max of 5s to acquire, which should be more than enough
+        for _ in range(5000):
+            if acquirable:
+                break
             time.sleep(0.001)
+
+        assert acquirable, "Failed to acquire resource within timeout"
         acquired.append(True)
 
-    def release() -> bool:
+    def release() -> None:
         nonlocal acquirable
         time.sleep(0.001)
         acquirable = True
-        return acquirable
 
     async with anyio.create_task_group() as tg:
         for _ in range(pool_size):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import time
 from collections.abc import Iterator
@@ -40,7 +41,7 @@ async def test_contextmanager_in_threadpool() -> None:
 @pytest.mark.usefixtures("reset_teardown_limiter")
 async def test_competing_acquire_release() -> None:
     """Check that the main threadpool does not block the teardown threadpool."""
-    pool_size = anyio.to_thread.current_default_thread_limiter().total_tokens
+    pool_size = int(anyio.to_thread.current_default_thread_limiter().total_tokens)
     acquirable = False
     acquired = []
 
@@ -63,6 +64,8 @@ async def test_competing_acquire_release() -> None:
 
         # The threadpool should now be full of threads waiting to acquire
         # The release function should be able to run without being blocked by acquires
-        await concurrency.run_in_teardown_threadpool(release)
+        await asyncio.wait_for(
+            concurrency.run_in_teardown_threadpool(release), timeout=10
+        )
 
     assert len(acquired) == pool_size

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import time
 from collections.abc import Iterator
@@ -38,6 +37,7 @@ async def test_contextmanager_in_threadpool() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.timeout(10, func_only=True)
 @pytest.mark.usefixtures("reset_teardown_limiter")
 async def test_competing_acquire_release() -> None:
     """Check that the main threadpool does not block the teardown threadpool."""
@@ -64,8 +64,6 @@ async def test_competing_acquire_release() -> None:
 
         # The threadpool should now be full of threads waiting to acquire
         # The release function should be able to run without being blocked by acquires
-        await asyncio.wait_for(
-            concurrency.run_in_teardown_threadpool(release), timeout=10
-        )
+        await concurrency.run_in_teardown_threadpool(release)
 
     assert len(acquired) == pool_size

--- a/tests/test_depends_deadlock.py
+++ b/tests/test_depends_deadlock.py
@@ -1,0 +1,56 @@
+import asyncio
+import threading
+import time
+from collections.abc import Iterator
+
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+
+# Mutex, and dependency acting as our "connection pool" for a database for example
+mutex = threading.Lock()
+
+
+# Simulate releaasing a pooled resource in the teardown of a Depends,
+# which in reality is usually a database connection or similar.
+def release_resource() -> Iterator[None]:
+    try:
+        time.sleep(0.001)
+        yield
+    finally:
+        time.sleep(0.001)
+        mutex.release()
+
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    id: int
+
+
+# An endpoint that uses Depends for resource management and also includes
+# a response_model definition would previously deadlock in the validation
+# of the model and the cleanup of the Depends
+@app.get("/deadlock", response_model=Item)
+def get_deadlock(dep: None = Depends(release_resource)) -> Item:
+    mutex.acquire()
+    return Item(name="foo", id=1)
+
+
+# Fire off 100 requests in parallel(ish) in order to create contention
+# over the shared resource (simulating a fastapi server that interacts with
+# a database connection pool).
+def test_depends_deadlock() -> None:
+    async def make_request(client: AsyncClient):
+        await client.get("/deadlock")
+
+    async def run_requests() -> None:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as aclient:
+            tasks = [make_request(aclient) for _ in range(100)]
+            await asyncio.gather(*tasks)
+
+    asyncio.run(run_requests())

--- a/tests/test_depends_deadlock.py
+++ b/tests/test_depends_deadlock.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 mutex = threading.Lock()
 
 
-# Simulate releaasing a pooled resource in the teardown of a Depends,
+# Simulate releasing a pooled resource in the teardown of a Depends,
 # which in reality is usually a database connection or similar.
 def release_resource() -> Iterator[None]:
     try:
@@ -53,4 +53,4 @@ def test_depends_deadlock() -> None:
             tasks = [make_request(aclient) for _ in range(100)]
             await asyncio.gather(*tasks)
 
-    asyncio.run(run_requests())
+    asyncio.run(asyncio.wait_for(run_requests(), timeout=10))

--- a/tests/test_depends_deadlock.py
+++ b/tests/test_depends_deadlock.py
@@ -1,5 +1,4 @@
 import asyncio
-import multiprocessing
 import threading
 import time
 from collections.abc import Iterator
@@ -36,36 +35,14 @@ class Item(BaseModel):
 # of the model and the cleanup of the Depends
 @app.get("/deadlock", response_model=Item)
 def get_deadlock(dep: None = Depends(release_resource)) -> Item:
-    mutex.acquire()
+    mutex.acquire(timeout=10)
     return Item(name="foo", id=1)
-
-
-# NOTE: the failure mode here can cause the test suite to hang.
-# Since the default threadpool is a global which is not easily patched
-# (and doing so would make the test somewhat fragile/pointless)
-# we need to use a subprocess to isolate the bad behaviour.
-# If you are struggling to debug, comment out this function and rename
-# the impl_ version to test_depends_deadlock
-def test_depends_deadlock() -> None:
-
-    proc = multiprocessing.Process(target=impl_test_depends_deadlock, daemon=True)
-    proc.start()
-    proc.join(timeout=10)
-
-    try:
-        assert not proc.is_alive(), (
-            "Process is still alive after timeout, likely due to a deadlock"
-        )
-    finally:
-        proc.kill()  # Ensure the process is terminated if it's still alive
-
-    assert proc.exitcode == 0, "Process did not exit cleanly, see logs for details"
 
 
 # Fire off 100 requests in parallel(ish) in order to create contention
 # over the shared resource (simulating a fastapi server that interacts with
 # a database connection pool).
-def impl_test_depends_deadlock() -> None:
+def test_depends_deadlock() -> None:
     async def make_request(client: AsyncClient):
         await client.get("/deadlock")
 

--- a/tests/test_depends_deadlock.py
+++ b/tests/test_depends_deadlock.py
@@ -3,6 +3,7 @@ import threading
 import time
 from collections.abc import Iterator
 
+import pytest
 from fastapi import Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
@@ -42,6 +43,7 @@ def get_deadlock(dep: None = Depends(release_resource)) -> Item:
 # Fire off 100 requests in parallel(ish) in order to create contention
 # over the shared resource (simulating a fastapi server that interacts with
 # a database connection pool).
+@pytest.mark.timeout(10, func_only=True)
 def test_depends_deadlock() -> None:
     async def make_request(client: AsyncClient):
         await client.get("/deadlock")
@@ -53,4 +55,4 @@ def test_depends_deadlock() -> None:
             tasks = [make_request(aclient) for _ in range(100)]
             await asyncio.gather(*tasks)
 
-    asyncio.run(asyncio.wait_for(run_requests(), timeout=10))
+    asyncio.run(run_requests())

--- a/tests/test_depends_deadlock.py
+++ b/tests/test_depends_deadlock.py
@@ -1,4 +1,5 @@
 import asyncio
+import multiprocessing
 import threading
 import time
 from collections.abc import Iterator
@@ -40,11 +41,30 @@ def get_deadlock(dep: None = Depends(release_resource)) -> Item:
     return Item(name="foo", id=1)
 
 
+# NOTE: the failure mode here can cause the test suite to hang.
+# Since the default threadpool is a global which is not easily patched
+# (and doing so would make the test somewhat fragile/pointless)
+# we need to use a subprocess to isolate the bad behaviour.
+# If you are struggling to debug, comment out this function and rename
+# the impl_ version to test_depends_deadlock
+def test_depends_deadlock() -> None:
+
+    proc = multiprocessing.Process(target=impl_test_depends_deadlock, daemon=True)
+    proc.start()
+    proc.join(timeout=10)
+
+    try:
+        assert not proc.is_alive(), "Process is still alive after timeout, likely due to a deadlock"
+    finally:
+        proc.kill()  # Ensure the process is terminated if it's still alive
+
+    assert proc.exitcode == 0, "Process did not exit cleanly, see logs for details"
+
+
 # Fire off 100 requests in parallel(ish) in order to create contention
 # over the shared resource (simulating a fastapi server that interacts with
 # a database connection pool).
-@pytest.mark.timeout(10, func_only=True)
-def test_depends_deadlock() -> None:
+def impl_test_depends_deadlock() -> None:
     async def make_request(client: AsyncClient):
         await client.get("/deadlock")
 

--- a/tests/test_depends_deadlock.py
+++ b/tests/test_depends_deadlock.py
@@ -4,7 +4,6 @@ import threading
 import time
 from collections.abc import Iterator
 
-import pytest
 from fastapi import Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
@@ -54,7 +53,9 @@ def test_depends_deadlock() -> None:
     proc.join(timeout=10)
 
     try:
-        assert not proc.is_alive(), "Process is still alive after timeout, likely due to a deadlock"
+        assert not proc.is_alive(), (
+            "Process is still alive after timeout, likely due to a deadlock"
+        )
     finally:
         proc.kill()  # Ensure the process is terminated if it's still alive
 


### PR DESCRIPTION
# what

This is https://github.com/fastapi/fastapi/pull/12066 but with a single global "teardown" CapacityLimiter instead of unlimited one-off capacity limiters (and hence threads).

# why

If there is a limited pool of resources, like database connections, we need separate pools of threads for acquiring and releasing those resources, otherwise there will always be deadlocks. However the PR doesn't seem to have moved for a while due to the use of one-off / unlimited CapacityLimiters.

# anything else

We use a fixed, but arbitrary, limit of 5. It seems that a limit of 1 is too low as operations will serialise. Testing locally with a concurrency of 1000 I didn't notice any difference beyond a limit of ~3. Any number under 40 could be deemed "wrong" if the user has expensive teardown operations.

We can still trigger similar deadlocks by releasing resources in the "finally" section of a middleware. However this is not recommended in the documentation (although it's not explicitly prohibited), so I think it's OK.