### PR TITLE
fix: pass include/exclude/custom_encoder in jsonable_encoder BaseModel recursive call

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -252,8 +252,13 @@ def jsonable_encoder(
         )
         return jsonable_encoder(
             obj_dict,
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
+            custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
         )
     if dataclasses.is_dataclass(obj):


### PR DESCRIPTION
Summary: When jsonable_encoder receives a BaseModel instance, it calls obj.model_dump() then makes a recursive call that silently drops custom_encoder, include, exclude, by_alias, and exclude_unset. The dataclass branch correctly passes all these parameters.

Verification:
- Not dead code: jsonable_encoder is called from serialize_response and is a documented public API.
- The existing test_custom_encoders test uses a TypedDict, not a BaseModel.
- custom_encoder is clearly a bug - it cannot affect nested values inside a BaseModel with the current code.