### PR TITLE
✏️ Fix Azkaban spelling typo in `virtual-environments.md‎`

### DIFF
--- a/docs/en/docs/virtual-environments.md
+++ b/docs/en/docs/virtual-environments.md
@@ -819,7 +819,7 @@ Traceback (most recent call last):
 
 </div>
 
-But if you deactivate the virtual environment and activate the new one for `prisoner-of-askaban` then when you run `python` it will use the Python from the virtual environment in `prisoner-of-azkaban`.
+But if you deactivate the virtual environment and activate the new one for `prisoner-of-azkaban` then when you run `python` it will use the Python from the virtual environment in `prisoner-of-azkaban`.
 
 <div class="termy">
 

--- a/docs/zh/docs/virtual-environments.md
+++ b/docs/zh/docs/virtual-environments.md
@@ -819,7 +819,7 @@ Traceback (most recent call last):
 
 </div>
 
-但是如果你停用虚拟环境并激活 `prisoner-of-azkaban` 的新虚拟环境，那么当你运行 `python` 时，它会使用 `prisoner-of-azkaban` 中的虚拟环境中的 Python。
+但是如果你停用虚拟环境并激活 `prisoner-of-askaban` 的新虚拟环境，那么当你运行 `python` 时，它会使用 `prisoner-of-askaban` 中的虚拟环境中的 Python。
 
 <div class="termy">
 

--- a/docs/zh/docs/virtual-environments.md
+++ b/docs/zh/docs/virtual-environments.md
@@ -819,7 +819,7 @@ Traceback (most recent call last):
 
 </div>
 
-但是如果你停用虚拟环境并激活 `prisoner-of-askaban` 的新虚拟环境，那么当你运行 `python` 时，它会使用 `prisoner-of-askaban` 中的虚拟环境中的 Python。
+但是如果你停用虚拟环境并激活 `prisoner-of-azkaban` 的新虚拟环境，那么当你运行 `python` 时，它会使用 `prisoner-of-azkaban` 中的虚拟环境中的 Python。
 
 <div class="termy">
 


### PR DESCRIPTION
### Description:

Corrected "prisoner-of-askaban" (s) to "prisoner-of-azkaban" (z) for consistency with the rest of the examples.

