### PR TITLE
docs(index): fix dead pydantic-extra-types link

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ There are some additional dependencies you might want to install.
 Additional optional Pydantic dependencies:
 
 * [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
-* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
+* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/concepts/types/#extra-types) - for extra types to be used with Pydantic.
 
 Additional optional FastAPI dependencies:
 

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -573,7 +573,7 @@ There are some additional dependencies you might want to install.
 Additional optional Pydantic dependencies:
 
 * [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
-* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
+* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/concepts/types/#extra-types) - for extra types to be used with Pydantic.
 
 Additional optional FastAPI dependencies:
 


### PR DESCRIPTION
Replaces `docs.pydantic.dev/latest/usage/types/extra_types/extra_types/` (404) with `docs.pydantic.dev/latest/concepts/types/#extra-types` (200) in `docs/en/docs/index.md`. Same pattern as #15822 which fixed release-notes.md.