### PR TITLE
Docs/readme footnote spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ FastAPI is a modern, fast (high-performance), web framework for building APIs wi
 The key features are:
 
 * **Fast**: Very high performance, on par with **NodeJS** and **Go** (thanks to Starlette and Pydantic). [One of the fastest Python frameworks available](#performance).
-* **Fast to code**: Increase the speed to develop features by about 200% to 300%. *
-* **Fewer bugs**: Reduce about 40% of human (developer) induced errors. *
+* **Fast to code**: Increase the speed to develop features by about 200% to 300%.*
+* **Fewer bugs**: Reduce about 40% of human (developer) induced errors.*
 * **Intuitive**: Great editor support. <dfn title="also known as auto-complete, autocompletion, IntelliSense">Completion</dfn> everywhere. Less time debugging.
 * **Easy**: Designed to be easy to use and learn. Less time reading docs.
 * **Short**: Minimize code duplication. Multiple features from each parameter declaration. Fewer bugs.

--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -194,7 +194,7 @@ Or, you can also pass the `--entrypoint` option to the `fastapi dev` command:
 $ fastapi dev --entrypoint main:app
 ```
 
-But you would have to remember to pass the correct path\entrypoint every time you call the `fastapi` command.
+But you would have to remember to pass the correct path/entrypoint every time you call the `fastapi` command.
 
 Additionally, other tools might not be able to find it, for example the [VS Code Extension](../editor-support.md) or [FastAPI Cloud](https://fastapicloud.com), so it is recommended to use the `entrypoint` in `pyproject.toml`.
 

--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -66,6 +66,16 @@ You will see the JSON response as:
 {"message": "Hello World"}
 ```
 
+To return additional fields, update your app to the following:
+
+{* ../../docs_src/first_steps/tutorial004_py310.py *}
+
+Then you will see a JSON response like:
+
+```JSON
+{"message": "Hello World", "status": "ok"}
+```
+
 ### Interactive API docs { #interactive-api-docs }
 
 Now go to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).

--- a/docs_src/first_steps/tutorial004_py310.py
+++ b/docs_src/first_steps/tutorial004_py310.py
@@ -6,4 +6,3 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"message": "Hello World", "status": "ok"}
-

--- a/docs_src/first_steps/tutorial004_py310.py
+++ b/docs_src/first_steps/tutorial004_py310.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World", "status": "ok"}
+


### PR DESCRIPTION
This PR makes a few tiny, docs-focused improvements:

- Fix spacing for README footnote markers in the feature list.
- Fix wording in the first-steps tutorial from `path\entrypoint` to `path/entrypoint`.
- Add a small extra `GET /` example in the first-steps tutorial (and `docs_src`) that returns an additional field (`"status": "ok"`) to show how to extend the basic example.

No behavior changes to the FastAPI library itself, only documentation and example updates.