### PR TITLE
Fix line splitting in format_sse_event to comply with SSE spec

### DIFF
--- a/fastapi/sse.py
+++ b/fastapi/sse.py
@@ -206,14 +206,14 @@ def format_sse_event(
     lines: list[str] = []
 
     if comment is not None:
-        for line in comment.splitlines():
+        for line in comment.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
             lines.append(f": {line}")
 
     if event is not None:
         lines.append(f"event: {event}")
 
     if data_str is not None:
-        for line in data_str.splitlines():
+        for line in data_str.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
             lines.append(f"data: {line}")
 
     if id is not None:


### PR DESCRIPTION
## Description

This resolves a protocol compliance issue with Server-Sent Events. Previously, `format_sse_event` used Python's `str.splitlines()` method, which incorrectly splits on multiple Unicode characters (like `\v` or `\x1e`).

The SSE specification strictly states that lines must be separated by `\r\n` (CRLF), `\n` (LF), or `\r` (CR) characters only. Replacing `splitlines()` with explicit `.replace("\r\n", "\n").replace("\r", "\n").split("\n")` ensures that valid data carrying strings with other splitting unicode markers do not corrupt the SSE stream framing.

Fixes #15515