### PR TITLE
🐛 Fix unhashable Annotated type in get_definitions OpenAPI schema generation

### DIFF
--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -317,9 +317,9 @@ def get_definitions(
         for model in flat_serialization_models
     ]
     flat_model_fields = flat_validation_model_fields + flat_serialization_model_fields
-    input_types = {f.field_info.annotation for f in fields}
+    input_type_ids = {id(f.field_info.annotation) for f in fields}
     unique_flat_model_fields = {
-        f for f in flat_model_fields if f.field_info.annotation not in input_types
+        f for f in flat_model_fields if id(f.field_info.annotation) not in input_type_ids
     }
     inputs = [
         (

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -319,7 +319,9 @@ def get_definitions(
     flat_model_fields = flat_validation_model_fields + flat_serialization_model_fields
     input_type_ids = {id(f.field_info.annotation) for f in fields}
     unique_flat_model_fields = {
-        f for f in flat_model_fields if id(f.field_info.annotation) not in input_type_ids
+        f
+        for f in flat_model_fields
+        if id(f.field_info.annotation) not in input_type_ids
     }
     inputs = [
         (

--- a/tests/test_openapi_unhashable_annotated.py
+++ b/tests/test_openapi_unhashable_annotated.py
@@ -1,0 +1,35 @@
+from typing import Annotated
+
+from pydantic.fields import FieldInfo
+
+from fastapi._compat.v2 import ModelField, get_definitions
+
+
+class UnhashableMetadata:
+    """Simulates third-party field metadata (e.g. from SQLModel extensions)
+    that does not implement ``__hash__``."""
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+def test_get_definitions_with_unhashable_annotation() -> None:
+    """``get_definitions()`` should not crash when a field annotation is an
+    ``Annotated`` type containing unhashable metadata.
+
+    Regression: the function used a set comprehension over
+    ``field_info.annotation`` values.  ``Annotated`` types that include
+    metadata with ``__hash__ = None`` (e.g. certain SQLModel / Pydantic
+    extension field-info objects) are themselves unhashable, causing
+    ``TypeError: unhashable type`` when building the set.
+    """
+    field = ModelField(
+        field_info=FieldInfo(annotation=Annotated[int, UnhashableMetadata()]),
+        name="test_field",
+        mode="validation",
+    )
+    # Should not raise TypeError
+    get_definitions(
+        fields=[field],
+        model_name_map={},
+        separate_input_output_schemas=True,
+    )

--- a/tests/test_openapi_unhashable_annotated.py
+++ b/tests/test_openapi_unhashable_annotated.py
@@ -1,8 +1,7 @@
 from typing import Annotated
 
-from pydantic.fields import FieldInfo
-
 from fastapi._compat.v2 import ModelField, get_definitions
+from pydantic.fields import FieldInfo
 
 
 class UnhashableMetadata:


### PR DESCRIPTION
## Summary

- `get_definitions()` in `fastapi/_compat/v2.py` uses a set comprehension to collect field annotations for deduplication
- On **Python 3.14** with **Pydantic v2.13+**, some `Annotated` types contain `FieldInfoMetadata` objects that are **not hashable**, causing a `TypeError` when generating the OpenAPI schema:

```
TypeError: cannot use 'typing._AnnotatedAlias' as a set element (unhashable type: 'FieldInfoMetadata')
```

- This is triggered when routes use `Annotated` parameters with metadata such as `Query(max_length=..., description=...)` or similar constructs that produce unhashable Pydantic field metadata

## Fix

Use `id()` for identity-based deduplication instead of relying on `__hash__` of annotation objects. Since annotations are interned type objects, `id()` comparison is semantically equivalent for this filtering purpose.

## Changes

```diff
-    input_types = {f.field_info.annotation for f in fields}
+    input_type_ids = {id(f.field_info.annotation) for f in fields}
     unique_flat_model_fields = {
-        f for f in flat_model_fields if f.field_info.annotation not in input_types
+        f for f in flat_model_fields if id(f.field_info.annotation) not in input_type_ids
     }
```

## Environment

- Python 3.14.3
- Pydantic 2.13.3
- FastAPI 0.136.1