### PR TITLE
📝 Fix out-of-range highlight lines in docs code embeds

### DIFF
--- a/docs/en/docs/advanced/response-headers.md
+++ b/docs/en/docs/advanced/response-headers.md
@@ -22,7 +22,7 @@ You can also add headers when you return a `Response` directly.
 
 Create a response as described in [Return a Response Directly](response-directly.md) and pass the headers as an additional parameter:
 
-{* ../../docs_src/response_headers/tutorial001_py310.py hl[10:12] *}
+{* ../../docs_src/response_headers/tutorial001_py310.py hl[10:11] *}
 
 /// note | Technical Details
 

--- a/docs/en/docs/advanced/websockets.md
+++ b/docs/en/docs/advanced/websockets.md
@@ -58,7 +58,7 @@ You could also use `from starlette.websockets import WebSocket`.
 
 In your WebSocket route you can `await` for messages and send messages.
 
-{* ../../docs_src/websockets_/tutorial001_py310.py hl[48:52] *}
+{* ../../docs_src/websockets_/tutorial001_py310.py hl[48:51] *}
 
 You can receive and send binary, text, and JSON data.
 

--- a/docs/en/docs/tutorial/body-updates.md
+++ b/docs/en/docs/tutorial/body-updates.md
@@ -6,7 +6,7 @@ To update an item you can use the [HTTP `PUT`](https://developer.mozilla.org/en-
 
 You can use the `jsonable_encoder` to convert the input data to data that can be stored as JSON (e.g. with a NoSQL database). For example, converting `datetime` to `str`.
 
-{* ../../docs_src/body_updates/tutorial001_py310.py hl[28:33] *}
+{* ../../docs_src/body_updates/tutorial001_py310.py hl[28:32] *}
 
 `PUT` is used to receive data that should replace the existing data.
 


### PR DESCRIPTION
Three docs `{* file hl[a:b] *}` embeds set the inclusive `hl` upper bound one line past the end of the referenced file. In each case the intended block ends at the file's last line, so the upper bound should be one lower.

| File | Referenced source | Lines in file | Was | Now |
| --- | --- | --- | --- | --- |
| `docs/en/docs/advanced/response-headers.md` | `docs_src/response_headers/tutorial001_py310.py` | 11 | `hl[10:12]` | `hl[10:11]` |
| `docs/en/docs/advanced/websockets.md` | `docs_src/websockets_/tutorial001_py310.py` | 51 | `hl[48:52]` | `hl[48:51]` |
| `docs/en/docs/tutorial/body-updates.md` | `docs_src/body_updates/tutorial001_py310.py` | 32 | `hl[28:33]` | `hl[28:32]` |

The corrected ranges still cover the same intended code (the response/header lines, the WebSocket endpoint body, and the `PUT` handler respectively).

The rendered docs are not affected: the phantom line is past end-of-file and was silently dropped, so the highlighted output already looked correct. This is just a range-correctness fix so the embed bounds match the files they point at.