### PR TITLE
📝 Fix image URLs in `index.md`

### DIFF
--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -86,16 +86,16 @@ The key features are:
 <div class="fastapi-opinions" data-fastapi-opinions>
   <div class="fastapi-opinions__tabs" role="tablist" aria-label="Companies using FastAPI">
     <button class="fastapi-opinions__tab" role="tab" type="button" id="fo-tab-microsoft" aria-controls="fo-panel-microsoft" aria-selected="true" tabindex="0">
-      <span class="fastapi-opinions__mark"><img src="img/logos/microsoft.svg" alt="Microsoft" loading="lazy"></span>
+      <span class="fastapi-opinions__mark"><img src="/img/logos/microsoft.svg" alt="Microsoft" loading="lazy"></span>
     </button>
     <button class="fastapi-opinions__tab" role="tab" type="button" id="fo-tab-uber" aria-controls="fo-panel-uber" aria-selected="false" tabindex="-1">
-      <span class="fastapi-opinions__mark"><img src="img/logos/uber.svg" alt="Uber" loading="lazy"></span>
+      <span class="fastapi-opinions__mark"><img src="/img/logos/uber.svg" alt="Uber" loading="lazy"></span>
     </button>
     <button class="fastapi-opinions__tab" role="tab" type="button" id="fo-tab-netflix" aria-controls="fo-panel-netflix" aria-selected="false" tabindex="-1">
-      <span class="fastapi-opinions__mark"><img src="img/logos/netflix.svg" alt="Netflix" loading="lazy"></span>
+      <span class="fastapi-opinions__mark"><img src="/img/logos/netflix.svg" alt="Netflix" loading="lazy"></span>
     </button>
     <button class="fastapi-opinions__tab" role="tab" type="button" id="fo-tab-cisco" aria-controls="fo-panel-cisco" aria-selected="false" tabindex="-1">
-      <span class="fastapi-opinions__mark"><img src="img/logos/cisco.svg" alt="Cisco" loading="lazy"></span>
+      <span class="fastapi-opinions__mark"><img src="/img/logos/cisco.svg" alt="Cisco" loading="lazy"></span>
     </button>
   </div>
 


### PR DESCRIPTION
Relative URLs don't work for translations, they point to `/es/img/logos/microsoft.svg` instead of `/img/logos/microsoft.svg`:

<img width="1347" height="337" alt="image" src="https://github.com/user-attachments/assets/afcf307b-2fb8-4ca0-bc9d-208ebc4fab41" />

Adding leading slash fixes it. See docs preview for RU translation PR: https://github.com/fastapi/fastapi/pull/15521