### PR TITLE
📝 Add API reference page for fastapi.sse

### DIFF
--- a/docs/en/docs/reference/sse.md
+++ b/docs/en/docs/reference/sse.md
@@ -1,0 +1,17 @@
+# Server-Sent Events - `EventSourceResponse` and `ServerSentEvent`
+
+To stream Server-Sent Events (SSE), use `yield` in your *path operation function* and set `response_class=EventSourceResponse`.
+
+If you need to set SSE fields like `event`, `id`, `retry`, or `comment`, you can `yield` `ServerSentEvent` objects instead of plain data.
+
+Read more about it in the [FastAPI docs for Server-Sent Events (SSE)](https://fastapi.tiangolo.com/tutorial/server-sent-events/).
+
+You can import them directly from `fastapi.sse`:
+
+```python
+from fastapi.sse import EventSourceResponse, ServerSentEvent
+```
+
+::: fastapi.sse.EventSourceResponse
+
+::: fastapi.sse.ServerSentEvent

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -213,6 +213,7 @@ nav:
   - reference/httpconnection.md
   - reference/response.md
   - reference/responses.md
+  - reference/sse.md
   - reference/middleware.md
   - "":
     - reference/openapi/index.md


### PR DESCRIPTION
The new SSE support (`EventSourceResponse` and `ServerSentEvent` in `fastapi.sse`) is already covered in the tutorial, but it doesn't have a dedicated page in the API Reference like the other public modules (such as `responses`, `websockets`, and `templating`).

This PR adds a new `docs/en/docs/reference/sse.md` page following the same pattern as the existing reference pages. It includes `:::` directives for `EventSourceResponse` and `ServerSentEvent`, and adds the page to the navigation alongside the other response-related reference pages.

I didn't include `format_sse_event` for now because the tutorial currently documents only the two public classes. If you'd prefer it to be part of the API reference as well, I'm happy to add it.

I also verified that the documentation builds successfully locally without any warnings, and the generated page correctly picks up the existing docstrings and `Doc()` annotations.
