### PR TITLE
fix: preserve empty form values for required params

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -763,8 +763,7 @@ def _get_multidict_value(
     else:
         value = values.get(alias, None)
     if value is None or (
-        field_annotation_is_sequence(field.field_info.annotation)
-        and len(value) == 0
+        field_annotation_is_sequence(field.field_info.annotation) and len(value) == 0
     ):
         if field.field_info.is_required():
             return

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -762,20 +762,22 @@ def _get_multidict_value(
         value = values.getlist(alias)
     else:
         value = values.get(alias, None)
-    if (
-        value is None
-        or (
-            isinstance(field.field_info, params.Form)
-            and isinstance(value, str)  # For type checks
-            and value == ""
-        )
-        or (
-            field_annotation_is_sequence(field.field_info.annotation)
-            and len(value) == 0
-        )
+    if value is None or (
+        field_annotation_is_sequence(field.field_info.annotation)
+        and len(value) == 0
     ):
         if field.field_info.is_required():
             return
+        else:
+            return deepcopy(field.default)
+
+    if (
+        isinstance(field.field_info, params.Form)
+        and isinstance(value, str)  # For type checks
+        and value == ""
+    ):
+        if field.field_info.is_required():
+            return value
         else:
             return deepcopy(field.default)
     return value

--- a/tests/test_form_default.py
+++ b/tests/test_form_default.py
@@ -19,6 +19,11 @@ async def post_multi_part(
     return {"file": file, "age": age}
 
 
+@app.post("/urlencoded-required")
+async def post_url_encoded_required(name: Annotated[str, Form()]):
+    return name
+
+
 client = TestClient(app)
 
 
@@ -32,3 +37,9 @@ def test_form_default_multi_part():
     response = client.post("/multipart", data={"age": ""})
     assert response.status_code == 200
     assert response.json() == {"file": None, "age": None}
+
+
+def test_required_form_field_with_empty_string():
+    response = client.post("/urlencoded-required", data={"name": ""})
+    assert response.status_code == 200
+    assert response.text == ""


### PR DESCRIPTION
## Pull Request

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Typos, grammar issues, broken links and other small docs improvements should be reported in the pinned Discussion thread "✏️ Report small docs improvements, including typos or broken links".
Please do not open a PR for these yourself.
-->

Discussion: <!-- Link to the GitHub Discussion -->

## Description
Fixes FastAPI form parsing so required `Form()` parameters preserve an explicit empty string (`""`) instead of being treated as missing.
- Updated `fastapi/dependencies/utils.py` to keep `""` as a valid value for required form parameters.
- Added a regression test in `tests/test_form_default.py` covering a required form field submitted with an empty string.

This is a targeted bug fix with test coverage for the regression.

## AI Disclaimer

No AI was used to generate this code change.

<details>
<summary>AI transcript</summary>

<!-- Paste here the entire AI transcript -->

</details>

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [X] I added tests for the change in tests/test_form_default.py.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.