### PR TITLE
fix: catch ImportError for optional ujson/orjson imports

### DIFF
--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -26,13 +26,13 @@ class _OrjsonModule(Protocol):
 
 try:
     ujson = cast(_UjsonModule, importlib.import_module("ujson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     ujson = None  # type: ignore[assignment]
 
 
 try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
 
 


### PR DESCRIPTION
Some environments raise `ImportError` rather than `ModuleNotFoundError` when optional dependencies like `ujson` or `orjson` are not installed. Since `ModuleNotFoundError` is a subclass of `ImportError`, catching only `ModuleNotFoundError` misses these cases.

This PR changes the exception handling in `fastapi/responses.py` to catch `ImportError` directly, which covers both `ImportError` and its subclass `ModuleNotFoundError`.

## Changes

- `fastapi/responses.py`: changed `except ModuleNotFoundError` → `except ImportError` for both `ujson` and `orjson` optional imports

Fixes #15536