### PR TITLE
🌐 Update LLM prompt for Russian translations

### DIFF
--- a/docs/ru/llm-prompt.md
+++ b/docs/ru/llm-prompt.md
@@ -4,13 +4,80 @@ Language code: ru.
 
 ---
 
+### Grammar and tone
+
 Use a neutral tone (not overly formal or informal).
 
 Use correct Russian grammar — appropriate cases, suffixes, and endings depending on context.
 
-For the following technical terms, use these specific translations to ensure consistency and clarity across the documentation:
+Address the reader as «вы». Never capitalize «вы», «ваш», «вам» mid-sentence: write «если вы сравниваете», not «если Вы сравниваете».
 
-* production (meaning production software or environment): продакшн (do not change the ending, for example, translate `in production` as `в продакшн` (not `в продакшене`))
+Write natural Russian, not word-for-word calques of English syntax. In particular:
+
+* Put the generic Russian noun before the Latin name: «приложение FastAPI» (not «FastAPI приложение»), «события lifespan» (not «lifespan события»), «эндпоинты FastAPI» (not «FastAPI эндпоинты»).
+* Hyphenate compounds where a Latin term modifies a Russian noun: «SQL-база данных», «JSON-схема», «бэкенд-API» (not «SQL база данных», «JSON схема», «бэкенд API»).
+* Never mix Latin and Cyrillic letters inside one word: every letter of a Russian word must be Cyrillic (a Latin «a» in «полезнa» or a Latin «e» in «созданиe» corrupts the text and breaks search).
+* Never leave stray English words in a Russian sentence: «…где именно и что было некорректно», not «…где именно and что было некорректно».
+* Do not attach Cyrillic case endings directly to Latin words. Rephrase so the Latin name stays unchanged: «Python придётся сравнить…», not «Pythonу придётся сравнить…».
+* A деепричастный оборот must share its subject with the main clause. Do not translate English "By doing X, …" as a dangling participle: «Если вы добавите звезду, другим пользователям будет проще найти проект», not «Добавив звезду, другим пользователям будет проще его найти».
+* Watch case government and agreement across coordinated parts: «быстрее вашего предыдущего фреймворка (или как минимум сопоставим с ним)», not «быстрее (или сопоставим) с вашим предыдущим фреймворком»; «Он перестал быть веб-фреймворком для API», not «Это перестал быть веб-фреймворк для API»; «объявленные в текущих зависимостях `Security` и во всех зависящих», not «…и всеми зависящими».
+* Use the correct prepositional forms: «об этих» (not «о этих»), «во внешний API» (not «в внешний API»).
+* Use «который», not colloquial «что», as the relative pronoun: «часть модуля `functools`, входящего в стандартную библиотеку Python», not «часть `functools`, что входит в стандартную библиотеку».
+* English singular "they" refers back to a singular noun — translate it with «тот»/«он»/«она», not plural «они»: «говорит повару, чтобы тот знал», not «чтобы они знали».
+* Do not stack infinitives literally: "to tell it to use base64" → «чтобы указать, что нужно использовать base64», not «указать использовать base64».
+* Preserve modality and hedging: "could trigger" → «может инициировать» (not «будет инициировать»); "could be less stable" → «может работать менее стабильно» (not «делает систему менее стабильной»); "probably" must not be dropped.
+* Do not translate "shared (among requests)" as «разделяются между» (ambiguous — reads as "divided among"); use «общие для всех запросов» / «используются совместно всеми запросами».
+
+Use the letter «ё» consistently everywhere it belongs: «начнёт», «своём», «ещё», «придётся», «развёртывание», «за счёт». Do not mix «ё» and «е» spellings of the same word within the documentation.
+
+### Headings
+
+Use noun-style headings, consistent with the rest of the Russian docs: "## Use a `Response` parameter" → «## Использование параметра `Response`», "### Simulate a File" → «### Имитация файла». Do not use the bare infinitive («## Использовать параметр `Response`», «### Симулировать файл»). Translate identical English headings identically on every page; different English headings on the same page must stay different in Russian (en "Requirements" and "Dependencies" must not both become «Зависимости»). Never change the anchor hash.
+
+### Typography
+
+* Use Russian guillemets «…» for quotes in prose, not straight quotes "…" or '…': «под капотом», «закрепить», «продвинутыми». Never change quotes inside inline code, code blocks, URLs, or file paths.
+* Use the em dash « — » in prose, including as the copula where English uses "is": «**FastAPI CLI** — это программа…», not «**FastAPI CLI** - это программа…». Use the hyphen «-» only inside compound words (sole exception: the fixed title «Учебник - Руководство пользователя» keeps its spaced hyphen — see the glossary).
+* The only hyphen character allowed is the ASCII hyphen-minus «-» (U+002D). Never use the non-breaking hyphen (U+2011): write «что-то», «HTTP-заголовок», «из-за», not «что‑то», «HTTP‑заголовок», «из‑за» — U+2011 breaks in-page text search.
+* Follow standard Russian comma rules: «Вы уже видели, как тестировать…»; «Чтобы обеспечить их срабатывание, используйте…»; no spurious comma between a fronted object and the subject that follows it («Так что выбор версии Starlette можно просто оставить за FastAPI», not «Так что решение об используемой версии Starlette, вы можете оставить FastAPI»).
+* Do not produce double periods or double spaces: «…и т.д. Эти изменения», not «…и т.д.. Эти изменения».
+* Do not copy English Title Case capitalization mid-sentence: «модель машинного обучения», «семантическое версионирование» (capitalize glossary terms only at the start of a sentence or in a heading).
+
+### Markdown structure
+
+* Preserve every **bold** and *italic* of the original — translate the emphasized words and keep the markers: "from my very **subjective** point of view" → «с моей очень **субъективной** точки зрения». Do not drop emphasis, and do not add emphasis, quotes, or code formatting that the original does not have (no «…» around headings).
+* Keep inline code in backticks exactly as in the original: `fastapi.status` must stay in backticks; never alter code blocks, URLs, or file paths.
+* Keep list markers and indentation exactly as in the original: `*` stays `*`, `-` stays `-`, and nested list items keep 4 spaces of indentation per level (with 2 spaces python-markdown renders the hierarchy flat).
+* Keep blank lines exactly as in the original, including the blank line after code-include macros like `{* ... *}`.
+
+### Links
+
+Never change link targets. When the link text is the title of another documentation page or section, use the exact Russian title of that target as it appears on that page: a link to `tutorial/encoder.md` reads «JSON-совместимый кодировщик», a link to `tutorial/bigger-applications.md` reads «Большие приложения — несколько файлов». Translate identical link texts identically on every page.
+
+### /// admonitions
+
+Keep the admonition keyword in English. When the English admonition has no title of its own, use exactly these Russian titles on every page (no variants):
+
+* `/// note` → `/// note | Примечание`
+* `/// tip` → `/// tip | Совет`
+* `/// warning` → `/// warning | Предупреждение`
+* `/// info` → `/// info | Информация`
+* `/// danger` → `/// danger | Осторожно`
+* `/// check` → `/// check | Проверка`
+
+When the English admonition already has its own title, translate that title instead of using the generic one, and translate identical titles identically on every page. Translate "Technical Details" in any casing or variant as «Технические детали»: `/// note | Technical Details` and `/// note | Technical details` → `/// note | Технические детали`, `/// note | Very Technical Details` → `/// note | Очень технические детали`, `/// note | Starlette Technical Details` → `/// note | Технические детали Starlette`. Other examples: `/// tip | Inspired **FastAPI** to` → `/// tip | Вдохновило **FastAPI** на`, `/// tip | Authorize button!` → `/// tip | Кнопка авторизации!`.
+
+Do not use «Подсказка», «Внимание», «Заметка», «Технические подробности».
+
+### Mermaid diagrams
+
+Translate all human-readable display text inside mermaid diagrams completely and consistently — notes, messages, and display labels (the text after a colon or introduced with `as`): "Note over Server: Server interprets headers" → «Note over Server: Сервер интерпретирует заголовки». Never translate the identifiers themselves — participant and node names like `Server` in `Note over Server:` must stay exactly as in the original, or the diagram stops rendering. Do not leave a diagram half-translated or mix languages in one label («с корректными HTTPS-URL», not «с верными HTTPS URLs»).
+
+### Terms
+
+For the following technical terms, use these specific translations to ensure consistency and clarity across the documentation. Use these translations, do not invent your own. The rules above and this glossary are both binding; if a general rule and a specific glossary entry conflict, the glossary entry wins. Both take precedence over an existing translation: if an existing translation uses a different term, spelling, quote style, or admonition title, update it to match this prompt. Translate the same English term with the same Russian term throughout a page and across pages — do not alternate synonyms («пользовательский» in one paragraph and «кастомный» in the next). When an entry lists an alternative translation, the first one is the default; use the alternative only in the context the entry states.
+
+* production (meaning production software or environment): продакшен (spelled with «е», like «ресепшен», «промоушен»; not «продакшн»; decline normally: «в продакшене»; translate "production applications" as «продакшен-приложения», not «приложения в продакшн»)
 * completion (meaning code auto-completion): автозавершение
 * editor (meaning component of IDE): редактор кода
 * adopt (meaning start to use): использовать (or `начать использовать`)
@@ -18,15 +85,15 @@ For the following technical terms, use these specific translations to ensure con
 * cookie sessions: сессии с использованием cookie
 * tested (adjective): протестированный
 * middleware: middleware (don't translate, but add `промежуточный слой` if clarification is needed)
-* path operation: операция пути (optionally clarify as `обработчик пути`)
+* path operation: операция пути (plural: «операции пути», not «операций путей»; optionally clarify as `обработчик пути`)
 * path operation function: функция-обработчик пути (or `функция обработки пути`)
 * proprietary: проприетарный
 * benchmark: бенчмарк (add (`тест производительности`) if clarification is needed or use just `тест производительности`)
 * ASGI server: ASGI-сервер
 * In a hurry? : Нет времени?
 * response status code: статус-код ответа
-* HTTP status code: HTTP статус-код
-* issue (meaning GitHub issue): Issue (add `тикет\обращение` if clarification is needed)
+* HTTP status code: HTTP-статус-код (hyphenated throughout, per the compound rule above; existing pages write «HTTP статус-код» — update it)
+* issue (meaning GitHub issue): Issue (add `тикет/обращение` if clarification is needed — with a slash, not a backslash)
 * PR (meaning GitHub pull request): пулл-реквест (add `запрос на изменение` if clarification is needed)
 * run (meaning run the code): запустить (or `прогнать` if it's about testing the program)
 * to reach users: донести до пользователей (or `привлечь внимание пользователей` in the promotion context)
@@ -34,7 +101,7 @@ For the following technical terms, use these specific translations to ensure con
 * body (meaning HTTP response body): тело ответа
 * body parameter : body-параметр (or `параметр тела запроса`)
 * validate: валидировать (or `выполнить валидацию`)
-* requirements (meaning dependencies): зависимости
+* requirements (meaning dependencies): зависимости (but translate a "Requirements" heading as «Требования» when the same page also has a "Dependencies" heading, so the two stay distinct)
 * auto-reload: авто-перезагрузка (or `перезагрузить автоматически` if used as a verb)
 * show (meaning show on the screen): отобразить
 * parsing (noun): парсинг
@@ -42,10 +109,10 @@ For the following technical terms, use these specific translations to ensure con
 * include: включать (add `в себя` if it's appropriate, or use `содержать` as an alternative)
 * virtual environment: виртуальное окружение
 * framework: фреймворк
-* path paremeter: path-параметр
+* path parameter: path-параметр
 * path (as in URL path): путь
 * form (as in HTML form): форма
-* media type: тип содержимого (or `медиа-тип`)
+* media type: тип содержимого
 * request: HTTP-запрос
 * response: HTTP-ответ
 * type hints: аннотации типов
@@ -65,23 +132,23 @@ For the following technical terms, use these specific translations to ensure con
 * full stack: full stack (do not translate)
 * full-stack: full-stack (do not translate)
 * loop (as in async loop): цикл событий
-* Machine Learning: Машинное обучение
-* Deep Learning: Глубокое обучение
+* Machine Learning: машинное обучение (capitalize only at the start of a sentence or in a heading: «модель машинного обучения» mid-sentence)
+* Deep Learning: глубокое обучение (same capitalization rule)
 * callback hell: callback hell (clarify as `ад обратных вызовов`)
 * on the fly: на лету
 * scratch the surface: поверхностно ознакомиться
-* tip: совет (or `подсказка` depending on context)
-* Pydantic model: Pydantic-модель (`модель Pydantic` and `Pydantic модель` are also fine)
+* tip: совет (never «подсказка»)
+* Pydantic model: Pydantic-модель (use `модель Pydantic` only where the declined form reads more naturally; never «Pydantic модель» — see the word-order rule)
 * declare: объявить
 * have the next best performance, after: быть на следующем месте по производительности после
 * timing attack: тайминговая атака (clarify `атака по времени` if needed)
 * OAuth2 scope: OAuth2 scope (clarify `область` if needed)
-* TLS Termination Proxy: прокси-сервер TSL-терминации
+* TLS Termination Proxy: прокси-сервер TLS-терминации
 * utilize (resources): использовать
-* сontent: содержимое (or `контент`)
-* raise exception: вызвать исключение (also possible to use `сгенерировать исключение` or `выбросить исключение`)
+* content: содержимое (not «контент»)
+* raise exception: выбросить исключение (do not use «вызвать» next to «возвращать»/«вызывать функцию», where it reads as "call")
 * password flow: password flow (clarify as `аутентификация по паролю` if needed)
-* tutorial: руководство (or `учебник`)
+* tutorial: руководство (use `учебник` only in the fixed title «Учебник - Руководство пользователя»)
 * too long; didn't read: слишком длинно; не читал
 * proxy with a stripped path prefix: прокси с функцией удаления префикса пути
 * nerd: умник
@@ -91,11 +158,32 @@ For the following technical terms, use these specific translations to ensure con
 * recap (noun): резюме
 * utility function: вспомогательная функция
 * fast to code: позволяет быстро писать код
-* Tutorial - User Guide: Учебник - Руководство пользователя
+* Tutorial - User Guide: Учебник - Руководство пользователя (use exactly this form with a hyphen; do not replace the hyphen with an em dash)
 * submodule: подмодуль
 * subpackage: подпакет
 * router: роутер
-* building, deploying, accessing (when describing features of FastAPI Cloud): созданиe образа, развертывание и доступ
+* building, deploying, accessing (when describing features of FastAPI Cloud): создание, развёртывание и доступ
 * type checker tool: инструмент проверки типов
+* backend: бэкенд (not «бекэнд»)
+* custom (as in custom response, custom class): пользовательский (not «кастомный»)
+* deployment: развёртывание (with «ё»; not «деплой», not «развертывание»)
+* WebSocket: веб-сокет (not «вебсокет»); WebSocket connection: WebSocket-соединение (or `соединение по веб-сокету`; not «веб-сокет соединение» — in hyphenated compounds the protocol name keeps its Latin spelling)
+* `with` statement: оператор `with` (not «менеджер контекста `with`» — a `with` statement is not a context manager)
+* parse (e.g. a request body): распарсить / разобрать (e.g. «тело запроса распарсено как JSON»; not «обработано» — that blurs parse vs. process)
+* cookies (plural, in prose): cookies (use this plural form consistently, not invariant «cookie»)
+* stream (verb, about sending a file/response): передавать потоком (e.g. "Asynchronously streams a file as the response" → «Асинхронно передаёт файл потоком в качестве ответа»; not simply «отправляет»)
+* testing or automation workflows: рабочие процессы тестирования и автоматизации (not «воркфлоу»)
+* as you normally would: как обычно (not «как и раньше»)
+* Semantic Versioning: семантическое версионирование (lowercase mid-sentence)
+* input location (e.g. the path passed to a generator's `-i`): путь к входному файлу (not «входное расположение»)
+* Global view (section heading): Общий обзор (not «Взгляд издалека»)
+* query parameter: query-параметр (not «параметр запроса», which reads as "request parameter")
+* Dependency Injection: внедрение зависимостей (not «встраивание зависимостей»; lowercase mid-sentence)
+* keyword arguments: именованные аргументы (not «ключевые аргументы»)
+* hash / hashed / hashing: хеш / хешированный / хеширование (never «хэш»)
+* directory: директория (use consistently; do not alternate with «каталог» and «папка»)
+* open source (adjective): с открытым исходным кодом ("the first open-source release" → «первый релиз с открытым исходным кодом», not «открытый релиз»)
+* Blueprints (Flask): Blueprints (do not translate as «шаблоны» — those are Flask templates, a different mechanism)
+* Advanced User Guide: Расширенное руководство пользователя (exactly the RU title of advanced/index.md; not «Продвинутое руководство пользователя»)
 
 Do not add whitespace in `т.д.`, `т.п.`.


### PR DESCRIPTION
## What this is

I compared all 123 Russian doc pages against their English originals and logged 271 findings (44 mistranslations, 66 terminology, 129 style, 26 markdown, 4 links, 2 outdated). Most of them are systematic — the same defect repeats across many pages because it originates in `docs/ru/llm-prompt.md` (or in a gap in it). Per the [translations policy](https://fastapi.tiangolo.com/contributing/#translations), the right fix is to improve the prompt and regenerate the affected pages, not to hand-edit translations, so this PR only touches `docs/ru/llm-prompt.md`.

## Bugs in the current prompt itself

* The glossary entry for TLS Termination Proxy contains a typo: `прокси-сервер TSL-терминации`. It has already propagated 8 times into `deployment/docker.md` (5×) and `deployment/concepts.md` (3×) — while `deployment/https.md` correctly says «TLS», so both spellings now coexist in the docs.
* The entry `building, deploying, accessing (when describing features of FastAPI Cloud): созданиe образа, развертывание и доступ` mandates a mistranslation: "It streamlines the process of **building**, **deploying**, and **accessing** an API" became «Он упрощает процесс **создания образа**, **развертывания** и **доступа** к API» on `tutorial/first-steps.md`, `deployment/cloud.md` and `deployment/fastapicloud.md` — "building an API" means creating the API, not building a container image. The same entry also contains a Latin «e» inside the Russian word «созданиe».
* The key of the `сontent` entry starts with a Cyrillic «с» (U+0441), which defeats term matching; `path paremeter` is misspelled; the backslash in `тикет\обращение` leaked verbatim into `alternatives.md` («Issue (тикет\обращение)»).
* The rule «продакшн (do not change the ending)» produces ungrammatical Russian in oblique cases: «готов к продакшн» (`index.md`), «используется в продакшн» (`deployment/versions.md`).
* «tip: совет (or `подсказка` depending on context)» legitimizes the current admonition mess: the same `/// tip` is titled «Совет» on some pages and «Подсказка» on others (likewise «Предупреждение»/«Внимание» for `/// warning`).

## Systematic error classes the new rules target

Each rule is grounded in concrete findings; the strongest examples:

* **Meaning inversions.** `tutorial/cors.md`: "A list of origins that should be permitted to make cross-origin requests" → «Список источников, **на которые** разрешено выполнять кросс-доменные запросы» (direction inverted). `tutorial/server-sent-events.md`: "Non-async" → «несинхронные» (reads as "asynchronous", the opposite). `tutorial/path-params.md`: "gives you automatic request 'parsing'" → «выполняет автоматический HTTP-запрос "парсинг"» (broken syntax, object of parsing lost).
* **Untranslated leftovers and mixed scripts.** `tutorial/body.md`: «…указывающую, где именно and что было некорректно» (English "and" left in the middle of a Russian sentence); «полезнa» with a Latin «a» (`advanced/async-tests.md`); «Pythonу» — a Cyrillic case ending glued to a Latin word (`advanced/security/http-basic-auth.md`).
* **Calques and dangling participles.** "By adding a star…" translated as «Добавив звезду, другим пользователям будет проще…» (subject-less деепричастный оборот); «сделали способ запускать» for "built a way to run" (`advanced/strict-content-type.md`); «FastAPI приложение» word order throughout `advanced/async-tests.md`.
* **Lost emphasis (not fixable by hand-edits, only by regeneration).** `advanced/openapi-webhooks.md` drops nearly every bold/italic of the original: "**you define** in your code … the **body of the request**" is rendered as plain text; ~15 pages have the same defect. New rule: preserve `**bold**`/`*italic*` exactly, translate the emphasized words.
* **Broken list nesting.** `advanced/security/oauth2-scopes.md` re-indented the dependency-tree list from 4 spaces per level to 2, so python-markdown renders the 8-level hierarchy completely flat (a point fix is in a separate PR; the new rule prevents regressions: keep markers and 4-space indentation exactly).
* **Non-breaking hyphen U+2011.** The generator emits U+2011 instead of the ASCII hyphen: 262 occurrences across 31 Russian pages today («что‑то», «HTTP‑заголовок», «из‑за»), often mixed with U+002D in identical contexts on the same line («какой-то» next to «что‑то»). It breaks in-page search (Ctrl+F) and produces noisy diffs. New rule: the only hyphen allowed is U+002D.
* **Terminology drift within and across pages.** "custom" → «кастомный»/«пользовательский» on the same page (`advanced/custom-response.md`); "directory" → «директория»/«каталог»/«папка» in one section (`virtual-environments.md`); «хеш»/«хэш» mixed in one sentence (`tutorial/security/oauth2-jwt.md`); "Advanced User Guide" → «Продвинутое руководство пользователя» in `tutorial/index.md` while the actual page title is «Расширенное руководство пользователя»; link texts not matching the RU titles of their target pages.

## What the prompt update adds

* **Grammar and tone**: natural word order («приложение FastAPI»), hyphenated compounds («SQL-база данных»), no mixed scripts, no stray English words, no dangling participles, modality preserved ("could" ≠ «будет»), «вы» lowercase, consistent «ё».
* **Headings**: noun-style, identical EN headings → identical RU headings, distinct EN headings stay distinct, anchors untouched.
* **Typography**: guillemets, em dash, the U+2011 ban, no double periods/spaces, no Title Case mid-sentence.
* **Markdown structure**: preserve bold/italic, inline code, list markers, 4-space nesting, blank lines around code-include macros.
* **Links**: link text = the exact RU title of the target page/section.
* **/// admonitions**: one canonical title per type («Совет», «Предупреждение», «Примечание», …), rules for admonitions with their own titles.
* **Mermaid diagrams**: translate fully, never half-translate a diagram.
* **Glossary**: fixes for the broken entries above plus new entries observed as unstable in the corpus (query parameter, Dependency Injection, keyword arguments, hash, directory, open source, WebSocket, backend, custom, deployment, `with` statement, parse, and others), and explicit precedence rules: rules and glossary win over existing translations, and a specific glossary entry wins over a general rule if they ever conflict. Entries that list an alternative translation now designate the first form as the default, with the alternative allowed only in the stated context (e.g. «учебник» only inside the fixed title «Учебник - Руководство пользователя»), so the no-alternation rule and the glossary agree.

## Regeneration request

Once this lands, I'd ask for regeneration of the pages where the findings concentrate:

`deployment/docker.md`, `deployment/concepts.md`, `deployment/cloud.md`, `deployment/fastapicloud.md`, `deployment/versions.md`, `deployment/server-workers.md`, `advanced/security/http-basic-auth.md`, `advanced/security/oauth2-scopes.md`, `advanced/async-tests.md`, `advanced/websockets.md`, `advanced/strict-content-type.md`, `advanced/generate-clients.md`, `advanced/behind-a-proxy.md`, `advanced/events.md`, `advanced/middleware.md`, `advanced/index.md`, `alternatives.md`, `benchmarks.md`, `history-design-future.md`, `fastapi-cli.md`, `help-fastapi.md`, `environment-variables.md`, `features.md`, `index.md`, `python-types.md`, `how-to/general.md`, `tutorial/first-steps.md`, `tutorial/path-params.md`, `tutorial/body.md`, `tutorial/body-multiple-params.md`, `tutorial/cors.md`, `tutorial/testing.md`, `tutorial/background-tasks.md`, `tutorial/bigger-applications.md`, `tutorial/dependencies/index.md`, `tutorial/dependencies/sub-dependencies.md`, `tutorial/header-params.md`, `tutorial/frontend.md`, `tutorial/query-param-models.md`, `tutorial/response-status-code.md`, `tutorial/security/oauth2-jwt.md`, `tutorial/server-sent-events.md`, `tutorial/sql-databases.md`

Two of these are also simply outdated: `tutorial/frontend.md` is missing the whole "Dependencies and Middleware" section added in 0.139.0, and `tutorial/header-params.md` still contains a sentence from the pre-`Annotated` English text ("Первое значение является значением по умолчанию…").

Russian-speaking reviewers: please check the rules and the glossary — especially the opinionated choices («директория» over «каталог», «хеш» over «хэш», «Совет» as the only title for `/// tip`, the headword «продакшен» declined normally («в продакшене»), and «HTTP-статус-код» hyphenated throughout for consistency with the other Latin+Russian compounds — current pages write «HTTP статус-код» and «продакшн», so both choices imply updates on regeneration). Happy to adjust to whatever the native-speaker consensus is.
