### PR TITLE
🔨 Use `gpt-5.5` model in `translate.py`, specify `-chat` to avoid warnings

### DIFF
--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -132,7 +132,7 @@ def translate_page(
         print(f"Found existing translation: {out_path}")
         old_translation = out_path.read_text(encoding="utf-8")
     print(f"Translating {en_path} to {language} ({language_name})")
-    agent = Agent("openai:gpt-5")
+    agent = Agent("openai-chat:gpt-5.5")
 
     MAX_ATTEMPTS = 3
     additional_instructions = ""


### PR DESCRIPTION
The `-chat` suffix is needed to avoid the warning:
```
/home/yurii/code/1.FastAPI/fastapi/.venv/lib/python3.11/site-packages/pydantic_ai/agent/__init__.py:414: PydanticAIDeprecationWarning: In v2.0, 'openai:' will resolve to the OpenAI Responses API by default. Use 'openai-chat:' to keep current Chat Completions behavior, or 'openai-responses:' to opt in early.
```