### PR TITLE
📝 Fix four-backtick code fence in OAuth2PasswordRequestForm docstrings

### DIFF
--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -112,7 +112,7 @@ class OAuth2PasswordRequestForm:
 
                 ```python
                 "items:read items:write users:read profile openid"
-                ````
+                ```
 
                 would represent the scopes:
 
@@ -278,7 +278,7 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
 
                 ```python
                 "items:read items:write users:read profile openid"
-                ````
+                ```
 
                 would represent the scopes:
 


### PR DESCRIPTION
## Pull Request

This is an obvious typo fix — no GitHub Discussion needed per the checklist.

## Description

Both `OAuth2PasswordRequestForm` and `OAuth2PasswordRequestFormStrict` have a code fence in their `scope` parameter docstring that opens with ` ```python ` (three backticks) but closes with ```` ```` ```` (four backticks):

```
```python
"items:read items:write users:read profile openid"
````        ← stray fourth backtick
```

The mismatch leaves a stray backtick character in the rendered docstring — visible in `help()` output and any documentation builder that parses the docstring (e.g. `mkdocstrings`).

**Fix**: Change both closing ```` ```` ```` to ` ``` ` in the two affected `Doc(...)` strings.

## Checklist

- [x] This PR is an obvious typo fix.
- [x] I added tests for the change — no runtime test needed; this is a docstring rendering fix with no code-path change.
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed — n/a (the fix itself is the docstring correction).