### PR TITLE
🔧 Enable checking `release-notes.md` for typos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,7 +319,6 @@ extend-exclude = [
     "docs/de/",
     "docs/en/data/",
     "docs/en/docs/img/",
-    "docs/en/docs/release-notes.md",
     "docs/es/",
     "docs/fr/",
     "docs/ja/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,7 +345,7 @@ extend-ignore-re = [
     # Quoted typo documented in a release note
     "'wll' to 'will'",
     # German article title in a release note
-    "FastAPI Modul",
+    "FastAPI Modul.",
 ]
 
 [tool.typos.default.extend-identifiers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,7 +340,7 @@ extend-exclude = [
 
 [tool.typos.default]
 extend-ignore-re = [
-    # GitHub usernames in @mentions, e.g. @OCE1960
+    # GitHub usernames in @mentions
     "@[a-zA-Z0-9](?:-?[a-zA-Z0-9])*",
     # Quoted typo documented in a release note
     "'wll' to 'will'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,10 @@ extend-exclude = [
 extend-ignore-re = [
     # GitHub usernames in @mentions, e.g. @OCE1960
     "@[a-zA-Z0-9](?:-?[a-zA-Z0-9])*",
+    # Quoted typo documented in a release note
+    "'wll' to 'will'",
+    # German article title in a release note
+    "FastAPI Modul",
 ]
 
 [tool.typos.default.extend-identifiers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,12 @@ extend-exclude = [
     "uv.lock",
 ]
 
+[tool.typos.default]
+extend-ignore-re = [
+    # GitHub usernames in @mentions, e.g. @OCE1960
+    "@[a-zA-Z0-9](?:-?[a-zA-Z0-9])*",
+]
+
 [tool.typos.default.extend-identifiers]
 alls = "alls"
 


### PR DESCRIPTION
🔧Enable checking `release-notes.md` for typos

This required adding rules to ignore:
* user mentions (to avoid checking user names in PR info for typos)
* `FastAPI Modul` - this is a German phrase in PR title
* `'wll' to 'will'` - this is a description of typo that was fixed by PR