### PR TITLE
✏️ Fix grammar typo in HTTP Basic Auth docs: "a type of attacks" -> "…

### DIFF
--- a/docs/en/docs/advanced/security/http-basic-auth.md
+++ b/docs/en/docs/advanced/security/http-basic-auth.md
@@ -50,7 +50,7 @@ if not (credentials.username == "stanleyjobson") or not (credentials.password ==
     ...
 ```
 
-But by using the `secrets.compare_digest()` it will be secure against a type of attacks called "timing attacks".
+But by using the `secrets.compare_digest()` it will be secure against a type of attack called "timing attacks".
 
 ### Timing Attacks { #timing-attacks }
 


### PR DESCRIPTION
## Pull Request

This is an obvious typo fix, so no GitHub Discussion is required.

## Description

Fixes a small grammar typo in the HTTP Basic Auth documentation (`docs/en/docs/advanced/security/http-basic-auth.md`).

The text previously read "secure against a type of attacks called timing attacks", which is grammatically incorrect. With the singular form, it now reads "secure against a type of attack called timing attacks".

No code or behavior changes are involved — this is a documentation-only fix.

## AI Disclaimer

No AI was used for this change.

## Checklist

- [x] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
