### PR TITLE
🐛 Propagate `stream_item_type` through `include_router` for SSE / JSONL routes (#15401)

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -844,7 +844,17 @@ class APIRoute(routing.Route):
         self.path = path
         self.endpoint = endpoint
         self.stream_item_type: Any | None = None
-        if isinstance(response_model, DefaultPlaceholder):
+        # Run stream-item detection both when response_model is the
+        # DefaultPlaceholder (the original code path: user-defined route)
+        # and when it's an explicit ``None``. The ``None`` case fires when
+        # ``include_router`` re-instantiates a route from a source whose
+        # ``response_model`` was already collapsed to ``None`` during the
+        # first ``__init__``: without it, the merged route would silently
+        # drop ``stream_item_type`` and the OpenAPI ``contentSchema`` for
+        # the streaming endpoint (#15401). Explicit ``response_model=None``
+        # for streaming endpoints is also a documented pattern, so opting
+        # those into detection is intentional.
+        if isinstance(response_model, DefaultPlaceholder) or response_model is None:
             return_annotation = get_typed_return_annotation(endpoint)
             if lenient_issubclass(return_annotation, Response):
                 response_model = None
@@ -863,7 +873,12 @@ class APIRoute(routing.Route):
                     ) and not lenient_issubclass(stream_item, ServerSentEvent):
                         self.stream_item_type = stream_item
                     response_model = None
-                else:
+                elif isinstance(response_model, DefaultPlaceholder):
+                    # Only fall back to using the return annotation as the
+                    # response_model when the caller did not pass an
+                    # explicit value: an explicit ``None`` must stay
+                    # ``None`` (otherwise we'd reintroduce response
+                    # validation that the caller deliberately turned off).
                     response_model = return_annotation
         self.response_model = response_model
         self.summary = summary

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -316,3 +316,60 @@ def test_no_keepalive_when_fast(client: TestClient):
     assert response.status_code == 200
     # KEEPALIVE_COMMENT is ": ping\n\n".
     assert ": ping\n" not in response.text
+
+
+def test_stream_item_type_propagated_through_include_router():
+    """Regression test for #15401.
+
+    When an SSE route is defined on an ``APIRouter`` and merged onto a
+    ``FastAPI`` app via ``include_router``, the merged route must carry
+    the same ``stream_item_type`` as the source route, and the emitted
+    OpenAPI schema must include the ``contentSchema`` describing the
+    streamed item under
+    ``responses.200.content["text/event-stream"].itemSchema.properties.data``.
+
+    Before the fix, ``stream_item_type`` detection in ``APIRoute.__init__``
+    was gated on ``response_model`` being a ``DefaultPlaceholder``. The
+    source route's ``response_model`` was collapsed to ``None`` during
+    its first ``__init__``, so when ``include_router`` re-instantiated
+    the route with that ``None``, detection was skipped and the merged
+    route's ``stream_item_type`` stayed ``None``.
+    """
+
+    class Frame(BaseModel):
+        kind: str
+
+    # Case A — route registered directly on the app (control)
+    app_a = FastAPI()
+
+    @app_a.post("/s", response_class=EventSourceResponse)
+    async def direct() -> AsyncIterable[Frame]:
+        yield Frame(kind="x")
+
+    # Case B — route on a router, then ``include_router`` (regression case)
+    router_b = APIRouter()
+
+    @router_b.post("/s", response_class=EventSourceResponse)
+    async def via_router() -> AsyncIterable[Frame]:
+        yield Frame(kind="x")
+
+    app_b = FastAPI()
+    app_b.include_router(router_b)
+
+    # Both routes must carry the detected item type.
+    direct_route = app_a.routes[-1]
+    merged_route = app_b.routes[-1]
+    assert direct_route.stream_item_type is Frame  # type: ignore[union-attr]
+    assert merged_route.stream_item_type is Frame  # type: ignore[union-attr]
+
+    # And both must surface the contentSchema in the emitted OpenAPI.
+    def has_content_schema(spec: dict) -> bool:
+        sse = spec["paths"]["/s"]["post"]["responses"]["200"]["content"][
+            "text/event-stream"
+        ]
+        return "contentSchema" in sse.get("itemSchema", {}).get("properties", {}).get(
+            "data", {}
+        )
+
+    assert has_content_schema(app_a.openapi())
+    assert has_content_schema(app_b.openapi())


### PR DESCRIPTION
## Summary

When an SSE (or JSONL streaming) route is defined on an `APIRouter` and merged onto a `FastAPI` app via `include_router`, the merged route silently lost its `stream_item_type`. The OpenAPI schema then dropped the `contentSchema` under `responses.200.content["text/event-stream"].itemSchema.properties.data`, so tools like `datamodel-codegen` could no longer generate frame models from the spec. This PR makes `stream_item_type` propagate through `include_router`, with a regression test.

Fixes fastapi/fastapi#15401 — *SSE `stream_item_type` not propagated through `APIRouter` + `include_router`*

## Context

`APIRoute.__init__` only ran the stream-item detection inside the `isinstance(response_model, DefaultPlaceholder)` branch:

```python
if isinstance(response_model, DefaultPlaceholder):
    return_annotation = get_typed_return_annotation(endpoint)
    ...
    stream_item = get_stream_item_type(return_annotation)
    if stream_item is not None:
        if (... or lenient_issubclass(response_class, EventSourceResponse)) ...:
            self.stream_item_type = stream_item
        response_model = None
```

The source route's `__init__` then assigns `self.response_model = None`. When `APIRouter.include_router` rebuilds the route, it calls `add_api_route(response_model=route.response_model, ...)` — passing the now-`None` value, which is **not** a `DefaultPlaceholder`. The detection branch is skipped on the merged route and `self.stream_item_type` stays at its initial `None`. The same gating affects JSONL streaming for the same reason.

## Changes

- `fastapi/routing.py` — extend the entry condition for stream-item detection to also fire when `response_model is None` on entry. Restrict the "promote return annotation to `response_model`" fallback to the original `DefaultPlaceholder` case so an explicit `response_model=None` still disables response validation as documented. A code comment captures the *why* so a reviewer reading the diff cold doesn't have to re-derive the chain through `include_router`.
- `tests/test_sse.py` — adds `test_stream_item_type_propagated_through_include_router` asserting both (a) `stream_item_type` is set on the merged route and (b) the emitted OpenAPI contains `contentSchema` under the SSE response.

## Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify this fix in ≤60s by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/fastapi/fastapi.git /tmp/repro && cd /tmp/repro
python3 -m venv .venv && source .venv/bin/activate
pip install -q -e ".[all]" pytest

cat > /tmp/repro/check.py <<'PY'
from collections.abc import AsyncIterator
from fastapi import APIRouter, FastAPI
from fastapi.sse import EventSourceResponse
from pydantic import BaseModel

class Frame(BaseModel):
    kind: str

router = APIRouter()

@router.post("/s", response_class=EventSourceResponse)
async def b() -> AsyncIterator[Frame]:
    yield Frame(kind="x")

app = FastAPI()
app.include_router(router)

print("APP (post-include) stream_item_type:", app.routes[-1].stream_item_type)

sse = app.openapi()["paths"]["/s"]["post"]["responses"]["200"]["content"]["text/event-stream"]
has_cs = "contentSchema" in sse.get("itemSchema", {}).get("properties", {}).get("data", {})
print("OpenAPI has contentSchema:", has_cs)
PY

# --- BEFORE (origin/master) ---
git checkout origin/master
python /tmp/repro/check.py
# Expected (BUG):
#   APP (post-include) stream_item_type: None
#   OpenAPI has contentSchema: False

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/fastapi.git feat/15401-sse-include-router
git checkout FETCH_HEAD
python /tmp/repro/check.py
# Expected (FIXED):
#   APP (post-include) stream_item_type: <class '__main__.Frame'>
#   OpenAPI has contentSchema: True

# --- Regression test (also imported into the suite) ---
pytest tests/test_sse.py::test_stream_item_type_propagated_through_include_router -v
# Expected: 1 passed
```

## What I ran locally

- `pytest tests/test_sse.py -v` → **19/19 passed** (including the new regression test).
- `pytest tests/test_sse.py tests/test_application.py tests/test_router_redirect_slashes.py tests/test_router_events.py tests/test_stream_bare_type.py tests/test_stream_cancellation.py tests/test_stream_json_validation_error.py tests/test_dependency_after_yield_streaming.py tests/test_openapi_examples.py` → **56/56 passed**.
- Full suite (excluding `tests/test_tutorial`): `pytest tests/ -q` → **1840 passed, 10 skipped** (1 skip pre-existing).
- `ruff check fastapi/routing.py tests/test_sse.py` → clean.
- `ruff format --check fastapi/routing.py tests/test_sse.py` → 2 files already formatted.
- Confirmed the new regression test **fails on `origin/master`** (asserts `merged_route.stream_item_type is Frame`, gets `None`) and **passes on this branch**.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | SSE route on `APIRouter` then `include_router` | `@router.post(..., response_class=EventSourceResponse)` returning `AsyncIterable[Frame]` | merged route's `stream_item_type` is `Frame`, OpenAPI carries `contentSchema` | `test_stream_item_type_propagated_through_include_router` |
| 2 | SSE route on `FastAPI` directly (control) | same endpoint registered with `@app.post(...)` | `stream_item_type` is `Frame`, OpenAPI carries `contentSchema` | same test, control case |
| 3 | Non-streaming routes still respect explicit `response_model=None` | regular `@app.get(..., response_model=None)` returning a model | `response_model` stays `None` (no validation reintroduced) | covered by existing `tests/test_application.py` and the conditional in the patch (the `elif isinstance(response_model, DefaultPlaceholder)` guard restricts the return-annotation fallback to the default-placeholder case only) |
| 4 | Existing SSE tests on the app (no `include_router`) | full `tests/test_sse.py` matrix incl. async/sync generators, `ServerSentEvent` raw data, mixed plain+SSE, keepalive, error paths | unchanged | `tests/test_sse.py` — 18 pre-existing tests still pass |

## Risk / blast radius

- The detection branch now also fires on `response_model is None` (previously skipped). The branch is gated on `response_class` being either `DefaultPlaceholder` (JSONL) or `EventSourceResponse`; for any other `response_class` the body of the branch is a no-op, so behaviour is unchanged.
- Routes registered with an explicit `response_model=SomeModel` are untouched (the entry condition does not match).
- Routes registered with an explicit `response_model=None` and a non-streaming `response_class` are untouched (`stream_item is None` → no-op).
- The `elif isinstance(response_model, DefaultPlaceholder):` guard preserves the existing semantics that an explicit `response_model=None` disables response validation; only the original default-placeholder path can promote the return annotation to `response_model`. This guard is the reason the change is non-trivially-conditional rather than a one-line widening.

## Release note

```release-note
Fix SSE / JSONL `stream_item_type` not being propagated through `APIRouter.include_router`, which previously caused the merged route's OpenAPI schema to drop the `contentSchema` for the streamed item.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `fastapi/fastapi`'s `master` branch and the upstream behaviour cited in the issue. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
