### PR TITLE
📝 Update renamed GitHub repo URLs for `isort` and `ujson`

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Additional optional Pydantic dependencies:
 Additional optional FastAPI dependencies:
 
 * [`orjson`](https://github.com/ijl/orjson) - Required if you want to use `ORJSONResponse`.
-* [`ujson`](https://github.com/esnme/ultrajson) - Required if you want to use `UJSONResponse`.
+* [`ujson`](https://github.com/ultrajson/ultrajson) - Required if you want to use `UJSONResponse`.
 
 ## License
 

--- a/docs/en/docs/alternatives.md
+++ b/docs/en/docs/alternatives.md
@@ -337,7 +337,7 @@ As it is based on the previous standard for synchronous Python web frameworks (W
 
 /// note
 
-Hug was created by Timothy Crosley, the same creator of [`isort`](https://github.com/timothycrosley/isort), a great tool to automatically sort imports in Python files.
+Hug was created by Timothy Crosley, the same creator of [`isort`](https://github.com/PyCQA/isort), a great tool to automatically sort imports in Python files.
 
 ///
 

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -578,7 +578,7 @@ Additional optional Pydantic dependencies:
 Additional optional FastAPI dependencies:
 
 * [`orjson`](https://github.com/ijl/orjson) - Required if you want to use `ORJSONResponse`.
-* [`ujson`](https://github.com/esnme/ultrajson) - Required if you want to use `UJSONResponse`.
+* [`ujson`](https://github.com/ultrajson/ultrajson) - Required if you want to use `UJSONResponse`.
 
 ## License { #license }
 


### PR DESCRIPTION
Two of the GitHub repositories linked in the docs were renamed/moved, so their old URLs now only work via a 301 redirect. This updates them to point directly at the current canonical repositories.

- `docs/en/docs/alternatives.md`: `isort` moved from `timothycrosley/isort` to `PyCQA/isort`.
- `docs/en/docs/index.md`: `ujson` (ultrajson) moved from `esnme/ultrajson` to `ultrajson/ultrajson`.

Both old URLs currently 301-redirect to these new owners; the change points the links at the canonical locations directly.