### PR TITLE
✅ Use custom `changing_dir` instead of `CLIRunner.isolated_filesystem` to set working dir

### DIFF
--- a/scripts/tests/test_translation_fixer/conftest.py
+++ b/scripts/tests/test_translation_fixer/conftest.py
@@ -1,5 +1,8 @@
+import os
 import shutil
 import sys
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -23,11 +26,20 @@ def pytest_collection_modifyitems(config, items: list[pytest.Item]) -> None:
             item.add_marker(skip_on_windows)
 
 
+@contextmanager
+def changing_dir(directory: str | Path) -> Generator[None, None, None]:
+    initial_dir = os.getcwd()
+    os.chdir(directory)
+    try:
+        yield
+    finally:
+        os.chdir(initial_dir)
+
+
 @pytest.fixture(name="runner")
-def get_runner():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        yield runner
+def get_runner(tmp_path: Path):
+    with changing_dir(tmp_path):
+        yield CliRunner()
 
 
 @pytest.fixture(name="root_dir")


### PR DESCRIPTION
## Description

Typer 0.26 removed `CLIRunner.isolated_filesystem` context manager that was used in tests to set working directory to temporary path.
So, FastAPI redistribute tests started to fail (they run with latest dependency versions) - see [logs](https://github.com/fastapi/fastapi/actions/runs/26507260262/job/78062757815?pr=15610).

Here is where `isolated_filesystem` is used: https://github.com/fastapi/fastapi/blob/dbfd55cea3a656029a9368924f3d8f1f829702c9/scripts/tests/test_translation_fixer/conftest.py#L29

The fix is to use custom context manager as in `fastapi-cloud-cli`: https://github.com/fastapilabs/fastapi-cloud-cli/blob/1d807db95e43d598f74ddecb8e7ce107396a99fa/tests/utils.py#L11-L18

## AI Disclaimer

No AI used

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
