### PR TITLE
fix: use None sentinel instead of mutable OAuthFlowsModel() default in OAuth2.__init__

### DIFF
--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -350,7 +350,7 @@ class OAuth2(SecurityBase):
                 The dictionary of OAuth2 flows.
                 """
             ),
-        ] = OAuthFlowsModel(),
+        ] = None,
         scheme_name: Annotated[
             str | None,
             Doc(
@@ -392,6 +392,8 @@ class OAuth2(SecurityBase):
             ),
         ] = True,
     ):
+        if flows is None:
+            flows = OAuthFlowsModel()
         self.model = OAuth2Model(
             flows=cast(OAuthFlowsModel, flows), description=description
         )


### PR DESCRIPTION
## Summary

`OAuth2.__init__` uses `OAuthFlowsModel()` as a mutable default argument. Every call to `OAuth2()` without explicit `flows` shares the same `OAuthFlowsModel` instance. Mutations to that instance propagate across all default-using instances.

Changed to `None` sentinel with `if flows is None: flows = OAuthFlowsModel()` inside the function body.

## Verification
- Called whenever OAuth2 is instantiated without explicit flows.
- Consistent with how `SecurityScopes` (same file, line 666) handles scopes defaults.