### PR TITLE
fix: pass include/exclude/by_alias params to jsonable_encoder when no response_model

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -330,7 +330,15 @@ async def serialize_response(
         )
 
     else:
-        return jsonable_encoder(response_content)
+        return jsonable_encoder(
+            response_content,
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )
 
 
 async def run_endpoint_function(


### PR DESCRIPTION
## Summary

`serialize_response` receives `include`, `exclude`, `by_alias`, `exclude_unset`, `exclude_defaults`, and `exclude_none` parameters. When `field` is None (no `response_model`), it calls `jsonable_encoder(response_content)` without passing any of those filtering parameters. They are silently ignored.

A user who writes `@app.get("/items", response_model_include={"name", "id"})` without a `response_model` would expect the exclude to work, but it doesn't.

## Verification
- Not dead code: called on every non-streaming endpoint response when no response_model is set.
- All existing tests pair `response_model_include`/`response_model_exclude` with `response_model`.