### PR TITLE
Serialize ServerSentEvent model data with by_alias=True

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -507,7 +507,7 @@ def get_request_handler(
                             data_str: str | None = item.raw_data
                         elif item.data is not None:
                             if hasattr(item.data, "model_dump_json"):
-                                data_str = item.data.model_dump_json()
+                                data_str = item.data.model_dump_json(by_alias=True)
                             else:
                                 data_str = json.dumps(jsonable_encoder(item.data))
                         else:

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -8,12 +8,16 @@ from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
 from fastapi.sse import ServerSentEvent
 from fastapi.testclient import TestClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Item(BaseModel):
     name: str
     description: str | None = None
+
+
+class AliasedItem(BaseModel):
+    name: str = Field(serialization_alias="itemName")
 
 
 items = [
@@ -78,6 +82,11 @@ async def sse_items_string():
 async def sse_items_post() -> AsyncIterable[Item]:
     for item in items:
         yield item
+
+
+@app.get("/items/stream-sse-aliased", response_class=EventSourceResponse)
+async def sse_items_aliased():
+    yield ServerSentEvent(data=AliasedItem(name="Portal Gun"))
 
 
 @app.get("/items/stream-raw", response_class=EventSourceResponse)
@@ -197,6 +206,17 @@ def test_sse_events_with_fields(client: TestClient):
 
     assert "retry: 5000\n" in text
     assert 'data: "retry-test"\n' in text
+
+
+def test_sse_event_model_data_uses_serialization_alias(client: TestClient):
+    response = client.get("/items/stream-sse-aliased")
+    assert response.status_code == 200
+    data_lines = [
+        line for line in response.text.strip().split("\n") if line.startswith("data: ")
+    ]
+    assert len(data_lines) == 1
+    assert '"itemName":"Portal Gun"' in data_lines[0]
+    assert '"name"' not in data_lines[0]
 
 
 def test_mixed_plain_and_sse_events(client: TestClient):


### PR DESCRIPTION
## Issue

Reported in #15703. When a `ServerSentEvent`'s `data` is a Pydantic model, `serialization_alias` (and any alias-only field) is dropped from the `data:` line:

```python
class Item(BaseModel):
    name: str = Field(serialization_alias="itemName")

@app.get("/events", response_class=EventSourceResponse)
async def events():
    yield ServerSentEvent(data=Item(name="Portal Gun"))
```

```
data: {"name":"Portal Gun"}        # got
data: {"itemName":"Portal Gun"}    # expected
```

## Cause

In `routing.py`, the `ServerSentEvent` data branch serialized models with `model_dump_json()` and no `by_alias`:

```python
if hasattr(item.data, "model_dump_json"):
    data_str = item.data.model_dump_json()
else:
    data_str = json.dumps(jsonable_encoder(item.data))
```

The two other SSE serialization paths already alias: the `else` branch above goes through `jsonable_encoder` (which defaults to `by_alias=True`), and plain yielded objects go through `stream_item_field.serialize_json(..., by_alias=response_model_by_alias)`. So only models wrapped in `ServerSentEvent` came out un-aliased, which is inconsistent with how response models serialize everywhere else in FastAPI.

## Fix

Pass `by_alias=True` to `model_dump_json()` so the `ServerSentEvent` model path matches the other paths.

## Tests

Added a test (`/items/stream-sse-aliased`) yielding a model with `serialization_alias`; it fails on `master` (emits `"name"`) and passes here (emits `"itemName"`). The rest of `tests/test_sse.py` stays green and `ruff` is clean.
