### PR TITLE
Refactor OpenIdConnect class and improve error handling

### DIFF
--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -35,8 +35,9 @@ DOCS = {
                 It is also useful when you want to have authentication that can be
                 provided in one of multiple optional ways (for example, with OpenID
                 Connect or in a cookie).
-                """)
+                """),
 }
+
 
 class OpenIdConnect(SecurityBase):
     """
@@ -57,11 +58,15 @@ class OpenIdConnect(SecurityBase):
         description: Annotated[str | None, DOCS["desc"]] = None,
         auto_error: Annotated[bool, DOCS["auto"]] = True,
     ):
-        self.model = OpenIdConnectModel(openIdConnectUrl=openIdConnectUrl, description=description)
+        self.model = OpenIdConnectModel(
+            openIdConnectUrl=openIdConnectUrl, description=description
+        )
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
 
-    def make_not_authenticated_error(self, detail: str = "Not authenticated") -> HTTPException:
+    def make_not_authenticated_error(
+        self, detail: str = "Not authenticated"
+    ) -> HTTPException:
         return HTTPException(
             status_code=HTTP_401_UNAUTHORIZED,
             detail=detail,
@@ -70,11 +75,13 @@ class OpenIdConnect(SecurityBase):
 
     async def __call__(self, request: Request) -> str | None:
         authorization = request.headers.get("Authorization")
-        
+
         # Case 1: Header is entirely missing
         if not authorization:
             if self.auto_error:
-                raise self.make_not_authenticated_error("Missing 'Authorization' header in request.")
+                raise self.make_not_authenticated_error(
+                    "Missing 'Authorization' header in request."
+                )
             return None
 
         # Case 2: Header exists but uses the wrong protocol/scheme (e.g., Basic, APIKey, or raw token)

--- a/fastapi/security/open_id_connect_url.py
+++ b/fastapi/security/open_id_connect_url.py
@@ -7,6 +7,36 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_401_UNAUTHORIZED
 
+DOCS = {
+    "url": Doc("""
+            The OpenID Connect URL.
+            """),
+    "scheme": Doc("""
+                Security scheme name.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """),
+    "desc": Doc("""
+                Security scheme description.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """),
+    "auto": Doc("""
+                By default, if no HTTP Authorization header is provided, required for
+                OpenID Connect authentication, it will automatically cancel the request
+                and send the client an error.
+
+                If `auto_error` is set to `False`, when the HTTP Authorization header
+                is not available, instead of erroring out, the dependency result will
+                be `None`.
+
+                This is useful when you want to have optional authentication.
+
+                It is also useful when you want to have authentication that can be
+                provided in one of multiple optional ways (for example, with OpenID
+                Connect or in a cookie).
+                """)
+}
 
 class OpenIdConnect(SecurityBase):
     """
@@ -22,73 +52,46 @@ class OpenIdConnect(SecurityBase):
     def __init__(
         self,
         *,
-        openIdConnectUrl: Annotated[
-            str,
-            Doc(
-                """
-            The OpenID Connect URL.
-            """
-            ),
-        ],
-        scheme_name: Annotated[
-            str | None,
-            Doc(
-                """
-                Security scheme name.
-
-                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
-                """
-            ),
-        ] = None,
-        description: Annotated[
-            str | None,
-            Doc(
-                """
-                Security scheme description.
-
-                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
-                """
-            ),
-        ] = None,
-        auto_error: Annotated[
-            bool,
-            Doc(
-                """
-                By default, if no HTTP Authorization header is provided, required for
-                OpenID Connect authentication, it will automatically cancel the request
-                and send the client an error.
-
-                If `auto_error` is set to `False`, when the HTTP Authorization header
-                is not available, instead of erroring out, the dependency result will
-                be `None`.
-
-                This is useful when you want to have optional authentication.
-
-                It is also useful when you want to have authentication that can be
-                provided in one of multiple optional ways (for example, with OpenID
-                Connect or in a cookie).
-                """
-            ),
-        ] = True,
+        openIdConnectUrl: Annotated[str, DOCS["url"]],
+        scheme_name: Annotated[str | None, DOCS["scheme"]] = None,
+        description: Annotated[str | None, DOCS["desc"]] = None,
+        auto_error: Annotated[bool, DOCS["auto"]] = True,
     ):
-        self.model = OpenIdConnectModel(
-            openIdConnectUrl=openIdConnectUrl, description=description
-        )
+        self.model = OpenIdConnectModel(openIdConnectUrl=openIdConnectUrl, description=description)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
 
-    def make_not_authenticated_error(self) -> HTTPException:
+    def make_not_authenticated_error(self, detail: str = "Not authenticated") -> HTTPException:
         return HTTPException(
             status_code=HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated",
+            detail=detail,
             headers={"WWW-Authenticate": "Bearer"},
         )
 
     async def __call__(self, request: Request) -> str | None:
         authorization = request.headers.get("Authorization")
+        
+        # Case 1: Header is entirely missing
         if not authorization:
             if self.auto_error:
-                raise self.make_not_authenticated_error()
-            else:
-                return None
+                raise self.make_not_authenticated_error("Missing 'Authorization' header in request.")
+            return None
+
+        # Case 2: Header exists but uses the wrong protocol/scheme (e.g., Basic, APIKey, or raw token)
+        if not authorization.lower().startswith("bearer "):
+            if self.auto_error:
+                raise self.make_not_authenticated_error(
+                    "Invalid authentication credentials. Expected a 'Bearer <token>' prefix."
+                )
+            return None
+
+        # Case 3: 'Bearer ' prefix is there, but no actual token follows it
+        token = authorization[7:].strip()
+        if not token:
+            if self.auto_error:
+                raise self.make_not_authenticated_error(
+                    "Authentication token value is empty or missing after 'Bearer' prefix."
+                )
+            return None
+
         return authorization


### PR DESCRIPTION
| Feature | Original FastAPI Code | Our Refactored Version |
| :--- | :--- | :--- |
| **Docstring Location** | Hardcoded inside `__init__` signature (over 60 lines of visual clutter). | Centralized in a global `DOCS` dictionary at the top of the file. |
| **Error Method Signature** | `make_not_authenticated_error` takes no arguments; message is hardcoded. | Accepts a dynamic `detail` string to pass hyper-specific feedback. |
| **Header Validation** | **1 Check:** Only verifies if the `Authorization` header exists. | **3 Checks:** Verifies existence, validates the `Bearer ` prefix, and checks for empty space tokens. |
| **Error Detail Specificity** | Always returns a generic `{"detail": "Not authenticated"}` message. | Returns distinct, actionable instructions telling the user exactly what to fix. |