### PR TITLE
Fix: preserve stream_item_type when using include_router with SSE routes

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1794,6 +1794,14 @@ class APIRouter(routing.Router):
                         self.strict_content_type,
                     ),
                 )
+                new_route = self.routes[-1]
+                if (
+                    isinstance(new_route, APIRoute)
+                    and isinstance(route, APIRoute)
+                    and getattr(route, "stream_item_type", None) is not None
+                ):
+                    new_route.stream_item_type = route.stream_item_type
+                    
             elif isinstance(route, routing.Route):
                 methods = list(route.methods or [])
                 self.add_route(

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1801,7 +1801,7 @@ class APIRouter(routing.Router):
                     and getattr(route, "stream_item_type", None) is not None
                 ):
                     new_route.stream_item_type = route.stream_item_type
-                    
+
             elif isinstance(route, routing.Route):
                 methods = list(route.methods or [])
                 self.add_route(

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -285,10 +285,14 @@ def test_include_router_copies_stream_item_type():
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
         data_lines = [
-            line for line in response.text.strip().split("\n") if line.startswith("data: ")
+            line
+            for line in response.text.strip().split("\n")
+            if line.startswith("data: ")
         ]
         assert len(data_lines) == 1
-        assert '"name":"Plumbus"' in data_lines[0] or '"name": "Plumbus"' in data_lines[0]
+        assert (
+            '"name":"Plumbus"' in data_lines[0] or '"name": "Plumbus"' in data_lines[0]
+        )
 
 
 # Keepalive ping tests

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterable, Iterable, AsyncIterator
+from collections.abc import AsyncIterable, AsyncIterator, Iterable
 
 import fastapi.routing
 import pytest
@@ -274,7 +274,7 @@ def test_include_router_copies_stream_item_type():
 
     assert getattr(sub_router.routes[-1], "stream_item_type", None) == Item
 
-    main_app = FastAPI() 
+    main_app = FastAPI()
     main_app.include_router(sub_router)
 
     route = next(r for r in main_app.routes if r.path == "/stream_item_type")

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -280,6 +280,16 @@ def test_include_router_copies_stream_item_type():
     route = next(r for r in main_app.routes if r.path == "/stream_item_type")
     assert getattr(route, "stream_item_type", None) == Item
 
+    with TestClient(main_app) as client:
+        response = client.get("/stream_item_type")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+        data_lines = [
+            line for line in response.text.strip().split("\n") if line.startswith("data: ")
+        ]
+        assert len(data_lines) == 1
+        assert '"name":"Plumbus"' in data_lines[0] or '"name": "Plumbus"' in data_lines[0]
+
 
 # Keepalive ping tests
 

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncIterable, Iterable, AsyncIterator
 
 import fastapi.routing
 import pytest
@@ -269,12 +269,12 @@ def test_include_router_copies_stream_item_type():
     sub_router = APIRouter()
 
     @sub_router.get("/stream_item_type", response_class=EventSourceResponse)
-    async def stream_item_type_route() -> AsyncIterable[Item]:
+    async def stream_item_type_route() -> AsyncIterator[Item]:
         yield items[0]
 
     assert getattr(sub_router.routes[-1], "stream_item_type", None) == Item
 
-    main_app = FastAPI()
+    main_app = FastAPI() 
     main_app.include_router(sub_router)
 
     route = next(r for r in main_app.routes if r.path == "/stream_item_type")

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -264,6 +264,23 @@ def test_sse_on_router_included_in_app(client: TestClient):
     ]
     assert len(data_lines) == 2
 
+def test_include_router_copies_stream_item_type():
+    sub_router = APIRouter()
+
+    @sub_router.get("/stream_item_type", response_class=EventSourceResponse)
+    async def stream_item_type_route() -> AsyncIterable[Item]:
+        yield items[0]
+
+    assert getattr(sub_router.routes[-1], "stream_item_type", None) == Item
+
+    main_app = FastAPI()
+    main_app.include_router(sub_router)
+
+    route = next(r for r in main_app.routes
+     if r.path == "/stream_item_type")
+    assert getattr(route, "stream_item_type", None) == Item
+
+
 
 # Keepalive ping tests
 

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -264,6 +264,7 @@ def test_sse_on_router_included_in_app(client: TestClient):
     ]
     assert len(data_lines) == 2
 
+
 def test_include_router_copies_stream_item_type():
     sub_router = APIRouter()
 
@@ -276,10 +277,8 @@ def test_include_router_copies_stream_item_type():
     main_app = FastAPI()
     main_app.include_router(sub_router)
 
-    route = next(r for r in main_app.routes
-     if r.path == "/stream_item_type")
+    route = next(r for r in main_app.routes if r.path == "/stream_item_type")
     assert getattr(route, "stream_item_type", None) == Item
-
 
 
 # Keepalive ping tests


### PR DESCRIPTION
## Problem

When defining SSE routes on an APIRouter and including it via include_router, the resulting route loses stream_item_type. This causes the OpenAPI schema to omit contentSchema for text/event-stream responses.

## Root Cause

APIRoute detects stream_item_type only when response_model is DefaultPlaceholder. During include_router, routes are recreated using add_api_route with response_model already resolved to None, so detection is skipped and stream_item_type is not set.

## Fix

After recreating the route via add_api_route, copy stream_item_type from the original route to the new route to preserve streaming metadata.

## Tests

- Added test to verify stream_item_type is preserved after include_router
- Ensured non-stream routes are unaffected