### PR TITLE
🐛 Fix race condition in _IncludedRouter cache rebuild under concurrent first requests

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import os
 import stat
+import threading
 import types
 from collections.abc import (
     AsyncIterator,
@@ -1579,49 +1580,60 @@ class _IncludedRouter(BaseRoute):
         default_factory=list
     )
     _effective_low_priority_routes_version: int | None = None
+    _rebuild_lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
 
     def effective_candidates(self) -> list["_EffectiveRouteContext | _IncludedRouter"]:
         routes_version = self.original_router._get_routes_version()
         if routes_version == self._effective_candidates_version:
             return self._effective_candidates
-        self._effective_candidates = []
-        candidates = self.original_router.routes
-        for route in candidates:
-            if isinstance(route, _IncludedRouter):
-                child_context = self.include_context.combine(route.include_context)
-                child_branch = _IncludedRouter(
-                    original_router=route.original_router,
-                    include_context=child_context,
-                )
-                self._effective_candidates.append(child_branch)
-                continue
-            route_context = self._build_effective_context(route)
-            if route_context is not None:
-                self._effective_candidates.append(route_context)
-        self._effective_candidates_version = routes_version
-        return self._effective_candidates
+        with self._rebuild_lock:
+            if routes_version == self._effective_candidates_version:
+                return self._effective_candidates
+            effective_candidates: list[_EffectiveRouteContext | _IncludedRouter] = []
+            candidates = self.original_router.routes
+            for route in candidates:
+                if isinstance(route, _IncludedRouter):
+                    child_context = self.include_context.combine(route.include_context)
+                    child_branch = _IncludedRouter(
+                        original_router=route.original_router,
+                        include_context=child_context,
+                    )
+                    effective_candidates.append(child_branch)
+                    continue
+                route_context = self._build_effective_context(route)
+                if route_context is not None:
+                    effective_candidates.append(route_context)
+            self._effective_candidates = effective_candidates
+            self._effective_candidates_version = routes_version
+            return effective_candidates
 
     def effective_low_priority_routes(self) -> list["_EffectiveRouteContext"]:
         routes_version = self.original_router._get_routes_version()
         if routes_version == self._effective_low_priority_routes_version:
             return self._effective_low_priority_routes
-        self._effective_low_priority_routes = []
-        for route in self.original_router._low_priority_routes:
-            route_context = self._build_effective_context(route)
-            if route_context is not None:
-                self._effective_low_priority_routes.append(route_context)
-        for route in self.original_router.routes:
-            if isinstance(route, _IncludedRouter):
-                child_context = self.include_context.combine(route.include_context)
-                child_branch = _IncludedRouter(
-                    original_router=route.original_router,
-                    include_context=child_context,
-                )
-                self._effective_low_priority_routes.extend(
-                    child_branch.effective_low_priority_routes()
-                )
-        self._effective_low_priority_routes_version = routes_version
-        return self._effective_low_priority_routes
+        with self._rebuild_lock:
+            if routes_version == self._effective_low_priority_routes_version:
+                return self._effective_low_priority_routes
+            low_priority_routes: list[_EffectiveRouteContext] = []
+            for route in self.original_router._low_priority_routes:
+                route_context = self._build_effective_context(route)
+                if route_context is not None:
+                    low_priority_routes.append(route_context)
+            for route in self.original_router.routes:
+                if isinstance(route, _IncludedRouter):
+                    child_context = self.include_context.combine(route.include_context)
+                    child_branch = _IncludedRouter(
+                        original_router=route.original_router,
+                        include_context=child_context,
+                    )
+                    low_priority_routes.extend(
+                        child_branch.effective_low_priority_routes()
+                    )
+            self._effective_low_priority_routes = low_priority_routes
+            self._effective_low_priority_routes_version = routes_version
+            return low_priority_routes
 
     def _build_effective_context(
         self, route: BaseRoute

--- a/tests/test_included_router_concurrent_rebuild.py
+++ b/tests/test_included_router_concurrent_rebuild.py
@@ -1,5 +1,6 @@
 import sys
 import threading
+from typing import Any
 
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import _IncludedRouter
@@ -48,3 +49,66 @@ def test_concurrent_first_requests_do_not_corrupt_candidate_cache() -> None:
         route for route in app.router.routes if isinstance(route, _IncludedRouter)
     )
     assert len(included.effective_candidates()) == N_ROUTES
+
+
+def get_included_router(app: FastAPI) -> _IncludedRouter:
+    return next(
+        route for route in app.router.routes if isinstance(route, _IncludedRouter)
+    )
+
+
+class StampCacheOnEnter:
+    """Lock stand-in simulating another thread finishing the rebuild first.
+
+    Entering the lock stamps the cache and its version, the same state a
+    waiting thread observes after losing the rebuild race.
+    """
+
+    def __init__(
+        self,
+        included: _IncludedRouter,
+        list_attr: str,
+        version_attr: str,
+        cache: list,
+    ) -> None:
+        self.included = included
+        self.list_attr = list_attr
+        self.version_attr = version_attr
+        self.cache = cache
+
+    def __enter__(self) -> None:
+        version = self.included.original_router._get_routes_version()
+        setattr(self.included, self.list_attr, self.cache)
+        setattr(self.included, self.version_attr, version)
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+
+def test_candidates_rebuilt_while_waiting_for_lock_are_reused() -> None:
+    app = FastAPI()
+    router = APIRouter()
+    router.add_api_route("/a", lambda: {}, methods=["GET"])
+    app.include_router(router)
+    included = get_included_router(app)
+    cache: list = []
+    included._rebuild_lock = StampCacheOnEnter(  # type: ignore[assignment]
+        included, "_effective_candidates", "_effective_candidates_version", cache
+    )
+    assert included.effective_candidates() is cache
+
+
+def test_low_priority_routes_rebuilt_while_waiting_for_lock_are_reused() -> None:
+    app = FastAPI()
+    router = APIRouter()
+    router.add_api_route("/a", lambda: {}, methods=["GET"])
+    app.include_router(router)
+    included = get_included_router(app)
+    cache: list = []
+    included._rebuild_lock = StampCacheOnEnter(  # type: ignore[assignment]
+        included,
+        "_effective_low_priority_routes",
+        "_effective_low_priority_routes_version",
+        cache,
+    )
+    assert included.effective_low_priority_routes() is cache

--- a/tests/test_included_router_concurrent_rebuild.py
+++ b/tests/test_included_router_concurrent_rebuild.py
@@ -1,6 +1,6 @@
 import sys
 import threading
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import _IncludedRouter
@@ -92,9 +92,10 @@ def test_candidates_rebuilt_while_waiting_for_lock_are_reused() -> None:
     app.include_router(router)
     included = get_included_router(app)
     cache: list = []
-    included._rebuild_lock = StampCacheOnEnter(  # type: ignore[assignment]
+    fake_lock = StampCacheOnEnter(
         included, "_effective_candidates", "_effective_candidates_version", cache
     )
+    included._rebuild_lock = cast(threading.Lock, fake_lock)
     assert included.effective_candidates() is cache
 
 
@@ -105,10 +106,11 @@ def test_low_priority_routes_rebuilt_while_waiting_for_lock_are_reused() -> None
     app.include_router(router)
     included = get_included_router(app)
     cache: list = []
-    included._rebuild_lock = StampCacheOnEnter(  # type: ignore[assignment]
+    fake_lock = StampCacheOnEnter(
         included,
         "_effective_low_priority_routes",
         "_effective_low_priority_routes_version",
         cache,
     )
+    included._rebuild_lock = cast(threading.Lock, fake_lock)
     assert included.effective_low_priority_routes() is cache

--- a/tests/test_included_router_concurrent_rebuild.py
+++ b/tests/test_included_router_concurrent_rebuild.py
@@ -1,0 +1,50 @@
+import sys
+import threading
+
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import _IncludedRouter
+from fastapi.testclient import TestClient
+
+N_ROUTES = 120
+N_THREADS = 6
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    router = APIRouter()
+    for i in range(N_ROUTES):
+
+        def endpoint(i: int = i) -> dict[str, int]:
+            return {"i": i}
+
+        router.add_api_route(f"/r{i}", endpoint, methods=["GET"])
+    app.include_router(router)
+    return app
+
+
+def test_concurrent_first_requests_do_not_corrupt_candidate_cache() -> None:
+    app = build_app()
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-5)
+    try:
+        barrier = threading.Barrier(N_THREADS)
+        statuses: list[int] = []
+
+        def worker() -> None:
+            client = TestClient(app)
+            barrier.wait()
+            statuses.append(client.get(f"/r{N_ROUTES - 1}").status_code)
+
+        threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    assert statuses == [200] * N_THREADS
+    included = next(
+        route for route in app.router.routes if isinstance(route, _IncludedRouter)
+    )
+    assert len(included.effective_candidates()) == N_ROUTES


### PR DESCRIPTION
Fixes #15974. Also reported in discussion #15914.

## Problem

`_IncludedRouter.effective_candidates()` and `_IncludedRouter.effective_low_priority_routes()` rebuild their cached lists lazily with no synchronization. The rebuild publishes an empty list on the shared attribute before filling it and stamps the version afterwards. When several threads send the app's first requests concurrently (per-thread `TestClient`s in a parallel test suite, or any setup that serves one app object from multiple event loops), multiple threads pass the version check and append into the same list. The cache ends up permanently holding duplicated candidates (around 600 entries for a 120 route app in the repro), a concurrent reader can see a partially built list and 404 a valid route, and the interleaved `warnings.catch_warnings()` calls inside the rebuild can leak global warnings filters.

## Fix

Guard the rebuild with a per-instance lock and double-checked version test, build the new list into a local variable, and publish it atomically (list first, version second). Readers on the fast path never see a partial list, concurrent first requests trigger exactly one rebuild, and the warnings filter state is no longer touched by interleaved rebuilds of the same router.

The lock field is excluded from the dataclass `repr` and `eq` so existing semantics are unchanged.

## Tests

Added `tests/test_included_router_concurrent_rebuild.py`, which fires the first requests from several threads through a barrier and asserts that all requests succeed and that the cache holds exactly one candidate per route. It fails on master and passes with this change. All existing router and include tests pass.
