### PR TITLE
🐛 Set `X-Accel-Buffering: no` on JSONL streaming responses

### DIFF
--- a/docs/en/docs/tutorial/stream-json-lines.md
+++ b/docs/en/docs/tutorial/stream-json-lines.md
@@ -72,6 +72,18 @@ If you want to stream binary data, for example video or audio, check the advance
 
 ///
 
+## Proxy Buffering { #proxy-buffering }
+
+When a JSON Lines response is served behind a proxy that buffers responses by default (for example Nginx with `proxy_buffering on`), the proxy could hold back the lines and deliver them all at once, which would defeat the streaming.
+
+To prevent that, FastAPI sets the `X-Accel-Buffering: no` header on JSON Lines responses, telling Nginx (and compatible proxies) not to buffer them.
+
+/// note
+
+Caching headers (like `Cache-Control`) are **not** set automatically, they are left up to you. JSON Lines is also used for bulk exports where caching can be legitimate, so FastAPI doesn't impose a caching policy. If you need one, you can set it on the [`Response`](../advanced/response-headers.md).
+
+///
+
 ## Stream JSON Lines with FastAPI { #stream-json-lines-with-fastapi }
 
 To stream JSON Lines with FastAPI you can, instead of using `return` in your *path operation function*, use `yield` to produce each item in turn.

--- a/docs/en/docs/tutorial/stream-json-lines.md
+++ b/docs/en/docs/tutorial/stream-json-lines.md
@@ -78,6 +78,8 @@ When a JSON Lines response is served behind a proxy that buffers responses by de
 
 To prevent that, FastAPI sets the `X-Accel-Buffering: no` header on JSON Lines responses, telling Nginx (and compatible proxies) not to buffer them.
 
+If you need a different behavior, you can set that header yourself on the [`Response`](../advanced/response-headers.md) and your value will be used instead.
+
 /// note
 
 Caching headers (like `Cache-Control`) are **not** set automatically, they are left up to you. JSON Lines is also used for bulk exports where caching can be legitimate, so FastAPI doesn't impose a caching policy. If you need one, you can set it on the [`Response`](../advanced/response-headers.md).

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -677,6 +677,9 @@ def get_request_handler(
                     media_type="application/jsonl",
                     **response_args,
                 )
+                response.headers["Cache-Control"] = "no-cache"
+                # For Nginx proxies to not buffer the streamed response
+                response.headers["X-Accel-Buffering"] = "no"
                 response.headers.raw.extend(solved_result.response.headers.raw)
             elif _is_async_gen_callable(dependant.call) or _is_gen_callable(
                 dependant.call

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -677,11 +677,14 @@ def get_request_handler(
                     media_type="application/jsonl",
                     **response_args,
                 )
+                response.headers.raw.extend(solved_result.response.headers.raw)
                 # For Nginx proxies to not buffer the streamed response.
+                # Set after extending, so an explicit header from the *path
+                # operation function* takes precedence and can re-enable
+                # buffering.
                 # Caching headers are intentionally left to the user, as JSONL
                 # is also used for bulk exports where caching can be legitimate.
-                response.headers["X-Accel-Buffering"] = "no"
-                response.headers.raw.extend(solved_result.response.headers.raw)
+                response.headers.setdefault("X-Accel-Buffering", "no")
             elif _is_async_gen_callable(dependant.call) or _is_gen_callable(
                 dependant.call
             ):

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -677,8 +677,9 @@ def get_request_handler(
                     media_type="application/jsonl",
                     **response_args,
                 )
-                response.headers["Cache-Control"] = "no-cache"
-                # For Nginx proxies to not buffer the streamed response
+                # For Nginx proxies to not buffer the streamed response.
+                # Caching headers are intentionally left to the user, as JSONL
+                # is also used for bulk exports where caching can be legitimate.
                 response.headers["X-Accel-Buffering"] = "no"
                 response.headers.raw.extend(solved_result.response.headers.raw)
             elif _is_async_gen_callable(dependant.call) or _is_gen_callable(

--- a/tests/test_stream_json_lines_headers.py
+++ b/tests/test_stream_json_lines_headers.py
@@ -1,0 +1,55 @@
+from collections.abc import AsyncIterator, Iterator
+
+from fastapi import Depends, FastAPI, Response
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    name: str
+
+
+app = FastAPI()
+
+
+@app.get("/items/stream")
+async def stream_items() -> AsyncIterator[Item]:
+    yield Item(name="foo")
+
+
+@app.get("/items/stream-sync")
+def stream_items_sync() -> Iterator[Item]:
+    yield Item(name="bar")
+
+
+def enable_proxy_buffering(response: Response) -> None:
+    response.headers["X-Accel-Buffering"] = "yes"
+
+
+@app.get(
+    "/items/stream-buffering-enabled", dependencies=[Depends(enable_proxy_buffering)]
+)
+async def stream_items_buffering_enabled() -> AsyncIterator[Item]:
+    yield Item(name="baz")
+
+
+client = TestClient(app)
+
+
+def test_stream_disables_proxy_buffering():
+    response = client.get("/items/stream")
+    assert response.status_code == 200, response.text
+    assert response.headers["x-accel-buffering"] == "no"
+
+
+def test_stream_sync_disables_proxy_buffering():
+    response = client.get("/items/stream-sync")
+    assert response.status_code == 200, response.text
+    assert response.headers["x-accel-buffering"] == "no"
+
+
+def test_stream_buffering_header_can_be_overridden():
+    response = client.get("/items/stream-buffering-enabled")
+    assert response.status_code == 200, response.text
+    assert response.headers["x-accel-buffering"] == "yes"
+    assert response.headers.get_list("x-accel-buffering") == ["yes"]

--- a/tests/test_tutorial/test_stream_json_lines/test_tutorial001.py
+++ b/tests/test_tutorial/test_stream_json_lines/test_tutorial001.py
@@ -52,14 +52,13 @@ def test_stream_items(client: TestClient, path: str):
         "/items/stream-no-async-no-annotation",
     ],
 )
-def test_stream_sets_streaming_headers(client: TestClient, path: str):
-    """JSONL streaming responses should disable proxy buffering and caching,
-    so intermediaries deliver items incrementally (matching SSE responses)."""
+def test_stream_disables_proxy_buffering(client: TestClient, path: str):
+    """JSONL streaming responses should disable proxy buffering, so
+    intermediaries (e.g. Nginx) deliver items incrementally instead of
+    holding them back until the buffer fills."""
     response = client.get(path)
     assert response.status_code == 200, response.text
-    # Tells proxies (e.g. Nginx) not to buffer the streamed response
     assert response.headers["x-accel-buffering"] == "no"
-    assert response.headers["cache-control"] == "no-cache"
 
 
 def test_openapi_schema(client: TestClient):

--- a/tests/test_tutorial/test_stream_json_lines/test_tutorial001.py
+++ b/tests/test_tutorial/test_stream_json_lines/test_tutorial001.py
@@ -43,6 +43,25 @@ def test_stream_items(client: TestClient, path: str):
     assert lines == expected_items
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/items/stream",
+        "/items/stream-no-async",
+        "/items/stream-no-annotation",
+        "/items/stream-no-async-no-annotation",
+    ],
+)
+def test_stream_sets_streaming_headers(client: TestClient, path: str):
+    """JSONL streaming responses should disable proxy buffering and caching,
+    so intermediaries deliver items incrementally (matching SSE responses)."""
+    response = client.get(path)
+    assert response.status_code == 200, response.text
+    # Tells proxies (e.g. Nginx) not to buffer the streamed response
+    assert response.headers["x-accel-buffering"] == "no"
+    assert response.headers["cache-control"] == "no-cache"
+
+
 def test_openapi_schema(client: TestClient):
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text


### PR DESCRIPTION
## What's wrong

FastAPI's Server-Sent Events responses set `X-Accel-Buffering: no` so streaming survives a buffering proxy (the `is_sse_stream` branch in `fastapi/routing.py`, added in #15030):

```python
# For Nginx proxies to not buffer server sent events
response.headers["X-Accel-Buffering"] = "no"
```

The JSON Lines streaming responses (the `yield`-based `application/jsonl` streaming added in #15022, the `is_json_stream` branch) stream items incrementally in the same way, but don't set it.

Behind a proxy that buffers by default (e.g. Nginx with `proxy_buffering on`), the JSONL lines are buffered and flushed together, which defeats the streaming: the client receives the `200` immediately, but the lines don't arrive until the proxy buffer fills. SSE isn't affected because it already sends `X-Accel-Buffering: no`. The two features landed in separate PRs (SSE #15030, JSONL #15022), which is likely why only the SSE path got the header.

## Change

Set `X-Accel-Buffering: no` on the JSONL `StreamingResponse`, so incremental streaming works through a buffering proxy the same way SSE does.

`Cache-Control` is intentionally **not** set: unlike SSE, JSON Lines is also used for bulk/streamed exports where caching can be legitimate, so the caching policy is left to the user (it can be set on the `Response`). This is documented in the JSON Lines tutorial. (Thanks @luzzodev for the review that clarified this.)

## Tests

- New `test_stream_disables_proxy_buffering` asserts `x-accel-buffering: no` across the four JSONL streaming tutorial variants (parametrized like the existing SSE streaming tests).
- The existing SSE and streaming suites still pass.

## Context

Discussed first in #15794, where the same failure mode was confirmed independently, including a report behind Nginx in production.
