### PR TITLE
🔒️ Only allow team members to modify dependencies

### DIFF
--- a/.github/workflows/guard-dependencies.yml
+++ b/.github/workflows/guard-dependencies.yml
@@ -1,0 +1,52 @@
+name: Guard Dependencies
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] -- This workflow only reads context.payload metadata, never checks out PR code
+    branches: [master]
+    paths:
+      - pyproject.toml
+      - uv.lock
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if author is org member or allowed bot
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const assoc = pr.author_association;
+
+            const botAllowlist = new Set(['dependabot[bot]']);
+            const orgAuthorAssociations = new Set(['MEMBER', 'OWNER']);
+
+            const allowed =
+              botAllowlist.has(author) ||
+              (assoc != null && orgAuthorAssociations.has(assoc));
+
+            if (!allowed) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `This PR modifies dependency files (\`pyproject.toml\` or \`uv.lock\`), which is restricted to members of the **${context.repo.owner}** organization on GitHub.\n\nIf you need a dependency change, please [open a discussion](https://github.com/${context.repo.owner}/${context.repo.repo}/discussions/new) describing what you need and why.\n\nClosing this PR automatically.`
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                state: 'closed'
+              });
+
+              core.setFailed('Dependency changes are restricted to organization members.');
+            } else {
+              console.log(`Author ${author} (author_association=${assoc}) is allowed to make dependency changes.`);
+            }

--- a/docs/en/docs/help-fastapi.md
+++ b/docs/en/docs/help-fastapi.md
@@ -210,6 +210,9 @@ You can [contribute](contributing.md) to the source code with Pull Requests, for
     * Make sure to add tests.
     * Make sure to add documentation if it's relevant.
 
+Note that PRs from non-team members are not allowed to modify `pyproject.toml` or `uv.lock`, to prevent supply chain risk.
+If you would like to add a new dependency, create a new [Discussion](https://github.com/fastapi/fastapi/discussions/categories/questions) to explain why.
+
 ## Help Maintain FastAPI { #help-maintain-fastapi }
 
 Help me maintain **FastAPI**! 🤓


### PR DESCRIPTION
Inspired by [pydantic-ai-harness](https://github.com/pydantic/pydantic-ai-harness/blob/main/.github/workflows/guard-dependencies.yml), going forward we'll only allow maintainers to modify `pyproject.toml` or `uv.lock`. PRs from other contributors will be automatically closed with the GH action commited in this PR (taken and modified from `pydantic-ai-harness`) 🙏 