### PR TITLE
fix: update broken Pydantic v2 and Ariadne documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,8 +526,8 @@ There are some additional dependencies you might want to install.
 
 Additional optional Pydantic dependencies:
 
-* [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
-* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
+* [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) - for settings management.
+* [`pydantic-extra-types`](https://github.com/pydantic/pydantic-extra-types) - for extra types to be used with Pydantic.
 
 Additional optional FastAPI dependencies:
 

--- a/docs/en/docs/how-to/graphql.md
+++ b/docs/en/docs/how-to/graphql.md
@@ -21,7 +21,7 @@ Here are some of the **GraphQL** libraries that have **ASGI** support. You could
 * [Strawberry](https://strawberry.rocks/) 🍓
     * With [docs for FastAPI](https://strawberry.rocks/docs/integrations/fastapi)
 * [Ariadne](https://ariadnegraphql.org/)
-    * With [docs for FastAPI](https://ariadnegraphql.org/docs/fastapi-integration)
+    * With [docs for FastAPI](https://ariadnegraphql.org/)
 * [Tartiflette](https://tartiflette.io/)
     * With [Tartiflette ASGI](https://tartiflette.github.io/tartiflette-asgi/) to provide ASGI integration
 * [Graphene](https://graphene-python.org/)

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -572,8 +572,8 @@ There are some additional dependencies you might want to install.
 
 Additional optional Pydantic dependencies:
 
-* [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
-* [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
+* [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) - for settings management.
+* [`pydantic-extra-types`](https://github.com/pydantic/pydantic-extra-types) - for extra types to be used with Pydantic.
 
 Additional optional FastAPI dependencies:
 

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -4012,8 +4012,8 @@ There are **tests for both Pydantic v1 and v2**, and test **coverage** is kept a
 * The attribute `schema_extra` for the internal class `Config` has been replaced by the key `json_schema_extra` in the new `model_config` dict.
     * You can read more about it in the docs for [Declare Request Example Data](https://fastapi.tiangolo.com/tutorial/schema-extra-example/).
 * When you install `"fastapi[all]"` it now also includes:
-    * [`pydantic-settings`](https://docs.pydantic.dev/latest/usage/pydantic_settings/) - for settings management.
-    * [`pydantic-extra-types`](https://docs.pydantic.dev/latest/usage/types/extra_types/extra_types/) - for extra types to be used with Pydantic.
+    * [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) - for settings management.
+    * [`pydantic-extra-types`](https://github.com/pydantic/pydantic-extra-types) - for extra types to be used with Pydantic.
 * Now Pydantic Settings is an additional optional package (included in `"fastapi[all]"`). To use settings you should now import `from pydantic_settings import BaseSettings` instead of importing from `pydantic` directly.
     * You can read more about it in the docs for [Settings and Environment Variables](https://fastapi.tiangolo.com/advanced/settings/).
 

--- a/docs/en/docs/tutorial/extra-data-types.md
+++ b/docs/en/docs/tutorial/extra-data-types.md
@@ -49,7 +49,7 @@ Here are some of the additional data types you can use:
 * `Decimal`:
     * Standard Python `Decimal`.
     * In requests and responses, handled the same as a `float`.
-* You can check all the valid Pydantic data types here: [Pydantic data types](https://docs.pydantic.dev/latest/usage/types/types/).
+* You can check all the valid Pydantic data types here: [Pydantic data types](https://docs.pydantic.dev/latest/concepts/types/).
 
 ## Example { #example }
 


### PR DESCRIPTION
## Summary

Several documentation links are returning 404 because Pydantic restructured their docs site when releasing v2, and Ariadne removed their FastAPI integration page.

## Changes

- `docs/en/docs/tutorial/extra-data-types.md`: Updated Pydantic types link from `/usage/types/types/` → `/concepts/types/`
- `docs/en/docs/index.md`: Updated `pydantic-settings` link from `/usage/pydantic_settings/` → `/concepts/pydantic_settings/`; updated `pydantic-extra-types` link (no longer has a standalone docs page) → GitHub repo
- `docs/en/docs/release-notes.md`: Same two Pydantic link fixes in the v0.100.0 changelog entry
- `docs/en/docs/how-to/graphql.md`: Updated broken Ariadne FastAPI integration link → Ariadne homepage

## Verification

All updated URLs return HTTP 200. The old URLs return HTTP 404 (Pydantic `/usage/types/types/` and `/usage/types/extra_types/extra_types/`) or HTTP 301→404 (Ariadne `/docs/fastapi-integration`).

## Related Issues

Fixes broken external links that lead to 404 pages, confusing users following the FastAPI documentation.