### PR TITLE
📝 Fix dead Ariadne FastAPI docs link in `How To - GraphQL`

### DIFF
--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -21,7 +21,7 @@ Here are some of the **GraphQL** libraries that have **ASGI** support. You could
 * [Strawberry](https://strawberry.rocks/) 🍓
     * With [docs for FastAPI](https://strawberry.rocks/docs/integrations/fastapi)
 * [Ariadne](https://ariadnegraphql.org/)
-    * With [docs for FastAPI](https://github.com/mirumee/ariadne)
+    * With [docs for FastAPI](https://ariadnegraphql.org/server/Integrations/fastapi-integration)
 * [Tartiflette](https://tartiflette.io/)
     * With [Tartiflette ASGI](https://tartiflette.github.io/tartiflette-asgi/) to provide ASGI integration
 * [Graphene](https://graphene-python.org/)

--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -21,7 +21,7 @@ Here are some of the **GraphQL** libraries that have **ASGI** support. You could
 * [Strawberry](https://strawberry.rocks/) 🍓
     * With [docs for FastAPI](https://strawberry.rocks/docs/integrations/fastapi)
 * [Ariadne](https://ariadnegraphql.org/)
-    * With [docs for FastAPI](https://ariadnegraphql.org/docs/fastapi-integration)
+    * With [docs for FastAPI](https://github.com/mirumee/ariadne)
 * [Tartiflette](https://tartiflette.io/)
     * With [Tartiflette ASGI](https://tartiflette.github.io/tartiflette-asgi/) to provide ASGI integration
 * [Graphene](https://graphene-python.org/)


### PR DESCRIPTION
## Description

The "docs for FastAPI" link under **Ariadne** on the *How To - GraphQL* page points to `https://ariadnegraphql.org/docs/fastapi-integration`, which now returns **HTTP 404**. Ariadne reorganized their site and removed the old `/docs/` tree, so that page no longer exists.

This repoints the link to the current canonical Ariadne resource: the project repository at `https://github.com/mirumee/ariadne`, whose README documents Ariadne's ASGI/FastAPI integration ("ASGI and WSGI support, with integrations for Django, FastAPI, Flask, and Starlette"). The Ariadne website itself now links to this repository for documentation.

## Verification

Checked both URLs with `curl -L -A "Mozilla/5.0"`:

- Old `https://ariadnegraphql.org/docs/fastapi-integration` -> **404**
- New `https://github.com/mirumee/ariadne` -> **200**

Single-line change to `docs/en/docs/how-to/graphql.md`.
