### PR TITLE
🐛 Catch ImportError (not just ModuleNotFoundError) for optional orjson/ujson imports

### DIFF
--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -26,13 +26,13 @@ class _OrjsonModule(Protocol):
 
 try:
     ujson = cast(_UjsonModule, importlib.import_module("ujson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     ujson = None  # type: ignore[assignment]
 
 
 try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
-except ModuleNotFoundError:  # pragma: nocover
+except ImportError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
 
 

--- a/tests/test_deprecated_responses.py
+++ b/tests/test_deprecated_responses.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 import warnings
 
 import pytest
@@ -77,3 +79,44 @@ def test_ujson_response_returns_correct_data():
 def test_ujson_response_emits_deprecation_warning():
     with pytest.warns(FastAPIDeprecationWarning, match="UJSONResponse is deprecated"):
         UJSONResponse(content={"hello": "world"})
+
+
+# Optional-import resilience
+
+
+def test_responses_importable_when_orjson_raises_import_error():
+    # A corrupt/broken orjson install raises ImportError (not ModuleNotFoundError)
+    # when its C extension fails to load. fastapi.responses must remain importable.
+    script = (
+        "import importlib; _real = importlib.import_module\n"
+        "def _fake(name, package=None):\n"
+        "    if name == 'orjson': raise ImportError('binary load failed')\n"
+        "    return _real(name, package)\n"
+        "importlib.import_module = _fake\n"
+        "import fastapi.responses\n"
+        "assert fastapi.responses.orjson is None\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_responses_importable_when_ujson_raises_import_error():
+    script = (
+        "import importlib; _real = importlib.import_module\n"
+        "def _fake(name, package=None):\n"
+        "    if name == 'ujson': raise ImportError('binary load failed')\n"
+        "    return _real(name, package)\n"
+        "importlib.import_module = _fake\n"
+        "import fastapi.responses\n"
+        "assert fastapi.responses.ujson is None\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Pull Request

This is an obvious bug fix — no GitHub Discussion needed per the checklist.

## Description

`fastapi/responses.py` uses `importlib.import_module` to probe for the optional `orjson` and `ujson` packages. The current code only catches `ModuleNotFoundError`:

```python
try:
    ujson = cast(_UjsonModule, importlib.import_module("ujson"))
except ModuleNotFoundError:  # pragma: nocover
    ujson = None
```

`ModuleNotFoundError` is the subclass raised when the package is **absent**. A **broken install** (e.g. C extension built for a different Python ABI, partial install, platform mismatch) raises a plain `ImportError` — the parent class. The narrow catch lets that propagate, so `import fastapi.responses` crashes even when the caller only needs `JSONResponse` or `HTMLResponse`.

The standard Python idiom for optional imports is `except ImportError`, which covers both cases because `ModuleNotFoundError` is a subclass.

**Fix**: Change both `except ModuleNotFoundError` blocks to `except ImportError`.

## Checklist

- [x] This PR is an obvious bug fix — standard Python optional-import idiom (`except ImportError`).
- [x] I added tests for the change.
- [x] The new tests fail on the main branch (no `test_responses_importable_when_*` tests exist) and pass on this PR.
- [x] Coverage stays at 100% — the changed lines are `# pragma: nocover` (only hit when the library is absent/broken, tested via subprocess).
- [x] The documentation explains the change if needed — no docs change needed.