### PR TITLE
docs: add module-level docstring to concurrency module

### DIFF
--- a/fastapi/concurrency.py
+++ b/fastapi/concurrency.py
@@ -1,3 +1,11 @@
+"""
+Concurrency utilities for FastAPI.
+
+Provides helpers for running context managers in thread pools to avoid
+blocking the async event loop, with re-exports of common Starlette
+concurrency primitives.
+"""
+
 from collections.abc import AsyncGenerator
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager


### PR DESCRIPTION
## Summary

Adds a module-level docstring to `fastapi/concurrency.py` explaining its role as the concurrency utilities provider.

## Why this helps

The concurrency module provides a critical utility (`contextmanager_in_threadpool`) that prevents blocking the async event loop when using synchronous context managers. Without a docstring, new contributors may not understand why this module exists or when to use it.

## Changes

- Added a concise docstring describing the module's purpose
- No behavioral changes, no import changes