### PR TITLE
docs: add module-level docstring to types module

### DIFF
--- a/fastapi/types.py
+++ b/fastapi/types.py
@@ -1,3 +1,11 @@
+"""
+Internal type aliases for FastAPI.
+
+Provides shared type definitions used throughout the framework, including
+the decorated callable type variable, union type compatibility shim, and
+Pydantic model name mapping types.
+"""
+
 import types
 from collections.abc import Callable
 from enum import Enum


### PR DESCRIPTION
## Summary

Adds a module-level docstring to `fastapi/types.py` documenting its role as the shared internal type alias provider.

## Why this helps

The types module defines several important type aliases (`DecoratedCallable`, `UnionType`, `ModelNameMap`, `DependencyCacheKey`) used across the framework but had no documentation explaining what they are for. A docstring helps contributors quickly understand the module's purpose.

## Changes

- Added a concise docstring describing the module's purpose and key types
- No behavioral changes, no import changes