### PR TITLE
📝 Fix outdated Traefik URLs in behind-a-proxy docs

### DIFF
--- a/docs/en/docs/advanced/behind-a-proxy.md
+++ b/docs/en/docs/advanced/behind-a-proxy.md
@@ -251,9 +251,9 @@ In a case like that (without a stripped path prefix), the proxy would listen on 
 
 ## Testing locally with Traefik { #testing-locally-with-traefik }
 
-You can easily run the experiment locally with a stripped path prefix using [Traefik](https://docs.traefik.io/).
+You can easily run the experiment locally with a stripped path prefix using [Traefik](https://doc.traefik.io/traefik/).
 
-[Download Traefik](https://github.com/containous/traefik/releases), it's a single binary, you can extract the compressed file and run it directly from the terminal.
+[Download Traefik](https://github.com/traefik/traefik/releases), it's a single binary, you can extract the compressed file and run it directly from the terminal.
 
 Then create a file `traefik.toml` with:
 


### PR DESCRIPTION
Traefik moved its docs from `docs.traefik.io` to `doc.traefik.io/traefik/` and its GitHub org from `containous` to `traefik`. Both old URLs now redirect via 301. This updates them to point directly to the canonical locations.