### PR TITLE
docs: add module-level docstring to logger module

### DIFF
--- a/fastapi/logger.py
+++ b/fastapi/logger.py
@@ -1,3 +1,10 @@
+"""
+Default logger for FastAPI.
+
+Provides a pre-configured logger instance named "fastapi" for internal
+logging throughout the framework.
+"""
+
 import logging
 
 logger = logging.getLogger("fastapi")


### PR DESCRIPTION
## Summary

Adds a module-level docstring to `fastapi/logger.py` explaining its role as the default logging provider for FastAPI.

## Why this helps

The logger module had no documentation, making it unclear to new contributors that this is where the framework's internal logger is configured. A quick docstring makes the module self-documenting and aligns with the project's existing documentation standards (e.g. `fastapi/background.py`, `fastapi/datastructures.py`).

## Changes

- Added a concise docstring describing the module's purpose
- No behavioral changes, no import changes