### PR TITLE
feat(deps): merge Body/Form/File/Query with Depends(model) in Annotated

### DIFF
--- a/docs/en/docs/advanced/body-depends-model-merge/body.md
+++ b/docs/en/docs/advanced/body-depends-model-merge/body.md
@@ -1,0 +1,19 @@
+# JSON request body { #json-request-body }
+
+Minimal end-to-end example: a helper `register_post_route` takes `schema: type[ItemBase]`. The path operation stays the same, while `Gadget` and `Part` change both the OpenAPI schema and the expected JSON body.
+
+The same `Annotated[..., Body(), Depends(schema)]` pattern works for all methods whenever you send JSON body.
+
+This file uses `POST` only to stay short. See [Which HTTP methods?](index.md#which-http-methods) on the overview page.
+
+## Models { #models }
+
+{* ../../docs_src/body_depends_model_merge_body/tutorial001_an_py310.py ln[10:19] hl[10:19] *}
+
+## The path operation { #the-path-operation }
+
+The parameter uses `ItemBase` for static typing, `Body()` so FastAPI treats the payload as JSON, and `Depends(schema)` so validation uses the class supplied when the route is registered. `register_post_route` wraps that in a factory; registrations mount `items_router` at prefix `/items`, so the paths are `/items/objects/gadgets/` and `/items/objects/parts/`:
+
+{* ../../docs_src/body_depends_model_merge_body/tutorial001_an_py310.py ln[22:53] hl[22:53] *}
+
+See [overview](index.md) for context and alternatives.

--- a/docs/en/docs/advanced/body-depends-model-merge/file.md
+++ b/docs/en/docs/advanced/body-depends-model-merge/file.md
@@ -1,0 +1,23 @@
+# File uploads { #file-uploads }
+
+Multipart uploads: `File()` inside `Annotated`, plus `Depends(schema)` when `schema` includes fields such as `UploadFile`. OpenAPI then describes file parts the same way as in the regular [Request Files](../../tutorial/request-files.md) tutorial.
+
+The sample uses `POST`, which is what browsers and most clients use for uploads. `PUT`, `PATCH`, or `DELETE` with multipart follow the same rules if the client actually sends multipart data. See [Which HTTP methods?](index.md#which-http-methods).
+
+## Models { #models }
+
+{* ../../docs_src/body_depends_model_merge_file/tutorial001_an_py310.py ln[10:19] hl[10:19] *}
+
+## The path operation { #the-path-operation }
+
+{* ../../docs_src/body_depends_model_merge_file/tutorial001_an_py310.py ln[22:41] hl[22:41] *}
+
+Full helper and registrations for `/files/attachments/commented/` and `/files/attachments/named/`:
+
+{* ../../docs_src/body_depends_model_merge_file/tutorial001_an_py310.py ln[44:57] hl[44:57] *}
+
+The handler returns a small JSON payload: upload metadata plus `data` from `model_dump(exclude={"file"})` so non-file fields (`comment`, `name`, …) stay JSON-serializable.
+
+Install [`python-multipart`](https://github.com/Kludex/python-multipart) for multipart support in your own project.
+
+See [overview](index.md) for context.

--- a/docs/en/docs/advanced/body-depends-model-merge/form.md
+++ b/docs/en/docs/advanced/body-depends-model-merge/form.md
@@ -1,0 +1,23 @@
+# Form data { #form-data }
+
+Form-encoded data needs `Form()` in the metadata and `Depends(YourModel)` when the provided model is only known in runtime.
+
+This example uses `POST` with `application/x-www-form-urlencoded`. The merge behaves the same on other methods if the client sends a form body. See [Which HTTP methods?](index.md#which-http-methods).
+
+## Models { #models }
+
+{* ../../docs_src/body_depends_model_merge_form/tutorial001_an_py310.py ln[10:19] hl[10:19] *}
+
+## The path operation { #the-path-operation }
+
+{* ../../docs_src/body_depends_model_merge_form/tutorial001_an_py310.py ln[22:37] hl[22:37] *}
+
+Full helper and router wiring (`/auth/session/password/` and `/auth/session/token/`):
+
+{* ../../docs_src/body_depends_model_merge_form/tutorial001_an_py310.py ln[40:53] hl[40:53] *}
+
+Install [`python-multipart`](https://github.com/Kludex/python-multipart) first. The [Form models](../../tutorial/request-form-models.md) tutorial has more background.
+
+For `GET` filters in the query string with a runtime `schema`, use `Annotated[..., Query(), Depends(schema)]` — see [Query parameters](query.md).
+
+See [overview](index.md) for context.

--- a/docs/en/docs/advanced/body-depends-model-merge/index.md
+++ b/docs/en/docs/advanced/body-depends-model-merge/index.md
@@ -1,0 +1,190 @@
+# Composing Annotated metadata for runtime validation schemas { #composing-annotated-metadata-for-runtime-validation-schemas }
+
+Several FastAPI helpers can live together inside one [`typing.Annotated`](../../python-types.md#type-hints-with-metadata-annotations) annotation: a normal Python type for your editor and for static analysis, plus markers such as `Body()`, `Form()`, `File()`, or `Query()` so FastAPI knows **where** to read the request, and `Depends(SomeModel)` so validation and OpenAPI know **which** Pydantic model to use.
+
+Sometimes the provided model is not fixed in source. You might build routes from a factory: the caller provides a model to generate a new view that validates against the provided class and exposes the right API. You also want the annotation to stay meaningful for type checkers.
+
+## Factories and dynamic models { #factories-and-dynamic-models }
+
+The straightforward closure passes the runtime schema type straight into the parameter annotation. FastAPI can use that to build request parsing and OpenAPI, because it inspects the annotation when the application loads:
+
+```python
+def new_create_view(schema: type[ItemBase]):
+    def create_view(
+        item_in: schema,
+    ):
+        print("creating a new item based on", item_in)
+        return ...
+
+    return create_view
+```
+
+For mypy, Pyright, and other static tools, this pattern won't work: the type for type checking should be static, and here the annotation is defined in runtime. Checkers expect annotations to describe types in a way they can resolve without executing any code, so you lose precise checking on `item_in` and the type checker will complain about using a variable as an annotation.
+
+Instead, you can use something wide as a static annotation, for example a shared base class. And the desired validation schema should be provided separately:
+
+```python
+def new_create_view(schema: type[ItemBase]):
+    def create_view(
+        item_in: Annotated[
+            ItemBase,
+            Body(),
+            Depends(schema),
+        ],
+    ):
+        print("creating a new item based on", item_in)
+        return ...
+
+    return create_view
+```
+
+The first argument to `Annotated` is the type you treat as `item_in` in typeshed-aware tooling: editors and checkers see `ItemBase`. Everything after it is metadata: `Body()` tells FastAPI the payload is a JSON body; `Depends(schema)` tells it which model class to use for validation and for generating OpenAPI for this route.
+
+A natural shape looks like this:
+
+```python
+def register(
+    router: APIRouter,
+    path_suffix: str,
+    schema: type[ItemBase],
+) -> None:
+
+    path = f"/create/{path_suffix}"
+
+    @router.post(path)
+    def create(
+        item_in: Annotated[
+            ItemBase,  # type annotation for the `item_in`
+            Body(),  # hint for FastAPI to expect Body
+            Depends(schema),  # required schema for body validation
+        ]
+    ):
+        print("processing item", item_in)
+        return ...
+```
+
+Older FastAPI kept only one of those `Annotated` markers. `Body()` could disappear, `Depends(schema)` was treated like an ordinary dependency, and the model fields were read from the query string instead of the JSON body.
+
+## Another approach: a small dependency per route { #another-approach-a-small-dependency-per-route }
+
+There's also another solution for older FastAPI versions, if you want to have proper annotation in the view and to specify the data location: create a new dependency function whose only parameter is the body, annotated with the desired model and `Body()`.
+
+The new way to do this is described in the [JSON request body example](body.md), here's the old way to do it:
+
+```python
+from fastapi import APIRouter, Body, Depends, FastAPI
+from pydantic import BaseModel
+
+
+class ItemBase(BaseModel):
+    name: str
+
+
+class Gadget(ItemBase):
+    description: str
+
+
+class Part(ItemBase):
+    sku: str
+
+
+def register_post_route(
+    router: APIRouter,
+    path: str,
+    schema: type[ItemBase],
+) -> None:
+
+    def parse_item(
+        item: schema = Body(),
+    ) -> ItemBase:
+        return item
+
+    @router.post(path)
+    def create_item(
+        item: ItemBase = Depends(parse_item),
+    ):
+        print("processing item", item)
+        return ...
+
+
+app = FastAPI()
+items_router = APIRouter()
+register_post_route(items_router, "/objects/gadgets/", Gadget)
+register_post_route(items_router, "/objects/parts/", Part)
+app.include_router(items_router, prefix="/items")
+```
+
+Each call to `register_post_route` closes over a different `schema`, so `parse_item` is not shared between routes. The tradeoff is boilerplate: an extra nested function and `Depends(...)` on the path-operation parameter, and also you will need to add ignore comments for mypy to skip the line with the `item: schema` annotation.
+
+## Merge inside `Annotated` { #merge-inside-annotated }
+
+FastAPI can combine `Body()`, `Form()`, `File()`, or `Query()` with `Depends(SomeModel)` when `SomeModel` is a subclass of Pydantic `BaseModel`. They collapse into one parameter: validation and OpenAPI use the model from `Depends`, while the first type argument to `Annotated` is what you use for static typing.
+
+The order of `Body`, `Form`, `File`, `Query`, and `Depends` inside `Annotated` does not matter.
+
+**You cannot mix** `Query()` with `Body()`, `Form()`, or `File()` in the same `Annotated` list.
+
+## Which HTTP methods? { #which-http-methods }
+
+The merge only fixes **where one parameter** is read. That is separate from the HTTP verb: `POST`, `PUT`, `PATCH`, `DELETE`, and the rest work the same for that parameter.
+
+### Query string and a merged body in the same path operation { #query-string-and-a-merged-body-in-the-same-path-operation }
+
+You cannot put `Query()` and `Body()` in the same `Annotated` list (see [limitations](#limitations)). You can add another parameter: e.g. bind data from the query string to one param, and bind payload from body to another parameter.
+
+#### Models { #models }
+
+Here we declare query models and record body models:
+
+{* ../../docs_src/body_depends_model_merge_query_plus_body/tutorial001_an_py310.py ln[10:31] hl[10:31] *}
+
+#### Path operation: merged query model + merged JSON body { #path-operation-merged-query-model-merged-json-body }
+
+{* ../../docs_src/body_depends_model_merge_query_plus_body/tutorial001_an_py310.py ln[34:52] hl[34:52] *}
+
+The `client_info` parameter uses merge for the query string:
+
+- static `ClientInfoBase` as type annotation
+- a `Query()` marker so FastAPI binds this parameter to query argument - bare `Query()` can be omitted, but it's ok to be placed to verbosely state that the query string should be processed here. Also, you will need to put `Query()` to provide extra OpenAPI options
+- `Depends(client_schema)` for the provided model
+
+The `record` parameter does the same for the JSON body with `Body()` and `Depends(record_schema)`.
+
+The first argument to each `Annotated[...]` (`ClientInfoBase`, `RecordBase`) is what language servers and type checkers use for static analysis.
+
+
+#### Handler body { #handler-body }
+
+Inside the handler, your IDE can suggest attributes such as `client_info.client_id` and `record.title`, also anything from parent class is available too, for example the `.model_dump()` method. And tools like mypy or Pyright check those attributes against the provided types. At runtime, FastAPI still validates data with the provided classes.
+
+{* ../../docs_src/body_depends_model_merge_query_plus_body/tutorial001_an_py310.py ln[53:57] hl[53:57] *}
+
+#### Register routes { #register-routes }
+
+Factories mount two POST routes under `/clients`, passing both record and client schemas:
+
+{* ../../docs_src/body_depends_model_merge_query_plus_body/tutorial001_an_py310.py ln[62:81] hl[62:81] *}
+
+The same layout applies if the body parameter uses `Form()` or `File()` with `Depends(schema)` instead of `Body()` - always as its own parameter alongside the merged query parameter, not mixed into one `Annotated`.
+
+## When this matters { #when-this-matters }
+
+It matters most when the validation model is chosen while registering routes (see the example above): your helper takes `schema: type[ItemBase]`, you want one implementation and several paths, and each path should expose the right OpenAPI schema. `Depends(schema)` alone means `Query`, but when you need to say where the data comes from, you need to provide `Body` / `Form` / `File` / `Query` as a hint for FastAPI.
+
+
+## Examples { #examples }
+
+* [JSON request body](body.md): `application/json`; the sample uses `POST` (same idea for `PUT`, `PATCH`, `DELETE` with a JSON body).
+* [Form data](form.md): `application/x-www-form-urlencoded`.
+* [File uploads](file.md): typical file upload flow.
+* [Query parameters](query.md): `GET` with a query model chosen at registration time.
+
+## Limitations { #limitations }
+
+The shortcut applies only when:
+
+* There is exactly one “shape” marker among `Body()`, `Form()`, `File()`, and `Query()`.
+* There is exactly one `Depends`.
+* You do not add other parameter markers such as `Path` or `Header` into the same `Annotated` bucket.
+
+If the declaration does not match these rules, FastAPI may raise an exception.

--- a/docs/en/docs/advanced/body-depends-model-merge/query.md
+++ b/docs/en/docs/advanced/body-depends-model-merge/query.md
@@ -1,0 +1,23 @@
+# Query parameters { #query-parameters }
+
+The same runtime `schema` idea as JSON `Body()` applies to query parameters: keep a base model in the type position and pass `Depends(schema)` when `schema` is fixed only at registration time. `Query()` must stay in `Annotated` so FastAPI reads fields from the query string. A bare base model on `GET` would still default to a body parameter.
+
+## Models { #models }
+
+{* ../../docs_src/body_depends_model_merge_query/tutorial001_an_py310.py ln[10:20] hl[10:20] *}
+
+## The path operation { #the-path-operation }
+
+{* ../../docs_src/body_depends_model_merge_query/tutorial001_an_py310.py ln[23:38] hl[23:38] *}
+
+You can still use `Annotated[SomeModel, Query()]` without `Depends` when your class never changes.
+And if it does, you can do `Annotated[SomeModelBase, Depends(SomeModel)]` to keep proper annotation.
+But if you need to explicitly state that the `Query` is required here, follow the example.
+
+## List routes wired with `schema` { #list-routes-wired-with-schema }
+
+One helper registers `/catalog/items/` (full filters), `/catalog/items-paginated/` (pagination fields), and `/catalog/basics/` (only the base fields):
+
+{* ../../docs_src/body_depends_model_merge_query/tutorial001_an_py310.py ln[41:59] hl[41:59] *}
+
+More on query handling: [Query params](../../tutorial/query-params.md), [Query parameter models](../../tutorial/query-param-models.md). [Overview](index.md) for this feature set.

--- a/docs/en/docs/tutorial/body.md
+++ b/docs/en/docs/tutorial/body.md
@@ -164,3 +164,5 @@ But adding the type annotations will allow your editor to give you better suppor
 ## Without Pydantic { #without-pydantic }
 
 If you don't want to use Pydantic models, you can also use **Body** parameters. See the docs for [Body - Multiple Parameters: Singular values in body](body-multiple-params.md#singular-values-in-body).
+
+If you need to provide a model for validation on-the-go, see [Composing Annotated metadata for runtime validation schemas](../advanced/body-depends-model-merge/index.md).

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -173,6 +173,12 @@ nav:
     - advanced/response-headers.md
     - advanced/response-change-status-code.md
     - advanced/advanced-dependencies.md
+    - Composing Annotated metadata for runtime validation schemas:
+      - advanced/body-depends-model-merge/index.md
+      - advanced/body-depends-model-merge/body.md
+      - advanced/body-depends-model-merge/form.md
+      - advanced/body-depends-model-merge/file.md
+      - advanced/body-depends-model-merge/query.md
     - Advanced Security:
       - advanced/security/index.md
       - advanced/security/oauth2-scopes.md

--- a/docs_src/app_testing/tutorial001_py310.py
+++ b/docs_src/app_testing/tutorial001_py310.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 app = FastAPI()
@@ -14,5 +14,5 @@ client = TestClient(app)
 
 def test_read_main():
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == status.HTTP_200_OK, response.text
     assert response.json() == {"msg": "Hello World"}

--- a/docs_src/body_depends_model_merge_body/tutorial001_an_py310.py
+++ b/docs_src/body_depends_model_merge_body/tutorial001_an_py310.py
@@ -1,0 +1,53 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+items_router = APIRouter()
+
+
+class ItemBase(BaseModel):
+    name: str
+
+
+class Gadget(ItemBase):
+    description: str
+
+
+class Part(ItemBase):
+    sku: str
+
+
+def register_post_route(
+    router: APIRouter,
+    path: str,
+    schema: type[ItemBase],
+):
+    @router.post(path)
+    def create_entity(
+        entity: Annotated[
+            ItemBase,
+            Body(),
+            Depends(schema),
+        ],
+    ):
+        return entity
+
+    return create_entity
+
+
+register_post_route(
+    items_router,
+    "/objects/gadgets/",
+    Gadget,
+)
+register_post_route(
+    items_router,
+    "/objects/parts/",
+    Part,
+)
+app.include_router(
+    items_router,
+    prefix="/items",
+)

--- a/docs_src/body_depends_model_merge_file/tutorial001_an_py310.py
+++ b/docs_src/body_depends_model_merge_file/tutorial001_an_py310.py
@@ -1,0 +1,57 @@
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, FastAPI, File, UploadFile
+from pydantic import BaseModel
+
+app = FastAPI()
+files_router = APIRouter()
+
+
+class AttachmentBase(BaseModel):
+    file: UploadFile
+
+
+class CommentedAttachment(AttachmentBase):
+    comment: str = ""
+
+
+class NamedAttachment(AttachmentBase):
+    name: str = ""
+
+
+def register_upload_route(
+    router: APIRouter,
+    path: str,
+    schema: type[AttachmentBase],
+):
+    @router.post(path)
+    async def upload(
+        attachment: Annotated[
+            AttachmentBase,
+            File(),
+            Depends(schema),
+        ],
+    ) -> dict[str, Any]:
+        return {
+            "filename": attachment.file.filename,
+            "content_type": attachment.file.content_type,
+            "data": attachment.model_dump(exclude={"file"}),
+        }
+
+    return upload
+
+
+register_upload_route(
+    files_router,
+    "/attachments/commented/",
+    CommentedAttachment,
+)
+register_upload_route(
+    files_router,
+    "/attachments/named/",
+    NamedAttachment,
+)
+app.include_router(
+    files_router,
+    prefix="/files",
+)

--- a/docs_src/body_depends_model_merge_form/tutorial001_an_py310.py
+++ b/docs_src/body_depends_model_merge_form/tutorial001_an_py310.py
@@ -1,0 +1,53 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, FastAPI, Form
+from pydantic import BaseModel
+
+app = FastAPI()
+auth_router = APIRouter()
+
+
+class AccountBase(BaseModel):
+    username: str
+
+
+class PasswordLogin(AccountBase):
+    password: str
+
+
+class TokenLogin(AccountBase):
+    token: str
+
+
+def register_form_post(
+    router: APIRouter,
+    path: str,
+    schema: type[AccountBase],
+):
+    @router.post(path)
+    def authenticate(
+        data: Annotated[
+            AccountBase,
+            Form(),
+            Depends(schema),
+        ],
+    ):
+        return data
+
+    return authenticate
+
+
+register_form_post(
+    auth_router,
+    "/session/password/",
+    PasswordLogin,
+)
+register_form_post(
+    auth_router,
+    "/session/token/",
+    TokenLogin,
+)
+app.include_router(
+    auth_router,
+    prefix="/auth",
+)

--- a/docs_src/body_depends_model_merge_query/tutorial001_an_py310.py
+++ b/docs_src/body_depends_model_merge_query/tutorial001_an_py310.py
@@ -1,0 +1,59 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, FastAPI, Query
+from pydantic import BaseModel
+
+app = FastAPI()
+catalog_router = APIRouter()
+
+
+class ProductFiltersBase(BaseModel):
+    category: str | None = None
+
+
+class ProductFiltersFull(ProductFiltersBase):
+    in_stock: bool = True
+
+
+class ProductFiltersPaginated(ProductFiltersBase):
+    page: int = 1
+    per_page: int = 10
+
+
+def register_product_list(
+    router: APIRouter,
+    path: str,
+    schema: type[ProductFiltersBase],
+):
+    @router.get(path)
+    def list_products(
+        params: Annotated[
+            ProductFiltersBase,
+            Query(),  # optional
+            Depends(schema),
+        ],
+    ):
+        return params
+
+    return list_products
+
+
+register_product_list(
+    catalog_router,
+    "/items/",
+    ProductFiltersFull,
+)
+register_product_list(
+    catalog_router,
+    "/items-paginated/",
+    ProductFiltersPaginated,
+)
+register_product_list(
+    catalog_router,
+    "/basics/",
+    ProductFiltersBase,
+)
+app.include_router(
+    catalog_router,
+    prefix="/catalog",
+)

--- a/docs_src/body_depends_model_merge_query_plus_body/tutorial001_an_py310.py
+++ b/docs_src/body_depends_model_merge_query_plus_body/tutorial001_an_py310.py
@@ -1,0 +1,77 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, FastAPI, Query
+from pydantic import BaseModel
+
+app = FastAPI()
+records_router = APIRouter()
+
+
+class ClientInfoBase(BaseModel):
+    client_id: str
+
+
+class RetailClientInfo(ClientInfoBase):
+    region: str | None = None
+
+
+class PartnerClientInfo(ClientInfoBase):
+    contract_ref: str
+
+
+class RecordBase(BaseModel):
+    title: str
+
+
+class CaseFileRecord(RecordBase):
+    case_number: str
+
+
+class ContractRecord(RecordBase):
+    contract_id: str
+
+
+def register_record_route(
+    router: APIRouter,
+    path: str,
+    record_schema: type[RecordBase],
+    client_schema: type[ClientInfoBase],
+):
+    @router.post(path)
+    def create_record(
+        client_info: Annotated[
+            ClientInfoBase,
+            Query(),
+            Depends(client_schema),
+        ],
+        record: Annotated[
+            RecordBase,
+            Body(),
+            Depends(record_schema),
+        ],
+    ):
+        print(f"processing client #{client_info.client_id} data {record.title!r}")
+        return {
+            "client_info": client_info.model_dump(),
+            "record": record.model_dump(),
+        }
+
+    return create_record
+
+
+register_record_route(
+    records_router,
+    "/case-files/",
+    CaseFileRecord,
+    RetailClientInfo,
+)
+register_record_route(
+    records_router,
+    "/contracts/",
+    ContractRecord,
+    PartnerClientInfo,
+)
+app.include_router(
+    records_router,
+    prefix="/clients",
+)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -55,7 +55,7 @@ from fastapi.concurrency import (
     contextmanager_in_threadpool,
 )
 from fastapi.dependencies.models import Dependant
-from fastapi.exceptions import DependencyScopeError
+from fastapi.exceptions import DependencyScopeError, FastAPIError
 from fastapi.logger import logger
 from fastapi.security.oauth2 import SecurityScopes
 from fastapi.types import DependencyCacheKey
@@ -390,6 +390,204 @@ class ParamDetails:
     field: ModelField | None
 
 
+@dataclass(slots=True)
+class _AnnotatedBodyDependsMerge:
+    """Result of ``Annotated[..., marker, Depends(Model)]`` (order-independent)."""
+
+    field_info: FieldInfo
+    use_annotation: Any
+
+
+class _AnnotatedBodyDependsMerger:
+    """
+    Merge ``Body`` / ``Form`` / ``File`` / ``Query`` with ``Depends(model_cls)`` inside ``Annotated``.
+
+    FastAPI normally keeps only the last marker in ``Annotated[...]``, so
+    ``Annotated[T, Body(), Depends(Foo)]`` used to ignore ``Body`` and treat ``Foo`` as a
+    dependency (e.g. query fields). This path combines them into one field (body, form,
+    multipart, or query): OpenAPI and validation use ``Foo``; the handler parameter's
+    declared type stays ``T`` (``declared_type``, i.e. the first ``Annotated`` argument).
+
+    Contract:
+    - Exactly one of ``Body()``, ``Form()``, ``File()``, or ``Query()`` among
+      FastAPI-specific metadata (not ``Body`` and ``Query`` together).
+    - Exactly one ``Depends``, whose dependency resolves to a single ``BaseModel`` subclass
+      (not a callable, not ``Security``).
+    - No other ``Param`` kinds in the same ``Annotated`` (e.g. ``Path``, ``Header``, …)
+      besides the single shape marker and ``Depends``.
+    - Not used on path parameters.
+    - Order of markers in ``Annotated`` does not matter.
+    """
+
+    __slots__ = (
+        "param_name",
+        "declared_type",
+        "fastapi_specific_annotations",
+        "value",
+        "is_path_param",
+    )
+
+    def __init__(
+        self,
+        *,
+        param_name: str,
+        declared_type: Any,
+        fastapi_specific_annotations: list[Any],
+        value: Any,
+        is_path_param: bool,
+    ) -> None:
+        self.param_name = param_name
+        self.declared_type = declared_type
+        self.fastapi_specific_annotations = fastapi_specific_annotations
+        self.value = value
+        self.is_path_param = is_path_param
+
+    def try_build(self) -> _AnnotatedBodyDependsMerge | None:
+        body_like_markers, query_markers, depends_markers = self._collect_markers()
+        if body_like_markers and query_markers:
+            raise FastAPIError(
+                f"Cannot combine `Query` with `Body`, `Form`, or `File` in `Annotated` for "
+                f"{self.param_name!r}"
+            )
+        shape_markers = body_like_markers or query_markers
+        if not (shape_markers and depends_markers):
+            return None
+
+        self._validate_path_parameter()
+        self._validate_single_body_like_marker(body_like_markers)
+        self._validate_single_query_marker(query_markers)
+        self._validate_single_depends_marker(depends_markers)
+        shape_marker = shape_markers[0]
+        self._validate_no_conflicting_param_markers(shape_marker=shape_marker)
+        dep_marker = self._copy_depends_marker_with_declared_type_fallback(
+            depends_markers=depends_markers,
+        )
+        self._validate_depends_not_security(dep_marker)
+        model_cls = self._require_pydantic_model_class(dep_marker)
+        field_info, merged_annotation = self._build_field_info_and_annotation(
+            model_cls=model_cls,
+            shape_marker=shape_marker,
+        )
+        self._apply_signature_default_to_field_info(field_info)
+        return _AnnotatedBodyDependsMerge(
+            field_info=field_info,
+            use_annotation=merged_annotation,
+        )
+
+    def _collect_markers(self) -> tuple[list[Any], list[Any], list[Any]]:
+        body_like = [
+            arg
+            for arg in self.fastapi_specific_annotations
+            if isinstance(arg, params.Body)
+        ]
+        queries = [
+            arg
+            for arg in self.fastapi_specific_annotations
+            if isinstance(arg, params.Query)
+        ]
+        depends = [
+            arg
+            for arg in self.fastapi_specific_annotations
+            if isinstance(arg, params.Depends)
+        ]
+        return body_like, queries, depends
+
+    def _validate_path_parameter(self) -> None:
+        if self.is_path_param:
+            raise FastAPIError(
+                f"Cannot combine `Body`/`Form`/`File`/`Query` with `Depends` in `Annotated` "
+                f"for path parameter {self.param_name!r}"
+            )
+
+    def _validate_single_body_like_marker(self, body_like_markers: list[Any]) -> None:
+        if len(body_like_markers) > 1:
+            raise FastAPIError(
+                f"Cannot specify multiple `Body`, `Form`, or `File` markers for "
+                f"{self.param_name!r} when using `Depends` in the same `Annotated`"
+            )
+
+    def _validate_single_query_marker(self, query_markers: list[Any]) -> None:
+        if len(query_markers) > 1:
+            raise FastAPIError(
+                f"Cannot specify multiple `Query` markers for {self.param_name!r} when "
+                f"using `Depends` in the same `Annotated`"
+            )
+
+    def _validate_single_depends_marker(self, depends_markers: list[Any]) -> None:
+        if len(depends_markers) > 1:
+            raise FastAPIError(
+                f"Cannot specify multiple `Depends` together with `Body`, `Form`, "
+                f"`File`, or `Query` in `Annotated` for {self.param_name!r}"
+            )
+
+    def _conflicting_param_markers(self, *, shape_marker: Any) -> list[Any]:
+        return [
+            arg
+            for arg in self.fastapi_specific_annotations
+            if isinstance(arg, params.Param) and arg is not shape_marker
+        ]
+
+    def _validate_no_conflicting_param_markers(self, *, shape_marker: Any) -> None:
+        if self._conflicting_param_markers(shape_marker=shape_marker):
+            raise FastAPIError(
+                f"Cannot combine `Body`/`Form`/`File`/`Query` with other parameter types "
+                f"(e.g. `Path`, `Header`) in `Annotated` for {self.param_name!r}"
+            )
+
+    def _copy_depends_marker_with_declared_type_fallback(
+        self, depends_markers: list[Any]
+    ) -> params.Depends:
+        dep_marker = cast(params.Depends, copy(depends_markers[0]))
+        if dep_marker.dependency is None:
+            dep_marker = dataclasses.replace(dep_marker, dependency=self.declared_type)
+        return dep_marker
+
+    def _validate_depends_not_security(self, dep_marker: params.Depends) -> None:
+        if isinstance(dep_marker, params.Security):
+            raise FastAPIError(
+                f"Cannot combine `Body`/`Form`/`File`/`Query` with `Security` in `Annotated` "
+                f"for {self.param_name!r}"
+            )
+
+    def _require_pydantic_model_class(
+        self, dep_marker: params.Depends
+    ) -> type[BaseModel]:
+        dependency = dep_marker.dependency
+        assert dependency is not None
+        if not isinstance(dependency, type) or not lenient_issubclass(
+            dependency, BaseModel
+        ):
+            raise FastAPIError(
+                f"When using `Body`, `Form`, `File`, or `Query` together with `Depends` in "
+                f"`Annotated` for {self.param_name!r}, `Depends` must reference a Pydantic "
+                f"model class (e.g. `Depends(MyModel)`), not a callable dependency."
+            )
+        return dependency
+
+    def _build_field_info_and_annotation(
+        self,
+        model_cls: type[BaseModel],
+        shape_marker: Any,
+    ) -> tuple[FieldInfo, Any]:
+        merged_annotation = Annotated[model_cls, shape_marker]  # type: ignore[valid-type]
+        field_info = copy_field_info(
+            field_info=shape_marker,
+            annotation=merged_annotation,
+        )
+        assert field_info.default == Undefined or field_info.default == RequiredParam, (
+            f"`{field_info.__class__.__name__}` default value cannot be set in"
+            f" `Annotated` for {self.param_name!r}. Set the default value with `=` instead."
+        )
+        return field_info, merged_annotation
+
+    def _apply_signature_default_to_field_info(self, field_info: FieldInfo) -> None:
+        if self.value is not inspect.Signature.empty:
+            assert not self.is_path_param, "Path parameters cannot have default values"
+            field_info.default = self.value
+        else:
+            field_info.default = RequiredParam
+
+
 def analyze_param(
     *,
     param_name: str,
@@ -428,14 +626,24 @@ def analyze_param(
                 ),
             )
         ]
-        if fastapi_specific_annotations:
-            fastapi_annotation: FieldInfo | params.Depends | None = (
-                fastapi_specific_annotations[-1]
-            )
-        else:
-            fastapi_annotation = None
-        # Set default for Annotated FieldInfo
-        if isinstance(fastapi_annotation, FieldInfo):
+        merged_body_depends = False
+        fastapi_annotation: FieldInfo | params.Depends | None = None
+        body_depends_merge = _AnnotatedBodyDependsMerger(
+            param_name=param_name,
+            declared_type=type_annotation,
+            fastapi_specific_annotations=fastapi_specific_annotations,
+            value=value,
+            is_path_param=is_path_param,
+        ).try_build()
+        if body_depends_merge is not None:
+            field_info = body_depends_merge.field_info
+            use_annotation = body_depends_merge.use_annotation
+            depends = None
+            merged_body_depends = True
+        elif fastapi_specific_annotations:
+            fastapi_annotation = fastapi_specific_annotations[-1]
+        # Set default for Annotated FieldInfo / Depends (single winner unless merged above)
+        if not merged_body_depends and isinstance(fastapi_annotation, FieldInfo):
             # Copy `field_info` because we mutate `field_info.default` below.
             field_info = copy_field_info(
                 field_info=fastapi_annotation,
@@ -452,8 +660,7 @@ def analyze_param(
                 field_info.default = value
             else:
                 field_info.default = RequiredParam
-        # Get Annotated Depends
-        elif isinstance(fastapi_annotation, params.Depends):
+        elif not merged_body_depends and isinstance(fastapi_annotation, params.Depends):
             depends = fastapi_annotation
     # Get Depends from default value
     if isinstance(value, params.Depends):

--- a/tests/_annotated_body_depends_merge_common.py
+++ b/tests/_annotated_body_depends_merge_common.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from fastapi import UploadFile
+from pydantic import BaseModel
+
+
+class BasePayload(BaseModel):
+    kind: str
+
+
+class FooPayload(BasePayload):
+    kind: str = "foo"
+    extra_foo: str
+
+
+class BarPayload(BasePayload):
+    kind: str = "bar"
+    extra_bar: str
+
+
+class FooFilePayload(BasePayload):
+    kind: str = "foo"
+    extra_foo: str
+    blob: UploadFile
+
+
+class BarFilePayload(BasePayload):
+    kind: str = "bar"
+    extra_bar: str
+    blob: UploadFile
+
+
+def openapi_request_body_schema_ref(
+    schema: dict[str, Any],
+    *,
+    path: str,
+    method: str = "post",
+    content_type: str,
+) -> str:
+    return schema["paths"][path][method]["requestBody"]["content"][content_type][
+        "schema"
+    ]["$ref"]

--- a/tests/docs_src/_loader.py
+++ b/tests/docs_src/_loader.py
@@ -1,0 +1,24 @@
+"""Load `docs_src` tutorial modules by path for smoke tests."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+_DOCS_SRC = Path(__file__).resolve().parent.parent.parent / "docs_src"
+
+
+def load_docs_src_module(unique_name: str, *relative_parts: str):
+    path = _DOCS_SRC.joinpath(*relative_parts)
+    spec = importlib.util.spec_from_file_location(unique_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[unique_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def docs_src_test_client(unique_name: str, *relative_parts: str) -> TestClient:
+    mod = load_docs_src_module(unique_name, *relative_parts)
+    return TestClient(mod.app)

--- a/tests/docs_src/body_depends_model_merge_body/test_body_depends_model_merge_tutorial001.py
+++ b/tests/docs_src/body_depends_model_merge_body/test_body_depends_model_merge_tutorial001.py
@@ -1,0 +1,34 @@
+import pytest
+from fastapi import status
+
+from tests.docs_src._loader import docs_src_test_client
+
+
+@pytest.fixture(scope="module")
+def client():
+    return docs_src_test_client(
+        "docs_src_body_depends_model_merge_body_tutorial001",
+        "body_depends_model_merge_body",
+        "tutorial001_an_py310.py",
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        pytest.param(
+            "/items/objects/gadgets/",
+            {"name": "G1", "description": "d1"},
+            id="gadget",
+        ),
+        pytest.param(
+            "/items/objects/parts/",
+            {"name": "P1", "sku": "S1"},
+            id="part",
+        ),
+    ],
+)
+def test_json_body_depends_model_merge(client, path, payload):
+    response = client.post(path, json=payload)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json() == payload

--- a/tests/docs_src/body_depends_model_merge_file/test_file_depends_model_merge_tutorial001.py
+++ b/tests/docs_src/body_depends_model_merge_file/test_file_depends_model_merge_tutorial001.py
@@ -1,0 +1,53 @@
+import pytest
+from fastapi import status
+
+from tests.docs_src._loader import docs_src_test_client
+
+
+@pytest.fixture(scope="module")
+def client():
+    return docs_src_test_client(
+        "docs_src_body_depends_model_merge_file_tutorial001",
+        "body_depends_model_merge_file",
+        "tutorial001_an_py310.py",
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "form_fields", "file_name", "file_bytes", "file_ct"),
+    [
+        pytest.param(
+            "/files/attachments/commented/",
+            {"comment": "Spec"},
+            "doc.pdf",
+            b"%PDF-1.4\n",
+            "application/pdf",
+            id="commented",
+        ),
+        pytest.param(
+            "/files/attachments/named/",
+            {"name": "My text file"},
+            "file.txt",
+            b"hello",
+            "text/plain",
+            id="named",
+        ),
+    ],
+)
+def test_file_depends_model_merge(
+    client,
+    path,
+    form_fields,
+    file_name,
+    file_bytes,
+    file_ct,
+):
+    upload = (file_name, file_bytes, file_ct)
+    response = client.post(path, data=form_fields, files={"file": upload})
+    assert response.status_code == status.HTTP_200_OK, response.text
+    expected = {
+        "filename": file_name,
+        "content_type": file_ct,
+        "data": form_fields,
+    }
+    assert response.json() == expected

--- a/tests/docs_src/body_depends_model_merge_form/test_form_depends_model_merge_tutorial001.py
+++ b/tests/docs_src/body_depends_model_merge_form/test_form_depends_model_merge_tutorial001.py
@@ -1,0 +1,34 @@
+import pytest
+from fastapi import status
+
+from tests.docs_src._loader import docs_src_test_client
+
+
+@pytest.fixture(scope="module")
+def client():
+    return docs_src_test_client(
+        "docs_src_body_depends_model_merge_form_tutorial001",
+        "body_depends_model_merge_form",
+        "tutorial001_an_py310.py",
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "form_data"),
+    [
+        pytest.param(
+            "/auth/session/password/",
+            {"username": "alice", "password": "secret"},
+            id="password",
+        ),
+        pytest.param(
+            "/auth/session/token/",
+            {"username": "bob", "token": "tok-123"},
+            id="token",
+        ),
+    ],
+)
+def test_form_depends_model_merge(client, path, form_data):
+    response = client.post(path, data=form_data)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json() == form_data

--- a/tests/docs_src/body_depends_model_merge_query/test_query_depends_model_merge_tutorial001.py
+++ b/tests/docs_src/body_depends_model_merge_query/test_query_depends_model_merge_tutorial001.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi import status
+
+from tests.docs_src._loader import docs_src_test_client
+
+
+@pytest.fixture(scope="module")
+def client():
+    return docs_src_test_client(
+        "docs_src_body_depends_model_merge_query_tutorial001",
+        "body_depends_model_merge_query",
+        "tutorial001_an_py310.py",
+    )
+
+
+_CATEGORY = "books"
+
+
+@pytest.mark.parametrize(
+    ("path", "params"),
+    [
+        pytest.param(
+            "/catalog/items/",
+            {"category": _CATEGORY, "in_stock": False},
+            id="items_full",
+        ),
+        pytest.param(
+            "/catalog/basics/",
+            {"category": _CATEGORY},
+            id="basics",
+        ),
+        pytest.param(
+            "/catalog/items-paginated/",
+            {"category": _CATEGORY, "page": 2, "per_page": 5},
+            id="paginated",
+        ),
+    ],
+)
+def test_query_depends_model_merge(client, path, params):
+    response = client.get(path, params=params)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json() == params

--- a/tests/docs_src/body_depends_model_merge_query_plus_body/test_query_plus_body_tutorial001.py
+++ b/tests/docs_src/body_depends_model_merge_query_plus_body/test_query_plus_body_tutorial001.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi import status
+
+from tests.docs_src._loader import docs_src_test_client
+
+
+@pytest.fixture(scope="module")
+def client():
+    return docs_src_test_client(
+        "docs_src_body_depends_model_merge_query_plus_body_tutorial001",
+        "body_depends_model_merge_query_plus_body",
+        "tutorial001_an_py310.py",
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "query", "json_body"),
+    [
+        (
+            "/clients/case-files/",
+            {"client_id": "rick", "region": "west"},
+            {"title": "Q1", "case_number": "C-9"},
+        ),
+        (
+            "/clients/contracts/",
+            {"client_id": "morty", "contract_ref": "R-9"},
+            {"title": "Partner deal", "contract_id": "Z-1"},
+        ),
+    ],
+    ids=["case_file", "contract"],
+)
+def test_query_plus_merged_json_body(client, path, query, json_body):
+    response = client.post(path, params=query, json=json_body)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    expected = {
+        "client_info": query,
+        "record": json_body,
+    }
+    assert response.json() == expected

--- a/tests/docs_src/body_depends_model_merge_query_plus_body/test_query_plus_body_tutorial001.py
+++ b/tests/docs_src/body_depends_model_merge_query_plus_body/test_query_plus_body_tutorial001.py
@@ -16,18 +16,19 @@ def client():
 @pytest.mark.parametrize(
     ("path", "query", "json_body"),
     [
-        (
+        pytest.param(
             "/clients/case-files/",
             {"client_id": "rick", "region": "west"},
             {"title": "Q1", "case_number": "C-9"},
+            id="case_file",
         ),
-        (
+        pytest.param(
             "/clients/contracts/",
             {"client_id": "morty", "contract_ref": "R-9"},
             {"title": "Partner deal", "contract_id": "Z-1"},
+            id="contract",
         ),
     ],
-    ids=["case_file", "contract"],
 )
 def test_query_plus_merged_json_body(client, path, query, json_body):
     response = client.post(path, params=query, json=json_body)

--- a/tests/test_annotated_body_depends_merge_body.py
+++ b/tests/test_annotated_body_depends_merge_body.py
@@ -36,10 +36,27 @@ class TestAnnotatedBodyDependsMergeBody:
             "model_cls",
             "expected_ref_suffix",
             "assert_no_query_params",
+            "payload",
         ),
         [
-            ("/a", Body(), Depends(FooPayload), FooPayload, "FooPayload", True),
-            ("/b", Depends(BarPayload), Body(), BarPayload, "BarPayload", False),
+            pytest.param(
+                "/a",
+                Body(),
+                Depends(FooPayload),
+                FooPayload,
+                "FooPayload",
+                True,
+                {"kind": "foo", "extra_foo": "hit"},
+            ),
+            pytest.param(
+                "/b",
+                Depends(BarPayload),
+                Body(),
+                BarPayload,
+                "BarPayload",
+                False,
+                {"kind": "bar", "extra_bar": "hit"},
+            ),
         ],
     )
     def test_openapi_json_body_depends_merge(
@@ -50,6 +67,7 @@ class TestAnnotatedBodyDependsMergeBody:
         model_cls: type[BasePayload],
         expected_ref_suffix: str,
         assert_no_query_params: bool,
+        payload: dict[str, str],
     ) -> None:
         app = FastAPI()
 
@@ -69,6 +87,9 @@ class TestAnnotatedBodyDependsMergeBody:
         )
         assert ref.endswith(f"/{expected_ref_suffix}")
 
+        ok = client.post(path, json=payload)
+        assert ok.status_code == status.HTTP_200_OK
+
     def test_runtime_json_validates_concrete_model(self) -> None:
         app = FastAPI()
 
@@ -79,9 +100,12 @@ class TestAnnotatedBodyDependsMergeBody:
             return {"extra": data.extra_foo}
 
         client = TestClient(app)
-        r = client.post("/c", json={"kind": "foo", "extra_foo": "x"})
+        extra = "ricksanchez"
+        payload = {"kind": "foo", "extra_foo": extra}
+        expected_json = {"extra": extra}
+        r = client.post("/c", json=payload)
         assert r.status_code == status.HTTP_200_OK
-        assert r.json() == {"extra": "x"}
+        assert r.json() == expected_json
 
         bad = client.post("/c", json={"kind": "foo"})
         # not status.*: Starlette confused HTTP_422_UNPROCESSABLE_CONTENT HTTP_422_UNPROCESSABLE_ENTITY
@@ -97,9 +121,12 @@ class TestAnnotatedBodyDependsMergeBody:
             return {"extra": data.extra_foo}
 
         client = TestClient(app)
-        r = client.post("/depends-empty", json={"kind": "foo", "extra_foo": "z"})
+        extra = "foobar"
+        payload = {"kind": "foo", "extra_foo": extra}
+        expected_json = {"extra": extra}
+        r = client.post("/depends-empty", json=payload)
         assert r.status_code == status.HTTP_200_OK
-        assert r.json() == {"extra": "z"}
+        assert r.json() == expected_json
 
     def test_merged_body_parameter_signature_default(self) -> None:
         app = FastAPI()
@@ -115,13 +142,15 @@ class TestAnnotatedBodyDependsMergeBody:
         client = TestClient(app)
         empty = client.post("/merged-default")
         assert empty.status_code == status.HTTP_200_OK
-        assert empty.json() == {"extra": "default"}
+        expected_default = {"extra": "default"}
+        assert empty.json() == expected_default
 
-        overridden = client.post(
-            "/merged-default", json={"kind": "foo", "extra_foo": "ov"}
-        )
+        override_extra = "hello world"
+        override_payload = {"kind": "foo", "extra_foo": override_extra}
+        expected_override = {"extra": override_extra}
+        overridden = client.post("/merged-default", json=override_payload)
         assert overridden.status_code == status.HTTP_200_OK
-        assert overridden.json() == {"extra": "ov"}
+        assert overridden.json() == expected_override
 
     def test_put_patch_json_body_depends_openapi(self) -> None:
         app = FastAPI()
@@ -149,16 +178,20 @@ class TestAnnotatedBodyDependsMergeBody:
             )
             assert ref.endswith("/FooPayload")
 
-        r = client.put("/items/1", json={"kind": "foo", "extra_foo": "a"})
+        put_extra = "fizz"
+        put_payload = {"kind": "foo", "extra_foo": put_extra}
+        r = client.put("/items/1", json=put_payload)
         assert r.status_code == status.HTTP_200_OK
-        r2 = client.patch("/items/1", json={"kind": "foo", "extra_foo": "b"})
+        patch_extra = "buzz"
+        patch_payload = {"kind": "foo", "extra_foo": patch_extra}
+        r2 = client.patch("/items/1", json=patch_payload)
         assert r2.status_code == status.HTTP_200_OK
 
     def test_rejects_body_with_callable_depends(self) -> None:
         app = FastAPI()
 
         def not_a_model() -> None:
-            return None
+            pass  # pragma: no cover
 
         with pytest.raises(FastAPIError, match="Pydantic model class"):
 
@@ -278,5 +311,4 @@ class TestAnnotatedBodyDependsMergeBody:
             @app.post("/path/{data}")
             def route_path(
                 data: Annotated[BasePayload, Body(), Depends(FooPayload)],
-            ) -> None:
-                pass  # pragma: no cover
+            ) -> None: ...

--- a/tests/test_annotated_body_depends_merge_body.py
+++ b/tests/test_annotated_body_depends_merge_body.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Annotated, Any
 
 import pytest
@@ -83,7 +84,8 @@ class TestAnnotatedBodyDependsMergeBody:
         assert r.json() == {"extra": "x"}
 
         bad = client.post("/c", json={"kind": "foo"})
-        assert bad.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        # not status.*: Starlette confused HTTP_422_UNPROCESSABLE_CONTENT HTTP_422_UNPROCESSABLE_ENTITY
+        assert bad.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
     def test_merge_depends_empty_falls_back_to_declared_model(self) -> None:
         app = FastAPI()

--- a/tests/test_annotated_body_depends_merge_body.py
+++ b/tests/test_annotated_body_depends_merge_body.py
@@ -1,8 +1,19 @@
 from typing import Annotated, Any
 
 import pytest
-from fastapi import Body, Depends, FastAPI, Form, status
+from fastapi import (
+    Body,
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    Header,
+    Query,
+    Security,
+    status,
+)
 from fastapi.exceptions import FastAPIError
+from fastapi.security import HTTPBearer
 from fastapi.testclient import TestClient
 
 from tests._annotated_body_depends_merge_common import (
@@ -11,6 +22,8 @@ from tests._annotated_body_depends_merge_common import (
     FooPayload,
     openapi_request_body_schema_ref,
 )
+
+_MERGED_BODY_DEFAULT = FooPayload(kind="foo", extra_foo="default")
 
 
 class TestAnnotatedBodyDependsMergeBody:
@@ -71,6 +84,42 @@ class TestAnnotatedBodyDependsMergeBody:
 
         bad = client.post("/c", json={"kind": "foo"})
         assert bad.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_merge_depends_empty_falls_back_to_declared_model(self) -> None:
+        app = FastAPI()
+
+        @app.post("/depends-empty")
+        def route(
+            data: Annotated[FooPayload, Body(), Depends()],
+        ) -> dict[str, str]:
+            return {"extra": data.extra_foo}
+
+        client = TestClient(app)
+        r = client.post("/depends-empty", json={"kind": "foo", "extra_foo": "z"})
+        assert r.status_code == status.HTTP_200_OK
+        assert r.json() == {"extra": "z"}
+
+    def test_merged_body_parameter_signature_default(self) -> None:
+        app = FastAPI()
+
+        @app.post("/merged-default")
+        def route(
+            data: Annotated[
+                BasePayload, Body(), Depends(FooPayload)
+            ] = _MERGED_BODY_DEFAULT,
+        ) -> dict[str, str]:
+            return {"extra": data.extra_foo}
+
+        client = TestClient(app)
+        empty = client.post("/merged-default")
+        assert empty.status_code == status.HTTP_200_OK
+        assert empty.json() == {"extra": "default"}
+
+        overridden = client.post(
+            "/merged-default", json={"kind": "foo", "extra_foo": "ov"}
+        )
+        assert overridden.status_code == status.HTTP_200_OK
+        assert overridden.json() == {"extra": "ov"}
 
     def test_put_patch_json_body_depends_openapi(self) -> None:
         app = FastAPI()
@@ -146,6 +195,76 @@ class TestAnnotatedBodyDependsMergeBody:
                     Form(),
                     Depends(FooPayload),
                 ],
+            ) -> None:
+                pass  # pragma: no cover
+
+    @pytest.mark.parametrize(
+        "shape_marker",
+        [
+            pytest.param(Body(), id="body"),
+            pytest.param(Form(), id="form"),
+            pytest.param(File(), id="file"),
+        ],
+    )
+    def test_rejects_query_with_body_like_in_same_annotated(
+        self, shape_marker: Any
+    ) -> None:
+        app = FastAPI()
+
+        with pytest.raises(FastAPIError, match="Cannot combine `Query`"):
+
+            @app.post("/query-shape")
+            def route_bad(
+                data: Annotated[
+                    BasePayload,
+                    shape_marker,
+                    Query(),
+                    Depends(FooPayload),
+                ],
+            ) -> None:
+                pass  # pragma: no cover
+
+    def test_rejects_multiple_query_with_depends(self) -> None:
+        app = FastAPI()
+
+        with pytest.raises(FastAPIError, match="multiple `Query`"):
+
+            @app.post("/multi-query")
+            def route_multi_query(
+                data: Annotated[
+                    BasePayload,
+                    Query(),
+                    Query(),
+                    Depends(FooPayload),
+                ],
+            ) -> None:
+                pass  # pragma: no cover
+
+    def test_rejects_body_like_with_other_param_in_same_annotated(self) -> None:
+        app = FastAPI()
+
+        with pytest.raises(FastAPIError, match="other parameter types"):
+
+            @app.post("/body-plus-header")
+            def route_body_header(
+                data: Annotated[
+                    BasePayload,
+                    Body(),
+                    Header(),
+                    Depends(FooPayload),
+                ],
+            ) -> None:
+                pass  # pragma: no cover
+
+    def test_rejects_security_with_body_like_merge(self) -> None:
+        app = FastAPI()
+        bearer = HTTPBearer(auto_error=False)
+
+        with pytest.raises(FastAPIError, match="`Security`"):
+
+            @app.post("/body-security")
+            def route_body_security(
+                data: Annotated[BasePayload, Body(), Security(bearer)],
             ) -> None:
                 pass  # pragma: no cover
 

--- a/tests/test_annotated_body_depends_merge_body.py
+++ b/tests/test_annotated_body_depends_merge_body.py
@@ -1,0 +1,161 @@
+from typing import Annotated, Any
+
+import pytest
+from fastapi import Body, Depends, FastAPI, Form, status
+from fastapi.exceptions import FastAPIError
+from fastapi.testclient import TestClient
+
+from tests._annotated_body_depends_merge_common import (
+    BarPayload,
+    BasePayload,
+    FooPayload,
+    openapi_request_body_schema_ref,
+)
+
+
+class TestAnnotatedBodyDependsMergeBody:
+    @pytest.mark.parametrize(
+        (
+            "path",
+            "ann1",
+            "ann2",
+            "model_cls",
+            "expected_ref_suffix",
+            "assert_no_query_params",
+        ),
+        [
+            ("/a", Body(), Depends(FooPayload), FooPayload, "FooPayload", True),
+            ("/b", Depends(BarPayload), Body(), BarPayload, "BarPayload", False),
+        ],
+    )
+    def test_openapi_json_body_depends_merge(
+        self,
+        path: str,
+        ann1: Any,
+        ann2: Any,
+        model_cls: type[BasePayload],
+        expected_ref_suffix: str,
+        assert_no_query_params: bool,
+    ) -> None:
+        app = FastAPI()
+
+        @app.post(path)
+        def route(
+            data: Annotated[BasePayload, ann1, ann2],
+        ) -> None:
+            assert isinstance(data, model_cls)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+        post = schema["paths"][path]["post"]
+        if assert_no_query_params:
+            assert post.get("parameters") in (None, [])
+        ref = openapi_request_body_schema_ref(
+            schema, path=path, method="post", content_type="application/json"
+        )
+        assert ref.endswith(f"/{expected_ref_suffix}")
+
+    def test_runtime_json_validates_concrete_model(self) -> None:
+        app = FastAPI()
+
+        @app.post("/c")
+        def route(
+            data: Annotated[BasePayload, Body(), Depends(FooPayload)],
+        ) -> dict[str, str]:
+            return {"extra": data.extra_foo}
+
+        client = TestClient(app)
+        r = client.post("/c", json={"kind": "foo", "extra_foo": "x"})
+        assert r.status_code == status.HTTP_200_OK
+        assert r.json() == {"extra": "x"}
+
+        bad = client.post("/c", json={"kind": "foo"})
+        assert bad.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_put_patch_json_body_depends_openapi(self) -> None:
+        app = FastAPI()
+        path = "/items/{item_id}"
+
+        @app.put(path)
+        def route_put(
+            item_id: str,
+            data: Annotated[BasePayload, Body(), Depends(FooPayload)],
+        ) -> None:
+            assert isinstance(data, FooPayload)
+
+        @app.patch(path)
+        def route_patch(
+            item_id: str,
+            data: Annotated[BasePayload, Depends(FooPayload), Body()],
+        ) -> None:
+            assert isinstance(data, FooPayload)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+        for method in ("put", "patch"):
+            ref = openapi_request_body_schema_ref(
+                schema, path=path, method=method, content_type="application/json"
+            )
+            assert ref.endswith("/FooPayload")
+
+        r = client.put("/items/1", json={"kind": "foo", "extra_foo": "a"})
+        assert r.status_code == status.HTTP_200_OK
+        r2 = client.patch("/items/1", json={"kind": "foo", "extra_foo": "b"})
+        assert r2.status_code == status.HTTP_200_OK
+
+    def test_rejects_body_with_callable_depends(self) -> None:
+        app = FastAPI()
+
+        def not_a_model() -> None:
+            return None
+
+        with pytest.raises(FastAPIError, match="Pydantic model class"):
+
+            @app.post("/d")
+            def route_d(
+                data: Annotated[BasePayload, Body(), Depends(not_a_model)],
+            ) -> None:
+                pass  # pragma: no cover
+
+    def test_rejects_multiple_depends_with_body(self) -> None:
+        app = FastAPI()
+
+        with pytest.raises(FastAPIError, match="multiple `Depends`"):
+
+            @app.post("/e")
+            def route_e(
+                data: Annotated[
+                    BasePayload,
+                    Body(),
+                    Depends(FooPayload),
+                    Depends(BarPayload),
+                ],
+            ) -> None:
+                pass  # pragma: no cover
+
+    def test_rejects_body_and_form_together(self) -> None:
+        app = FastAPI()
+
+        with pytest.raises(FastAPIError, match="multiple `Body`"):
+
+            @app.post("/conflict")
+            def route_conflict(
+                data: Annotated[
+                    BasePayload,
+                    Body(),
+                    Form(),
+                    Depends(FooPayload),
+                ],
+            ) -> None:
+                pass  # pragma: no cover
+
+    def test_rejects_merge_on_path_parameter(self) -> None:
+        app = FastAPI()
+
+        with pytest.raises(FastAPIError, match="path parameter"):
+
+            @app.post("/path/{data}")
+            def route_path(
+                data: Annotated[BasePayload, Body(), Depends(FooPayload)],
+            ) -> None:
+                pass  # pragma: no cover

--- a/tests/test_annotated_body_depends_merge_file.py
+++ b/tests/test_annotated_body_depends_merge_file.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from io import BytesIO
 from typing import Annotated, Any
 
@@ -81,7 +82,8 @@ class TestAnnotatedBodyDependsMergeFile:
             data={"kind": "foo"},
             files={"blob": ("up.txt", BytesIO(b"x"), "text/plain")},
         )
-        assert bad.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        # not status.*: Starlette confused HTTP_422_UNPROCESSABLE_CONTENT HTTP_422_UNPROCESSABLE_ENTITY
+        assert bad.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
     def test_rejects_file_and_form_together(self) -> None:
         app = FastAPI()

--- a/tests/test_annotated_body_depends_merge_file.py
+++ b/tests/test_annotated_body_depends_merge_file.py
@@ -1,0 +1,100 @@
+from io import BytesIO
+from typing import Annotated, Any
+
+import pytest
+from fastapi import Depends, FastAPI, File, Form, status
+from fastapi.exceptions import FastAPIError
+from fastapi.testclient import TestClient
+
+from tests._annotated_body_depends_merge_common import (
+    BarFilePayload,
+    BasePayload,
+    FooFilePayload,
+    FooPayload,
+)
+
+
+class TestAnnotatedBodyDependsMergeFile:
+    @pytest.mark.parametrize(
+        ("path", "ann1", "ann2", "model_cls", "expected_ref_suffix"),
+        [
+            (
+                "/file-a",
+                File(),
+                Depends(FooFilePayload),
+                FooFilePayload,
+                "FooFilePayload",
+            ),
+            (
+                "/file-b",
+                Depends(BarFilePayload),
+                File(),
+                BarFilePayload,
+                "BarFilePayload",
+            ),
+        ],
+    )
+    def test_openapi_file_depends_merge(
+        self,
+        path: str,
+        ann1: Any,
+        ann2: Any,
+        model_cls: type[BasePayload],
+        expected_ref_suffix: str,
+    ) -> None:
+        app = FastAPI()
+
+        @app.post(path)
+        def route_file(
+            data: Annotated[BasePayload, ann1, ann2],
+        ) -> None:
+            assert isinstance(data, model_cls)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+        rb = schema["paths"][path]["post"]["requestBody"]
+        content = rb["content"]
+        assert "multipart/form-data" in content
+        ref = content["multipart/form-data"]["schema"]["$ref"]
+        assert ref.endswith(f"/{expected_ref_suffix}")
+
+    def test_runtime_file_validates_concrete_model(self) -> None:
+        app = FastAPI()
+
+        @app.post("/file-c")
+        def route_file(
+            data: Annotated[BasePayload, File(), Depends(FooFilePayload)],
+        ) -> dict[str, str]:
+            return {"extra": data.extra_foo, "fn": data.blob.filename or ""}
+
+        client = TestClient(app)
+        r = client.post(
+            "/file-c",
+            data={"kind": "foo", "extra_foo": "u"},
+            files={"blob": ("up.txt", BytesIO(b"xyz"), "text/plain")},
+        )
+        assert r.status_code == status.HTTP_200_OK
+        assert r.json() == {"extra": "u", "fn": "up.txt"}
+
+        bad = client.post(
+            "/file-c",
+            data={"kind": "foo"},
+            files={"blob": ("up.txt", BytesIO(b"x"), "text/plain")},
+        )
+        assert bad.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_rejects_file_and_form_together(self) -> None:
+        app = FastAPI()
+
+        with pytest.raises(FastAPIError, match="multiple `Body`"):
+
+            @app.post("/file-conflict")
+            def route_conflict(
+                data: Annotated[
+                    BasePayload,
+                    File(),
+                    Form(),
+                    Depends(FooPayload),
+                ],
+            ) -> None:
+                pass  # pragma: no cover

--- a/tests/test_annotated_body_depends_merge_file.py
+++ b/tests/test_annotated_body_depends_merge_file.py
@@ -17,7 +17,7 @@ from tests._annotated_body_depends_merge_common import (
 
 class TestAnnotatedBodyDependsMergeFile:
     @pytest.mark.parametrize(
-        ("path", "ann1", "ann2", "model_cls", "expected_ref_suffix"),
+        ("path", "ann1", "ann2", "model_cls", "expected_ref_suffix", "payload"),
         [
             (
                 "/file-a",
@@ -25,6 +25,7 @@ class TestAnnotatedBodyDependsMergeFile:
                 Depends(FooFilePayload),
                 FooFilePayload,
                 "FooFilePayload",
+                {"kind": "foo", "extra_foo": "hit"},
             ),
             (
                 "/file-b",
@@ -32,6 +33,7 @@ class TestAnnotatedBodyDependsMergeFile:
                 File(),
                 BarFilePayload,
                 "BarFilePayload",
+                {"kind": "bar", "extra_bar": "hit"},
             ),
         ],
     )
@@ -42,6 +44,7 @@ class TestAnnotatedBodyDependsMergeFile:
         ann2: Any,
         model_cls: type[BasePayload],
         expected_ref_suffix: str,
+        payload: dict[str, str],
     ) -> None:
         app = FastAPI()
 
@@ -59,6 +62,10 @@ class TestAnnotatedBodyDependsMergeFile:
         ref = content["multipart/form-data"]["schema"]["$ref"]
         assert ref.endswith(f"/{expected_ref_suffix}")
 
+        blob = ("blob.bin", BytesIO(b"x"), "application/octet-stream")
+        ok = client.post(path, data=payload, files={"blob": blob})
+        assert ok.status_code == status.HTTP_200_OK
+
     def test_runtime_file_validates_concrete_model(self) -> None:
         app = FastAPI()
 
@@ -69,13 +76,14 @@ class TestAnnotatedBodyDependsMergeFile:
             return {"extra": data.extra_foo, "fn": data.blob.filename or ""}
 
         client = TestClient(app)
-        r = client.post(
-            "/file-c",
-            data={"kind": "foo", "extra_foo": "u"},
-            files={"blob": ("up.txt", BytesIO(b"xyz"), "text/plain")},
-        )
+        extra = "info"
+        filename = "file.txt"
+        payload = {"kind": "foo", "extra_foo": extra}
+        file_field = (filename, BytesIO(b"xyz"), "text/plain")
+        expected_json = {"extra": extra, "fn": filename}
+        r = client.post("/file-c", data=payload, files={"blob": file_field})
         assert r.status_code == status.HTTP_200_OK
-        assert r.json() == {"extra": "u", "fn": "up.txt"}
+        assert r.json() == expected_json
 
         bad = client.post(
             "/file-c",
@@ -98,5 +106,4 @@ class TestAnnotatedBodyDependsMergeFile:
                     Form(),
                     Depends(FooPayload),
                 ],
-            ) -> None:
-                pass  # pragma: no cover
+            ) -> None: ...

--- a/tests/test_annotated_body_depends_merge_form.py
+++ b/tests/test_annotated_body_depends_merge_form.py
@@ -14,10 +14,24 @@ from tests._annotated_body_depends_merge_common import (
 
 class TestAnnotatedBodyDependsMergeForm:
     @pytest.mark.parametrize(
-        ("path", "ann1", "ann2", "model_cls", "expected_ref_suffix"),
+        ("path", "ann1", "ann2", "model_cls", "expected_ref_suffix", "payload"),
         [
-            ("/form-a", Form(), Depends(FooPayload), FooPayload, "FooPayload"),
-            ("/form-b", Depends(BarPayload), Form(), BarPayload, "BarPayload"),
+            (
+                "/form-a",
+                Form(),
+                Depends(FooPayload),
+                FooPayload,
+                "FooPayload",
+                {"kind": "foo", "extra_foo": "hit"},
+            ),
+            (
+                "/form-b",
+                Depends(BarPayload),
+                Form(),
+                BarPayload,
+                "BarPayload",
+                {"kind": "bar", "extra_bar": "hit"},
+            ),
         ],
     )
     def test_openapi_form_depends_merge(
@@ -27,6 +41,7 @@ class TestAnnotatedBodyDependsMergeForm:
         ann2: Any,
         model_cls: type[BasePayload],
         expected_ref_suffix: str,
+        payload: dict[str, str],
     ) -> None:
         app = FastAPI()
 
@@ -44,6 +59,9 @@ class TestAnnotatedBodyDependsMergeForm:
         ref = content["application/x-www-form-urlencoded"]["schema"]["$ref"]
         assert ref.endswith(f"/{expected_ref_suffix}")
 
+        ok = client.post(path, data=payload)
+        assert ok.status_code == status.HTTP_200_OK
+
     def test_runtime_form_validates_concrete_model(self) -> None:
         app = FastAPI()
 
@@ -54,12 +72,12 @@ class TestAnnotatedBodyDependsMergeForm:
             return {"extra": data.extra_foo}
 
         client = TestClient(app)
-        r = client.post(
-            "/form-c",
-            data={"kind": "foo", "extra_foo": "z"},
-        )
+        extra = "z"
+        payload = {"kind": "foo", "extra_foo": extra}
+        expected_json = {"extra": extra}
+        r = client.post("/form-c", data=payload)
         assert r.status_code == status.HTTP_200_OK
-        assert r.json() == {"extra": "z"}
+        assert r.json() == expected_json
 
         bad = client.post("/form-c", data={"kind": "foo"})
         # not status.*: Starlette confused HTTP_422_UNPROCESSABLE_CONTENT HTTP_422_UNPROCESSABLE_ENTITY

--- a/tests/test_annotated_body_depends_merge_form.py
+++ b/tests/test_annotated_body_depends_merge_form.py
@@ -1,0 +1,64 @@
+from typing import Annotated, Any
+
+import pytest
+from fastapi import Depends, FastAPI, Form, status
+from fastapi.testclient import TestClient
+
+from tests._annotated_body_depends_merge_common import (
+    BarPayload,
+    BasePayload,
+    FooPayload,
+)
+
+
+class TestAnnotatedBodyDependsMergeForm:
+    @pytest.mark.parametrize(
+        ("path", "ann1", "ann2", "model_cls", "expected_ref_suffix"),
+        [
+            ("/form-a", Form(), Depends(FooPayload), FooPayload, "FooPayload"),
+            ("/form-b", Depends(BarPayload), Form(), BarPayload, "BarPayload"),
+        ],
+    )
+    def test_openapi_form_depends_merge(
+        self,
+        path: str,
+        ann1: Any,
+        ann2: Any,
+        model_cls: type[BasePayload],
+        expected_ref_suffix: str,
+    ) -> None:
+        app = FastAPI()
+
+        @app.post(path)
+        def route_form(
+            data: Annotated[BasePayload, ann1, ann2],
+        ) -> None:
+            assert isinstance(data, model_cls)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+        rb = schema["paths"][path]["post"]["requestBody"]
+        content = rb["content"]
+        assert "application/x-www-form-urlencoded" in content
+        ref = content["application/x-www-form-urlencoded"]["schema"]["$ref"]
+        assert ref.endswith(f"/{expected_ref_suffix}")
+
+    def test_runtime_form_validates_concrete_model(self) -> None:
+        app = FastAPI()
+
+        @app.post("/form-c")
+        def route_form(
+            data: Annotated[BasePayload, Form(), Depends(FooPayload)],
+        ) -> dict[str, str]:
+            return {"extra": data.extra_foo}
+
+        client = TestClient(app)
+        r = client.post(
+            "/form-c",
+            data={"kind": "foo", "extra_foo": "z"},
+        )
+        assert r.status_code == status.HTTP_200_OK
+        assert r.json() == {"extra": "z"}
+
+        bad = client.post("/form-c", data={"kind": "foo"})
+        assert bad.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/tests/test_annotated_body_depends_merge_form.py
+++ b/tests/test_annotated_body_depends_merge_form.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Annotated, Any
 
 import pytest
@@ -61,4 +62,5 @@ class TestAnnotatedBodyDependsMergeForm:
         assert r.json() == {"extra": "z"}
 
         bad = client.post("/form-c", data={"kind": "foo"})
-        assert bad.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        # not status.*: Starlette confused HTTP_422_UNPROCESSABLE_CONTENT HTTP_422_UNPROCESSABLE_ENTITY
+        assert bad.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/tests/test_annotated_body_depends_merge_query_plus_shape.py
+++ b/tests/test_annotated_body_depends_merge_query_plus_shape.py
@@ -1,0 +1,144 @@
+"""Query() alongside a second parameter that uses Body/Form/File + Depends(model)."""
+
+from io import BytesIO
+from typing import Annotated, Any
+
+from fastapi import Body, Depends, FastAPI, File, Form, Query
+from fastapi.testclient import TestClient
+
+from tests._annotated_body_depends_merge_common import (
+    BarFilePayload,
+    BarPayload,
+    BasePayload,
+    FooFilePayload,
+    FooPayload,
+    openapi_request_body_schema_ref,
+)
+
+
+def _param_names(post_schema: dict[str, Any]) -> list[str]:
+    params = post_schema.get("parameters") or []
+    return [p["name"] for p in params]
+
+
+class TestQueryPlusMergedShape:
+    def test_openapi_query_plus_json_body(self) -> None:
+        app = FastAPI()
+
+        @app.post("/mix-json")
+        def route(
+            client_id: Annotated[str, Query()],
+            data: Annotated[BasePayload, Body(), Depends(FooPayload)],
+        ) -> None:
+            assert isinstance(data, FooPayload)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+        post = schema["paths"]["/mix-json"]["post"]
+        assert "client_id" in _param_names(post)
+        ref = openapi_request_body_schema_ref(
+            schema,
+            path="/mix-json",
+            method="post",
+            content_type="application/json",
+        )
+        assert ref.endswith("/FooPayload")
+
+    def test_runtime_query_plus_json_body(self) -> None:
+        app = FastAPI()
+
+        @app.post("/r-json")
+        def route(
+            client_id: Annotated[str, Query()],
+            data: Annotated[BasePayload, Body(), Depends(FooPayload)],
+        ) -> dict[str, str]:
+            return {"client": client_id, "extra": data.extra_foo}
+
+        client = TestClient(app)
+        r = client.post(
+            "/r-json?client_id=c1",
+            json={"kind": "foo", "extra_foo": "e"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"client": "c1", "extra": "e"}
+
+    def test_openapi_query_plus_form(self) -> None:
+        app = FastAPI()
+
+        @app.post("/mix-form")
+        def route(
+            client_id: Annotated[str, Query()],
+            data: Annotated[BasePayload, Form(), Depends(BarPayload)],
+        ) -> None:
+            assert isinstance(data, BarPayload)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+        post = schema["paths"]["/mix-form"]["post"]
+        assert "client_id" in _param_names(post)
+        rb = post["requestBody"]["content"]
+        assert "application/x-www-form-urlencoded" in rb
+        ref = rb["application/x-www-form-urlencoded"]["schema"]["$ref"]
+        assert ref.endswith("/BarPayload")
+
+    def test_runtime_query_plus_form(self) -> None:
+        app = FastAPI()
+
+        @app.post("/r-form")
+        def route(
+            client_id: Annotated[str, Query()],
+            data: Annotated[BasePayload, Form(), Depends(FooPayload)],
+        ) -> dict[str, str]:
+            return {"client": client_id, "extra": data.extra_foo}
+
+        client = TestClient(app)
+        r = client.post(
+            "/r-form",
+            params={"client_id": "c2"},
+            data={"kind": "foo", "extra_foo": "f"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"client": "c2", "extra": "f"}
+
+    def test_openapi_query_plus_file_multipart(self) -> None:
+        app = FastAPI()
+
+        @app.post("/mix-file")
+        def route(
+            client_id: Annotated[str, Query()],
+            data: Annotated[BasePayload, File(), Depends(FooFilePayload)],
+        ) -> None:
+            assert isinstance(data, FooFilePayload)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+        post = schema["paths"]["/mix-file"]["post"]
+        assert "client_id" in _param_names(post)
+        rb = post["requestBody"]["content"]
+        assert "multipart/form-data" in rb
+        ref = rb["multipart/form-data"]["schema"]["$ref"]
+        assert ref.endswith("/FooFilePayload")
+
+    def test_runtime_query_plus_file_multipart(self) -> None:
+        app = FastAPI()
+
+        @app.post("/r-file")
+        def route(
+            client_id: Annotated[str, Query()],
+            data: Annotated[BasePayload, File(), Depends(BarFilePayload)],
+        ) -> dict[str, str]:
+            return {
+                "client": client_id,
+                "extra": data.extra_bar,
+                "fn": data.blob.filename or "",
+            }
+
+        client = TestClient(app)
+        r = client.post(
+            "/r-file",
+            params={"client_id": "c3"},
+            data={"kind": "bar", "extra_bar": "b"},
+            files={"blob": ("up.bin", BytesIO(b"abc"), "application/octet-stream")},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"client": "c3", "extra": "b", "fn": "up.bin"}

--- a/tests/test_annotated_body_depends_merge_query_plus_shape.py
+++ b/tests/test_annotated_body_depends_merge_query_plus_shape.py
@@ -3,7 +3,7 @@
 from io import BytesIO
 from typing import Annotated, Any
 
-from fastapi import Body, Depends, FastAPI, File, Form, Query
+from fastapi import Body, Depends, FastAPI, File, Form, Query, status
 from fastapi.testclient import TestClient
 
 from tests._annotated_body_depends_merge_common import (
@@ -44,6 +44,10 @@ class TestQueryPlusMergedShape:
         )
         assert ref.endswith("/FooPayload")
 
+        hit_payload = {"kind": "foo", "extra_foo": "x"}
+        hit = client.post("/mix-json?client_id=hit", json=hit_payload)
+        assert hit.status_code == status.HTTP_200_OK
+
     def test_runtime_query_plus_json_body(self) -> None:
         app = FastAPI()
 
@@ -55,12 +59,13 @@ class TestQueryPlusMergedShape:
             return {"client": client_id, "extra": data.extra_foo}
 
         client = TestClient(app)
-        r = client.post(
-            "/r-json?client_id=c1",
-            json={"kind": "foo", "extra_foo": "e"},
-        )
-        assert r.status_code == 200
-        assert r.json() == {"client": "c1", "extra": "e"}
+        client_id = "c1"
+        extra = "helloworld"
+        payload = {"kind": "foo", "extra_foo": extra}
+        expected_json = {"client": client_id, "extra": extra}
+        r = client.post(f"/r-json?client_id={client_id}", json=payload)
+        assert r.status_code == status.HTTP_200_OK
+        assert r.json() == expected_json
 
     def test_openapi_query_plus_form(self) -> None:
         app = FastAPI()
@@ -81,6 +86,10 @@ class TestQueryPlusMergedShape:
         ref = rb["application/x-www-form-urlencoded"]["schema"]["$ref"]
         assert ref.endswith("/BarPayload")
 
+        hit_payload = {"kind": "bar", "extra_bar": "y"}
+        hit = client.post("/mix-form", params={"client_id": "hit"}, data=hit_payload)
+        assert hit.status_code == status.HTTP_200_OK
+
     def test_runtime_query_plus_form(self) -> None:
         app = FastAPI()
 
@@ -92,13 +101,13 @@ class TestQueryPlusMergedShape:
             return {"client": client_id, "extra": data.extra_foo}
 
         client = TestClient(app)
-        r = client.post(
-            "/r-form",
-            params={"client_id": "c2"},
-            data={"kind": "foo", "extra_foo": "f"},
-        )
-        assert r.status_code == 200
-        assert r.json() == {"client": "c2", "extra": "f"}
+        client_id = "c2"
+        extra = "foo"
+        payload = {"kind": "foo", "extra_foo": extra}
+        expected_json = {"client": client_id, "extra": extra}
+        r = client.post("/r-form", params={"client_id": client_id}, data=payload)
+        assert r.status_code == status.HTTP_200_OK
+        assert r.json() == expected_json
 
     def test_openapi_query_plus_file_multipart(self) -> None:
         app = FastAPI()
@@ -119,6 +128,18 @@ class TestQueryPlusMergedShape:
         ref = rb["multipart/form-data"]["schema"]["$ref"]
         assert ref.endswith("/FooFilePayload")
 
+        hit_form = {"kind": "foo", "extra_foo": "u"}
+        hit_files = {
+            "blob": ("up.bin", BytesIO(b"abc"), "application/octet-stream"),
+        }
+        hit = client.post(
+            "/mix-file",
+            params={"client_id": "hit"},
+            data=hit_form,
+            files=hit_files,
+        )
+        assert hit.status_code == status.HTTP_200_OK
+
     def test_runtime_query_plus_file_multipart(self) -> None:
         app = FastAPI()
 
@@ -134,11 +155,17 @@ class TestQueryPlusMergedShape:
             }
 
         client = TestClient(app)
+        client_id = "c3"
+        extra = "bar"
+        filename = "up.bin"
+        payload = {"kind": "bar", "extra_bar": extra}
+        file_field = (filename, BytesIO(b"abc"), "application/octet-stream")
+        expected_json = {"client": client_id, "extra": extra, "fn": filename}
         r = client.post(
             "/r-file",
-            params={"client_id": "c3"},
-            data={"kind": "bar", "extra_bar": "b"},
-            files={"blob": ("up.bin", BytesIO(b"abc"), "application/octet-stream")},
+            params={"client_id": client_id},
+            data=payload,
+            files={"blob": file_field},
         )
-        assert r.status_code == 200
-        assert r.json() == {"client": "c3", "extra": "b", "fn": "up.bin"}
+        assert r.status_code == status.HTTP_200_OK
+        assert r.json() == expected_json


### PR DESCRIPTION
### Example

```python

def register_post_route(
    path: str,
    schema: type[ItemBase],
):
    @router.post(path)
    def create_item(
        item: Annotated[
            ItemBase,  # for type checkers and IDEs
            Body(),  # for FastAPI - where to search
            Depends(schema),  # for FastAPI - what to expect
        ],
    ):
        return item

    return create_item
```

### Summary

FastAPI can combine `Body` / `Form` / `File` / `Query` with `Depends(some_model)` inside the same `Annotated[...]` so validation / OpenAPI use the runtime model while the parameter’s declared type stays the static first argument (e.g. base class for type checkers).

Order of `Body`/`Form` / … and `Depends` in `Annotated` does not matter.

### Motivation

Factories / dynamic routes need a non-literal model class; documenting and supporting `Annotated[Base, Body(), Depends(schema)]` avoids losing the location marker or the model.

### Implementation notes (high level)

New merge path in dependency / param handling (`fastapi/dependencies/utils.py`): detects compatible marker sets, validates constraints (e.g. no `Query` combined with body-like markers, not on path params, `Depends` resolves to a single `BaseModel` subclass, etc.), builds merged field info and annotation.

### Docs

New advanced section **“Composing Annotated metadata for runtime validation schemas”** with subpages (body / form / file / query), nav in `mkdocs.yml`, link from Request Body tutorial.

### Tests

- integration-style tests for body, file, form, query, and query+body shapes
- shared helpers / doc example loaders as staged under `tests/`.
