### PR TITLE
feat: add TimingMiddleware for request timing

### DIFF
--- a/docs_src/middleware/tutorial002.py
+++ b/docs_src/middleware/tutorial002.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from fastapi.middleware.timing import TimingMiddleware
+
+app = FastAPI()
+
+app.add_middleware(TimingMiddleware)
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+
+
+@app.get("/items/{item_id}")
+async def read_item(item_id: int, q: str | None = None):
+    return {"item_id": item_id, "q": q}

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -9,6 +9,7 @@ from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
+from .middleware.timing import TimingMiddleware as TimingMiddleware
 from .param_functions import Body as Body
 from .param_functions import Cookie as Cookie
 from .param_functions import Depends as Depends

--- a/fastapi/middleware/__init__.py
+++ b/fastapi/middleware/__init__.py
@@ -1,1 +1,3 @@
 from starlette.middleware import Middleware as Middleware
+
+from fastapi.middleware.timing import TimingMiddleware as TimingMiddleware

--- a/fastapi/middleware/__init__.py
+++ b/fastapi/middleware/__init__.py
@@ -1,3 +1,2 @@
-from starlette.middleware import Middleware as Middleware
-
 from fastapi.middleware.timing import TimingMiddleware as TimingMiddleware
+from starlette.middleware import Middleware as Middleware

--- a/fastapi/middleware/timing.py
+++ b/fastapi/middleware/timing.py
@@ -1,0 +1,26 @@
+import time
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+class TimingMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        header_name: str = "X-Process-Time",
+    ) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        start_time = time.perf_counter()
+        response = await call_next(request)
+        process_time = time.perf_counter() - start_time
+        response.headers[self.header_name] = f"{process_time:.4f}"
+        return response

--- a/tests/test_middleware/test_timing_middleware.py
+++ b/tests/test_middleware/test_timing_middleware.py
@@ -1,0 +1,80 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.timing import TimingMiddleware
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app_with_default_middleware():
+    app = FastAPI()
+    app.add_middleware(TimingMiddleware)
+
+    @app.get("/")
+    async def root():
+        return {"message": "Hello World"}
+
+    @app.get("/items/{item_id}")
+    async def read_item(item_id: int, q: str | None = None):
+        return {"item_id": item_id, "q": q}
+
+    return app
+
+
+@pytest.fixture
+def app_with_custom_header():
+    app = FastAPI()
+    app.add_middleware(TimingMiddleware, header_name="X-Custom-Time")
+
+    @app.get("/")
+    async def root():
+        return {"message": "Custom Header"}
+
+    return app
+
+
+def test_response_header_exists(app_with_default_middleware):
+    client = TestClient(app_with_default_middleware)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "X-Process-Time" in response.headers
+
+
+def test_response_header_value_is_positive(app_with_default_middleware):
+    client = TestClient(app_with_default_middleware)
+    response = client.get("/")
+    assert response.status_code == 200
+    process_time = float(response.headers["X-Process-Time"])
+    assert process_time > 0
+
+
+def test_custom_header_name(app_with_custom_header):
+    client = TestClient(app_with_custom_header)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "X-Custom-Time" in response.headers
+    assert "X-Process-Time" not in response.headers
+    process_time = float(response.headers["X-Custom-Time"])
+    assert process_time > 0
+
+
+def test_middleware_does_not_affect_response_content(app_with_default_middleware):
+    client = TestClient(app_with_default_middleware)
+    response = client.get("/items/42?q=test")
+    assert response.status_code == 200
+    assert response.json() == {"item_id": 42, "q": "test"}
+    assert "X-Process-Time" in response.headers
+
+
+def test_multiple_requests_have_independent_timing(app_with_default_middleware):
+    client = TestClient(app_with_default_middleware)
+    response1 = client.get("/")
+    response2 = client.get("/items/1")
+
+    assert response1.status_code == 200
+    assert response2.status_code == 200
+
+    time1 = float(response1.headers["X-Process-Time"])
+    time2 = float(response2.headers["X-Process-Time"])
+
+    assert time1 > 0
+    assert time2 > 0


### PR DESCRIPTION
## Summary

- Add TimingMiddleware to fastapi/middleware/timing.py
- Export TimingMiddleware from fastapi.middleware and fastapi
- Add docs_src/middleware/tutorial002.py usage example
- Add 5 unit tests, all passing

## Test plan

- [x] pytest tests/test_middleware/test_timing_middleware.py -v -- 5 passed
- [x] from fastapi import TimingMiddleware import successful
- [x] Custom header name functionality verified

Generated with Claude Code