### PR TITLE
📝 Fix copy button copying HTML markup on Termynal command lines

### DIFF
--- a/docs/en/docs/deployment/manually.md
+++ b/docs/en/docs/deployment/manually.md
@@ -7,7 +7,7 @@ In short, use `fastapi run` to serve your FastAPI application:
 <div class="termy">
 
 ```console
-$ <font color="#4E9A06">fastapi</font> run <u style="text-decoration-style:solid">main.py</u>
+$ fastapi run main.py
 
   <span style="background-color:#009485"><font color="#D3D7CF"> FastAPI </font></span>  Starting production server 🚀
 

--- a/docs/en/docs/deployment/server-workers.md
+++ b/docs/en/docs/deployment/server-workers.md
@@ -36,7 +36,7 @@ If you use the `fastapi` command:
 <div class="termy">
 
 ```console
-$ <font color="#4E9A06">fastapi</font> run --workers 4 <u style="text-decoration-style:solid">main.py</u>
+$ fastapi run --workers 4 main.py
 
   <span style="background-color:#009485"><font color="#D3D7CF"> FastAPI </font></span>  Starting production server 🚀
 

--- a/docs/en/docs/fastapi-cli.md
+++ b/docs/en/docs/fastapi-cli.md
@@ -9,7 +9,7 @@ To run your FastAPI app for development, you can use the `fastapi dev` command:
 <div class="termy">
 
 ```console
-$ <font color="#4E9A06">fastapi</font> dev
+$ fastapi dev
 
   <span style="background-color:#009485"><font color="#D3D7CF"> FastAPI </font></span>  Starting development server 🚀
 

--- a/docs/en/docs/tutorial/first-steps.md
+++ b/docs/en/docs/tutorial/first-steps.md
@@ -11,7 +11,7 @@ Run the live server:
 <div class="termy">
 
 ```console
-$ <font color="#4E9A06">fastapi</font> dev
+$ fastapi dev
 
   <span style="background-color:#009485"><font color="#D3D7CF"> FastAPI </font></span>  Starting development server 🚀
 

--- a/docs/en/docs/tutorial/index.md
+++ b/docs/en/docs/tutorial/index.md
@@ -15,7 +15,7 @@ To run any of the examples, copy the code to a file `main.py`, and start `fastap
 <div class="termy">
 
 ```console
-$ <font color="#4E9A06">fastapi</font> dev
+$ fastapi dev
 
   <span style="background-color:#009485"><font color="#D3D7CF"> FastAPI </font></span>  Starting development server 🚀
 


### PR DESCRIPTION
## What this fixes

Several pages in the docs write the terminal **input** lines inside `termy`/`console` blocks with HTML coloring, for example:

```
$ <font color="#4E9A06">fastapi</font> dev
```

Termynal animates the input line using `textContent`, so the `<font>` tags never render on screen. However, MkDocs Material's copy button reads the underlying code, not the rendered text, so clicking it copies the literal markup:

```
<font color="#4E9A06">fastapi</font> dev
```

Users then paste the markup instead of the command.

## The fix

Strip the HTML wrappers from only the `$` input command lines so the copy button yields the plain command. The colored **output** lines below each command are intentional styling and are left untouched.

The homepage block already uses the plain `$ fastapi dev` form and copies correctly, so this just brings these pages in line with it.

Lines changed (input commands only):

- `docs/en/docs/fastapi-cli.md`
- `docs/en/docs/tutorial/first-steps.md`
- `docs/en/docs/tutorial/index.md`
- `docs/en/docs/deployment/manually.md`
- `docs/en/docs/deployment/server-workers.md`

See discussion #15700.
