### PR TITLE
Fix inconsistent type ignore comments

### DIFF
--- a/fastapi/_compat/shared.py
+++ b/fastapi/_compat/shared.py
@@ -23,7 +23,7 @@ _T = TypeVar("_T")
 
 # Copy from Pydantic: pydantic/_internal/_typing_extra.py
 WithArgsTypes: tuple[Any, ...] = (
-    typing._GenericAlias,  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    typing._GenericAlias,  # type: ignore[attr-defined]  # type: ignore[unresolved-attribute]
     types.GenericAlias,
     types.UnionType,
 )  # pyright: ignore[reportAttributeAccessIssue]
@@ -48,7 +48,7 @@ def lenient_issubclass(
     cls: Any, class_or_tuple: type[_T] | tuple[type[_T], ...] | None
 ) -> TypeGuard[type[_T]]:
     try:
-        return isinstance(cls, type) and issubclass(cls, class_or_tuple)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        return isinstance(cls, type) and issubclass(cls, class_or_tuple)  # type: ignore[arg-type]  # type: ignore[invalid-argument-type]
     except TypeError:  # pragma: no cover
         if isinstance(cls, WithArgsTypes):
             return False

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -49,7 +49,7 @@ def evaluate_forwardref(
     try_eval_type = getattr(_pydantic_typing_extra, "try_eval_type", None)
     if try_eval_type is not None:
         return try_eval_type(value, globalns, localns)[0]
-    return _pydantic_typing_extra.eval_type_lenient(  # ty: ignore[deprecated]
+    return _pydantic_typing_extra.eval_type_lenient(  # type: ignore[deprecated]
         value, globalns, localns
     )
 
@@ -161,7 +161,7 @@ class ModelField:
                 Field(**field_dict["attributes"]),
             )
             self._type_adapter: TypeAdapter[Any] = TypeAdapter(
-                Annotated[annotated_args],  # ty: ignore[invalid-type-form]
+                Annotated[annotated_args],  # type: ignore[invalid-type-form]
                 config=self.config,
             )
 
@@ -372,8 +372,8 @@ def serialize_sequence_value(*, field: ModelField, value: Any) -> Sequence[Any]:
                 continue
             origin_type = get_origin(union_arg) or union_arg
             break
-    assert issubclass(origin_type, shared.sequence_types)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-    return shared.sequence_annotation_to_type[origin_type](value)  # type: ignore[no-any-return,index]  # ty: ignore[invalid-return-type]
+    assert issubclass(origin_type, shared.sequence_types)  # type: ignore[arg-type]  # type: ignore[invalid-argument-type]
+    return shared.sequence_annotation_to_type[origin_type](value)  # type: ignore[no-any-return,index]  # type: ignore[invalid-return-type]
 
 
 def get_missing_field_error(loc: tuple[int | str, ...]) -> dict[str, Any]:
@@ -381,14 +381,14 @@ def get_missing_field_error(loc: tuple[int | str, ...]) -> dict[str, Any]:
         "Field required", [{"type": "missing", "loc": loc, "input": {}}]
     ).errors(include_url=False)[0]
     error["input"] = None
-    return error  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+    return error  # type: ignore[return-value]  # type: ignore[invalid-return-type]
 
 
 def create_body_model(
     *, fields: Sequence[ModelField], model_name: str
 ) -> type[BaseModel]:
     field_params = {f.name: (f.field_info.annotation, f.field_info) for f in fields}
-    BodyModel: type[BaseModel] = create_model(model_name, **field_params)  # type: ignore[call-overload]  # ty: ignore[no-matching-overload]
+    BodyModel: type[BaseModel] = create_model(model_name, **field_params)  # type: ignore[call-overload]  # type: ignore[no-matching-overload]
     return BodyModel
 
 

--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -4595,7 +4595,7 @@ class FastAPI(Starlette):
         Read more about it in the
         [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/#alternative-events-deprecated).
         """
-        return self.router.on_event(event_type)  # ty: ignore[deprecated]
+        return self.router.on_event(event_type)  # type: ignore[deprecated]
 
     def middleware(
         self,

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -33,7 +33,7 @@ from ._compat import (
 
 try:
     # pydantic.color.Color is deprecated since v2.0b3, but supporting for bwd-compat
-    from pydantic.color import Color  # ty: ignore[deprecated]
+    from pydantic.color import Color  # type: ignore[deprecated]
 except ImportError:  # pragma: no cover
 
     class Color:  # type: ignore[no-redef]
@@ -237,9 +237,9 @@ def jsonable_encoder(
                 if isinstance(obj, encoder_type):
                     return encoder_instance(obj)
     if include is not None and not isinstance(include, (set, dict)):
-        include = set(include)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        include = set(include)  # type: ignore[assignment]  # type: ignore[invalid-assignment]
     if exclude is not None and not isinstance(exclude, (set, dict)):
-        exclude = set(exclude)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        exclude = set(exclude)  # type: ignore[assignment]  # type: ignore[invalid-assignment]
     if isinstance(obj, BaseModel):
         obj_dict = obj.model_dump(
             mode="json",

--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -215,7 +215,7 @@ class Example(TypedDict, total=False):
     value: Any | None
     externalValue: AnyUrl | None
 
-    __pydantic_config__ = {"extra": "allow"}  # type: ignore[misc]  # ty: ignore[invalid-typed-dict-statement]
+    __pydantic_config__ = {"extra": "allow"}  # type: ignore[misc]  # type: ignore[invalid-typed-dict-statement]
 
 
 class ParameterInType(Enum):

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -23,7 +23,7 @@ class ParamTypes(Enum):
     cookie = "cookie"
 
 
-class Param(FieldInfo):  # type: ignore[misc]  # ty: ignore[subclass-of-final-class]
+class Param(FieldInfo):  # type: ignore[misc]  # type: ignore[subclass-of-final-class]
     in_: ParamTypes
 
     def __init__(
@@ -128,7 +128,7 @@ class Param(FieldInfo):  # type: ignore[misc]  # ty: ignore[subclass-of-final-cl
 
         use_kwargs = {k: v for k, v in kwargs.items() if v is not _Unset}
 
-        super().__init__(**use_kwargs)  # ty: ignore[invalid-argument-type]
+        super().__init__(**use_kwargs)  # type: ignore[invalid-argument-type]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.default})"
@@ -466,7 +466,7 @@ class Cookie(Param):  # type: ignore[misc]
         )
 
 
-class Body(FieldInfo):  # type: ignore[misc]  # ty: ignore[subclass-of-final-class]
+class Body(FieldInfo):  # type: ignore[misc]  # type: ignore[subclass-of-final-class]
     def __init__(
         self,
         default: Any = Undefined,
@@ -572,7 +572,7 @@ class Body(FieldInfo):  # type: ignore[misc]  # ty: ignore[subclass-of-final-cla
 
         use_kwargs = {k: v for k, v in kwargs.items() if v is not _Unset}
 
-        super().__init__(**use_kwargs)  # ty: ignore[invalid-argument-type]
+        super().__init__(**use_kwargs)  # type: ignore[invalid-argument-type]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.default})"

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -105,7 +105,7 @@ def request_response(
         func  # type: ignore[assignment]
         if is_async_callable(func)
         else functools.partial(run_in_threadpool, func)  # type: ignore[call-arg]
-    )  # ty: ignore[invalid-assignment]
+    )  # type: ignore[invalid-assignment]
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive, send)
@@ -220,7 +220,7 @@ def _merge_lifespan_context(
                 else:
                     yield {**(maybe_nested_state or {}), **(maybe_original_state or {})}
 
-    return merged_lifespan  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+    return merged_lifespan  # type: ignore[return-value]  # type: ignore[invalid-return-type]
 
 
 class _DefaultLifespan:
@@ -639,7 +639,7 @@ def get_request_handler(
                 else:
 
                     def _sync_stream_jsonl() -> Iterator[bytes]:
-                        for item in gen:  # ty: ignore[not-iterable]
+                        for item in gen:  # type: ignore[not-iterable]
                             yield _serialize_item(item)
 
                     jsonl_stream_content = _sync_stream_jsonl()

--- a/fastapi/security/api_key.py
+++ b/fastapi/security/api_key.py
@@ -22,7 +22,7 @@ class APIKeyBase(SecurityBase):
         self.auto_error = auto_error
 
         self.model: APIKey = APIKey(
-            **{"in": location},  # ty: ignore[invalid-argument-type]
+            **{"in": location},  # type: ignore[invalid-argument-type]
             name=name,
             description=description,
         )


### PR DESCRIPTION
This PR fixes and standardizes inconsistent type ignore comments across the codebase.

Some files currently use the incorrect `# ty: ignore` comment format instead of the proper `# type: ignore` syntax recognized by type checkers like mypy and Pyright.

This change replaces all inconsistent usages with the correct format for improved consistency :

```python
# Before
# ty: ignore

# After
# type: ignore
```

No existing issue was found for this; opening a direct consistency/cleanup PR.