### PR TITLE
👷 Use `FASTAPI_LATEST_CHANGES` token in `bump-pre-commit-hooks` workflow

### DIFF
--- a/.github/workflows/bump-pre-commit-hooks.yml
+++ b/.github/workflows/bump-pre-commit-hooks.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ secrets.FASTAPI_PR_TOKEN }}
+          token: ${{ secrets.FASTAPI_LATEST_CHANGES }}
           persist-credentials: true
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -38,7 +38,7 @@ jobs:
         run: uv run prek auto-update --freeze --cooldown-days 7
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.FASTAPI_PR_TOKEN }}
+          GH_TOKEN: ${{ secrets.FASTAPI_LATEST_CHANGES }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Use `FASTAPI_LATEST_CHANGES` token in `bump-pre-commit-hooks` workflow as in other repositories.