### PR TITLE
⬆️ Update issue-manager to 0.8.1

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -29,6 +29,6 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - uses: tiangolo/issue-manager@75d60679db1ea348f6f6ea1d0e20de80a7c04645 # 0.7.1
+      - uses: tiangolo/issue-manager@dc846170c36eb62fb434b3d943b36399fe240fb5 # 0.8.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Update the `tiangolo/issue-manager` GitHub Action pin to `0.8.1`.

This picks up the action runtime fix so the Docker action uses its baked-in virtual environment instead of letting `uv run` inspect the consumer repository Python version configuration.

## Checks

- `yq '.jobs' .github/workflows/issue-manager.yml`
- `git diff --check`

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
