### PR TITLE
docs: fix typo in websockets reference page

### DIFF
--- a/docs/en/docs/reference/websockets.md
+++ b/docs/en/docs/reference/websockets.md
@@ -60,7 +60,7 @@ from fastapi.websockets import WebSocketDisconnect, WebSocketState
 
 When a client disconnects, a `WebSocketDisconnect` exception is raised, you can catch it.
 
-You can import it directly form `fastapi`:
+You can import it directly from `fastapi`:
 
 ```python
 from fastapi import WebSocketDisconnect


### PR DESCRIPTION
## Pull Request

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Obvious typo fixes can be made in a PR without starting a discussion.
-->

Discussion: 

## Description

Corrected a typo in the WebSockets reference page (docs/en/docs/reference/websockets.md): changed "directly form fastapi" to "directly from fastapi".

## AI Disclaimer

Used Antigravity (an AI coding assistant powered by Gemini) to run a custom python script scanning documentation files for common typos and formatting issues.

## Checklist

- [x] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.