### PR TITLE
📝 Add local documentation preview instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,44 @@ Additional optional FastAPI dependencies:
 * [`orjson`](https://github.com/ijl/orjson) - Required if you want to use `ORJSONResponse`.
 * [`ujson`](https://github.com/esnme/ultrajson) - Required if you want to use `UJSONResponse`.
 
+## Develop the FastAPI Documentation Locally
+
+To work on the FastAPI documentation locally, install the documentation dependencies first:
+
+```console
+$ uv sync --locked --no-dev --group docs
+```
+
+Then start the local documentation server with live reload:
+
+```console
+$ uv run python ./scripts/docs.py live
+```
+
+This serves the English documentation locally and automatically reloads on changes.
+
+### Preview the Full Multilingual Documentation Site
+
+To build and preview the complete documentation site with all translations:
+
+```console
+$ uv run python ./scripts/docs.py build-all
+$ uv run python ./scripts/docs.py serve
+```
+
+This serves the generated `./site/` directory locally.
+
+### Alternative: Direct MkDocs Usage
+
+The English documentation can also be served directly from `docs/en/`:
+
+```console
+$ cd docs/en
+$ mkdocs serve
+```
+
+However, the `scripts/docs.py` commands are the preferred project-integrated workflow.
+
 ## License
 
 This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
Document the recommended workflow for serving the FastAPI documentation locally using scripts/docs.py. Also add instructions for previewing the multilingual documentation site and clarify the difference from directly running mkdocs serve.

## Pull Request

Discussion: N/A (small documentation clarification)

## Description

Add README instructions for developing and previewing the FastAPI documentation locally.

This documents the repository-integrated documentation workflow using `scripts/docs.py`, including:

* local live preview for documentation development
* multilingual documentation preview with `build-all`
* the relationship between the integrated workflow and direct `mkdocs serve` usage

The repository already provides these tools, but the workflow is not currently discoverable from the main README.

## AI Disclaimer

Model used: ChatGPT (OpenAI GPT-5.5)

Summary of AI usage:

* Helped investigate the existing documentation tooling in the repository
* Helped draft the README wording
* Helped refine the PR description

<details>
<summary>AI transcript</summary>

Used ChatGPT to:

* inspect the repository structure and existing docs tooling
* compare `mkdocs serve` with `scripts/docs.py`
* draft and refine README documentation text
* refine the PR wording and contributor workflow explanation

</details>

## Checklist

- [X] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [X] The documentation explains the change if needed.
