### PR TITLE
fix(sse): emit data field for empty SSE data payload

### DIFF
--- a/fastapi/sse.py
+++ b/fastapi/sse.py
@@ -213,7 +213,9 @@ def format_sse_event(
         lines.append(f"event: {event}")
 
     if data_str is not None:
-        for line in data_str.splitlines():
+        # An empty data payload must still emit a single `data:` field;
+        # `"".splitlines()` returns `[]`, which would drop the field entirely.
+        for line in data_str.splitlines() or [""]:
             lines.append(f"data: {line}")
 
     if id is not None:

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -264,6 +264,14 @@ def test_data_and_raw_data_mutually_exclusive():
         ServerSentEvent(data="json", raw_data="raw")
 
 
+def test_format_sse_event_empty_data_str():
+    """An empty data payload must still emit a single `data:` field and the
+    `\\n\\n` event terminator (`"".splitlines()` would otherwise drop it)."""
+    from fastapi.sse import format_sse_event
+
+    assert format_sse_event(data_str="") == b"data: \n\n"
+
+
 def test_sse_on_router_included_in_app(client: TestClient):
     response = client.get("/api/events")
     assert response.status_code == 200


### PR DESCRIPTION
## What's broken
`format_sse_event()` drops the `data:` field entirely when the data payload is an empty string. It builds data lines via `data_str.splitlines()`, and `"".splitlines()` returns `[]`, so the loop never runs. Yielding `ServerSentEvent(raw_data="")` from an SSE endpoint produces a malformed event with no `data:` line and a single `\n` instead of the documented `\n\n` terminator, so clients can't recognize it as a discrete event.

```python
format_sse_event(data_str="")   # before: b'\n'   (expected b'data: \n\n')
```

## Why it happens
`str.splitlines()` returns `[]` for `""`, conflating an empty-but-present data payload with the "no data" (`None`) case, even though they're distinct.

## Fix
Emit a single empty `data:` line when the payload is the empty string (`data_str.splitlines() or [""]`), leaving the `None` case untouched.

## Test
Added `test_format_sse_event_empty_data_str` asserting `format_sse_event(data_str="") == b"data: \n\n"`. Fails before, passes after; full SSE suite (25) green.
