### PR TITLE
Fix duplicate operationId for routes registered with multiple HTTP methods

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -242,7 +242,32 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
+    if route.operation_id:
+        operation_id = route.operation_id
+    elif len(route.methods) == 1:
+        # Single-method route: use the pre-computed unique_id as-is (backward compatible).
+        operation_id = route.unique_id
+    else:
+        # Multi-method route: route.unique_id was computed with only one method from the
+        # set (the first in sorted order). Derive a per-method operation ID by stripping
+        # that method suffix and replacing it with the current method so every operation
+        # on this route gets its own unique operationId in the OpenAPI schema.
+        base_operation_id = route.unique_id
+        for _http_method in (
+            "delete",
+            "get",
+            "head",
+            "options",
+            "patch",
+            "post",
+            "put",
+            "trace",
+        ):
+            _suffix = f"_{_http_method}"
+            if base_operation_id.endswith(_suffix):
+                base_operation_id = base_operation_id[: -len(_suffix)]
+                break
+        operation_id = f"{base_operation_id}_{method.lower()}"
     if operation_id in operation_ids:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"

--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -96,7 +96,7 @@ def generate_unique_id(route: "APIRoute") -> str:
     operation_id = f"{route.name}{route.path_format}"
     operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    operation_id = f"{operation_id}_{sorted(route.methods)[0].lower()}"
     return operation_id
 
 

--- a/tests/test_multi_method_route_operation_id.py
+++ b/tests/test_multi_method_route_operation_id.py
@@ -1,0 +1,218 @@
+"""
+Regression tests for https://github.com/fastapi/fastapi/issues/XXXX
+
+When a FastAPI route is registered with multiple HTTP methods
+(e.g. methods=["GET", "POST"]), the OpenAPI schema must assign a *unique*
+operationId to every operation.  Before the fix, all operations on such a
+route shared the same operationId (the one baked into route.unique_id at
+construction time), which is invalid per the OpenAPI 3.x specification and
+caused a spurious "Duplicate Operation ID" UserWarning on every schema
+generation.
+"""
+
+import warnings
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _handler(request: Request) -> dict:
+    return {"method": request.method}
+
+
+# ---------------------------------------------------------------------------
+# Core bug: duplicate operationId
+# ---------------------------------------------------------------------------
+
+
+def test_multi_method_route_generates_unique_operation_ids() -> None:
+    """Each HTTP method of a multi-method route must get its own operationId."""
+    app = FastAPI()
+    app.add_api_route("/multi", _handler, methods=["GET", "POST"], name="multi_handler")
+
+    client = TestClient(app)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+
+    # No duplicate-operation-ID warning must be emitted
+    dup_warnings = [w for w in caught if "Duplicate Operation ID" in str(w.message)]
+    assert dup_warnings == [], f"Unexpected duplicate-ID warnings: {dup_warnings}"
+
+    paths = response.json()["paths"]
+    assert "/multi" in paths
+    get_op_id = paths["/multi"]["get"]["operationId"]
+    post_op_id = paths["/multi"]["post"]["operationId"]
+
+    assert get_op_id != post_op_id, (
+        f"GET and POST operations share the same operationId {get_op_id!r}; "
+        "they must be unique"
+    )
+    assert "get" in get_op_id.lower(), f"Expected 'get' in {get_op_id!r}"
+    assert "post" in post_op_id.lower(), f"Expected 'post' in {post_op_id!r}"
+
+
+def test_three_method_route_all_operation_ids_unique() -> None:
+    """A route with three methods must produce three distinct operationIds."""
+    app = FastAPI()
+    app.add_api_route(
+        "/resource",
+        _handler,
+        methods=["GET", "POST", "PUT"],
+        name="resource_handler",
+    )
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    ops = response.json()["paths"]["/resource"]
+    ids = [ops[m]["operationId"] for m in ("get", "post", "put")]
+    assert len(set(ids)) == 3, f"Expected 3 unique operationIds, got {ids}"
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: single-method routes must be unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_single_method_routes_operation_ids_unchanged() -> None:
+    """
+    Single-method routes (the overwhelming majority) must generate the same
+    operationId as they did before the fix.
+    """
+    app = FastAPI()
+
+    @app.get("/items")
+    def get_items() -> list:
+        return []  # pragma: no cover
+
+    @app.post("/items")
+    def create_item() -> dict:
+        return {}  # pragma: no cover
+
+    @app.put("/items/{item_id}")
+    def update_item(item_id: int) -> dict:
+        return {}  # pragma: no cover
+
+    @app.delete("/items/{item_id}")
+    def delete_item(item_id: int) -> None:
+        return None  # pragma: no cover
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    paths = response.json()["paths"]
+    assert paths["/items"]["get"]["operationId"] == "get_items_items_get"
+    assert paths["/items"]["post"]["operationId"] == "create_item_items_post"
+    assert paths["/items/{item_id}"]["put"]["operationId"] == "update_item_items__item_id__put"
+    assert paths["/items/{item_id}"]["delete"]["operationId"] == "delete_item_items__item_id__delete"
+
+
+# ---------------------------------------------------------------------------
+# Explicit operation_id always wins (unchanged behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_operation_id_not_affected() -> None:
+    """
+    When a route has an explicit operation_id, it is used as-is for every
+    method on that route, exactly as before.
+    """
+    app = FastAPI()
+    app.add_api_route(
+        "/explicit",
+        _handler,
+        methods=["GET", "POST"],
+        name="explicit_handler",
+        operation_id="my_custom_operation",
+    )
+
+    client = TestClient(app)
+
+    # Explicit duplicate operation IDs will still warn – that's expected and
+    # intentional (the user set them explicitly).
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        response = client.get("/openapi.json")
+
+    paths = response.json()["paths"]["/explicit"]
+    assert paths["get"]["operationId"] == "my_custom_operation"
+    assert paths["post"]["operationId"] == "my_custom_operation"
+
+
+# ---------------------------------------------------------------------------
+# Router-level routes
+# ---------------------------------------------------------------------------
+
+
+def test_multi_method_route_via_api_router() -> None:
+    """Multi-method routes added via APIRouter must also get unique operationIds."""
+    router = APIRouter()
+    router.add_api_route(
+        "/things",
+        _handler,
+        methods=["GET", "POST"],
+        name="things_handler",
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        response = client.get("/openapi.json")
+
+    dup_warnings = [w for w in caught if "Duplicate Operation ID" in str(w.message)]
+    assert dup_warnings == [], f"Unexpected duplicate-ID warnings: {dup_warnings}"
+
+    ops = response.json()["paths"]["/things"]
+    get_op_id = ops["get"]["operationId"]
+    post_op_id = ops["post"]["operationId"]
+    assert get_op_id != post_op_id
+
+
+# ---------------------------------------------------------------------------
+# Determinism: unique_id must not change across runs
+# ---------------------------------------------------------------------------
+
+
+def test_generate_unique_id_is_deterministic() -> None:
+    """
+    generate_unique_id must return the same value regardless of set-iteration
+    order (i.e. it must not depend on PYTHONHASHSEED).
+    """
+    from fastapi.utils import generate_unique_id
+
+    app = FastAPI()
+    app.add_api_route(
+        "/stable",
+        _handler,
+        methods=["POST", "GET"],  # intentionally reversed order
+        name="stable_handler",
+    )
+
+    route = next(r for r in app.routes if getattr(r, "name", None) == "stable_handler")
+    uid1 = generate_unique_id(route)
+
+    # Call again – must be identical
+    uid2 = generate_unique_id(route)
+    assert uid1 == uid2
+
+    # The baked-in method must be the alphabetically first one ("get" < "post")
+    assert uid1.endswith("_get"), (
+        f"Expected unique_id to end with '_get' (sorted first), got {uid1!r}"
+    )

--- a/tests/test_multi_method_route_operation_id.py
+++ b/tests/test_multi_method_route_operation_id.py
@@ -12,11 +12,9 @@ generation.
 
 import warnings
 
-import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -116,8 +114,14 @@ def test_single_method_routes_operation_ids_unchanged() -> None:
     paths = response.json()["paths"]
     assert paths["/items"]["get"]["operationId"] == "get_items_items_get"
     assert paths["/items"]["post"]["operationId"] == "create_item_items_post"
-    assert paths["/items/{item_id}"]["put"]["operationId"] == "update_item_items__item_id__put"
-    assert paths["/items/{item_id}"]["delete"]["operationId"] == "delete_item_items__item_id__delete"
+    assert (
+        paths["/items/{item_id}"]["put"]["operationId"]
+        == "update_item_items__item_id__put"
+    )
+    assert (
+        paths["/items/{item_id}"]["delete"]["operationId"]
+        == "delete_item_items__item_id__delete"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_multi_method_route_operation_id.py
+++ b/tests/test_multi_method_route_operation_id.py
@@ -43,6 +43,11 @@ def test_multi_method_route_generates_unique_operation_ids() -> None:
 
     assert response.status_code == 200
 
+    # Execute the handler to ensure coverage and runtime correctness
+    response_multi = client.get("/multi")
+    assert response_multi.status_code == 200
+    assert response_multi.json() == {"method": "GET"}
+
     # No duplicate-operation-ID warning must be emitted
     dup_warnings = [w for w in caught if "Duplicate Operation ID" in str(w.message)]
     assert dup_warnings == [], f"Unexpected duplicate-ID warnings: {dup_warnings}"


### PR DESCRIPTION
## Description

When a route is registered with multiple HTTP methods (e.g. `methods=['GET', 'POST']`), the OpenAPI schema generator assigns the **same `operationId`** to every operation on that route. This violates the [OpenAPI 3.x specification](https://spec.openapis.org/oas/v3.1.0#operation-object) which requires `operationId` to be unique across all operations in a document.

Additionally, a spurious `UserWarning: Duplicate Operation ID` is emitted on every schema generation for such routes.

## Minimal Reproduction

`python
from fastapi import FastAPI
from fastapi.testclient import TestClient
from starlette.requests import Request

app = FastAPI()

async def handler(request: Request):
    return {}

app.add_api_route('/multi', handler, methods=['GET', 'POST'], name='multi_handler')

client = TestClient(app)
schema = client.get('/openapi.json').json()
print(schema['paths']['/multi']['get']['operationId'])   # multi_handler_multi_get
print(schema['paths']['/multi']['post']['operationId'])  # multi_handler_multi_get  <- BUG: same!
`

## Root Cause

Two issues compound each other:

**1. `fastapi/utils.py` — `generate_unique_id()`** uses `list(route.methods)[0]` on a `set`, which is **non-deterministic** across Python runs (`PYTHONHASHSEED` randomisation).

**2. `fastapi/openapi/utils.py` — `get_openapi_operation_metadata()`** iterates `for method in route.methods` but always uses `route.unique_id` (computed once at route construction) as the `operationId`, so every method gets the **same value**.

## Fix

- `generate_unique_id()`: use `sorted(route.methods)[0]` so `route.unique_id` is stable and deterministic.
- `get_openapi_operation_metadata()`: for single-method routes (the vast majority) the existing `route.unique_id` is used unchanged. For multi-method routes, the method suffix in `route.unique_id` is replaced with the current iteration method, producing a unique `operationId` per operation.

## Backward Compatibility

| Route type | Before | After |
|---|---|---|
| Single-method (`@app.get`, etc.) | unchanged | **unchanged** |
| Explicit `operation_id` | unchanged | **unchanged** |
| Multi-method (`methods=['GET','POST']`) | duplicate IDs + warning | **unique per method** |

## Tests Added

`tests/test_multi_method_route_operation_id.py` — 6 tests covering the core regression, three-method routes, single-method backward compat, explicit `operation_id` passthrough, `APIRouter` paths, and `generate_unique_id` determinism.