### PR TITLE
docs: fix grammar in contributing translations section

### DIFF
--- a/docs/en/docs/contributing.md
+++ b/docs/en/docs/contributing.md
@@ -222,7 +222,7 @@ Let's say that you want to request translations for a language that is not yet t
 * The first step would be for you to find other 2 people that would be willing to be reviewing translation PRs for that language with you.
 * Once there are at least 3 people that would be willing to commit to help maintain that language, you can continue the next steps.
 * Create a new discussion following the template.
-* Tag the other 2 people that will help with the language, and ask them to confirm there they will help.
+* Tag the other 2 people that will help with the language, and ask them to confirm that they will help.
 
 Once there are several people in the discussion, the FastAPI team can evaluate it and can make it an official translation.
 


### PR DESCRIPTION
Fixes wording in the guide for requesting a new translation language: 'confirm there they will help' -> 'confirm that they will help' (docs/en/docs/contributing.md).