### PR TITLE
fix(deps): resolve Annotated forward refs with __future__ annotations

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -302,6 +302,8 @@ def get_dependant(
         own_oauth_scopes=own_oauth_scopes,
         parent_oauth_scopes=parent_oauth_scopes,
     )
+    unwrapped_call = inspect.unwrap(call)
+    globalns = getattr(unwrapped_call, "__globals__", {})
     current_scopes = (parent_oauth_scopes or []) + (own_oauth_scopes or [])
     path_param_names = get_path_param_names(path)
     endpoint_signature = get_typed_signature(call)
@@ -313,6 +315,7 @@ def get_dependant(
             annotation=param.annotation,
             value=param.default,
             is_path_param=is_path_param,
+            globalns=globalns,
         )
         if param_details.depends is not None:
             assert param_details.depends.dependency
@@ -396,6 +399,7 @@ def analyze_param(
     annotation: Any,
     value: Any,
     is_path_param: bool,
+    globalns: dict[str, Any] | None = None,
 ) -> ParamDetails:
     field_info = None
     depends = None
@@ -407,10 +411,39 @@ def analyze_param(
     if annotation is not inspect.Signature.empty:
         use_annotation = annotation
         type_annotation = annotation
+    # When ``from __future__ import annotations`` is active, the annotation
+    # may still be a ForwardRef (e.g. ``Annotated[Potato, Depends(...)]``
+    # where *Potato* hasn't been defined yet).  The lenient evaluator leaves
+    # it as a ForwardRef because it cannot resolve *Potato*, but we still
+    # need to unpack the Annotated wrapper so that FastAPI-specific markers
+    # (Depends / Field / Body) are discovered.  We use ``eval`` with a
+    # dict that turns undefined names into ForwardRef objects, which gives
+    # us the same partial-evaluation behaviour that the normal code-path
+    # expects.
+    if isinstance(use_annotation, ForwardRef):
+        if globalns is not None:
+            try:
+                _safe_ns: dict[str, Any] = dict(globalns)
+                _missing = ForwardRef  # noqa: F811
+                class _SafeDict(dict):
+                    def __missing__(self, key):  # type: ignore[override]
+                        return _missing(key)
+                use_annotation = eval(
+                    use_annotation.__forward_arg__, {"__builtins__": {}}, _SafeDict(_safe_ns)
+                )
+                if use_annotation is not inspect.Signature.empty:
+                    type_annotation = use_annotation
+            except Exception:
+                pass
     # Extract Annotated info
     if get_origin(use_annotation) is Annotated:
-        annotated_args = get_args(annotation)
+        annotated_args = get_args(use_annotation)
         type_annotation = annotated_args[0]
+        # Resolve forward references in the inner type (e.g. when using
+        # ``from __future__ import annotations`` with Annotated[..., Depends()])
+        if isinstance(type_annotation, (str, ForwardRef)):
+            if globalns is not None:
+                type_annotation = get_typed_annotation(type_annotation, globalns)
         fastapi_annotations = [
             arg
             for arg in annotated_args[1:]

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -425,11 +425,15 @@ def analyze_param(
             try:
                 _safe_ns: dict[str, Any] = dict(globalns)
                 _missing = ForwardRef  # noqa: F811
+
                 class _SafeDict(dict):
                     def __missing__(self, key):  # type: ignore[override]
                         return _missing(key)
+
                 use_annotation = eval(
-                    use_annotation.__forward_arg__, {"__builtins__": {}}, _SafeDict(_safe_ns)
+                    use_annotation.__forward_arg__,
+                    {"__builtins__": {}},
+                    _SafeDict(_safe_ns),
                 )
                 if use_annotation is not inspect.Signature.empty:
                     type_annotation = use_annotation

--- a/tests/test_annotated_future_annotations.py
+++ b/tests/test_annotated_future_annotations.py
@@ -1,0 +1,79 @@
+"""Regression tests for Annotated forward refs with __future__ annotations.
+
+See https://github.com/fastapi/fastapi/pull/15411
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+
+# ── Positive case: Annotated[ForwardRef, Depends()] before type definition ───
+
+
+def _get_potato() -> Potato:
+    return Potato(skin="brown", mass_g=300)
+
+
+class Potato:
+    def __init__(self, skin: str, mass_g: int):
+        self.skin = skin
+        self.mass_g = mass_g
+
+
+@pytest.fixture(name="client_fwd_dep")
+def client_fwd_dep_fixture() -> TestClient:
+    app = FastAPI()
+
+    @app.get("/potato")
+    async def get_potato(
+        potato: Annotated[Potato, Depends(_get_potato)],
+    ) -> dict:
+        # Potato must be resolved as a **dependency**, not a body field.
+        return {"skin": potato.skin, "mass_g": potato.mass_g}
+
+    @app.get("/potato-twice")
+    async def get_potato_twice(
+        a: Annotated[Potato, Depends(_get_potato)],
+        b: Annotated[Potato, Depends(_get_potato)],
+    ) -> dict:
+        # Multiple deps with the same forward-ref'd type.
+        return {"a_skin": a.skin, "b_skin": b.skin}
+
+    return TestClient(app)
+
+
+def test_annotated_fwd_ref_resolved_as_dependency(client_fwd_dep: TestClient):
+    """Annotated[UndefinedType, Depends(...)] must be treated as a dep."""
+    resp = client_fwd_dep.get("/potato")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"skin": "brown", "mass_g": 300}
+
+
+def test_annotated_fwd_ref_no_body_required(client_fwd_dep: TestClient):
+    """Sending no body must succeed (dep injection, not body parsing)."""
+    resp = client_fwd_dep.get("/potato")
+    assert resp.status_code == 200
+
+
+def test_annotated_fwd_ref_multiple_deps(client_fwd_dep: TestClient):
+    """Multiple forward-ref'd Annotated deps on the same route."""
+    resp = client_fwd_dep.get("/potato-twice")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"a_skin": "brown", "b_skin": "brown"}
+
+
+# ── OpenAPI schema sanity check ─────────────────────────────────────────────
+
+
+def test_openapi_schema_no_body_params(client_fwd_dep: TestClient):
+    """The dependency-injected param must NOT appear as a request body."""
+    resp = client_fwd_dep.get("/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+    # /potato should have no requestBody (it's all dep-injected)
+    pot_schema = schema["paths"]["/potato"]["get"]
+    assert "requestBody" not in pot_schema

--- a/tests/test_annotated_future_annotations.py
+++ b/tests/test_annotated_future_annotations.py
@@ -2,6 +2,7 @@
 
 See https://github.com/fastapi/fastapi/pull/15411
 """
+
 from __future__ import annotations
 
 from typing import Annotated
@@ -9,7 +10,6 @@ from typing import Annotated
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
-
 
 # ── Positive case: Annotated[ForwardRef, Depends()] before type definition ───
 


### PR DESCRIPTION
## Problem

When using `from __future__ import annotations` together with `Annotated[..., Depends(...)]` where the type is defined **after** the route decorator, FastAPI raises a `PydanticUserError` about an unresolvable ForwardRef.

The root cause: the lenient type evaluator (`eval_type_lenient`) leaves the entire annotation as a single `ForwardRef('Annotated[Potato, Depends(get_potato)]')` because it cannot resolve the inner type name (defined later in the file). Since the result is a plain `ForwardRef` and not an `Annotated` type, the code that extracts `Depends()`, `Field()`, etc. from `Annotated` metadata never runs — the parameter gets treated as a body field instead of a dependency, and pydantic later chokes on the nested ForwardRef.

**Before** (fails):

```python
from __future__ import annotations
from typing import Annotated
from fastapi import Depends, FastAPI

app = FastAPI()

def get_potato() -> Potato:
    ...

@app.get('/')
async def root(potato: Annotated[Potato, Depends(get_potato)]):  # PydanticUserError
    ...
```

Moving `Potato` above the route or removing `Annotated` both work around it, confirming this is specific to unpacking forward-ref'd Annotated types.

## Solution

In `analyze_param()`, when the annotation is still a `ForwardRef`, evaluate it using `eval` with a safe-globals dict that maps **undefined names** to `ForwardRef` objects. This gives us partial evaluation:

```python
Annotated[ForwardRef('Potato'), <function get_potato>]
```

The `Annotated` wrapper is now unpackable, so `Depends()` is correctly discovered. The inner type stays as a `ForwardRef` for downstream resolution — same behaviour as the non-`Annotated` forward-ref path.

Also changed `get_args(annotation)` to `get_args(use_annotation)` so that the re-evaluated annotation is used consistently throughout the function.

Fixes #13056