### PR TITLE
🐛 Fix Server-Sent Event data ignoring Pydantic serialization_alias

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -523,7 +523,13 @@ def get_request_handler(
                             data_str: str | None = item.raw_data
                         elif item.data is not None:
                             if hasattr(item.data, "model_dump_json"):
-                                data_str = item.data.model_dump_json()
+                                # Thread `response_model_by_alias` (default `True`)
+                                # so Pydantic `serialization_alias`/`alias` are
+                                # honored, like the rest of FastAPI's response
+                                # serialization. See #15703.
+                                data_str = item.data.model_dump_json(
+                                    by_alias=response_model_by_alias
+                                )
                             else:
                                 data_str = json.dumps(jsonable_encoder(item.data))
                         else:

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -8,12 +8,16 @@ from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
 from fastapi.sse import ServerSentEvent
 from fastapi.testclient import TestClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Item(BaseModel):
     name: str
     description: str | None = None
+
+
+class AliasedItem(BaseModel):
+    name: str = Field(serialization_alias="itemName")
 
 
 items = [
@@ -85,6 +89,20 @@ async def sse_items_raw():
     yield ServerSentEvent(raw_data="plain text without quotes")
     yield ServerSentEvent(raw_data="<div>html fragment</div>", event="html")
     yield ServerSentEvent(raw_data="cpu,87.3,1709145600", event="csv")
+
+
+@app.get("/items/stream-sse-event-alias", response_class=EventSourceResponse)
+async def sse_items_event_alias():
+    yield ServerSentEvent(data=AliasedItem(name="Portal Gun"))
+
+
+@app.get(
+    "/items/stream-sse-event-alias-disabled",
+    response_class=EventSourceResponse,
+    response_model_by_alias=False,
+)
+async def sse_items_event_alias_disabled():
+    yield ServerSentEvent(data=AliasedItem(name="Portal Gun"))
 
 
 router = APIRouter()
@@ -214,6 +232,27 @@ def test_string_data_json_encoded(client: TestClient):
     response = client.get("/items/stream-string")
     assert response.status_code == 200
     assert 'data: "plain text data"\n' in response.text
+
+
+def test_sse_event_data_uses_serialization_alias(client: TestClient):
+    """`ServerSentEvent(data=model)` must honor Pydantic `serialization_alias`.
+
+    Regression test for
+    https://github.com/fastapi/fastapi/discussions/15703
+    """
+    response = client.get("/items/stream-sse-event-alias")
+    assert response.status_code == 200
+    assert 'data: {"itemName":"Portal Gun"}\n' in response.text
+    assert '"name"' not in response.text
+
+
+def test_sse_event_data_respects_response_model_by_alias(client: TestClient):
+    """`response_model_by_alias=False` disables aliasing for SSE event data too,
+    consistent with plainly-yielded items."""
+    response = client.get("/items/stream-sse-event-alias-disabled")
+    assert response.status_code == 200
+    assert 'data: {"name":"Portal Gun"}\n' in response.text
+    assert "itemName" not in response.text
 
 
 def test_server_sent_event_null_id_rejected():


### PR DESCRIPTION
## Description

Reported in [#15703](https://github.com/fastapi/fastapi/discussions/15703).

When a Pydantic model is sent as the `data` of a `ServerSentEvent`, its `serialization_alias` (and `alias`) were ignored:

```python
class Item(BaseModel):
    name: str = Field(serialization_alias="itemName")


@app.get("/events", response_class=EventSourceResponse)
async def events():
    yield ServerSentEvent(data=Item(name="Portal Gun"))

# before: data: {"name":"Portal Gun"}
# after:  data: {"itemName":"Portal Gun"}
```

## Root cause

In `get_request_handler` (`fastapi/routing.py`), `ServerSentEvent.data` was serialized with `item.data.model_dump_json()`, which defaults to `by_alias=False` in Pydantic v2 — so aliases were dropped. Every other response-serialization path in FastAPI threads `response_model_by_alias` (default `True`).

## Fix

Serialize the model with `by_alias=response_model_by_alias`. This honors `serialization_alias`/`alias` by default and respects a route-level `response_model_by_alias=False`, consistent with plainly-yielded models and regular JSON responses. Only the Pydantic-model branch changes; `dict`, `raw_data`, and other values are untouched.

## Tests

Added two tests to `tests/test_sse.py`:

- `test_sse_event_data_uses_serialization_alias` — aliases are honored by default (fails without the fix).
- `test_sse_event_data_respects_response_model_by_alias` — `response_model_by_alias=False` disables aliasing for SSE event data too, consistent with plainly-yielded items.

The full test suite, `mypy`, `ty`, and `ruff` all pass.

## Note

This is a behavior change: code that yields `ServerSentEvent(data=<model with aliases>)` will now emit aliased field names by default, aligned with FastAPI's global `response_model_by_alias=True` default.
