### PR TITLE
🐛 Fix copy button copying HTML tags from termynal command lines

### DIFF
--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -85,7 +85,9 @@ function setupTermynal() {
                     .filter(line => line.type === "input")
                     .map(line => line.value)
                     .join("\n");
-                node.textContent = inputCommands;
+                const plainTextExtractor = document.createElement("div");
+                plainTextExtractor.innerHTML = inputCommands;
+                node.textContent = plainTextExtractor.textContent;
                 const div = document.createElement("div");
                 node.style.display = "none";
                 node.after(div);


### PR DESCRIPTION
I reported this bug in this discussion: https://github.com/fastapi/fastapi/discussions/15700

**Issue**: on several docs pages, the copy button on termynal terminal blocks copies HTML styling tags into the clipboard instead of the plain shell command. For example, on https://fastapi.tiangolo.com/fastapi-cli/ copying the first terminal block gives `<font color="#4E9A06">fastapi</font> dev` instead of `fastapi dev`.

**Fix**: the command lines in the markdown can contain HTML styling tags (e.g. `<font color="...">`). `custom.js` builds a hidden `code` element with the raw input lines for the copy button to read, so the tags end up in the clipboard. This change extracts only the plain text when building that element, the same way Termynal itself does when typing the command lines. This keeps the formatting in the markdown source (so it can still be rendered in the future) and fixes all translated docs at once.

**Testing**: tested locally with the docs live server on all the affected pages (`/fastapi-cli/`, `/tutorial/`, `/tutorial/first-steps/`, `/deployment/manually/`, `/deployment/server-workers/`), including commands that also contain `<u>` tags. The copy button now copies clean commands and the terminal animation renders as before.

Made with [Cursor](https://cursor.com)