### PR TITLE
Fix typo "re-used" -> "reused" in Depends/Security docstrings

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -2303,7 +2303,7 @@ def Depends(  # noqa: N802
             By default, after a dependency is called the first time in a request, if
             the dependency is declared again for the rest of the request (for example
             if the dependency is needed by several dependencies), the value will be
-            re-used for the rest of the request.
+            reused for the rest of the request.
 
             Set `use_cache` to `False` to disable this behavior and ensure the
             dependency is called again (if declared more than once) in the same request.
@@ -2411,7 +2411,7 @@ def Security(  # noqa: N802
             By default, after a dependency is called the first time in a request, if
             the dependency is declared again for the rest of the request (for example
             if the dependency is needed by several dependencies), the value will be
-            re-used for the rest of the request.
+            reused for the rest of the request.
 
             Set `use_cache` to `False` to disable this behavior and ensure the
             dependency is called again (if declared more than once) in the same request.


### PR DESCRIPTION

**Repo:** tiangolo/fastapi (⭐ 75000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Replaces the misspelling "re-used" with the standard form "reused" in the
`use_cache` parameter docstrings of both `fastapi.Depends` and `fastapi.Security`
in `fastapi/param_functions.py`. These docstrings are surfaced in IDE tooltips
and in the API reference documentation.

## Why
"re-used" is flagged by `codespell` as a misspelling of "reused" (the standard
unhyphenated form is preferred in modern English and matches the rest of the
FastAPI documentation style). The two occurrences are identical paragraphs
duplicated across the `Depends` and `Security` definitions, so users see this
text in two highly visible public APIs.

## Testing
- Visual diff inspection: only the targeted strings change.
- `codespell fastapi/param_functions.py` no longer reports the two `re-used`
  hits (only the unrelated `dependant` matches remain, which are intentional
  FastAPI-specific terminology).
- No code paths or tests reference the docstring text.

## Risk
Low — comment/docstring-only edit in two adjacent public APIs.
