### PR TITLE
fix: update starlette version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "starlette>=0.46.0",
+    "starlette>=1.3.1",
     "pydantic>=2.9.0",
     "typing-extensions>=4.8.0",
     "typing-inspection>=0.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1289,7 +1289,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'standard'", specifier = ">=0.0.18" },
     { name = "python-multipart", marker = "extra == 'standard-no-fastapi-cloud-cli'", specifier = ">=0.0.18" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=5.3.1" },
-    { name = "starlette", specifier = ">=0.46.0" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
     { name = "typing-inspection", specifier = ">=0.4.2" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'all'", specifier = ">=0.12.0" },


### PR DESCRIPTION
## Pull Request
Fix the starlette version in pyproject.toml


## Description
The version already pined to starlette@1.3.1 in uv.lock, however, the pyproject.toml lags behind.
This fix should address this issue.

Also, the older version of starlette has multiple security findings. This should help the security scanner tool get the accurate dependency info.



## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [x] The documentation above explains the change if needed.
