### PR TITLE
👷 Fix missing credentials issue in `translate` workflow

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -79,6 +79,8 @@ jobs:
     if: github.repository_owner == 'fastapi'
     needs: langs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         lang: ${{ fromJson(needs.langs.outputs.langs) }}
@@ -91,7 +93,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true # Required for `git push` in `translate.py`
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
Currently translation workflow fails with `fatal: could not read Username for 'https://github.com/': No such device or address` due to missing credentials.
This PR fixes it

---

Should we also add `fail-fast: false`, so that if one job fails, others would not be cancelled?
