### PR TITLE
fix(security): upgrade Starlette dependency to patched version for CVE-2026-48710

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.46.0",
+    "starlette>=1.0.1",
     "pydantic>=2.9.0",
     "typing-extensions>=4.8.0",
     "typing-inspection>=0.4.2",


### PR DESCRIPTION
This PR upgrades the Starlette dependency to a patched version addressing the Host header parsing vulnerability tracked as CVE-2026-48710 (“BadHost”).

The issue allows malformed `Host` headers to manipulate `request.url.path`, potentially bypassing middleware-based security controls in ASGI applications.

### Changes

* Bump Starlette to patched version
* Align FastAPI dependency tree with upstream security fix
* Mitigate Host header authentication bypass scenarios

### References

* CVE-2026-48710 - https://security-tracker.debian.org/tracker/CVE-2026-48710