### PR TITLE
docs(guide/response-model): fix dead pydantic v1 #modeldict link

### DIFF
--- a/docs/en/docs/tutorial/response-model.md
+++ b/docs/en/docs/tutorial/response-model.md
@@ -258,7 +258,7 @@ You can also use:
 * `response_model_exclude_defaults=True`
 * `response_model_exclude_none=True`
 
-as described in [the Pydantic docs](https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict) for `exclude_defaults` and `exclude_none`.
+as described in [the Pydantic docs](https://docs.pydantic.dev/latest/concepts/serialization/#model-dict) for `exclude_defaults` and `exclude_none`.
 
 ///
 


### PR DESCRIPTION
Replaces `https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict` (404 — pydantic v1 docs retired) with `https://docs.pydantic.dev/latest/concepts/serialization/#model-dict` (200). Anchor updated to v2 hyphenated slug.