### PR TITLE
fix: include servers field in OpenAPI schema when root_path_in_servers=True

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1104,7 +1104,14 @@ class FastAPI(Starlette):
             async def openapi(req: Request) -> JSONResponse:
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 schema = self.openapi()
-                if root_path and self.root_path_in_servers:
+                if self.root_path_in_servers and "servers" not in schema:
+                    if root_path:
+                        schema = dict(schema)
+                        schema["servers"] = [{"url": root_path}]
+                    else:
+                        schema = dict(schema)
+                        schema["servers"] = [{"url": "/"}]
+                elif root_path and self.root_path_in_servers:
                     server_urls = {s.get("url") for s in schema.get("servers", [])}
                     if root_path not in server_urls:
                         schema = dict(schema)


### PR DESCRIPTION
## Summary

Fix the OpenAPI schema to include the `servers` field when `root_path_in_servers=True` (the default) and no custom `servers` are configured.

## Problem

When `root_path_in_servers=True` (default) and no explicit `servers` are provided, the generated OpenAPI JSON at `/openapi.json` omits the `servers` key entirely. Per the OpenAPI specification and FastAPI documentation, it should include `{"url": "/"}` when served at the root path.

Reproduction:
```python
from fastapi import FastAPI
app = FastAPI()
# GET /openapi.json → missing "servers" key
```

## Root Cause

In `fastapi/applications.py`, the condition `if root_path and self.root_path_in_servers:` evaluates to `False` when `root_path` is empty (or stripped to empty from `/`), so the `servers` key is never added to the schema.

## Fix

When `root_path_in_servers=True` and no custom `servers` are configured, always include `servers: [{"url": "/"}]` regardless of whether `root_path` is set.

Fixes #12246