### PR TITLE
Docs: Clarify required nullable query parameter behavior

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -224,6 +224,14 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
 
+/// info
+
+Keep in mind that for **query parameters** specifically, since they are extracted from the URL as strings, it's not really possible to send a `None` value natively. If you omit the parameter from the URL, you will get an error saying it's required. If you send it empty like `?q=`, the value will be an empty string `""`, not `None`.
+
+This "required but can be None" pattern is much more useful and common when working with JSON data (request bodies) where you can explicitly send a `null` value. 🤓
+
+///
+
 To do that, you can declare that `None` is a valid type but simply do not declare a default value:
 
 {* ../../docs_src/query_params_str_validations/tutorial006c_an_py310.py hl[9] *}


### PR DESCRIPTION
### Description

This PR clarifies the "Required, can be None" documentation section for query parameters.

As discussed in #12419, the previous wording was slightly ambiguous as it implied clients could natively send a "None" value in a URL query string. This update explicitly clarifies that:
1. Query parameters are extracted as strings.
2. Omitting the parameter raises a "required" validation error.
3. Sending it empty (e.g., "?q=") results in an empty string "", rather than "None".
4. The "str | None" required pattern is primarily useful for JSON request bodies where "null" can be explicitly passed.

Fixes #12419

### Checklist

* [x] I added a very descriptive title to this PR.
* [x] I used the GitHub search to find a similar PR and didn't find it.
* [x] I searched the FastAPI documentation, with the integrated search.
* [x] I already read and followed all the tutorial in the docs and didn't find an answer.