### PR TITLE
Fix typo in release notes

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -262,7 +262,7 @@ hide:
 ### Features
 
 * ✨ Add support for streaming JSON Lines and binary data with `yield`. PR [#15022](https://github.com/fastapi/fastapi/pull/15022) by [@tiangolo](https://github.com/tiangolo).
-    * This also upgrades Starlette from `>=0.40.0` to `>=0.46.0`, as it's needed to properly unrwap and re-raise exceptions from exception groups.
+    * This also upgrades Starlette from `>=0.40.0` to `>=0.46.0`, as it's needed to properly unwrap and re-raise exceptions from exception groups.
     * New docs: [Stream JSON Lines](https://fastapi.tiangolo.com/tutorial/stream-json-lines/).
     * And new docs: [Stream Data](https://fastapi.tiangolo.com/advanced/stream-data/).
 


### PR DESCRIPTION
## Summary

* Fix typo: "unrwap" -> "unwrap" in release notes.

## Testing

* Not applicable (docs-only change).
