### PR TITLE
Fix outdated on_event reference in async tests docs

### DIFF
--- a/docs/en/docs/advanced/async-tests.md
+++ b/docs/en/docs/advanced/async-tests.md
@@ -94,6 +94,6 @@ As the testing function is now asynchronous, you can now also call (and `await`)
 
 /// tip
 
-If you encounter a `RuntimeError: Task attached to a different loop` when integrating asynchronous function calls in your tests (e.g. when using [MongoDB's MotorClient](https://stackoverflow.com/questions/41584243/runtimeerror-task-attached-to-a-different-loop)), remember to instantiate objects that need an event loop only within async functions, e.g. an `@app.on_event("startup")` callback.
+If you encounter a `RuntimeError: Task attached to a different loop` when integrating asynchronous function calls in your tests (e.g. when using [MongoDB's MotorClient](https://stackoverflow.com/questions/41584243/runtimeerror-task-attached-to-a-different-loop)), remember to instantiate objects that need an event loop only within async functions, e.g. an async `lifespan` handler.
 
 ///


### PR DESCRIPTION
### Summary

The Async Tests page recommends instantiating event-loop-bound objects inside an `@app.on_event("startup")` callback to avoid a `RuntimeError: Task attached to a different loop`.

`on_event` is deprecated in favor of the `lifespan` parameter (see the Lifespan Events page). The same async-tests page already talks about "lifespan events" a few lines above (in the `AsyncClient` warning box), so the `on_event` mention is both outdated and inconsistent with the rest of the page.

This PR updates the tip to reference the `lifespan` handler instead, matching current FastAPI guidance.

### Checklist

- Verified `on_event` is documented as deprecated in `fastapi/routing.py`
- Verified no other English docs page has the same stale reference
- Ran the `typos` pre-commit hook against the changed file