### PR TITLE
🐛 Fix decimal_encoder crash on Decimal("sNaN") (signaling NaN)

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -73,12 +73,20 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
     >>> decimal_encoder(Decimal("NaN"))
     nan
+
+    >>> decimal_encoder(Decimal("sNaN"))
+    nan
     """
     exponent = dec_value.as_tuple().exponent
     if isinstance(exponent, int) and exponent >= 0:
         return int(dec_value)
     else:
-        return float(dec_value)
+        try:
+            return float(dec_value)
+        except ValueError:
+            # Signaling NaN (sNaN) cannot be converted to float directly.
+            # Treat it as a quiet NaN, consistent with Decimal("NaN") behaviour.
+            return float("nan")
 
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -299,6 +299,14 @@ def test_decimal_encoder_infinity():
     assert isinf(jsonable_encoder(data)["value"])
 
 
+def test_decimal_encoder_signaling_nan():
+    # Decimal("sNaN") (signaling NaN) previously raised ValueError when
+    # decimal_encoder called float() on it. It should now return float("nan")
+    # consistently with Decimal("NaN") behaviour.
+    data = {"value": Decimal("sNaN")}
+    assert isnan(jsonable_encoder(data)["value"])
+
+
 def test_encode_deque_encodes_child_models():
     class Model(BaseModel):
         test: str


### PR DESCRIPTION
## Bug

`decimal_encoder` in `fastapi/encoders.py` raises `ValueError` when encoding `Decimal("sNaN")` (signaling NaN). Signaling NaN is a valid `decimal.Decimal` value that cannot be converted to float via `float()`:

```python
>>> float(Decimal("NaN"))    # quiet NaN — works, returns nan
nan
>>> float(Decimal("sNaN"))   # signaling NaN — CRASHES
ValueError: cannot convert signaling NaN to float
```

The else branch of `decimal_encoder` unconditionally calls `float(dec_value)`, which crashes for `sNaN`. The existing tests only cover `Decimal("NaN")` (quiet NaN) and `Decimal("Infinity")`, leaving signaling NaN uncovered.

## Fix

Wrap the `float()` call in a `try/except ValueError` and return `float("nan")` as a fallback, consistent with how `Decimal("NaN")` is already handled.

## Verification

```
pytest tests/test_jsonable_encoder.py -k decimal -v
```

Before fix:
```
FAILED tests/test_jsonable_encoder.py::test_decimal_encoder_signaling_nan
ValueError: cannot convert signaling NaN to float
```

After fix:
```
tests/test_jsonable_encoder.py::test_decimal_encoder_float PASSED
tests/test_jsonable_encoder.py::test_decimal_encoder_int PASSED
tests/test_jsonable_encoder.py::test_decimal_encoder_nan PASSED
tests/test_jsonable_encoder.py::test_decimal_encoder_infinity PASSED
tests/test_jsonable_encoder.py::test_decimal_encoder_signaling_nan PASSED
5 passed
```

> AI-assisted: this PR was developed with the help of an LLM coding agent.