### PR TITLE
docs: fix grammar in handling-errors.md

### DIFF
--- a/docs/en/docs/tutorial/handling-errors.md
+++ b/docs/en/docs/tutorial/handling-errors.md
@@ -229,7 +229,7 @@ But when you register an exception handler, you should register it for Starlette
 
 This way, if any part of Starlette's internal code, or a Starlette extension or plug-in, raises a Starlette `HTTPException`, your handler will be able to catch and handle it.
 
-In this example, to be able to have both `HTTPException`s in the same code, Starlette's exceptions is renamed to `StarletteHTTPException`:
+In this example, to be able to have both `HTTPException`s in the same code, Starlette's exceptions are renamed to `StarletteHTTPException`:
 
 ```Python
 from starlette.exceptions import HTTPException as StarletteHTTPException


### PR DESCRIPTION
## Description

Fixed a grammar error in the handling-errors tutorial.

## Change

Changed 'exceptions is renamed' to 'exceptions are renamed' for correct subject-verb agreement.

## Checklist

- [x] Documentation fix
- [x] Grammar correction
- [x] No code changes