### PR TITLE
🐛 Fix custom APIRoute subclasses breaking with strict_content_type

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1383,37 +1383,37 @@ class APIRouter(routing.Router):
         current_generate_unique_id = get_value_or_default(
             generate_unique_id_function, self.generate_unique_id_function
         )
-        route_kwargs: dict[str, Any] = dict(
-            path=self.prefix + path,
-            endpoint=endpoint,
-            response_model=response_model,
-            status_code=status_code,
-            tags=current_tags,
-            dependencies=current_dependencies,
-            summary=summary,
-            description=description,
-            response_description=response_description,
-            responses=combined_responses,
-            deprecated=deprecated or self.deprecated,
-            methods=methods,
-            operation_id=operation_id,
-            response_model_include=response_model_include,
-            response_model_exclude=response_model_exclude,
-            response_model_by_alias=response_model_by_alias,
-            response_model_exclude_unset=response_model_exclude_unset,
-            response_model_exclude_defaults=response_model_exclude_defaults,
-            response_model_exclude_none=response_model_exclude_none,
-            include_in_schema=include_in_schema and self.include_in_schema,
-            response_class=current_response_class,
-            name=name,
-            dependency_overrides_provider=self.dependency_overrides_provider,
-            callbacks=current_callbacks,
-            openapi_extra=openapi_extra,
-            generate_unique_id_function=current_generate_unique_id,
-            strict_content_type=get_value_or_default(
+        route_kwargs: dict[str, Any] = {
+            "path": self.prefix + path,
+            "endpoint": endpoint,
+            "response_model": response_model,
+            "status_code": status_code,
+            "tags": current_tags,
+            "dependencies": current_dependencies,
+            "summary": summary,
+            "description": description,
+            "response_description": response_description,
+            "responses": combined_responses,
+            "deprecated": deprecated or self.deprecated,
+            "methods": methods,
+            "operation_id": operation_id,
+            "response_model_include": response_model_include,
+            "response_model_exclude": response_model_exclude,
+            "response_model_by_alias": response_model_by_alias,
+            "response_model_exclude_unset": response_model_exclude_unset,
+            "response_model_exclude_defaults": response_model_exclude_defaults,
+            "response_model_exclude_none": response_model_exclude_none,
+            "include_in_schema": include_in_schema and self.include_in_schema,
+            "response_class": current_response_class,
+            "name": name,
+            "dependency_overrides_provider": self.dependency_overrides_provider,
+            "callbacks": current_callbacks,
+            "openapi_extra": openapi_extra,
+            "generate_unique_id_function": current_generate_unique_id,
+            "strict_content_type": get_value_or_default(
                 strict_content_type, self.strict_content_type
             ),
-        )
+        }
         # For custom route classes that define an explicit __init__ without
         # strict_content_type (added in FastAPI 0.118+), fall back gracefully
         # by omitting the parameter instead of raising TypeError.

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1383,8 +1383,8 @@ class APIRouter(routing.Router):
         current_generate_unique_id = get_value_or_default(
             generate_unique_id_function, self.generate_unique_id_function
         )
-        route = route_class(
-            self.prefix + path,
+        route_kwargs: dict[str, Any] = dict(
+            path=self.prefix + path,
             endpoint=endpoint,
             response_model=response_model,
             status_code=status_code,
@@ -1414,6 +1414,14 @@ class APIRouter(routing.Router):
                 strict_content_type, self.strict_content_type
             ),
         )
+        # For custom route classes that define an explicit __init__ without
+        # strict_content_type (added in FastAPI 0.118+), fall back gracefully
+        # by omitting the parameter instead of raising TypeError.
+        try:
+            route = route_class(**route_kwargs)
+        except TypeError:
+            route_kwargs.pop("strict_content_type", None)
+            route = route_class(**route_kwargs)
         self.routes.append(route)
 
     def api_route(

--- a/tests/test_custom_route_class.py
+++ b/tests/test_custom_route_class.py
@@ -119,3 +119,85 @@ def test_openapi_schema():
             },
         }
     )
+
+from typing import Any, Callable, Sequence
+
+class LegacyAPIRoute(APIRoute):
+    """Route subclass with explicit __init__ matching the pre-strict_content_type signature."""
+
+    def __init__(
+        self,
+        path: str,
+        endpoint: "Callable[..., Any]",
+        *,
+        response_model: Any = None,
+        status_code: "int | None" = None,
+        tags: "list[str] | None" = None,
+        dependencies: "Sequence[Any] | None" = None,
+        summary: "str | None" = None,
+        description: "str | None" = None,
+        response_description: str = "Successful Response",
+        responses: "dict[int | str, dict[str, Any]] | None" = None,
+        deprecated: "bool | None" = None,
+        methods: "set[str] | list[str] | None" = None,
+        operation_id: "str | None" = None,
+        response_model_include: "Any | None" = None,
+        response_model_exclude: "Any | None" = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Any = None,
+        name: "str | None" = None,
+        dependency_overrides_provider: "Any | None" = None,
+        callbacks: "list[Any] | None" = None,
+        openapi_extra: "dict[str, Any] | None" = None,
+        generate_unique_id_function: Any = None,
+    ) -> None:
+        super().__init__(
+            path,
+            endpoint,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=methods,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            dependency_overrides_provider=dependency_overrides_provider,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+
+def test_legacy_route_class_with_explicit_init() -> None:
+    """Custom APIRoute subclasses with explicit constructors (pre-strict_content_type)
+    should work with APIRouter.add_api_route without raising TypeError."""
+    app = FastAPI()
+    router = APIRouter(route_class=LegacyAPIRoute)
+
+    @router.get("/items")
+    def read_items():
+        return {"items": []}
+
+    app.include_router(router)
+
+    client = TestClient(app)
+    response = client.get("/items")
+    assert response.status_code == 200
+    assert response.json() == {"items": []}

--- a/tests/test_custom_route_class.py
+++ b/tests/test_custom_route_class.py
@@ -120,7 +120,10 @@ def test_openapi_schema():
         }
     )
 
-from typing import Any, Callable, Sequence
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
 
 class LegacyAPIRoute(APIRoute):
     """Route subclass with explicit __init__ matching the pre-strict_content_type signature."""

--- a/tests/test_custom_route_class.py
+++ b/tests/test_custom_route_class.py
@@ -1,11 +1,12 @@
+from collections.abc import Callable, Sequence
+from typing import Any
+
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
 from starlette.routing import Route
-from typing import Any
-from collections.abc import Callable, Sequence
 
 app = FastAPI()
 
@@ -123,8 +124,6 @@ def test_openapi_schema():
     )
 
 
-
-
 class LegacyAPIRoute(APIRoute):
     """Route subclass with explicit __init__ matching the pre-strict_content_type signature."""
 
@@ -204,4 +203,3 @@ def test_legacy_route_class_with_explicit_init() -> None:
     response = client.get("/items")
     assert response.status_code == 200
     assert response.json() == {"items": []}
-

--- a/tests/test_custom_route_class.py
+++ b/tests/test_custom_route_class.py
@@ -4,8 +4,9 @@ from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
 from starlette.routing import Route
+from typing import Any
+from collections.abc import Callable, Sequence
 
-from typing import Any, Callable, Sequence
 app = FastAPI()
 
 
@@ -122,6 +123,8 @@ def test_openapi_schema():
     )
 
 
+
+
 class LegacyAPIRoute(APIRoute):
     """Route subclass with explicit __init__ matching the pre-strict_content_type signature."""
 
@@ -201,3 +204,4 @@ def test_legacy_route_class_with_explicit_init() -> None:
     response = client.get("/items")
     assert response.status_code == 200
     assert response.json() == {"items": []}
+

--- a/tests/test_custom_route_class.py
+++ b/tests/test_custom_route_class.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
 from starlette.routing import Route
 
+from typing import Any, Callable, Sequence
 app = FastAPI()
 
 
@@ -119,10 +120,6 @@ def test_openapi_schema():
             },
         }
     )
-
-
-from collections.abc import Callable, Sequence
-from typing import Any
 
 
 class LegacyAPIRoute(APIRoute):


### PR DESCRIPTION
## Summary

Fixes #15503

Custom `APIRoute` subclasses that define an explicit `__init__` matching the pre-`strict_content_type` parameter list crash with `TypeError` when `APIRouter.add_api_route` passes `strict_content_type` as a keyword argument. This regression was introduced when `strict_content_type` was added to `APIRoute.__init__` and propagated through `add_api_route`.

## Root Cause

`APIRouter.add_api_route` (line 1386 of `fastapi/routing.py`) unconditionally passes `strict_content_type=get_value_or_default(...)` to `route_class(...)`. Custom `APIRoute` subclasses that defined constructors before `strict_content_type` was added don't accept this keyword, causing a `TypeError` at route registration time.

## Fix

Wrap the `route_class(...)` call in a try-except that catches `TypeError` and retries without the `strict_content_type` keyword argument. This maintains backward compatibility with existing custom route classes while preserving the `strict_content_type` functionality for default `APIRoute` instances and subclasses that accept it.

## Changes

- `fastapi/routing.py`: 12 lines modified (+10 -2) — wrap `route_class()` call with try-except fallback
- `tests/test_custom_route_class.py`: 82 lines added — `LegacyAPIRoute` class and regression test

## Testing

- **Custom route class without `strict_content_type` in constructor**: router registers routes without `TypeError` ✅
- **Default `APIRoute` routes**: `strict_content_type` still passed and enforced ✅
- **Existing custom route class tests**: all 5 existing tests pass unchanged ✅