### PR TITLE
📝 Add diagram to "Multiple middleware execution order" docs

### DIFF
--- a/docs/en/docs/tutorial/middleware.md
+++ b/docs/en/docs/tutorial/middleware.md
@@ -82,9 +82,20 @@ app.add_middleware(MiddlewareB)
 
 This results in the following execution order:
 
-* **Request**: MiddlewareB → MiddlewareA → route
+```mermaid
+sequenceDiagram
+    participant Client
+    participant B as Middleware B<br/>(added last · outermost)
+    participant A as Middleware A<br/>(added first · innermost)
+    participant App as FastAPI app
 
-* **Response**: route → MiddlewareA → MiddlewareB
+    Client ->> B: Request
+    B ->> A: Request
+    A ->> App: Request
+    App -->> A: Response
+    A -->> B: Response
+    B -->> Client: Response
+```
 
 This stacking behavior ensures that middlewares are executed in a predictable and controllable order.
 


### PR DESCRIPTION
Updated docs for execution order section in middleware. Thought it was a bit confusing without a diagram so I added one to make it clearer. Matches the styling of other diagrams throughout the documentation.