### PR TITLE
Handle broken optional JSON imports in fastapi.responses

### DIFF
--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -26,13 +26,13 @@ class _OrjsonModule(Protocol):
 
 try:
     ujson = cast(_UjsonModule, importlib.import_module("ujson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     ujson = None  # type: ignore[assignment]
 
 
 try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
 
 

--- a/tests/test_deprecated_responses.py
+++ b/tests/test_deprecated_responses.py
@@ -1,3 +1,4 @@
+import importlib
 import warnings
 
 import pytest
@@ -77,3 +78,25 @@ def test_ujson_response_returns_correct_data():
 def test_ujson_response_emits_deprecation_warning():
     with pytest.warns(FastAPIDeprecationWarning, match="UJSONResponse is deprecated"):
         UJSONResponse(content={"hello": "world"})
+
+
+@pytest.mark.parametrize("module_name", ["orjson", "ujson"])
+def test_importing_fastapi_responses_ignores_broken_optional_json_installs(
+    monkeypatch: pytest.MonkeyPatch, module_name: str
+) -> None:
+    import fastapi.responses as responses
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None):
+        if name == module_name:
+            raise ImportError(f"simulated broken {module_name} install")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    try:
+        reloaded = importlib.reload(responses)
+        assert getattr(reloaded, module_name) is None
+    finally:
+        monkeypatch.setattr(importlib, "import_module", real_import_module)
+        importlib.reload(responses)


### PR DESCRIPTION
## Summary
- catch `ImportError` when importing optional `orjson` and `ujson` encoders in `fastapi.responses`
- keep broken optional installs from failing `import fastapi.responses`
- add a regression test that reloads the module with simulated broken optional imports

Related to #15535, which still reproduces on current `master`.

## Testing
- `.\.venv\Scripts\python -m pytest tests/test_default_response_class.py tests/test_deprecated_responses.py -q`
- `.\.venv\Scripts\ruff check fastapi\responses.py tests\test_deprecated_responses.py`