### PR TITLE
fix: replace mutable default arg and add encoding to open() calls

### DIFF
--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -173,7 +173,7 @@ class ModelField:
     def validate(
         self,
         value: Any,
-        values: dict[str, Any] = {},  # noqa: B006
+        values: dict[str, Any] | None = None,
         *,
         loc: tuple[int | str, ...] = (),
     ) -> tuple[Any, list[dict[str, Any]]]:

--- a/scripts/add_latest_release_date.py
+++ b/scripts/add_latest_release_date.py
@@ -9,7 +9,7 @@ RELEASE_HEADER_PATTERN = re.compile(r"^## (\d+\.\d+\.\d+)\s*(\(.*\))?\s*$")
 
 
 def main() -> None:
-    with open(RELEASE_NOTES_FILE) as f:
+    with open(RELEASE_NOTES_FILE, encoding="utf-8") as f:
         lines = f.readlines()
 
     for i, line in enumerate(lines):
@@ -28,7 +28,7 @@ def main() -> None:
         lines[i] = f"## {version} ({today})\n"
         print(f"Added date: {version} ({today})")
 
-        with open(RELEASE_NOTES_FILE, "w") as f:
+        with open(RELEASE_NOTES_FILE, "w", encoding="utf-8") as f:
             f.writelines(lines)
         sys.exit(0)
 


### PR DESCRIPTION
## Summary

This PR fixes two categories of code quality issues:

### 1. Mutable default argument in `fastapi/_compat/v2.py`

**File:** `fastapi/_compat/v2.py`

Replaced the mutable default argument `values: dict[str, Any] = {}` in `ModelField.validate()` with `values: dict[str, Any] | None = None`. Using a mutable object (like `{}`) as a default argument is a well-known Python pitfall (Pylint W0102 / flake8 B006) — the same dict instance is shared across all calls, which can lead to subtle bugs if the dict is ever mutated.

### 2. `open()` calls without explicit encoding in `scripts/`

**File:** `scripts/add_latest_release_date.py`

Added `encoding='utf-8'` to both `open()` calls (read and write). Without an explicit encoding, Python falls back to the platform locale default, which can differ between developer machines and CI environments (e.g. Windows uses cp1252 by default). Explicitly specifying UTF-8 ensures consistent behaviour everywhere (Pylint W1514).

## Changes

- `fastapi/_compat/v2.py`: `values: dict[str, Any] = {}` → `values: dict[str, Any] | None = None`
- `scripts/add_latest_release_date.py`: `open(RELEASE_NOTES_FILE)` → `open(RELEASE_NOTES_FILE, encoding='utf-8')`
- `scripts/add_latest_release_date.py`: `open(RELEASE_NOTES_FILE, 'w')` → `open(RELEASE_NOTES_FILE, 'w', encoding='utf-8')`