### PR TITLE
Fix jsonable_encoder crash on invalid UTF‑8 bytes

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -82,7 +82,7 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
+    bytes: lambda o: o.decode(errors="replace"),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -299,6 +299,11 @@ def test_decimal_encoder_infinity():
     assert isinf(jsonable_encoder(data)["value"])
 
 
+def test_encode_bytes_with_invalid_utf8_does_not_raise():
+    data = {"value": b"\xff"}
+    assert jsonable_encoder(data) == {"value": "\ufffd"}
+
+
 def test_encode_deque_encodes_child_models():
     class Model(BaseModel):
         test: str


### PR DESCRIPTION
jsonable_encoder currently decodes bytes using the default UTF‑8 settings, which can raise UnicodeDecodeError for arbitrary binary payloads.

This PR makes bytes encoding more robust by decoding with errors="replace", so encoding never crashes and instead produces a safe, JSON-serializable string.

Update bytes encoder to o.decode(errors="replace")
Add a regression test covering b"\xff" (invalid UTF‑8) to ensure it doesn’t raise and encodes to "\ufffd"
No API changes intended—this just prevents an unexpected exception during encoding.