### PR TITLE
📝 Fix out-of-range highlight in advanced settings docs

### DIFF
--- a/docs/en/docs/advanced/settings.md
+++ b/docs/en/docs/advanced/settings.md
@@ -126,7 +126,7 @@ This could be especially useful during testing, as it's very easy to override a 
 
 Coming from the previous example, your `config.py` file could look like:
 
-{* ../../docs_src/settings/app02_an_py310/config.py hl[10] *}
+{* ../../docs_src/settings/app02_an_py310/config.py *}
 
 Notice that now we don't create a default instance `settings = Settings()`.
 


### PR DESCRIPTION
In `docs/en/docs/advanced/settings.md`, the config file embed uses `hl[10]`:

```
{* ../../docs_src/settings/app02_an_py310/config.py hl[10] *}
```

But `docs_src/settings/app02_an_py310/config.py` is only 7 lines long, so `hl[10]` highlights a line that does not exist.

This looks like a leftover from the earlier app01 example, where line 10 was `settings = Settings()`. The prose right below the embed confirms there is no such line here:

> Notice that now we don't create a default instance `settings = Settings()`.

This PR removes the `hl[10]` so nothing out of range is highlighted.
