### PR TITLE
✏️ Use `Annotated` in inline example in `docs/en/docs/tutorial/body-multiple-params.md`

### DIFF
--- a/docs/en/docs/tutorial/body-multiple-params.md
+++ b/docs/en/docs/tutorial/body-multiple-params.md
@@ -126,7 +126,7 @@ By default, **FastAPI** will then expect its body directly.
 But if you want it to expect a JSON with a key `item` and inside of it the model contents, as it does when you declare extra body parameters, you can use the special `Body` parameter `embed`:
 
 ```Python
-item: Item = Body(embed=True)
+item: Annotated[Item, Body(embed=True)]
 ```
 
 as in:


### PR DESCRIPTION
The full example in the "Body - Multiple Parameters" tutorial recommends and uses Annotated, but one line still uses the non-Annotated version.

## Pull Request

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Obvious typo fixes can be made in a PR without starting a discussion.
-->

Discussion: This seemed like an obvious issue with a straightforward fix, so I did not start a discussion.

## Description

My PR updates the line to use Annotated.

## AI Disclaimer

No AI used :)

## Checklist

- [x] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change. - No tests needed
- [ ] The new or updated tests fail on the main branch and pass on this PR. - No tests needed
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
