### PR TITLE
docs: add module-level docstrings to staticfiles and templating modules

### DIFF
--- a/fastapi/staticfiles.py
+++ b/fastapi/staticfiles.py
@@ -1,1 +1,8 @@
+"""
+Static file serving for FastAPI.
+
+Re-exports Starlette's StaticFiles class for serving static files
+(CSS, JavaScript, images) in FastAPI applications.
+"""
+
 from starlette.staticfiles import StaticFiles as StaticFiles  # noqa

--- a/fastapi/templating.py
+++ b/fastapi/templating.py
@@ -1,1 +1,8 @@
+"""
+Template rendering for FastAPI.
+
+Re-exports Starlette's Jinja2Templates class for server-side rendering
+with Jinja2 templates in FastAPI applications.
+"""
+
 from starlette.templating import Jinja2Templates as Jinja2Templates  # noqa


### PR DESCRIPTION
## Summary

Adds module-level docstrings to `fastapi/staticfiles.py` and `fastapi/templating.py` documenting their roles as re-export modules.

## Why this helps

Both modules are thin re-exports from Starlette but had no documentation. Docstrings help contributors understand these provide convenient FastAPI import paths for StaticFiles and Jinja2Templates.

## Changes

- Added docstrings to both staticfiles.py and templating.py
- No behavioral changes, no import changes