### PR TITLE
🐛 Fix `jsonable_encoder` not encoding `Enum` values that are not JSON-serializable

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -271,7 +271,11 @@ def jsonable_encoder(
             sqlalchemy_safe=sqlalchemy_safe,
         )
     if isinstance(obj, Enum):
-        return obj.value
+        return jsonable_encoder(
+            obj.value,
+            custom_encoder=custom_encoder,
+            sqlalchemy_safe=sqlalchemy_safe,
+        )
     if isinstance(obj, PurePath):
         return str(obj)
     if isinstance(obj, (str, int, float, type(None))):

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import deque
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from enum import Enum
 from math import isinf, isnan
@@ -238,6 +238,31 @@ def test_custom_enum_encoders():
         instance, custom_encoder={MyEnum: custom_enum_encoder}
     )
     assert encoded_instance == custom_enum_encoder(instance)
+
+
+def test_encode_enum_with_non_primitive_values():
+    class DateEnum(Enum):
+        release = date(2024, 1, 1)
+
+    class DecimalEnum(Enum):
+        half = Decimal("0.5")
+
+    class BytesEnum(Enum):
+        data = b"data"
+
+    assert jsonable_encoder(DateEnum.release) == "2024-01-01"
+    assert jsonable_encoder(DecimalEnum.half) == 0.5
+    assert jsonable_encoder(BytesEnum.data) == "data"
+
+
+def test_encode_enum_value_with_custom_encoder():
+    class DateEnum(Enum):
+        release = date(2024, 1, 1)
+
+    encoded_instance = jsonable_encoder(
+        DateEnum.release, custom_encoder={date: lambda o: o.strftime("%d/%m/%Y")}
+    )
+    assert encoded_instance == "01/01/2024"
 
 
 def test_encode_model_with_pure_path():


### PR DESCRIPTION
## Problem

`jsonable_encoder` returns `Enum.value` as-is, without encoding it. For enums whose values are not JSON primitives (`date`, `bytes`, `Decimal`, ...), the raw value reaches `JSONResponse.render`, where `json.dumps` raises `TypeError` and the request fails with a 500. Every other branch of `jsonable_encoder` (models, dataclasses, dicts, sequences) encodes contained values recursively, and Pydantic's `model_dump(mode="json")` handles the same enums correctly — only the bare `Enum` branch skipped the recursion.

## Reproduction

```python
import datetime
from enum import Enum

from fastapi import FastAPI
from fastapi.testclient import TestClient


class DateEnum(Enum):
    D = datetime.date(2024, 1, 1)


app = FastAPI()


@app.get("/enum")
def get_enum():
    return {"v": DateEnum.D}


client = TestClient(app)
response = client.get("/enum")  # 500: Object of type date is not JSON serializable
```

Directly, `jsonable_encoder(DateEnum.D)` returns `datetime.date(2024, 1, 1)` instead of `"2024-01-01"`.

## Fix

In the `Enum` branch of `jsonable_encoder`, encode `obj.value` recursively with `jsonable_encoder`, passing through `custom_encoder` and `sqlalchemy_safe`, matching how the other branches handle nested values. Enums with primitive values (`str`, `int`, ...) behave exactly as before; enums with values like `date`, `Decimal`, or `bytes` are now encoded to their JSON-compatible representation, consistent with Pydantic's `mode="json"` serialization.