### PR TITLE
Add context to response serialization

### DIFF
--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -176,10 +176,13 @@ class ModelField:
         values: dict[str, Any] = {},  # noqa: B006
         *,
         loc: tuple[int | str, ...] = (),
+        context: Any | None = None,
     ) -> tuple[Any, list[dict[str, Any]]]:
         try:
             return (
-                self._type_adapter.validate_python(value, from_attributes=True),
+                self._type_adapter.validate_python(
+                    value, from_attributes=True, context=context
+                ),
                 [],
             )
         except ValidationError as exc:

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -201,6 +201,7 @@ class ModelField:
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        context: Any | None = None,
     ) -> Any:
         # What calls this code passes a value that already called
         # self._type_adapter.validate_python(value)
@@ -213,6 +214,7 @@ class ModelField:
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
+            context=context,
         )
 
     def serialize_json(
@@ -225,6 +227,7 @@ class ModelField:
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        context: Any | None = None,
     ) -> bytes:
         # What calls this code passes a value that already called
         # self._type_adapter.validate_python(value)
@@ -239,6 +242,7 @@ class ModelField:
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
+            context=context,
         )
 
     def __hash__(self) -> int:

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -215,6 +215,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    context: Annotated[
+        Any | None,
+        Doc(
+            """
+            Pydantic's `context` parameter, passed to Pydantic models to define
+            a context that will be passed to custom encoders and validators.
+            """
+        ),
+    ] = None,
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -249,12 +258,14 @@ def jsonable_encoder(
             exclude_unset=exclude_unset,
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
+            context=context,
         )
         return jsonable_encoder(
             obj_dict,
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            context=context,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +280,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            context=context,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -302,6 +314,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    context=context,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +323,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    context=context,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +341,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    context=context,
                 )
             )
         return encoded_list
@@ -361,4 +376,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        context=context,
     )

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -287,10 +287,13 @@ async def serialize_response(
     is_coroutine: bool = True,
     endpoint_ctx: EndpointContext | None = None,
     dump_json: bool = False,
+    context: Any | None = None,
 ) -> Any:
     if field:
         if is_coroutine:
-            value, errors = field.validate(response_content, {}, loc=("response",))
+            value, errors = field.validate(
+                response_content, {}, loc=("response",), context=context
+            )
         else:
             value, errors = await run_in_threadpool(
                 field.validate, response_content, {}, loc=("response",)
@@ -704,6 +707,7 @@ def get_request_handler(
                         is_coroutine=is_coroutine,
                         endpoint_ctx=endpoint_ctx,
                         dump_json=use_dump_json,
+                        context=request,
                     )
                     if use_dump_json:
                         response = Response(

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -296,7 +296,7 @@ async def serialize_response(
             )
         else:
             value, errors = await run_in_threadpool(
-                field.validate, response_content, {}, loc=("response",)
+                field.validate, response_content, {}, loc=("response",), context=context
             )
         if errors:
             ctx = endpoint_ctx or EndpointContext()
@@ -314,10 +314,11 @@ async def serialize_response(
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
+            context=context,
         )
 
     else:
-        return jsonable_encoder(response_content)
+        return jsonable_encoder(response_content, context=context)
 
 
 async def run_endpoint_function(
@@ -474,7 +475,7 @@ def get_request_handler(
             def _serialize_data(data: Any) -> bytes:
                 if stream_item_field:
                     value, errors_ = stream_item_field.validate(
-                        data, {}, loc=("response",)
+                        data, {}, loc=("response",), context=request
                     )
                     if errors_:
                         ctx = endpoint_ctx or EndpointContext()
@@ -491,6 +492,7 @@ def get_request_handler(
                         exclude_unset=response_model_exclude_unset,
                         exclude_defaults=response_model_exclude_defaults,
                         exclude_none=response_model_exclude_none,
+                        context=request,
                     )
                 else:
                     data = jsonable_encoder(data)

--- a/tests/test_response_model_context.py
+++ b/tests/test_response_model_context.py
@@ -1,0 +1,70 @@
+import json
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.responses import EventSourceResponse
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, SerializationInfo, field_serializer
+from starlette.requests import Request
+
+
+class ItemWithContext(BaseModel):
+    name: str
+    request_path: str | None = None
+
+    @field_serializer("request_path", mode="plain")
+    def serialize_request_path(
+        self, value: str | None, info: SerializationInfo
+    ) -> str | None:
+        if not isinstance(info.context, Request):
+            return value
+        return info.context.url.path
+
+
+app = FastAPI()
+
+
+@app.get("/items/non-stream", response_model=ItemWithContext)
+async def non_stream_item() -> ItemWithContext:
+    return ItemWithContext(name="plain")
+
+
+@app.get("/items/stream-jsonl")
+async def stream_jsonl_items() -> AsyncIterable[ItemWithContext]:
+    yield ItemWithContext(name="foo")
+
+
+@app.get("/items/stream-sse", response_class=EventSourceResponse)
+async def stream_sse_items() -> AsyncIterable[ItemWithContext]:
+    yield ItemWithContext(name="bar")
+
+
+client = TestClient(app)
+
+
+def test_non_stream_response_model_serializer_receives_request_context() -> None:
+    response = client.get("/items/non-stream")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    assert response.json() == {"name": "plain", "request_path": "/items/non-stream"}
+
+
+def test_jsonl_stream_response_model_serializer_receives_request_context() -> None:
+    response = client.get("/items/stream-jsonl")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/jsonl"
+    items = [json.loads(line) for line in response.text.strip().splitlines()]
+    assert items == [{"name": "foo", "request_path": "/items/stream-jsonl"}]
+
+
+def test_sse_stream_response_model_serializer_receives_request_context() -> None:
+    response = client.get("/items/stream-sse")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+    data_lines = [
+        line.removeprefix("data: ")
+        for line in response.text.strip().splitlines()
+        if line.startswith("data: ")
+    ]
+    items = [json.loads(line) for line in data_lines]
+    assert items == [{"name": "bar", "request_path": "/items/stream-sse"}]


### PR DESCRIPTION
## Description

This PR adds support for passing `context` to response serialization.

This allows serializers/validators to access runtime context during serialization, for example the current `Request`, and adjust the serialized output accordingly.

## Use case

This can be useful for cases where the serialized response depends on request-specific data or other runtime state.

For example, selecting a localized value from a dict using a request header:

```python
def validator(
    v: Any, handler: ValidatorFunctionWrapHandler, info: "ValidationInfo[Request]"
):
    if isinstance(v, dict) and isinstance(info.context, Request):
        if lang := info.context.headers.get("x-lang"):
            return v.get(lang)
    return None
```

## Possible applications

* Localized response content based on request headers.
* Conditional serialization depending on the current user or permissions.
* Masking or transforming fields before returning the response.
* Adjusting serialized output based on tenant, API version, or feature flags.

## Motivation

Currently, response serialization does not receive `context`, which makes these kinds of use cases harder to implement cleanly at the schema/serialization layer.

Passing `context` makes response serialization more flexible and keeps this logic closer to the model/serializer definitions instead of requiring custom handling in route functions.