### PR TITLE
docs: clarify required nullable query parameters

### DIFF
--- a/docs/en/docs/tutorial/query-params-str-validations.md
+++ b/docs/en/docs/tutorial/query-params-str-validations.md
@@ -222,7 +222,17 @@ So, when you need to declare a value as required while using `Query`, you can si
 
 ### Required, can be `None` { #required-can-be-none }
 
-You can declare that a parameter can accept `None`, but that it's still required. This would force clients to send a value, even if the value is `None`.
+You can declare that a parameter can accept `None`, but that it's still required.
+
+This means that clients have to include the parameter in the request, even if its value could be `None` in the Python code.
+
+/// note
+
+Query parameters are sent in the URL, so they are normally strings. There isn't a standard way to send a Python `None` value in a query parameter.
+
+For example, omitting `q` would make the parameter missing, and sending `?q=` would send an empty string instead of `None`.
+
+///
 
 To do that, you can declare that `None` is a valid type but simply do not declare a default value:
 


### PR DESCRIPTION
## Summary

Clarify the docs for required query parameters that can be `None` by explaining that query parameters are sent as URL strings and there is no standard way to send a Python `None` value in a query parameter.

This addresses the confusion raised in #12419.

## Checks

- `uv run pytest tests/test_application.py -q`
- `uv run python scripts/docs.py build-lang en`
- `git diff --check`