### PR TITLE
Optimize `jsonable_encoder` to skip building key set when no `include`/`exclude`

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -280,11 +280,13 @@ def jsonable_encoder(
         return None
     if isinstance(obj, dict):
         encoded_dict = {}
-        allowed_keys = set(obj.keys())
-        if include is not None:
-            allowed_keys &= set(include)
-        if exclude is not None:
-            allowed_keys -= set(exclude)
+        allowed_keys: set[Any] | None = None
+        if include is not None or exclude is not None:
+            allowed_keys = set(obj.keys())
+            if include is not None:
+                allowed_keys &= set(include)
+            if exclude is not None:
+                allowed_keys -= set(exclude)
         for key, value in obj.items():
             if (
                 (
@@ -293,7 +295,7 @@ def jsonable_encoder(
                     or (not key.startswith("_sa"))
                 )
                 and (value is not None or not exclude_none)
-                and key in allowed_keys
+                and (allowed_keys is None or key in allowed_keys)
             ):
                 encoded_key = jsonable_encoder(
                     key,


### PR DESCRIPTION
## Summary

In the `dict` branch of `jsonable_encoder`, the function unconditionally builds `allowed_keys = set(obj.keys())` and then checks `key in allowed_keys` for every key — even when neither `include` nor `exclude` is provided, which is the common case for most serialized responses. In that case `allowed_keys` ends up containing all of the dict's keys, so building the set and doing the membership checks is pure overhead.

This change only builds `allowed_keys` when `include` or `exclude` is set. Otherwise the per-key guard short-circuits on a cheap `allowed_keys is None` identity check.

## Behavior

Unchanged. When `include`/`exclude` are set, `allowed_keys` is computed exactly as before. When both are `None`, the previous code allowed every key through (the set contained all keys); the new code does the same via `allowed_keys is None`. Verified equivalent across `include`, `exclude`, `exclude_none`, `sqlalchemy_safe`, nested lists of dicts, Pydantic models, and empty dicts.

## Performance

Local micro-benchmark on a dict-heavy payload (a 50-key dict containing 20 nested dicts), best-of-5 × 20k iterations on my machine:

| | µs/call |
|---|---|
| `master` | ~235 |
| this PR | ~209 |

~11% faster on the common path on this payload. Exact numbers will vary by machine and payload shape; CodSpeed CI will show the effect on the project's own benchmark suite.


## Test plan

- [x] `pytest tests/test_jsonable_encoder.py` — all pass.
- [x] `ruff check fastapi/encoders.py` and `ruff format --check` pass.
- [x] `mypy` reports no errors introduced by this change in `encoders.py`.
- [x] No behavior change — only the order/conditionality of building `allowed_keys`.
