### PR TITLE
docs: add module-level docstring to websockets module

### DIFF
--- a/fastapi/websockets.py
+++ b/fastapi/websockets.py
@@ -1,3 +1,11 @@
+"""
+WebSocket support for FastAPI.
+
+Re-exports Starlette's WebSocket classes for use in FastAPI applications,
+providing a consistent import path for WebSocket, WebSocketDisconnect, and
+WebSocketState.
+"""
+
 from starlette.websockets import WebSocket as WebSocket  # noqa
 from starlette.websockets import WebSocketDisconnect as WebSocketDisconnect  # noqa
 from starlette.websockets import WebSocketState as WebSocketState  # noqa


### PR DESCRIPTION
## Summary

Adds a module-level docstring to `fastapi/websockets.py` documenting its role as the WebSocket re-export module.

## Why this helps

The websockets module re-exports Starlette's WebSocket classes but had no documentation explaining this. A docstring helps contributors understand why these classes are re-exported and where to find the actual implementation.

## Changes

- Added a concise docstring describing the module's purpose
- No behavioral changes, no import changes