### PR TITLE
Handle ImportError for optional JSON response imports

### DIFF
--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -26,13 +26,13 @@ class _OrjsonModule(Protocol):
 
 try:
     ujson = cast(_UjsonModule, importlib.import_module("ujson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     ujson = None  # type: ignore[assignment]
 
 
 try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
 
 

--- a/tests/test_responses_import.py
+++ b/tests/test_responses_import.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_responses_import.py
+++ b/tests/test_responses_import.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("optional_module_name", ("ujson", "orjson"))
+def test_responses_imports_when_optional_json_import_raises_import_error(
+    optional_module_name: str,
+) -> None:
+    code = textwrap.dedent(
+        f"""
+        import importlib
+
+        real_import_module = importlib.import_module
+
+        def fake_import_module(name, package=None):
+            if name == {optional_module_name!r}:
+                raise ImportError("simulated optional dependency load failure")
+            return real_import_module(name, package)
+
+        importlib.import_module = fake_import_module
+
+        import fastapi.responses as responses
+
+        assert getattr(responses, {optional_module_name!r}) is None
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## Summary

- Catch `ImportError` when importing optional `ujson` and `orjson` modules for response classes.
- Treat optional JSON encoder load failures the same as missing optional packages at import time.
- Add import-time regression coverage for plain `ImportError` from both optional imports.

Fixes #15535

## Tests

- `python -m pytest tests/test_responses_import.py -q`
- `python -m pytest tests/test_responses_import.py tests/test_deprecated_responses.py tests/test_orjson_response_class.py -q`
- `git diff --check origin/master..HEAD`
