### PR TITLE
Fix incorrect statement about response_model union syntax in Python 3.10+

### DIFF
--- a/docs/en/docs/tutorial/extra-models.md
+++ b/docs/en/docs/tutorial/extra-models.md
@@ -184,7 +184,9 @@ If it was in a type annotation we could have used the vertical bar, as:
 some_variable: PlaneItem | CarItem
 ```
 
-But if we put that in the assignment `response_model=PlaneItem | CarItem` we would get an error, because Python would try to perform an **invalid operation** between `PlaneItem` and `CarItem` instead of interpreting that as a type annotation.
+In Python 3.10 and later, using `PlaneItem | CarItem` in assignments such as `response_model=...` is valid, since `|` represents a type union (PEP 604) and produces a `UnionType` object at runtime.
+In Python versions prior to 3.10, this syntax raises an error because `|` is interpreted as a bitwise OR operator.
+Therefore, this limitation only applies to Python 3.9 and earlier.
 
 ## List of models { #list-of-models }
 

--- a/docs/zh/docs/tutorial/extra-models.md
+++ b/docs/zh/docs/tutorial/extra-models.md
@@ -183,8 +183,11 @@ UserInDB(
 ```Python
 some_variable: PlaneItem | CarItem
 ```
+在 Python 3.10 及以上版本中，`PlaneItem | CarItem` 在赋值表达式中是合法的，因为 `|` 已被用于表示类型联合（PEP 604），并返回 `UnionType` 对象。
 
-但如果把它写成赋值 `response_model=PlaneItem | CarItem`，就会报错，因为 Python 会尝试在 `PlaneItem` 和 `CarItem` 之间执行一个“无效的运算”，而不是把它当作类型注解来解析。
+在 Python 3.10 之前版本中，这种写法会被当作按位或运算符处理，因此会报错。
+
+因此，该限制仅适用于 Python 3.9 及以下版本。
 
 ## 模型列表 { #list-of-models }
 


### PR DESCRIPTION
The current wording does not clearly distinguish Python version behavior, which may mislead users on Python 3.10+ into thinking the syntax is invalid.