### PR TITLE
Validate event and id fields in format_sse_event

### DIFF
--- a/fastapi/sse.py
+++ b/fastapi/sse.py
@@ -203,6 +203,9 @@ def format_sse_event(
 
     The result always ends with `\n\n` (the event terminator).
     """
+    _check_event_single_line(event)
+    _check_id_valid(id)
+
     lines: list[str] = []
 
     if comment is not None:

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -6,7 +6,7 @@ import fastapi.routing
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
-from fastapi.sse import ServerSentEvent
+from fastapi.sse import ServerSentEvent, format_sse_event
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
@@ -228,6 +228,35 @@ def test_server_sent_event_single_line_fields_reject_newlines(
 ):
     with pytest.raises(ValueError, match=f"SSE '{field_name}' must be a single line"):
         ServerSentEvent(data="test", **{field_name: value})  # ty: ignore[invalid-argument-type]
+
+
+@pytest.mark.parametrize("value", ["first\nsecond", "first\rsecond", "first\r\nsecond"])
+def test_format_sse_event_rejects_multiline_event(value: str):
+    with pytest.raises(ValueError, match="SSE 'event' must be a single line"):
+        format_sse_event(data_str="safe", event=value)
+
+
+@pytest.mark.parametrize("value", ["first\nsecond", "first\rsecond", "first\r\nsecond"])
+def test_format_sse_event_rejects_multiline_id(value: str):
+    with pytest.raises(ValueError, match="SSE 'id' must be a single line"):
+        format_sse_event(data_str="safe", id=value)
+
+
+def test_format_sse_event_rejects_null_id():
+    with pytest.raises(ValueError, match="null"):
+        format_sse_event(data_str="safe", id="has\0null")
+
+
+def test_format_sse_event_validates_before_rendering_injected_event():
+    with pytest.raises(ValueError, match="SSE 'event' must be a single line"):
+        format_sse_event(data_str="safe", event="message\ndata: injected")
+
+
+def test_format_sse_event_accepts_valid_event_and_id():
+    assert (
+        format_sse_event(data_str="safe", event="message", id="event-1")
+        == b"event: message\ndata: safe\nid: event-1\n\n"
+    )
 
 
 def test_server_sent_event_negative_retry_rejected():


### PR DESCRIPTION
## Summary

`ServerSentEvent` already validates SSE `event` and `id` fields before rendering. This applies the same checks in the public `format_sse_event()` helper so callers cannot accidentally render multiline `event` or `id` values into extra SSE fields.

Discussion: https://github.com/fastapi/fastapi/discussions/15648

## Changes

- Reuse the existing SSE validators at the start of `format_sse_event()`.
- Add regression tests for multiline `event`, multiline `id`, null-byte `id`, an injected `data:` line, and a valid `event`/`id` output.

## Validation

- `pytest -q tests/test_sse.py`
- `pytest -q tests/test_sse.py tests/test_tutorial/test_server_sent_events`
- `ruff check fastapi/sse.py tests/test_sse.py`
- `git diff --check`
