### PR TITLE
👷 Fix notify translations checkout target

### DIFF
--- a/.github/workflows/notify-translations.yml
+++ b/.github/workflows/notify-translations.yml
@@ -32,6 +32,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
## What changed

- Configure the `notify-translations` workflow checkout step to use the repository default branch explicitly.
- This keeps `pull_request_target` runs on trusted base-repository code when `actions/checkout@v7` is used.

## Why

`actions/checkout@v7` refuses fork PR code in trusted `pull_request_target` contexts. The workflow only needs trusted repository code to run the notification script/action.

## Validation

- Ran `git diff --check` for the changed workflow.

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
