### PR TITLE
📝 Remove "NGINX Unit" from the list of ASGI-servers in docs

### DIFF
--- a/docs/en/docs/deployment/manually.md
+++ b/docs/en/docs/deployment/manually.md
@@ -56,7 +56,6 @@ There are several alternatives, including:
 * [Hypercorn](https://hypercorn.readthedocs.io/): an ASGI server compatible with HTTP/2 and Trio among other features.
 * [Daphne](https://github.com/django/daphne): the ASGI server built for Django Channels.
 * [Granian](https://github.com/emmett-framework/granian): A Rust HTTP server for Python applications.
-* [NGINX Unit](https://unit.nginx.org/howto/fastapi/): NGINX Unit is a lightweight and versatile web application runtime.
 
 ## Server Machine and Server Program { #server-machine-and-server-program }
 


### PR DESCRIPTION
hi i've removed nginx unit web server from docs because its unmaintained months and archived
https://github.com/fastapi/fastapi/discussions/15450