### PR TITLE
docs: add module-level docstring to exception_handlers module

### DIFF
--- a/fastapi/exception_handlers.py
+++ b/fastapi/exception_handlers.py
@@ -1,3 +1,11 @@
+"""
+Default exception handlers for FastAPI applications.
+
+Provides async handler functions for HTTP exceptions, request validation
+errors, and WebSocket validation errors. These are registered automatically
+when a FastAPI application is created.
+"""
+
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
 from fastapi.utils import is_body_allowed_for_status_code


### PR DESCRIPTION
## Summary

Adds a module-level docstring to `fastapi/exception_handlers.py` documenting the default exception handlers.

## Why this helps

The exception_handlers module contains the three default handlers that FastAPI registers for HTTP exceptions, request validation errors, and WebSocket validation errors. A docstring helps contributors understand these are the framework's default error responses.

## Changes

- Added a concise docstring describing the module's purpose and the three handler functions
- No behavioral changes, no import changes