### PR TITLE
docs(release-notes): fix dead pydantic v1 extra_types link

### DIFF
--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -3965,7 +3965,7 @@ There are **tests for both Pydantic v1 and v2**, and test **coverage** is kept a
     * You can read more about it in the docs for [Declare Request Example Data](https://fastapi.tiangolo.com/tutorial/schema-extra-example/).
 * When you install `"fastapi[all]"` it now also includes:
     * [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
-    * [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
+    * [`pydantic-extra-types`](https://docs.pydantic.dev/latest/concepts/types/#extra-types) - for extra types to be used with Pydantic.
 * Now Pydantic Settings is an additional optional package (included in `"fastapi[all]"`). To use settings you should now import `from pydantic_settings import BaseSettings` instead of importing from `pydantic` directly.
     * You can read more about it in the docs for [Settings and Environment Variables](https://fastapi.tiangolo.com/advanced/settings/).
 

--- a/docs/en/docs/tutorial/response-model.md
+++ b/docs/en/docs/tutorial/response-model.md
@@ -258,7 +258,7 @@ You can also use:
 * `response_model_exclude_defaults=True`
 * `response_model_exclude_none=True`
 
-as described in [the Pydantic docs](https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict) for `exclude_defaults` and `exclude_none`.
+as described in [the Pydantic docs](https://docs.pydantic.dev/latest/concepts/serialization/#model-dict) for `exclude_defaults` and `exclude_none`.
 
 ///
 


### PR DESCRIPTION
Replaces `https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/` (404) with `https://docs.pydantic.dev/latest/concepts/types/#extra-types` (200) — the pydantic v1 /usage/types/ docs path was retired.