### PR TITLE
🌐 Fix broken Markdown in Korean custom response docs

### DIFF
--- a/docs/ko/docs/advanced/custom-response.md
+++ b/docs/ko/docs/advanced/custom-response.md
@@ -173,7 +173,7 @@ HTTP 리디렉션 응답을 반환합니다. 기본적으로 상태 코드는 30
 
 ### `StreamingResponse` { #streamingresponse }
 
-비동기 제너레이터 또는 일반 제너레이터/이터레이터(`yield`가 있는 함수`)를 받아 응답 본문을 스트리밍합니다.
+비동기 제너레이터 또는 일반 제너레이터/이터레이터(`yield`가 있는 함수)를 받아 응답 본문을 스트리밍합니다.
 
 {* ../../docs_src/custom_response/tutorial007_py310.py hl[3,16] *}
 


### PR DESCRIPTION
## Pull Request

Discussion: N/A — this is an obvious Markdown fix.

## Description

This PR fixes broken Markdown in the Korean documentation page:

* docs/ko/docs/advanced/custom-response.md

No translation or content changes are included.
## AI Disclaimer

## Checklist

- [x] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
