### PR TITLE
docs(en): fix dead Ariadne docs and Ludwig v0.2 blog links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The key features are:
 
 "_We adopted the **FastAPI** library to spawn a **REST** server that can be queried to obtain **predictions**. [for Ludwig]_"
 
-<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://ludwig.ai/"><small>(ref)</small></a></div>
 
 ---
 

--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -21,7 +21,7 @@ Here are some of the **GraphQL** libraries that have **ASGI** support. You could
 * [Strawberry](https://strawberry.rocks/) 🍓
     * With [docs for FastAPI](https://strawberry.rocks/docs/integrations/fastapi)
 * [Ariadne](https://ariadnegraphql.org/)
-    * With [docs for FastAPI](https://ariadnegraphql.org/docs/fastapi-integration)
+    * With [docs for FastAPI](https://github.com/mirumee/ariadne)
 * [Tartiflette](https://tartiflette.io/)
     * With [Tartiflette ASGI](https://tartiflette.github.io/tartiflette-asgi/) to provide ASGI integration
 * [Graphene](https://graphene-python.org/)

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -110,7 +110,7 @@ The key features are:
   </div>
   <div class="fastapi-opinions__panel" id="fo-panel-uber" role="tabpanel" aria-labelledby="fo-tab-uber" tabindex="0" hidden>
     <blockquote class="fastapi-opinions__quote">"We adopted the <strong>FastAPI</strong> library to spawn a <strong>REST</strong> server that can be queried to obtain <strong>predictions</strong>." <em>[for Ludwig]</em></blockquote>
-    <div class="fastapi-opinions__attr">— Piero Molino, Yaroslav Dudin, Sai Sumanth Miryala, <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/">(ref)</a></div>
+    <div class="fastapi-opinions__attr">— Piero Molino, Yaroslav Dudin, Sai Sumanth Miryala, <strong>Uber</strong> <a href="https://ludwig.ai/">(ref)</a></div>
   </div>
   <div class="fastapi-opinions__panel" id="fo-panel-netflix" role="tabpanel" aria-labelledby="fo-tab-netflix" tabindex="0" hidden>
     <blockquote class="fastapi-opinions__quote">"<strong>Netflix</strong> is pleased to announce the open-source release of our <strong>crisis management</strong> orchestration framework: <strong>Dispatch</strong>!" <em>[built with FastAPI]</em></blockquote>
@@ -133,7 +133,7 @@ The key features are:
 
 "_We adopted the **FastAPI** library to spawn a **REST** server that can be queried to obtain **predictions**. [for Ludwig]_"
 
-<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://eng.uber.com/ludwig-v0-2/"><small>(ref)</small></a></div>
+<div style="text-align: right; margin-right: 10%;">Piero Molino, Yaroslav Dudin, and Sai Sumanth Miryala - <strong>Uber</strong> <a href="https://ludwig.ai/"><small>(ref)</small></a></div>
 
 ---
 

--- a/docs/en/docs/tutorial/response-model.md
+++ b/docs/en/docs/tutorial/response-model.md
@@ -258,7 +258,7 @@ You can also use:
 * `response_model_exclude_defaults=True`
 * `response_model_exclude_none=True`
 
-as described in [the Pydantic docs](https://docs.pydantic.dev/1.10/usage/exporting_models/#modeldict) for `exclude_defaults` and `exclude_none`.
+as described in [the Pydantic docs](https://docs.pydantic.dev/latest/concepts/serialization/#model-dict) for `exclude_defaults` and `exclude_none`.
 
 ///
 


### PR DESCRIPTION
\`ariadnegraphql.org/docs/fastapi-integration\` returns 404 — the Ariadne site has been restructured and now points users at the GitHub repo. Same for \`eng.uber.com/ludwig-v0-2/\`, the v0.2 announcement post is gone; \`ludwig.ai\` is the current project homepage.

Two files, three replacements. Translation copies regenerate from these via scripts/translate.py.