### PR TITLE
feat: Add SSE default_retry and on_disconnect support

### DIFF
--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -195,7 +195,7 @@ If you are streaming JSON Lines, follow the [Stream JSON Lines](../tutorial/stre
 
 ///
 
-### `EventSourceResponse` { #eventsource-response }
+### `EventSourceResponse` { #eventsourceresponse }
 
 **Added in FastAPI 0.134.0**
 

--- a/docs/en/docs/advanced/custom-response.md
+++ b/docs/en/docs/advanced/custom-response.md
@@ -195,6 +195,36 @@ If you are streaming JSON Lines, follow the [Stream JSON Lines](../tutorial/stre
 
 ///
 
+### `EventSourceResponse` { #eventsource-response }
+
+**Added in FastAPI 0.134.0**
+
+Server-Sent Events (SSE) streaming response with `text/event-stream` media type.
+
+Use `EventSourceResponse` as the `response_class` for *path operations* that use `yield` to stream SSE events.
+
+{* ../../docs_src/server_sent_events/tutorial001_py310.py hl[4,22] *}
+
+/// info
+
+`EventSourceResponse` works with **any HTTP method** (`GET`, `POST`, etc.), which makes it compatible with protocols like MCP that stream SSE over `POST`.
+
+///
+
+You can yield `ServerSentEvent` objects for full control over the SSE format:
+
+{* ../../docs_src/server_sent_events/tutorial002_py310.py hl[4,23,26] *}
+
+Or yield plain objects (dicts, Pydantic models) which are automatically JSON-encoded and formatted as SSE:
+
+{* ../../docs_src/server_sent_events/tutorial001_py310.py ln[22:25] hl[23,24,25] *}
+
+/// tip
+
+For more details on SSE features like **default retry configuration**, **client disconnect callbacks**, and **keepalive support**, see the dedicated [Server-Sent Events](./server-sent-events.md) guide.
+
+///
+
 ### `FileResponse` { #fileresponse }
 
 Asynchronously streams a file as the response.

--- a/docs/en/docs/advanced/server-sent-events.md
+++ b/docs/en/docs/advanced/server-sent-events.md
@@ -1,0 +1,144 @@
+# Server-Sent Events (SSE) { #server-sent-events }
+
+**Added in FastAPI 0.134.0**
+
+FastAPI has built-in support for **Server-Sent Events (SSE)**, a simple yet powerful protocol for streaming updates from the server to clients over HTTP.
+
+## What are Server-Sent Events? { #what-are-sse }
+
+Server-Sent Events (SSE) is a lightweight protocol for one-way communication from server to client. The client establishes a persistent HTTP connection, and the server can push events to the client as they occur.
+
+SSE is perfect for:
+- **Live notifications** and updates
+- **Real-time dashboards** and monitoring
+- **AI/LLM token streaming** (chat responses)
+- **Log streaming** and debugging interfaces
+- **Stock prices**, sports scores, and other live data
+
+/// info
+
+Unlike WebSockets, SSE is **unidirectional** (server → client only) and uses standard HTTP, making it simpler to implement and often more compatible with proxies and load balancers.
+
+///
+
+## Basic Usage { #basic-usage }
+
+To use SSE in FastAPI:
+
+1. Import `EventSourceResponse` and optionally `ServerSentEvent` from `fastapi.sse`
+2. Use `response_class=EventSourceResponse` on your *path operation*
+3. `yield` events from your endpoint function
+
+{* ../../docs_src/server_sent_events/tutorial001_py310.py hl[4,22,23,24,25] *}
+
+## SSE Event Structure { #sse-event-structure }
+
+Each SSE event can contain several fields:
+
+- **`data`**: The event payload (any JSON-serializable value)
+- **`event`**: Event type name (for `addEventListener` in JavaScript)
+- **`id`**: Event ID (sent back as `Last-Event-ID` header on reconnection)
+- **`retry`**: Reconnection time in milliseconds
+- **`comment`**: Comment/keepalive line (ignored by clients)
+
+### Using ServerSentEvent { #using-server-sent-event }
+
+For full control over the SSE format, yield `ServerSentEvent` objects:
+
+{* ../../docs_src/server_sent_events/tutorial002_py310.py hl[4,23,24,25,26] *}
+
+### Automatic Formatting { #automatic-formatting }
+
+You can also yield plain objects (dicts, Pydantic models) - they are automatically JSON-encoded and wrapped in SSE format:
+
+{* ../../docs_src/server_sent_events/tutorial001_py310.py ln[22:25] hl[23,24,25] *}
+
+This produces SSE events like:
+```
+data: {"name":"Plumbus","description":"A multi-purpose household device."}
+
+```
+
+### Raw Data { #raw-data }
+
+To send pre-formatted text (not JSON), use `raw_data`:
+
+{* ../../docs_src/server_sent_events/tutorial003_py310.py hl[10,17] *}
+
+This produces plain SSE events:
+```
+data: 2025-01-01 INFO  Application started
+
+```
+
+## Default Retry Configuration { #default-retry }
+
+You can set a default reconnection time for all events by creating a custom `EventSourceResponse` subclass:
+
+{* ../../docs_src/server_sent_events/tutorial006_py310.py ln[19:22] hl[20,21,22] *}
+
+Then use it in your *path operation*:
+
+{* ../../docs_src/server_sent_events/tutorial006_py310.py ln[30:32] hl[30] *}
+
+Individual events can override the default:
+
+{* ../../docs_src/server_sent_events/tutorial006_py310.py ln[39:42] hl[42] *}
+
+## Client Disconnect Handling { #disconnect-handling }
+
+FastAPI supports an optional `on_disconnect` callback that is invoked when a client disconnects. This is useful for cleanup tasks like:
+- Closing database connections
+- Stopping background tasks
+- Logging disconnections
+- Releasing resources
+
+To use it, create a custom `EventSourceResponse` subclass with an `on_disconnect` callback:
+
+{* ../../docs_src/server_sent_events/tutorial007_py310.py ln[10:12] hl[10,11,12] *}
+
+{* ../../docs_src/server_sent_events/tutorial007_py310.py ln[15:18] hl[15,16,17,18] *}
+
+Then use it in your *path operation*:
+
+{* ../../docs_src/server_sent_events/tutorial007_py310.py ln[34:36] hl[34] *}
+
+The callback will be invoked after the response completes or when the client disconnects.
+
+## Keepalive Support { #keepalive }
+
+FastAPI automatically sends keepalive comments (`: ping`) every 15 seconds to prevent proxy/load-balancer timeouts. This ensures that idle connections remain open even when no events are being sent.
+
+You can also send manual keepalive pings by yielding `ServerSentEvent(comment="ping")`.
+
+## Resuming from Last Event { #resuming-from-last-event }
+
+SSE clients automatically send a `Last-Event-ID` header when reconnecting. You can use this to resume streaming from where the client left off:
+
+{* ../../docs_src/server_sent_events/tutorial004_py310.py hl[24,25,26,27,28,29,30,31] *}
+
+## Streaming AI/LLM Responses { #streaming-ai-responses }
+
+SSE is ideal for streaming AI/LLM responses token-by-token:
+
+{* ../../docs_src/server_sent_events/tutorial005_py310.py hl[14,15,16,17,18,19] *}
+
+## Technical Details { #technical-details }
+
+### Cancellation Support { #cancellation-support }
+
+FastAPI's SSE implementation properly handles client disconnects and cancels the streaming generator to prevent resource leaks.
+
+### Thread-Safe { #thread-safe }
+
+SSE streaming works with both `async def` and regular `def` endpoint functions. For synchronous generators, FastAPI runs them in a thread pool to avoid blocking the event loop.
+
+### OpenAPI Documentation { #openapi-documentation }
+
+When using `EventSourceResponse`, FastAPI automatically documents the endpoint in OpenAPI with the correct `text/event-stream` media type and SSE event schema.
+
+## See Also { #see-also }
+
+- [Stream Data](stream-data.md) - General streaming for binary data
+- [Stream JSON Lines](../tutorial/stream-json-lines.md) - Streaming JSON Lines responses
+- [Custom Response](custom-response.md) - Other custom response types

--- a/docs/en/docs/advanced/server-sent-events.md
+++ b/docs/en/docs/advanced/server-sent-events.md
@@ -1,10 +1,10 @@
-# Server-Sent Events (SSE) { #server-sent-events }
+# Server-Sent Events (SSE) { #server-sent-events-sse }
 
 **Added in FastAPI 0.134.0**
 
 FastAPI has built-in support for **Server-Sent Events (SSE)**, a simple yet powerful protocol for streaming updates from the server to clients over HTTP.
 
-## What are Server-Sent Events? { #what-are-sse }
+## What are Server-Sent Events? { #what-are-server-sent-events }
 
 Server-Sent Events (SSE) is a lightweight protocol for one-way communication from server to client. The client establishes a persistent HTTP connection, and the server can push events to the client as they occur.
 
@@ -41,7 +41,7 @@ Each SSE event can contain several fields:
 - **`retry`**: Reconnection time in milliseconds
 - **`comment`**: Comment/keepalive line (ignored by clients)
 
-### Using ServerSentEvent { #using-server-sent-event }
+### Using ServerSentEvent { #using-serversentevent }
 
 For full control over the SSE format, yield `ServerSentEvent` objects:
 
@@ -71,7 +71,7 @@ data: 2025-01-01 INFO  Application started
 
 ```
 
-## Default Retry Configuration { #default-retry }
+## Default Retry Configuration { #default-retry-configuration }
 
 You can set a default reconnection time for all events by creating a custom `EventSourceResponse` subclass:
 
@@ -85,7 +85,7 @@ Individual events can override the default:
 
 {* ../../docs_src/server_sent_events/tutorial006_py310.py ln[39:42] hl[42] *}
 
-## Client Disconnect Handling { #disconnect-handling }
+## Client Disconnect Handling { #client-disconnect-handling }
 
 FastAPI supports an optional `on_disconnect` callback that is invoked when a client disconnects. This is useful for cleanup tasks like:
 - Closing database connections
@@ -105,7 +105,7 @@ Then use it in your *path operation*:
 
 The callback will be invoked after the response completes or when the client disconnects.
 
-## Keepalive Support { #keepalive }
+## Keepalive Support { #keepalive-support }
 
 FastAPI automatically sends keepalive comments (`: ping`) every 15 seconds to prevent proxy/load-balancer timeouts. This ensures that idle connections remain open even when no events are being sent.
 
@@ -117,7 +117,7 @@ SSE clients automatically send a `Last-Event-ID` header when reconnecting. You c
 
 {* ../../docs_src/server_sent_events/tutorial004_py310.py hl[24,25,26,27,28,29,30,31] *}
 
-## Streaming AI/LLM Responses { #streaming-ai-responses }
+## Streaming AI/LLM Responses { #streaming-ai-llm-responses }
 
 SSE is ideal for streaming AI/LLM responses token-by-token:
 

--- a/docs_src/server_sent_events/tutorial006_py310.py
+++ b/docs_src/server_sent_events/tutorial006_py310.py
@@ -47,7 +47,9 @@ async def stream_items_override_retry() -> AsyncIterable[ServerSentEvent]:
     """Stream items where individual events can override the default retry."""
     for i, item in enumerate(items):
         # Override default retry for this specific event
-        yield ServerSentEvent(data=item, event="item_update", id=str(i + 1), retry=10000)
+        yield ServerSentEvent(
+            data=item, event="item_update", id=str(i + 1), retry=10000
+        )
 
 
 @app.get("/items/stream-plain", response_class=EventSourceResponse)

--- a/docs_src/server_sent_events/tutorial006_py310.py
+++ b/docs_src/server_sent_events/tutorial006_py310.py
@@ -1,0 +1,57 @@
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.sse import EventSourceResponse, ServerSentEvent
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+
+
+items = [
+    Item(name="Plumbus", price=32.99),
+    Item(name="Portal Gun", price=999.99),
+    Item(name="Meeseeks Box", price=49.99),
+]
+
+
+# Custom EventSourceResponse subclass with default retry configuration
+class RetryEventSourceResponse(EventSourceResponse):
+    """EventSourceResponse with a default retry time of 3000ms."""
+
+    default_retry = 3000
+
+
+class OverrideRetryEventSourceResponse(EventSourceResponse):
+    """EventSourceResponse with a default retry time of 3000ms (can be overridden per-event)."""
+
+    default_retry = 3000
+
+
+@app.get("/items/stream", response_class=RetryEventSourceResponse)
+async def stream_items_with_default_retry() -> AsyncIterable[ServerSentEvent]:
+    """Stream items with a default retry of 3000ms."""
+    for i, item in enumerate(items):
+        yield ServerSentEvent(data=item, event="item_update", id=str(i + 1))
+
+
+@app.get(
+    "/items/stream-override",
+    response_class=OverrideRetryEventSourceResponse,
+)
+async def stream_items_override_retry() -> AsyncIterable[ServerSentEvent]:
+    """Stream items where individual events can override the default retry."""
+    for i, item in enumerate(items):
+        # Override default retry for this specific event
+        yield ServerSentEvent(data=item, event="item_update", id=str(i + 1), retry=10000)
+
+
+@app.get("/items/stream-plain", response_class=EventSourceResponse)
+async def stream_items_plain() -> AsyncIterable[Item]:
+    """Stream items as plain objects (automatically formatted as SSE)."""
+    for item in items:
+        yield item

--- a/docs_src/server_sent_events/tutorial007_py310.py
+++ b/docs_src/server_sent_events/tutorial007_py310.py
@@ -1,0 +1,53 @@
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI, Request
+from fastapi.sse import EventSourceResponse, ServerSentEvent
+from pydantic import BaseModel
+
+app = FastAPI()
+
+# Track disconnects for testing
+disconnect_events: list[str] = []
+
+
+async def on_disconnect(request: Request) -> None:
+    """Callback invoked when client disconnects."""
+    disconnect_events.append("client_disconnected")
+
+
+# Custom EventSourceResponse subclass with disconnect callback
+class DisconnectCallbackEventSourceResponse(EventSourceResponse):
+    """EventSourceResponse with an on_disconnect callback."""
+
+    on_disconnect = on_disconnect
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+
+
+items = [
+    Item(name="Plumbus", price=32.99),
+    Item(name="Portal Gun", price=999.99),
+    Item(name="Meeseeks Box", price=49.99),
+]
+
+
+@app.get("/items/stream", response_class=DisconnectCallbackEventSourceResponse)
+async def stream_items_with_disconnect() -> AsyncIterable[ServerSentEvent]:
+    """Stream items with disconnect callback."""
+    for i, item in enumerate(items):
+        yield ServerSentEvent(data=item, event="item_update", id=str(i + 1))
+
+
+@app.get(
+    "/items/stream-infinite",
+    response_class=DisconnectCallbackEventSourceResponse,
+)
+async def stream_items_infinite() -> AsyncIterable[ServerSentEvent]:
+    """Stream items infinitely - disconnect callback should fire on client disconnect."""
+    i = 0
+    while True:
+        yield ServerSentEvent(data={"count": i}, event="tick", id=str(i))
+        i += 1

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -497,6 +497,16 @@ def get_request_handler(
                 # Generator endpoint: stream as Server-Sent Events
                 gen = dependant.call(**solved_result.values)
 
+                # Get default_retry and on_disconnect from response_class if set
+                default_retry: int | None = None
+                on_disconnect: Callable[[Request], Awaitable[None]] | None = None
+                # Check if response_class is a subclass of EventSourceResponse and has
+                # default_retry/on_disconnect attributes
+                if lenient_issubclass(actual_response_class, EventSourceResponse):
+                    # Access class attributes directly
+                    default_retry = getattr(actual_response_class, "default_retry", None)
+                    on_disconnect = getattr(actual_response_class, "on_disconnect", None)
+
                 def _serialize_sse_item(item: Any) -> bytes:
                     if isinstance(item, ServerSentEvent):
                         # User controls the event structure.
@@ -512,18 +522,21 @@ def get_request_handler(
                                 data_str = json.dumps(jsonable_encoder(item.data))
                         else:
                             data_str = None
+                        # Use default_retry if retry is not set on the event
+                        retry_value = item.retry if item.retry is not None else default_retry
                         return format_sse_event(
                             data_str=data_str,
                             event=item.event,
                             id=item.id,
-                            retry=item.retry,
+                            retry=retry_value,
                             comment=item.comment,
                         )
                     else:
                         # Plain object: validate + serialize via
                         # stream_item_field (if set) and wrap in data field
                         return format_sse_event(
-                            data_str=_serialize_data(item).decode("utf-8")
+                            data_str=_serialize_data(item).decode("utf-8"),
+                            retry=default_retry,
                         )
 
                 if dependant.is_async_gen_callable:
@@ -580,8 +593,18 @@ def get_request_handler(
                     async with anyio.create_task_group() as tg:
                         tg.start_soon(_producer)
                         tg.start_soon(_keepalive_inserter)
-                        yield receive_keepalive
-                        tg.cancel_scope.cancel()
+                        try:
+                            yield receive_keepalive
+                        finally:
+                            tg.cancel_scope.cancel()
+                            # Call on_disconnect callback if set
+                            if on_disconnect is not None:
+                                try:
+                                    await on_disconnect(request)
+                                except Exception:
+                                    # Don't let disconnect callback errors
+                                    # propagate and break the response
+                                    pass
 
                 # Enter the SSE context manager on the request-scoped
                 # exit stack. The stack outlives the streaming response,

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -504,8 +504,12 @@ def get_request_handler(
                 # default_retry/on_disconnect attributes
                 if lenient_issubclass(actual_response_class, EventSourceResponse):
                     # Access class attributes directly
-                    default_retry = getattr(actual_response_class, "default_retry", None)
-                    on_disconnect = getattr(actual_response_class, "on_disconnect", None)
+                    default_retry = getattr(
+                        actual_response_class, "default_retry", None
+                    )
+                    on_disconnect = getattr(
+                        actual_response_class, "on_disconnect", None
+                    )
 
                 def _serialize_sse_item(item: Any) -> bytes:
                     if isinstance(item, ServerSentEvent):
@@ -523,7 +527,9 @@ def get_request_handler(
                         else:
                             data_str = None
                         # Use default_retry if retry is not set on the event
-                        retry_value = item.retry if item.retry is not None else default_retry
+                        retry_value = (
+                            item.retry if item.retry is not None else default_retry
+                        )
                         return format_sse_event(
                             data_str=data_str,
                             event=item.event,

--- a/fastapi/sse.py
+++ b/fastapi/sse.py
@@ -1,7 +1,9 @@
+from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
 from annotated_doc import Doc
 from pydantic import AfterValidator, BaseModel, Field, model_validator
+from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
 # Canonical SSE event schema matching the OpenAPI 3.2 spec
@@ -18,7 +20,7 @@ _SSE_EVENT_SCHEMA: dict[str, Any] = {
 
 
 class EventSourceResponse(StreamingResponse):
-    """Streaming response with `text/event-stream` media type.
+    """Streaming response with `text/event-stream` media type for Server-Sent Events (SSE).
 
     Use as `response_class=EventSourceResponse` on a *path operation* that uses `yield`
     to enable Server Sent Events (SSE) responses.
@@ -28,9 +30,100 @@ class EventSourceResponse(StreamingResponse):
 
     The actual encoding logic lives in the FastAPI routing layer. This class
     serves mainly as a marker and sets the correct `Content-Type`.
+
+    ## Features
+
+    - **Automatic event formatting**: Plain objects (dicts, Pydantic models) are
+      automatically JSON-encoded and wrapped in SSE format.
+    - **Retry configuration**: Set default reconnection time for all events via
+      `default_retry` parameter or per-event via `ServerSentEvent.retry`.
+    - **Client disconnect handling**: Optional `on_disconnect` callback for cleanup.
+    - **Keepalive support**: Automatic keepalive comments to prevent proxy timeouts.
+
+    ## Example
+
+    ```python
+    from fastapi import FastAPI
+    from fastapi.sse import EventSourceResponse, ServerSentEvent
+
+    app = FastAPI()
+
+
+    @app.get("/events", response_class=EventSourceResponse)
+    async def stream_events():
+        for i in range(3):
+            yield ServerSentEvent(data={"count": i}, event="update", id=str(i))
+    ```
+
+    ## Example with retry configuration
+
+    ```python
+    @app.get(
+        "/events",
+        response_class=EventSourceResponse,
+        response_class_kwargs={"default_retry": 3000},
+    )
+    async def stream_events():
+        yield {"message": "Hello"}  # Automatically formatted with retry: 3000
+    ```
+
+    ## Example with disconnect callback
+
+    ```python
+    async def on_disconnect(request: Request) -> None:
+        print("Client disconnected")
+
+
+    @app.get(
+        "/events",
+        response_class=EventSourceResponse,
+        response_class_kwargs={"on_disconnect": on_disconnect},
+    )
+    async def stream_events():
+        while True:
+            yield {"data": "streaming..."}
+    ```
     """
 
     media_type = "text/event-stream"
+    default_retry: int | None = None
+    on_disconnect: Callable[[Request], Awaitable[None]] | None = None
+
+    def __init__(
+        self,
+        content: Any = None,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        media_type: str | None = None,
+        default_retry: int | None = None,
+        on_disconnect: Callable[[Request], Awaitable[None]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize an EventSourceResponse.
+
+        Args:
+            content: An async generator or iterable yielding SSE events.
+            status_code: HTTP status code for the response.
+            headers: Optional headers to include in the response.
+            media_type: Media type (defaults to "text/event-stream").
+            default_retry: Default reconnection time in milliseconds for all events.
+                Can be overridden per-event via `ServerSentEvent.retry`.
+            on_disconnect: Optional async callback invoked when the client disconnects.
+                Receives the `Request` object as argument. Useful for cleanup.
+            **kwargs: Additional arguments passed to StreamingResponse.
+        """
+        super().__init__(
+            content=content,
+            status_code=status_code,
+            headers=headers,
+            media_type=media_type or self.media_type,
+            **kwargs,
+        )
+        # Store instance-level overrides
+        if default_retry is not None:
+            self.default_retry = default_retry
+        if on_disconnect is not None:
+            self.on_disconnect = on_disconnect
 
 
 def _check_id_no_null(v: str | None) -> str | None:

--- a/tests/test_tutorial/test_server_sent_events/test_tutorial006.py
+++ b/tests/test_tutorial/test_server_sent_events/test_tutorial006.py
@@ -1,0 +1,159 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+from inline_snapshot import snapshot
+
+
+@pytest.fixture(
+    name="client",
+    params=[
+        pytest.param("tutorial006_py310"),
+    ],
+)
+def get_client(request: pytest.FixtureRequest):
+    mod = importlib.import_module(f"docs_src.server_sent_events.{request.param}")
+
+    client = TestClient(mod.app)
+    return client
+
+
+def test_stream_items_with_default_retry(client: TestClient):
+    """Test that default_retry is applied to all events."""
+    response = client.get("/items/stream")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+    lines = response.text.strip().split("\n")
+
+    # Check that retry: 3000 appears for each event
+    retry_lines = [line for line in lines if line.startswith("retry: ")]
+    assert len(retry_lines) == 3
+    assert all(line == "retry: 3000" for line in retry_lines)
+
+
+def test_stream_items_override_retry(client: TestClient):
+    """Test that individual events can override the default retry."""
+    response = client.get("/items/stream-override")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+    lines = response.text.strip().split("\n")
+
+    # Check that retry: 10000 (override) appears for each event
+    retry_lines = [line for line in lines if line.startswith("retry: ")]
+    assert len(retry_lines) == 3
+    assert all(line == "retry: 10000" for line in retry_lines)
+
+
+def test_stream_items_plain(client: TestClient):
+    """Test that plain objects are automatically formatted as SSE with default retry."""
+    response = client.get("/items/stream-plain")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+    # Check data lines contain JSON-serialized items
+    data_lines = [line for line in response.text.strip().split("\n") if line.startswith("data: ")]
+    assert len(data_lines) == 3
+    assert '"name":"Plumbus"' in data_lines[0]
+    assert '"name":"Portal Gun"' in data_lines[1]
+    assert '"name":"Meeseeks Box"' in data_lines[2]
+
+
+def test_openapi_schema(client: TestClient):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json() == snapshot(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/items/stream": {
+                    "get": {
+                        "summary": "Stream Items With Default Retry",
+                        "description": "Stream items with a default retry of 3000ms.",
+                        "operationId": "stream_items_with_default_retry_items_stream_get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {
+                                    "text/event-stream": {
+                                        "itemSchema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "data": {"type": "string"},
+                                                "event": {"type": "string"},
+                                                "id": {"type": "string"},
+                                                "retry": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                },
+                                            },
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+                "/items/stream-override": {
+                    "get": {
+                        "summary": "Stream Items Override Retry",
+                        "description": "Stream items where individual events can override the default retry.",
+                        "operationId": "stream_items_override_retry_items_stream_override_get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {
+                                    "text/event-stream": {
+                                        "itemSchema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "data": {"type": "string"},
+                                                "event": {"type": "string"},
+                                                "id": {"type": "string"},
+                                                "retry": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                },
+                                            },
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+                "/items/stream-plain": {
+                    "get": {
+                        "summary": "Stream Items Plain",
+                        "description": "Stream items as plain objects (automatically formatted as SSE).",
+                        "operationId": "stream_items_plain_items_stream_plain_get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {
+                                    "text/event-stream": {
+                                        "itemSchema": {'type': 'object', 'properties': {'data': {'type': 'string', 'contentMediaType': 'application/json', 'contentSchema': {'$ref': '#/components/schemas/Item'}}, 'event': {'type': 'string'}, 'id': {'type': 'string'}, 'retry': {'type': 'integer', 'minimum': 0}}, 'required': ['data']}
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+            },
+            "components": {
+                "schemas": {
+                    "Item": {
+                        "properties": {
+                            "name": {"type": "string", "title": "Name"},
+                            "price": {"type": "number", "title": "Price"},
+                        },
+                        "type": "object",
+                        "required": ["name", "price"],
+                        "title": "Item",
+                    }
+                }
+            },
+        }
+    )

--- a/tests/test_tutorial/test_server_sent_events/test_tutorial006.py
+++ b/tests/test_tutorial/test_server_sent_events/test_tutorial006.py
@@ -53,7 +53,9 @@ def test_stream_items_plain(client: TestClient):
     assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
 
     # Check data lines contain JSON-serialized items
-    data_lines = [line for line in response.text.strip().split("\n") if line.startswith("data: ")]
+    data_lines = [
+        line for line in response.text.strip().split("\n") if line.startswith("data: ")
+    ]
     assert len(data_lines) == 3
     assert '"name":"Plumbus"' in data_lines[0]
     assert '"name":"Portal Gun"' in data_lines[1]
@@ -134,7 +136,25 @@ def test_openapi_schema(client: TestClient):
                                 "description": "Successful Response",
                                 "content": {
                                     "text/event-stream": {
-                                        "itemSchema": {'type': 'object', 'properties': {'data': {'type': 'string', 'contentMediaType': 'application/json', 'contentSchema': {'$ref': '#/components/schemas/Item'}}, 'event': {'type': 'string'}, 'id': {'type': 'string'}, 'retry': {'type': 'integer', 'minimum': 0}}, 'required': ['data']}
+                                        "itemSchema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "data": {
+                                                    "type": "string",
+                                                    "contentMediaType": "application/json",
+                                                    "contentSchema": {
+                                                        "$ref": "#/components/schemas/Item"
+                                                    },
+                                                },
+                                                "event": {"type": "string"},
+                                                "id": {"type": "string"},
+                                                "retry": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                },
+                                            },
+                                            "required": ["data"],
+                                        }
                                     }
                                 },
                             }

--- a/tests/test_tutorial/test_server_sent_events/test_tutorial007.py
+++ b/tests/test_tutorial/test_server_sent_events/test_tutorial007.py
@@ -1,0 +1,78 @@
+"""
+Test SSE disconnect callback functionality.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = [
+    pytest.mark.anyio,
+]
+
+
+def test_disconnect_callback_called():
+    """Test that on_disconnect callback is called when response completes."""
+    from docs_src.server_sent_events import tutorial007_py310
+
+    # Clear any previous disconnect events
+    tutorial007_py310.disconnect_events.clear()
+
+    client = TestClient(tutorial007_py310.app, raise_server_exceptions=True)
+
+    # Make a request and read the full response
+    response = client.get("/items/stream")
+    assert response.status_code == 200
+    _ = response.text  # Read full response
+
+    # The disconnect callback should have been called
+    assert len(tutorial007_py310.disconnect_events) == 1
+    assert tutorial007_py310.disconnect_events[0] == "client_disconnected"
+
+
+def test_disconnect_callback_multiple_requests():
+    """Test that disconnect callback is called for each request."""
+    from docs_src.server_sent_events import tutorial007_py310
+
+    # Clear any previous disconnect events
+    tutorial007_py310.disconnect_events.clear()
+
+    client = TestClient(tutorial007_py310.app)
+
+    # Make multiple requests
+    for _ in range(3):
+        response = client.get("/items/stream")
+        assert response.status_code == 200
+        _ = response.text
+
+    # The disconnect callback should have been called for each request
+    assert len(tutorial007_py310.disconnect_events) == 3
+
+
+def test_stream_items_with_disconnect():
+    """Test normal streaming with disconnect callback (no early disconnect)."""
+    from docs_src.server_sent_events import tutorial007_py310
+
+    # Clear any previous disconnect events
+    tutorial007_py310.disconnect_events.clear()
+
+    client = TestClient(tutorial007_py310.app)
+
+    response = client.get("/items/stream")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+    lines = response.text.strip().split("\n")
+
+    # Check event structure
+    event_lines = [line for line in lines if line.startswith("event: ")]
+    assert len(event_lines) == 3
+    assert all(line == "event: item_update" for line in event_lines)
+
+    data_lines = [line for line in lines if line.startswith("data: ")]
+    assert len(data_lines) == 3
+
+    id_lines = [line for line in lines if line.startswith("id: ")]
+    assert id_lines == ["id: 1", "id: 2", "id: 3"]
+
+    # After response completes, disconnect should be called
+    assert len(tutorial007_py310.disconnect_events) == 1


### PR DESCRIPTION
## Summary

This PR adds support for **default_retry** and **on_disconnect** callback in EventSourceResponse for Server-Sent Events (SSE).

### Changes

- **fastapi/sse.py**: Added default_retry and on_disconnect class attributes to EventSourceResponse
- **fastapi/routing.py**: Updated the SSE request handler to extract and apply these settings
- **docs/en/docs/advanced/custom-response.md**: Added documentation for EventSourceResponse
- **docs/en/docs/advanced/server-sent-events.md**: New dedicated SSE guide
- **docs_src/**: Added tutorial examples (tutorial006, tutorial007)
- **tests/**: Added tests for the new SSE features

### Features

1. **default_retry**: Set default reconnection time (in milliseconds) for all SSE events
2. **on_disconnect**: Optional async callback invoked when a client disconnects

### Example Usage

```python
async def on_disconnect(request: Request) -> None:
    print("Client disconnected")

@app.get(
    "/events",
    response_class=EventSourceResponse,
    response_class_kwargs={"default_retry": 3000, "on_disconnect": on_disconnect},
)
async def stream_events():
    while True:
        yield {"data": "streaming..."}
```