### PR TITLE
📝 Clarify "Required, can be None" query parameter docs

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -222,7 +222,9 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 ### Required, can be `None` { #required-can-be-none }
 
-You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
+You can declare that a parameter can accept `None`, while still requiring clients to provide the parameter in the request.
+
+Keep in mind that HTTP query parameters are sent as strings, so clients cannot directly send Python `None` values.
 
 To do that, you can declare that `None` is a valid type but simply do not declare a default value:
 


### PR DESCRIPTION
## Summary

Clarifies the wording in the "Required, can be `None`" section of the query parameter validation docs.

The previous wording implied that clients could directly send Python `None` values in HTTP query parameters, which can be confusing because query parameters are transmitted as strings.

This update clarifies that:

* the parameter type can allow `None`
* the parameter can still be required
* HTTP query parameters themselves are string-based

## Changes

* Updated wording in:

  * `docs/en/docs/tutorial/query-params-str-validations.md`

## Related

Related to issue #12419
