### PR TITLE
Restore PEP 740 release attestations (lost in the uv migration)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,9 @@ jobs:
       - name: Build distribution
         run: uv build
       - name: Publish
-        run: uv publish
+        # gh-action-pypi-publish emits PEP 740 attestations by default under Trusted
+        # Publishing; `uv publish` does not generate them. Using it here restores the
+        # release provenance that fastapi published up to and including 0.128.0.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
Hi — thanks for FastAPI.

I noticed the published wheels lost their signed provenance in the switch to `uv`, and I don't think it was intended. Checking PyPI's integrity API:

| version | uploaded | `/integrity/.../provenance` |
| --- | --- | --- |
| 0.127.0 | 2025-12-21 | HTTP 200 — signed |
| 0.128.0 | 2025-12-27 | HTTP 200 — signed |
| **0.129.0** | 2026-02-12 | **HTTP 404 — none** |
| 0.139.0 (latest) | 2026-07-01 | HTTP 404 — none |

The first release without provenance is the first one after `⬆️ Migrate to uv (#14676)`. That commit replaced `pypa/gh-action-pypi-publish` (which emits PEP 740 attestations by default for Trusted Publishing projects) with `uv publish`, and uv's docs note it *"does not currently generate attestations."* The Trusted Publishing identity (`id-token: write`) is still configured, so it looks like only the emission step was dropped, silently — nothing fails in CI when attestations stop being produced, which is probably why it went unnoticed.

This PR keeps `uv build` and hands the upload back to `pypa/gh-action-pypi-publish`, which restores attestation emission. It's the one step, nothing else changes.

For a quick sanity check that the action still attests under Trusted Publishing: `huggingface/transformers` publishes this way and its wheels carry provenance today (`https://pypi.org/integrity/transformers/5.13.1/transformers-5.13.1-py3-none-any.whl/provenance` → 200).

I may be missing a reason `uv publish` was preferred here — if so, please just close this, no problem at all. If you'd rather keep `uv publish` and generate the attestations separately before upload, that works too; happy to adjust.

<sub>I used an AI assistant to trace this and prepare the change; it's credited in the commit trailer. I verified every step myself.</sub>
