### PR TITLE
:pencil2: Fix typos in release notes

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -81,7 +81,7 @@ Still, for now, consider this very experimental and potentially changing and bre
 
 #### Future Features Enabled
 
-* Custom `APIRoute` subclasses (undocumented, but alraedy works as described above)
+* Custom `APIRoute` subclasses (undocumented, but already works as described above)
 * Custom `APIRouter` subclasses (undocumented, but already works as described above)
 * Dependencies per router
 * Exception handlers per router

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -81,7 +81,7 @@ Still, for now, consider this very experimental and potentially changing and bre
 
 #### Future Features Enabled
 
-* Custom `APIRoute` subclasses (undocumented, but alraedy works as desccribed above)
+* Custom `APIRoute` subclasses (undocumented, but alraedy works as described above)
 * Custom `APIRouter` subclasses (undocumented, but already works as described above)
 * Dependencies per router
 * Exception handlers per router


### PR DESCRIPTION
Corrected typos in release notes regarding custom APIRoute subclasses.