### PR TITLE
docs: fix dropped word in get_swagger_ui_html docstring

### DIFF
--- a/fastapi/openapi/docs.py
+++ b/fastapi/openapi/docs.py
@@ -135,7 +135,7 @@ def get_swagger_ui_html(
     ] = None,
 ) -> HTMLResponse:
     """
-    Generate and return the HTML  that loads Swagger UI for the interactive
+    Generate and return the HTML response that loads Swagger UI for the interactive
     API docs (normally served at `/docs`).
 
     You would only call this function yourself if you needed to override some parts,


### PR DESCRIPTION
The `get_swagger_ui_html` docstring reads "Generate and return the HTML  that loads Swagger UI" — a word is missing (and there's a leftover double space). The parallel `get_redoc_html` docstring correctly reads "Generate and return the HTML response that loads ReDoc", confirming the intended wording. This inserts "response" so the two docstrings match.