### PR TITLE
fix: support unresolved forward refs in annotated dependencies

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -242,10 +242,21 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
     return typed_signature
 
 
+class _DictWithForwardRefs(dict[str, Any]):
+    def __missing__(self, key: str) -> Any:
+        value = ForwardRef(key)
+        self[key] = value
+        return value
+
+
 def get_typed_annotation(annotation: Any, globalns: dict[str, Any]) -> Any:
     if isinstance(annotation, str):
+        annotation_string = annotation
         annotation = ForwardRef(annotation)
         annotation = evaluate_forwardref(annotation, globalns, globalns)
+        if isinstance(annotation, ForwardRef) and "Annotated" in annotation_string:
+            annotationns = _DictWithForwardRefs(globalns)
+            annotation = eval(annotation_string, annotationns, annotationns)
         if annotation is type(None):
             return None
     return annotation

--- a/tests/test_stringified_annotation_dependency.py
+++ b/tests/test_stringified_annotation_dependency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated
 
 import pytest
@@ -26,6 +27,25 @@ async def get_client() -> AsyncGenerator[DummyClient, None]:
 
 
 Client = Annotated[DummyClient, Depends(get_client)]
+
+app_with_late_forward_ref = FastAPI()
+
+
+def get_potato() -> Potato:
+    return Potato(color="red", size=10)
+
+
+@app_with_late_forward_ref.get("/")
+async def get_late_forward_ref(
+    potato: Annotated[Potato, Depends(get_potato)],
+) -> dict[str, str]:
+    return {"color": potato.color}
+
+
+@dataclass
+class Potato:
+    color: str
+    size: int
 
 
 @pytest.fixture(name="client")
@@ -67,6 +87,46 @@ def test_openapi_schema(client: TestClient):
                                             "items": {},
                                             "type": "array",
                                             "title": "Response Get People  Get",
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    )
+
+
+def test_late_forward_ref_dependency():
+    client = TestClient(app_with_late_forward_ref)
+
+    response = client.get("/")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"color": "red"}
+
+
+def test_late_forward_ref_dependency_openapi():
+    assert app_with_late_forward_ref.openapi() == snapshot(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "FastAPI", "version": "0.1.0"},
+            "paths": {
+                "/": {
+                    "get": {
+                        "summary": "Get Late Forward Ref",
+                        "operationId": "get_late_forward_ref__get",
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "additionalProperties": {"type": "string"},
+                                            "type": "object",
+                                            "title": "Response Get Late Forward Ref  Get",
                                         }
                                     }
                                 },


### PR DESCRIPTION
## Summary

Fix dependency detection for stringified `Annotated` parameters when the inner type is a forward reference that is not defined yet at route registration time.

When full annotation evaluation leaves the whole `Annotated[...]` expression unresolved, FastAPI now falls back to evaluating the outer annotation with missing names represented as `ForwardRef`s. This preserves FastAPI metadata such as `Depends(...)` while keeping the unresolved type reference intact.

Closes #13056.

## Checks

- `uv run pytest tests/test_stringified_annotation_dependency.py -q`
- `uv run pytest tests/test_dependencies_utils.py tests/test_stringified_annotation_dependency.py tests/test_stringified_annotations_simple.py -q`
- `uv run ruff check fastapi/dependencies/utils.py tests/test_stringified_annotation_dependency.py`
- `uv run ruff format fastapi/dependencies/utils.py tests/test_stringified_annotation_dependency.py --check`
- `uv run mypy fastapi/dependencies/utils.py`
- `uv run ty check fastapi/dependencies/utils.py`
- `git diff --check`