### PR TITLE
📝 Fix topic repository list not being displayed and `skip_users` not being applied

### DIFF
--- a/docs/en/data/skip_users.yml
+++ b/docs/en/data/skip_users.yml
@@ -1,5 +1,6 @@
-- tiangolo
-- codecov
-- github-actions
-- pre-commit-ci
-- dependabot
+users:
+  - tiangolo
+  - codecov
+  - github-actions
+  - pre-commit-ci
+  - dependabot

--- a/docs/en/data/skip_users.yml
+++ b/docs/en/data/skip_users.yml
@@ -1,6 +1,6 @@
 users:
-  - tiangolo
-  - codecov
-  - github-actions
-  - pre-commit-ci
-  - dependabot
+- tiangolo
+- codecov
+- github-actions
+- pre-commit-ci
+- dependabot

--- a/docs/en/data/topic_repos.yml
+++ b/docs/en/data/topic_repos.yml
@@ -1,496 +1,496 @@
 repos:
-  - name: headroom
-    html_url: https://github.com/headroomlabs-ai/headroom
-    stars: 55017
-    owner_login: headroomlabs-ai
-    owner_html_url: https://github.com/headroomlabs-ai
-  - name: full-stack-fastapi-template
-    html_url: https://github.com/fastapi/full-stack-fastapi-template
-    stars: 43994
-    owner_login: fastapi
-    owner_html_url: https://github.com/fastapi
-  - name: Hello-Python
-    html_url: https://github.com/mouredev/Hello-Python
-    stars: 36226
-    owner_login: mouredev
-    owner_html_url: https://github.com/mouredev
-  - name: serve
-    html_url: https://github.com/jina-ai/serve
-    stars: 21862
-    owner_login: jina-ai
-    owner_html_url: https://github.com/jina-ai
-  - name: HivisionIDPhotos
-    html_url: https://github.com/Zeyi-Lin/HivisionIDPhotos
-    stars: 21212
-    owner_login: Zeyi-Lin
-    owner_html_url: https://github.com/Zeyi-Lin
-  - name: Douyin_TikTok_Download_API
-    html_url: https://github.com/Evil0ctal/Douyin_TikTok_Download_API
-    stars: 18599
-    owner_login: Evil0ctal
-    owner_html_url: https://github.com/Evil0ctal
-  - name: sqlmodel
-    html_url: https://github.com/fastapi/sqlmodel
-    stars: 18156
-    owner_login: fastapi
-    owner_html_url: https://github.com/fastapi
-  - name: fastapi-best-practices
-    html_url: https://github.com/zhanymkanov/fastapi-best-practices
-    stars: 17608
-    owner_login: zhanymkanov
-    owner_html_url: https://github.com/zhanymkanov
-  - name: SurfSense
-    html_url: https://github.com/MODSetter/SurfSense
-    stars: 15161
-    owner_login: MODSetter
-    owner_html_url: https://github.com/MODSetter
-  - name: machine-learning-zoomcamp
-    html_url: https://github.com/DataTalksClub/machine-learning-zoomcamp
-    stars: 13445
-    owner_login: DataTalksClub
-    owner_html_url: https://github.com/DataTalksClub
-  - name: peewee
-    html_url: https://github.com/coleifer/peewee
-    stars: 11976
-    owner_login: coleifer
-    owner_html_url: https://github.com/coleifer
-  - name: fastapi_mcp
-    html_url: https://github.com/tadata-org/fastapi_mcp
-    stars: 11932
-    owner_login: tadata-org
-    owner_html_url: https://github.com/tadata-org
-  - name: XHS-Downloader
-    html_url: https://github.com/JoeanAmier/XHS-Downloader
-    stars: 11768
-    owner_login: JoeanAmier
-    owner_html_url: https://github.com/JoeanAmier
-  - name: awesome-fastapi
-    html_url: https://github.com/mjhea0/awesome-fastapi
-    stars: 11478
-    owner_login: mjhea0
-    owner_html_url: https://github.com/mjhea0
-  - name: polar
-    html_url: https://github.com/polarsource/polar
-    stars: 9999
-    owner_login: polarsource
-    owner_html_url: https://github.com/polarsource
-  - name: pycaret
-    html_url: https://github.com/pycaret/pycaret
-    stars: 9818
-    owner_login: pycaret
-    owner_html_url: https://github.com/pycaret
-  - name: FastUI
-    html_url: https://github.com/pydantic/FastUI
-    stars: 8970
-    owner_login: pydantic
-    owner_html_url: https://github.com/pydantic
-  - name: FileCodeBox
-    html_url: https://github.com/vastsa/FileCodeBox
-    stars: 8376
-    owner_login: vastsa
-    owner_html_url: https://github.com/vastsa
-  - name: nonebot2
-    html_url: https://github.com/nonebot/nonebot2
-    stars: 7593
-    owner_login: nonebot
-    owner_html_url: https://github.com/nonebot
-  - name: hatchet
-    html_url: https://github.com/hatchet-dev/hatchet
-    stars: 7441
-    owner_login: hatchet-dev
-    owner_html_url: https://github.com/hatchet-dev
-  - name: fastapi-users
-    html_url: https://github.com/fastapi-users/fastapi-users
-    stars: 6182
-    owner_login: fastapi-users
-    owner_html_url: https://github.com/fastapi-users
-  - name: Yuxi
-    html_url: https://github.com/xerrors/Yuxi
-    stars: 5926
-    owner_login: xerrors
-    owner_html_url: https://github.com/xerrors
-  - name: serge
-    html_url: https://github.com/serge-chat/serge
-    stars: 5723
-    owner_login: serge-chat
-    owner_html_url: https://github.com/serge-chat
-  - name: honcho
-    html_url: https://github.com/plastic-labs/honcho
-    stars: 5680
-    owner_login: plastic-labs
-    owner_html_url: https://github.com/plastic-labs
-  - name: Kokoro-FastAPI
-    html_url: https://github.com/remsky/Kokoro-FastAPI
-    stars: 5085
-    owner_login: remsky
-    owner_html_url: https://github.com/remsky
-  - name: devpush
-    html_url: https://github.com/hunvreus/devpush
-    stars: 4693
-    owner_login: hunvreus
-    owner_html_url: https://github.com/hunvreus
-  - name: strawberry
-    html_url: https://github.com/strawberry-graphql/strawberry
-    stars: 4677
-    owner_login: strawberry-graphql
-    owner_html_url: https://github.com/strawberry-graphql
-  - name: poem
-    html_url: https://github.com/poem-web/poem
-    stars: 4415
-    owner_login: poem-web
-    owner_html_url: https://github.com/poem-web
-  - name: logfire
-    html_url: https://github.com/pydantic/logfire
-    stars: 4340
-    owner_login: pydantic
-    owner_html_url: https://github.com/pydantic
-  - name: dynaconf
-    html_url: https://github.com/dynaconf/dynaconf
-    stars: 4310
-    owner_login: dynaconf
-    owner_html_url: https://github.com/dynaconf
-  - name: chatgpt-web-share
-    html_url: https://github.com/chatpire/chatgpt-web-share
-    stars: 4269
-    owner_login: chatpire
-    owner_html_url: https://github.com/chatpire
-  - name: huma
-    html_url: https://github.com/danielgtaylor/huma
-    stars: 4203
-    owner_login: danielgtaylor
-    owner_html_url: https://github.com/danielgtaylor
-  - name: atrilabs-engine
-    html_url: https://github.com/Atri-Labs/atrilabs-engine
-    stars: 4071
-    owner_login: Atri-Labs
-    owner_html_url: https://github.com/Atri-Labs
-  - name: mcp-context-forge
-    html_url: https://github.com/IBM/mcp-context-forge
-    stars: 3989
-    owner_login: IBM
-    owner_html_url: https://github.com/IBM
-  - name: datamodel-code-generator
-    html_url: https://github.com/koxudaxi/datamodel-code-generator
-    stars: 3952
-    owner_login: koxudaxi
-    owner_html_url: https://github.com/koxudaxi
-  - name: LitServe
-    html_url: https://github.com/Lightning-AI/LitServe
-    stars: 3901
-    owner_login: Lightning-AI
-    owner_html_url: https://github.com/Lightning-AI
-  - name: fastapi-admin
-    html_url: https://github.com/fastapi-admin/fastapi-admin
-    stars: 3799
-    owner_login: fastapi-admin
-    owner_html_url: https://github.com/fastapi-admin
-  - name: tracecat
-    html_url: https://github.com/TracecatHQ/tracecat
-    stars: 3703
-    owner_login: TracecatHQ
-    owner_html_url: https://github.com/TracecatHQ
-  - name: farfalle
-    html_url: https://github.com/rashadphz/farfalle
-    stars: 3535
-    owner_login: rashadphz
-    owner_html_url: https://github.com/rashadphz
-  - name: Rapid-MLX
-    html_url: https://github.com/raullenchai/Rapid-MLX
-    stars: 3155
-    owner_login: raullenchai
-    owner_html_url: https://github.com/raullenchai
-  - name: opyrator
-    html_url: https://github.com/ml-tooling/opyrator
-    stars: 3133
-    owner_login: ml-tooling
-    owner_html_url: https://github.com/ml-tooling
-  - name: docarray
-    html_url: https://github.com/docarray/docarray
-    stars: 3121
-    owner_login: docarray
-    owner_html_url: https://github.com/docarray
-  - name: fastapi-realworld-example-app
-    html_url: https://github.com/nsidnev/fastapi-realworld-example-app
-    stars: 3109
-    owner_login: nsidnev
-    owner_html_url: https://github.com/nsidnev
-  - name: uvicorn-gunicorn-fastapi-docker
-    html_url: https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
-    stars: 2914
-    owner_login: tiangolo
-    owner_html_url: https://github.com/tiangolo
-  - name: any-auto-register
-    html_url: https://github.com/lxf746/any-auto-register
-    stars: 2832
-    owner_login: lxf746
-    owner_html_url: https://github.com/lxf746
-  - name: FastAPI-template
-    html_url: https://github.com/s3rius/FastAPI-template
-    stars: 2810
-    owner_login: s3rius
-    owner_html_url: https://github.com/s3rius
-  - name: YC-Killer
-    html_url: https://github.com/sahibzada-allahyar/YC-Killer
-    stars: 2779
-    owner_login: sahibzada-allahyar
-    owner_html_url: https://github.com/sahibzada-allahyar
-  - name: sqladmin
-    html_url: https://github.com/smithyhq/sqladmin
-    stars: 2759
-    owner_login: smithyhq
-    owner_html_url: https://github.com/smithyhq
-  - name: best-of-web-python
-    html_url: https://github.com/ml-tooling/best-of-web-python
-    stars: 2731
-    owner_login: ml-tooling
-    owner_html_url: https://github.com/ml-tooling
-  - name: NoteDiscovery
-    html_url: https://github.com/gamosoft/NoteDiscovery
-    stars: 2595
-    owner_login: gamosoft
-    owner_html_url: https://github.com/gamosoft
-  - name: fastapi-react
-    html_url: https://github.com/Buuntu/fastapi-react
-    stars: 2588
-    owner_login: Buuntu
-    owner_html_url: https://github.com/Buuntu
-  - name: supabase-py
-    html_url: https://github.com/supabase/supabase-py
-    stars: 2530
-    owner_login: supabase
-    owner_html_url: https://github.com/supabase
-  - name: 30-Days-of-Python
-    html_url: https://github.com/codingforentrepreneurs/30-Days-of-Python
-    stars: 2483
-    owner_login: codingforentrepreneurs
-    owner_html_url: https://github.com/codingforentrepreneurs
-  - name: RasaGPT
-    html_url: https://github.com/paulpierre/RasaGPT
-    stars: 2462
-    owner_login: paulpierre
-    owner_html_url: https://github.com/paulpierre
-  - name: fastapi-langgraph-agent-production-ready-template
-    html_url: https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template
-    stars: 2456
-    owner_login: wassim249
-    owner_html_url: https://github.com/wassim249
-  - name: AIstudioProxyAPI
-    html_url: https://github.com/CJackHwang/AIstudioProxyAPI
-    stars: 2445
-    owner_login: CJackHwang
-    owner_html_url: https://github.com/CJackHwang
-  - name: nextpy
-    html_url: https://github.com/dot-agent/nextpy
-    stars: 2341
-    owner_login: dot-agent
-    owner_html_url: https://github.com/dot-agent
-  - name: langserve
-    html_url: https://github.com/langchain-ai/langserve
-    stars: 2329
-    owner_login: langchain-ai
-    owner_html_url: https://github.com/langchain-ai
-  - name: fastapi-best-architecture
-    html_url: https://github.com/fastapi-practices/fastapi-best-architecture
-    stars: 2318
-    owner_login: fastapi-practices
-    owner_html_url: https://github.com/fastapi-practices
-  - name: fastapi-utils
-    html_url: https://github.com/fastapiutils/fastapi-utils
-    stars: 2308
-    owner_login: fastapiutils
-    owner_html_url: https://github.com/fastapiutils
-  - name: vue-fastapi-admin
-    html_url: https://github.com/mizhexiaoxiao/vue-fastapi-admin
-    stars: 2184
-    owner_login: mizhexiaoxiao
-    owner_html_url: https://github.com/mizhexiaoxiao
-  - name: solara
-    html_url: https://github.com/widgetti/solara
-    stars: 2166
-    owner_login: widgetti
-    owner_html_url: https://github.com/widgetti
-  - name: mangum
-    html_url: https://github.com/Kludex/mangum
-    stars: 2125
-    owner_login: Kludex
-    owner_html_url: https://github.com/Kludex
-  - name: codex-lb
-    html_url: https://github.com/Soju06/codex-lb
-    stars: 2122
-    owner_login: Soju06
-    owner_html_url: https://github.com/Soju06
-  - name: kiro-gateway
-    html_url: https://github.com/jwadow/kiro-gateway
-    stars: 2068
-    owner_login: jwadow
-    owner_html_url: https://github.com/jwadow
-  - name: open-wearables
-    html_url: https://github.com/the-momentum/open-wearables
-    stars: 2036
-    owner_login: the-momentum
-    owner_html_url: https://github.com/the-momentum
-  - name: slowapi
-    html_url: https://github.com/laurentS/slowapi
-    stars: 2022
-    owner_login: laurentS
-    owner_html_url: https://github.com/laurentS
-  - name: xhs_ai_publisher
-    html_url: https://github.com/BetaStreetOmnis/xhs_ai_publisher
-    stars: 2004
-    owner_login: BetaStreetOmnis
-    owner_html_url: https://github.com/BetaStreetOmnis
-  - name: FastAPI-boilerplate
-    html_url: https://github.com/benavlabs/FastAPI-boilerplate
-    stars: 1984
-    owner_login: benavlabs
-    owner_html_url: https://github.com/benavlabs
-  - name: openapi-python-client
-    html_url: https://github.com/openapi-generators/openapi-python-client
-    stars: 1967
-    owner_login: openapi-generators
-    owner_html_url: https://github.com/openapi-generators
-  - name: agentkit
-    html_url: https://github.com/BCG-X-Official/agentkit
-    stars: 1944
-    owner_login: BCG-X-Official
-    owner_html_url: https://github.com/BCG-X-Official
-  - name: piccolo
-    html_url: https://github.com/piccolo-orm/piccolo
-    stars: 1922
-    owner_login: piccolo-orm
-    owner_html_url: https://github.com/piccolo-orm
-  - name: manage-fastapi
-    html_url: https://github.com/ycd/manage-fastapi
-    stars: 1905
-    owner_login: ycd
-    owner_html_url: https://github.com/ycd
-  - name: fastapi-cache
-    html_url: https://github.com/long2ice/fastapi-cache
-    stars: 1866
-    owner_login: long2ice
-    owner_html_url: https://github.com/long2ice
-  - name: ormar
-    html_url: https://github.com/ormar-orm/ormar
-    stars: 1806
-    owner_login: ormar-orm
-    owner_html_url: https://github.com/ormar-orm
-  - name: python-week-2022
-    html_url: https://github.com/rochacbruno/python-week-2022
-    stars: 1806
-    owner_login: rochacbruno
-    owner_html_url: https://github.com/rochacbruno
-  - name: WebRPA
-    html_url: https://github.com/pmh1314520/WebRPA
-    stars: 1781
-    owner_login: pmh1314520
-    owner_html_url: https://github.com/pmh1314520
-  - name: termpair
-    html_url: https://github.com/cs01/termpair
-    stars: 1735
-    owner_login: cs01
-    owner_html_url: https://github.com/cs01
-  - name: fastapi-crudrouter
-    html_url: https://github.com/awtkns/fastapi-crudrouter
-    stars: 1694
-    owner_login: awtkns
-    owner_html_url: https://github.com/awtkns
-  - name: bracket
-    html_url: https://github.com/evroon/bracket
-    stars: 1694
-    owner_login: evroon
-    owner_html_url: https://github.com/evroon
-  - name: fastapi-pagination
-    html_url: https://github.com/uriyyo/fastapi-pagination
-    stars: 1670
-    owner_login: uriyyo
-    owner_html_url: https://github.com/uriyyo
-  - name: langchain-serve
-    html_url: https://github.com/jina-ai/langchain-serve
-    stars: 1640
-    owner_login: jina-ai
-    owner_html_url: https://github.com/jina-ai
-  - name: awesome-fastapi-projects
-    html_url: https://github.com/Kludex/awesome-fastapi-projects
-    stars: 1608
-    owner_login: Kludex
-    owner_html_url: https://github.com/Kludex
-  - name: coronavirus-tracker-api
-    html_url: https://github.com/ExpDev07/coronavirus-tracker-api
-    stars: 1568
-    owner_login: ExpDev07
-    owner_html_url: https://github.com/ExpDev07
-  - name: fastapi-amis-admin
-    html_url: https://github.com/amisadmin/fastapi-amis-admin
-    stars: 1559
-    owner_login: amisadmin
-    owner_html_url: https://github.com/amisadmin
-  - name: fastcrud
-    html_url: https://github.com/benavlabs/fastcrud
-    stars: 1531
-    owner_login: benavlabs
-    owner_html_url: https://github.com/benavlabs
-  - name: tavily-key-generator
-    html_url: https://github.com/skernelx/tavily-key-generator
-    stars: 1526
-    owner_login: skernelx
-    owner_html_url: https://github.com/skernelx
-  - name: fastapi-boilerplate
-    html_url: https://github.com/teamhide/fastapi-boilerplate
-    stars: 1491
-    owner_login: teamhide
-    owner_html_url: https://github.com/teamhide
-  - name: full-stack-ai-agent-template
-    html_url: https://github.com/vstorm-co/full-stack-ai-agent-template
-    stars: 1484
-    owner_login: vstorm-co
-    owner_html_url: https://github.com/vstorm-co
-  - name: prometheus-fastapi-instrumentator
-    html_url: https://github.com/trallnag/prometheus-fastapi-instrumentator
-    stars: 1471
-    owner_login: trallnag
-    owner_html_url: https://github.com/trallnag
-  - name: awesome-python-resources
-    html_url: https://github.com/DjangoEx/awesome-python-resources
-    stars: 1451
-    owner_login: DjangoEx
-    owner_html_url: https://github.com/DjangoEx
-  - name: aktools
-    html_url: https://github.com/akfamily/aktools
-    stars: 1431
-    owner_login: akfamily
-    owner_html_url: https://github.com/akfamily
-  - name: RuoYi-Vue3-FastAPI
-    html_url: https://github.com/insistence/RuoYi-Vue3-FastAPI
-    stars: 1419
-    owner_login: insistence
-    owner_html_url: https://github.com/insistence
-  - name: fastapi-tutorial
-    html_url: https://github.com/liaogx/fastapi-tutorial
-    stars: 1418
-    owner_login: liaogx
-    owner_html_url: https://github.com/liaogx
-  - name: fastapi-code-generator
-    html_url: https://github.com/koxudaxi/fastapi-code-generator
-    stars: 1396
-    owner_login: koxudaxi
-    owner_html_url: https://github.com/koxudaxi
-  - name: yubal
-    html_url: https://github.com/guillevc/yubal
-    stars: 1388
-    owner_login: guillevc
-    owner_html_url: https://github.com/guillevc
-  - name: budgetml
-    html_url: https://github.com/ebhy/budgetml
-    stars: 1343
-    owner_login: ebhy
-    owner_html_url: https://github.com/ebhy
-  - name: Chatterbox-TTS-Server
-    html_url: https://github.com/devnen/Chatterbox-TTS-Server
-    stars: 1328
-    owner_login: devnen
-    owner_html_url: https://github.com/devnen
-  - name: restish
-    html_url: https://github.com/rest-sh/restish
-    stars: 1321
-    owner_login: rest-sh
-    owner_html_url: https://github.com/rest-sh
+- name: headroom
+  html_url: https://github.com/headroomlabs-ai/headroom
+  stars: 55017
+  owner_login: headroomlabs-ai
+  owner_html_url: https://github.com/headroomlabs-ai
+- name: full-stack-fastapi-template
+  html_url: https://github.com/fastapi/full-stack-fastapi-template
+  stars: 43994
+  owner_login: fastapi
+  owner_html_url: https://github.com/fastapi
+- name: Hello-Python
+  html_url: https://github.com/mouredev/Hello-Python
+  stars: 36226
+  owner_login: mouredev
+  owner_html_url: https://github.com/mouredev
+- name: serve
+  html_url: https://github.com/jina-ai/serve
+  stars: 21862
+  owner_login: jina-ai
+  owner_html_url: https://github.com/jina-ai
+- name: HivisionIDPhotos
+  html_url: https://github.com/Zeyi-Lin/HivisionIDPhotos
+  stars: 21212
+  owner_login: Zeyi-Lin
+  owner_html_url: https://github.com/Zeyi-Lin
+- name: Douyin_TikTok_Download_API
+  html_url: https://github.com/Evil0ctal/Douyin_TikTok_Download_API
+  stars: 18599
+  owner_login: Evil0ctal
+  owner_html_url: https://github.com/Evil0ctal
+- name: sqlmodel
+  html_url: https://github.com/fastapi/sqlmodel
+  stars: 18156
+  owner_login: fastapi
+  owner_html_url: https://github.com/fastapi
+- name: fastapi-best-practices
+  html_url: https://github.com/zhanymkanov/fastapi-best-practices
+  stars: 17608
+  owner_login: zhanymkanov
+  owner_html_url: https://github.com/zhanymkanov
+- name: SurfSense
+  html_url: https://github.com/MODSetter/SurfSense
+  stars: 15161
+  owner_login: MODSetter
+  owner_html_url: https://github.com/MODSetter
+- name: machine-learning-zoomcamp
+  html_url: https://github.com/DataTalksClub/machine-learning-zoomcamp
+  stars: 13445
+  owner_login: DataTalksClub
+  owner_html_url: https://github.com/DataTalksClub
+- name: peewee
+  html_url: https://github.com/coleifer/peewee
+  stars: 11976
+  owner_login: coleifer
+  owner_html_url: https://github.com/coleifer
+- name: fastapi_mcp
+  html_url: https://github.com/tadata-org/fastapi_mcp
+  stars: 11932
+  owner_login: tadata-org
+  owner_html_url: https://github.com/tadata-org
+- name: XHS-Downloader
+  html_url: https://github.com/JoeanAmier/XHS-Downloader
+  stars: 11768
+  owner_login: JoeanAmier
+  owner_html_url: https://github.com/JoeanAmier
+- name: awesome-fastapi
+  html_url: https://github.com/mjhea0/awesome-fastapi
+  stars: 11478
+  owner_login: mjhea0
+  owner_html_url: https://github.com/mjhea0
+- name: polar
+  html_url: https://github.com/polarsource/polar
+  stars: 9999
+  owner_login: polarsource
+  owner_html_url: https://github.com/polarsource
+- name: pycaret
+  html_url: https://github.com/pycaret/pycaret
+  stars: 9818
+  owner_login: pycaret
+  owner_html_url: https://github.com/pycaret
+- name: FastUI
+  html_url: https://github.com/pydantic/FastUI
+  stars: 8970
+  owner_login: pydantic
+  owner_html_url: https://github.com/pydantic
+- name: FileCodeBox
+  html_url: https://github.com/vastsa/FileCodeBox
+  stars: 8376
+  owner_login: vastsa
+  owner_html_url: https://github.com/vastsa
+- name: nonebot2
+  html_url: https://github.com/nonebot/nonebot2
+  stars: 7593
+  owner_login: nonebot
+  owner_html_url: https://github.com/nonebot
+- name: hatchet
+  html_url: https://github.com/hatchet-dev/hatchet
+  stars: 7441
+  owner_login: hatchet-dev
+  owner_html_url: https://github.com/hatchet-dev
+- name: fastapi-users
+  html_url: https://github.com/fastapi-users/fastapi-users
+  stars: 6182
+  owner_login: fastapi-users
+  owner_html_url: https://github.com/fastapi-users
+- name: Yuxi
+  html_url: https://github.com/xerrors/Yuxi
+  stars: 5926
+  owner_login: xerrors
+  owner_html_url: https://github.com/xerrors
+- name: serge
+  html_url: https://github.com/serge-chat/serge
+  stars: 5723
+  owner_login: serge-chat
+  owner_html_url: https://github.com/serge-chat
+- name: honcho
+  html_url: https://github.com/plastic-labs/honcho
+  stars: 5680
+  owner_login: plastic-labs
+  owner_html_url: https://github.com/plastic-labs
+- name: Kokoro-FastAPI
+  html_url: https://github.com/remsky/Kokoro-FastAPI
+  stars: 5085
+  owner_login: remsky
+  owner_html_url: https://github.com/remsky
+- name: devpush
+  html_url: https://github.com/hunvreus/devpush
+  stars: 4693
+  owner_login: hunvreus
+  owner_html_url: https://github.com/hunvreus
+- name: strawberry
+  html_url: https://github.com/strawberry-graphql/strawberry
+  stars: 4677
+  owner_login: strawberry-graphql
+  owner_html_url: https://github.com/strawberry-graphql
+- name: poem
+  html_url: https://github.com/poem-web/poem
+  stars: 4415
+  owner_login: poem-web
+  owner_html_url: https://github.com/poem-web
+- name: logfire
+  html_url: https://github.com/pydantic/logfire
+  stars: 4340
+  owner_login: pydantic
+  owner_html_url: https://github.com/pydantic
+- name: dynaconf
+  html_url: https://github.com/dynaconf/dynaconf
+  stars: 4310
+  owner_login: dynaconf
+  owner_html_url: https://github.com/dynaconf
+- name: chatgpt-web-share
+  html_url: https://github.com/chatpire/chatgpt-web-share
+  stars: 4269
+  owner_login: chatpire
+  owner_html_url: https://github.com/chatpire
+- name: huma
+  html_url: https://github.com/danielgtaylor/huma
+  stars: 4203
+  owner_login: danielgtaylor
+  owner_html_url: https://github.com/danielgtaylor
+- name: atrilabs-engine
+  html_url: https://github.com/Atri-Labs/atrilabs-engine
+  stars: 4071
+  owner_login: Atri-Labs
+  owner_html_url: https://github.com/Atri-Labs
+- name: mcp-context-forge
+  html_url: https://github.com/IBM/mcp-context-forge
+  stars: 3989
+  owner_login: IBM
+  owner_html_url: https://github.com/IBM
+- name: datamodel-code-generator
+  html_url: https://github.com/koxudaxi/datamodel-code-generator
+  stars: 3952
+  owner_login: koxudaxi
+  owner_html_url: https://github.com/koxudaxi
+- name: LitServe
+  html_url: https://github.com/Lightning-AI/LitServe
+  stars: 3901
+  owner_login: Lightning-AI
+  owner_html_url: https://github.com/Lightning-AI
+- name: fastapi-admin
+  html_url: https://github.com/fastapi-admin/fastapi-admin
+  stars: 3799
+  owner_login: fastapi-admin
+  owner_html_url: https://github.com/fastapi-admin
+- name: tracecat
+  html_url: https://github.com/TracecatHQ/tracecat
+  stars: 3703
+  owner_login: TracecatHQ
+  owner_html_url: https://github.com/TracecatHQ
+- name: farfalle
+  html_url: https://github.com/rashadphz/farfalle
+  stars: 3535
+  owner_login: rashadphz
+  owner_html_url: https://github.com/rashadphz
+- name: Rapid-MLX
+  html_url: https://github.com/raullenchai/Rapid-MLX
+  stars: 3155
+  owner_login: raullenchai
+  owner_html_url: https://github.com/raullenchai
+- name: opyrator
+  html_url: https://github.com/ml-tooling/opyrator
+  stars: 3133
+  owner_login: ml-tooling
+  owner_html_url: https://github.com/ml-tooling
+- name: docarray
+  html_url: https://github.com/docarray/docarray
+  stars: 3121
+  owner_login: docarray
+  owner_html_url: https://github.com/docarray
+- name: fastapi-realworld-example-app
+  html_url: https://github.com/nsidnev/fastapi-realworld-example-app
+  stars: 3109
+  owner_login: nsidnev
+  owner_html_url: https://github.com/nsidnev
+- name: uvicorn-gunicorn-fastapi-docker
+  html_url: https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
+  stars: 2914
+  owner_login: tiangolo
+  owner_html_url: https://github.com/tiangolo
+- name: any-auto-register
+  html_url: https://github.com/lxf746/any-auto-register
+  stars: 2832
+  owner_login: lxf746
+  owner_html_url: https://github.com/lxf746
+- name: FastAPI-template
+  html_url: https://github.com/s3rius/FastAPI-template
+  stars: 2810
+  owner_login: s3rius
+  owner_html_url: https://github.com/s3rius
+- name: YC-Killer
+  html_url: https://github.com/sahibzada-allahyar/YC-Killer
+  stars: 2779
+  owner_login: sahibzada-allahyar
+  owner_html_url: https://github.com/sahibzada-allahyar
+- name: sqladmin
+  html_url: https://github.com/smithyhq/sqladmin
+  stars: 2759
+  owner_login: smithyhq
+  owner_html_url: https://github.com/smithyhq
+- name: best-of-web-python
+  html_url: https://github.com/ml-tooling/best-of-web-python
+  stars: 2731
+  owner_login: ml-tooling
+  owner_html_url: https://github.com/ml-tooling
+- name: NoteDiscovery
+  html_url: https://github.com/gamosoft/NoteDiscovery
+  stars: 2595
+  owner_login: gamosoft
+  owner_html_url: https://github.com/gamosoft
+- name: fastapi-react
+  html_url: https://github.com/Buuntu/fastapi-react
+  stars: 2588
+  owner_login: Buuntu
+  owner_html_url: https://github.com/Buuntu
+- name: supabase-py
+  html_url: https://github.com/supabase/supabase-py
+  stars: 2530
+  owner_login: supabase
+  owner_html_url: https://github.com/supabase
+- name: 30-Days-of-Python
+  html_url: https://github.com/codingforentrepreneurs/30-Days-of-Python
+  stars: 2483
+  owner_login: codingforentrepreneurs
+  owner_html_url: https://github.com/codingforentrepreneurs
+- name: RasaGPT
+  html_url: https://github.com/paulpierre/RasaGPT
+  stars: 2462
+  owner_login: paulpierre
+  owner_html_url: https://github.com/paulpierre
+- name: fastapi-langgraph-agent-production-ready-template
+  html_url: https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template
+  stars: 2456
+  owner_login: wassim249
+  owner_html_url: https://github.com/wassim249
+- name: AIstudioProxyAPI
+  html_url: https://github.com/CJackHwang/AIstudioProxyAPI
+  stars: 2445
+  owner_login: CJackHwang
+  owner_html_url: https://github.com/CJackHwang
+- name: nextpy
+  html_url: https://github.com/dot-agent/nextpy
+  stars: 2341
+  owner_login: dot-agent
+  owner_html_url: https://github.com/dot-agent
+- name: langserve
+  html_url: https://github.com/langchain-ai/langserve
+  stars: 2329
+  owner_login: langchain-ai
+  owner_html_url: https://github.com/langchain-ai
+- name: fastapi-best-architecture
+  html_url: https://github.com/fastapi-practices/fastapi-best-architecture
+  stars: 2318
+  owner_login: fastapi-practices
+  owner_html_url: https://github.com/fastapi-practices
+- name: fastapi-utils
+  html_url: https://github.com/fastapiutils/fastapi-utils
+  stars: 2308
+  owner_login: fastapiutils
+  owner_html_url: https://github.com/fastapiutils
+- name: vue-fastapi-admin
+  html_url: https://github.com/mizhexiaoxiao/vue-fastapi-admin
+  stars: 2184
+  owner_login: mizhexiaoxiao
+  owner_html_url: https://github.com/mizhexiaoxiao
+- name: solara
+  html_url: https://github.com/widgetti/solara
+  stars: 2166
+  owner_login: widgetti
+  owner_html_url: https://github.com/widgetti
+- name: mangum
+  html_url: https://github.com/Kludex/mangum
+  stars: 2125
+  owner_login: Kludex
+  owner_html_url: https://github.com/Kludex
+- name: codex-lb
+  html_url: https://github.com/Soju06/codex-lb
+  stars: 2122
+  owner_login: Soju06
+  owner_html_url: https://github.com/Soju06
+- name: kiro-gateway
+  html_url: https://github.com/jwadow/kiro-gateway
+  stars: 2068
+  owner_login: jwadow
+  owner_html_url: https://github.com/jwadow
+- name: open-wearables
+  html_url: https://github.com/the-momentum/open-wearables
+  stars: 2036
+  owner_login: the-momentum
+  owner_html_url: https://github.com/the-momentum
+- name: slowapi
+  html_url: https://github.com/laurentS/slowapi
+  stars: 2022
+  owner_login: laurentS
+  owner_html_url: https://github.com/laurentS
+- name: xhs_ai_publisher
+  html_url: https://github.com/BetaStreetOmnis/xhs_ai_publisher
+  stars: 2004
+  owner_login: BetaStreetOmnis
+  owner_html_url: https://github.com/BetaStreetOmnis
+- name: FastAPI-boilerplate
+  html_url: https://github.com/benavlabs/FastAPI-boilerplate
+  stars: 1984
+  owner_login: benavlabs
+  owner_html_url: https://github.com/benavlabs
+- name: openapi-python-client
+  html_url: https://github.com/openapi-generators/openapi-python-client
+  stars: 1967
+  owner_login: openapi-generators
+  owner_html_url: https://github.com/openapi-generators
+- name: agentkit
+  html_url: https://github.com/BCG-X-Official/agentkit
+  stars: 1944
+  owner_login: BCG-X-Official
+  owner_html_url: https://github.com/BCG-X-Official
+- name: piccolo
+  html_url: https://github.com/piccolo-orm/piccolo
+  stars: 1922
+  owner_login: piccolo-orm
+  owner_html_url: https://github.com/piccolo-orm
+- name: manage-fastapi
+  html_url: https://github.com/ycd/manage-fastapi
+  stars: 1905
+  owner_login: ycd
+  owner_html_url: https://github.com/ycd
+- name: fastapi-cache
+  html_url: https://github.com/long2ice/fastapi-cache
+  stars: 1866
+  owner_login: long2ice
+  owner_html_url: https://github.com/long2ice
+- name: ormar
+  html_url: https://github.com/ormar-orm/ormar
+  stars: 1806
+  owner_login: ormar-orm
+  owner_html_url: https://github.com/ormar-orm
+- name: python-week-2022
+  html_url: https://github.com/rochacbruno/python-week-2022
+  stars: 1806
+  owner_login: rochacbruno
+  owner_html_url: https://github.com/rochacbruno
+- name: WebRPA
+  html_url: https://github.com/pmh1314520/WebRPA
+  stars: 1781
+  owner_login: pmh1314520
+  owner_html_url: https://github.com/pmh1314520
+- name: termpair
+  html_url: https://github.com/cs01/termpair
+  stars: 1735
+  owner_login: cs01
+  owner_html_url: https://github.com/cs01
+- name: fastapi-crudrouter
+  html_url: https://github.com/awtkns/fastapi-crudrouter
+  stars: 1694
+  owner_login: awtkns
+  owner_html_url: https://github.com/awtkns
+- name: bracket
+  html_url: https://github.com/evroon/bracket
+  stars: 1694
+  owner_login: evroon
+  owner_html_url: https://github.com/evroon
+- name: fastapi-pagination
+  html_url: https://github.com/uriyyo/fastapi-pagination
+  stars: 1670
+  owner_login: uriyyo
+  owner_html_url: https://github.com/uriyyo
+- name: langchain-serve
+  html_url: https://github.com/jina-ai/langchain-serve
+  stars: 1640
+  owner_login: jina-ai
+  owner_html_url: https://github.com/jina-ai
+- name: awesome-fastapi-projects
+  html_url: https://github.com/Kludex/awesome-fastapi-projects
+  stars: 1608
+  owner_login: Kludex
+  owner_html_url: https://github.com/Kludex
+- name: coronavirus-tracker-api
+  html_url: https://github.com/ExpDev07/coronavirus-tracker-api
+  stars: 1568
+  owner_login: ExpDev07
+  owner_html_url: https://github.com/ExpDev07
+- name: fastapi-amis-admin
+  html_url: https://github.com/amisadmin/fastapi-amis-admin
+  stars: 1559
+  owner_login: amisadmin
+  owner_html_url: https://github.com/amisadmin
+- name: fastcrud
+  html_url: https://github.com/benavlabs/fastcrud
+  stars: 1531
+  owner_login: benavlabs
+  owner_html_url: https://github.com/benavlabs
+- name: tavily-key-generator
+  html_url: https://github.com/skernelx/tavily-key-generator
+  stars: 1526
+  owner_login: skernelx
+  owner_html_url: https://github.com/skernelx
+- name: fastapi-boilerplate
+  html_url: https://github.com/teamhide/fastapi-boilerplate
+  stars: 1491
+  owner_login: teamhide
+  owner_html_url: https://github.com/teamhide
+- name: full-stack-ai-agent-template
+  html_url: https://github.com/vstorm-co/full-stack-ai-agent-template
+  stars: 1484
+  owner_login: vstorm-co
+  owner_html_url: https://github.com/vstorm-co
+- name: prometheus-fastapi-instrumentator
+  html_url: https://github.com/trallnag/prometheus-fastapi-instrumentator
+  stars: 1471
+  owner_login: trallnag
+  owner_html_url: https://github.com/trallnag
+- name: awesome-python-resources
+  html_url: https://github.com/DjangoEx/awesome-python-resources
+  stars: 1451
+  owner_login: DjangoEx
+  owner_html_url: https://github.com/DjangoEx
+- name: aktools
+  html_url: https://github.com/akfamily/aktools
+  stars: 1431
+  owner_login: akfamily
+  owner_html_url: https://github.com/akfamily
+- name: RuoYi-Vue3-FastAPI
+  html_url: https://github.com/insistence/RuoYi-Vue3-FastAPI
+  stars: 1419
+  owner_login: insistence
+  owner_html_url: https://github.com/insistence
+- name: fastapi-tutorial
+  html_url: https://github.com/liaogx/fastapi-tutorial
+  stars: 1418
+  owner_login: liaogx
+  owner_html_url: https://github.com/liaogx
+- name: fastapi-code-generator
+  html_url: https://github.com/koxudaxi/fastapi-code-generator
+  stars: 1396
+  owner_login: koxudaxi
+  owner_html_url: https://github.com/koxudaxi
+- name: yubal
+  html_url: https://github.com/guillevc/yubal
+  stars: 1388
+  owner_login: guillevc
+  owner_html_url: https://github.com/guillevc
+- name: budgetml
+  html_url: https://github.com/ebhy/budgetml
+  stars: 1343
+  owner_login: ebhy
+  owner_html_url: https://github.com/ebhy
+- name: Chatterbox-TTS-Server
+  html_url: https://github.com/devnen/Chatterbox-TTS-Server
+  stars: 1328
+  owner_login: devnen
+  owner_html_url: https://github.com/devnen
+- name: restish
+  html_url: https://github.com/rest-sh/restish
+  stars: 1321
+  owner_login: rest-sh
+  owner_html_url: https://github.com/rest-sh

--- a/docs/en/data/topic_repos.yml
+++ b/docs/en/data/topic_repos.yml
@@ -1,495 +1,496 @@
-- name: headroom
-  html_url: https://github.com/headroomlabs-ai/headroom
-  stars: 55017
-  owner_login: headroomlabs-ai
-  owner_html_url: https://github.com/headroomlabs-ai
-- name: full-stack-fastapi-template
-  html_url: https://github.com/fastapi/full-stack-fastapi-template
-  stars: 43994
-  owner_login: fastapi
-  owner_html_url: https://github.com/fastapi
-- name: Hello-Python
-  html_url: https://github.com/mouredev/Hello-Python
-  stars: 36226
-  owner_login: mouredev
-  owner_html_url: https://github.com/mouredev
-- name: serve
-  html_url: https://github.com/jina-ai/serve
-  stars: 21862
-  owner_login: jina-ai
-  owner_html_url: https://github.com/jina-ai
-- name: HivisionIDPhotos
-  html_url: https://github.com/Zeyi-Lin/HivisionIDPhotos
-  stars: 21212
-  owner_login: Zeyi-Lin
-  owner_html_url: https://github.com/Zeyi-Lin
-- name: Douyin_TikTok_Download_API
-  html_url: https://github.com/Evil0ctal/Douyin_TikTok_Download_API
-  stars: 18599
-  owner_login: Evil0ctal
-  owner_html_url: https://github.com/Evil0ctal
-- name: sqlmodel
-  html_url: https://github.com/fastapi/sqlmodel
-  stars: 18156
-  owner_login: fastapi
-  owner_html_url: https://github.com/fastapi
-- name: fastapi-best-practices
-  html_url: https://github.com/zhanymkanov/fastapi-best-practices
-  stars: 17608
-  owner_login: zhanymkanov
-  owner_html_url: https://github.com/zhanymkanov
-- name: SurfSense
-  html_url: https://github.com/MODSetter/SurfSense
-  stars: 15161
-  owner_login: MODSetter
-  owner_html_url: https://github.com/MODSetter
-- name: machine-learning-zoomcamp
-  html_url: https://github.com/DataTalksClub/machine-learning-zoomcamp
-  stars: 13445
-  owner_login: DataTalksClub
-  owner_html_url: https://github.com/DataTalksClub
-- name: peewee
-  html_url: https://github.com/coleifer/peewee
-  stars: 11976
-  owner_login: coleifer
-  owner_html_url: https://github.com/coleifer
-- name: fastapi_mcp
-  html_url: https://github.com/tadata-org/fastapi_mcp
-  stars: 11932
-  owner_login: tadata-org
-  owner_html_url: https://github.com/tadata-org
-- name: XHS-Downloader
-  html_url: https://github.com/JoeanAmier/XHS-Downloader
-  stars: 11768
-  owner_login: JoeanAmier
-  owner_html_url: https://github.com/JoeanAmier
-- name: awesome-fastapi
-  html_url: https://github.com/mjhea0/awesome-fastapi
-  stars: 11478
-  owner_login: mjhea0
-  owner_html_url: https://github.com/mjhea0
-- name: polar
-  html_url: https://github.com/polarsource/polar
-  stars: 9999
-  owner_login: polarsource
-  owner_html_url: https://github.com/polarsource
-- name: pycaret
-  html_url: https://github.com/pycaret/pycaret
-  stars: 9818
-  owner_login: pycaret
-  owner_html_url: https://github.com/pycaret
-- name: FastUI
-  html_url: https://github.com/pydantic/FastUI
-  stars: 8970
-  owner_login: pydantic
-  owner_html_url: https://github.com/pydantic
-- name: FileCodeBox
-  html_url: https://github.com/vastsa/FileCodeBox
-  stars: 8376
-  owner_login: vastsa
-  owner_html_url: https://github.com/vastsa
-- name: nonebot2
-  html_url: https://github.com/nonebot/nonebot2
-  stars: 7593
-  owner_login: nonebot
-  owner_html_url: https://github.com/nonebot
-- name: hatchet
-  html_url: https://github.com/hatchet-dev/hatchet
-  stars: 7441
-  owner_login: hatchet-dev
-  owner_html_url: https://github.com/hatchet-dev
-- name: fastapi-users
-  html_url: https://github.com/fastapi-users/fastapi-users
-  stars: 6182
-  owner_login: fastapi-users
-  owner_html_url: https://github.com/fastapi-users
-- name: Yuxi
-  html_url: https://github.com/xerrors/Yuxi
-  stars: 5926
-  owner_login: xerrors
-  owner_html_url: https://github.com/xerrors
-- name: serge
-  html_url: https://github.com/serge-chat/serge
-  stars: 5723
-  owner_login: serge-chat
-  owner_html_url: https://github.com/serge-chat
-- name: honcho
-  html_url: https://github.com/plastic-labs/honcho
-  stars: 5680
-  owner_login: plastic-labs
-  owner_html_url: https://github.com/plastic-labs
-- name: Kokoro-FastAPI
-  html_url: https://github.com/remsky/Kokoro-FastAPI
-  stars: 5085
-  owner_login: remsky
-  owner_html_url: https://github.com/remsky
-- name: devpush
-  html_url: https://github.com/hunvreus/devpush
-  stars: 4693
-  owner_login: hunvreus
-  owner_html_url: https://github.com/hunvreus
-- name: strawberry
-  html_url: https://github.com/strawberry-graphql/strawberry
-  stars: 4677
-  owner_login: strawberry-graphql
-  owner_html_url: https://github.com/strawberry-graphql
-- name: poem
-  html_url: https://github.com/poem-web/poem
-  stars: 4415
-  owner_login: poem-web
-  owner_html_url: https://github.com/poem-web
-- name: logfire
-  html_url: https://github.com/pydantic/logfire
-  stars: 4340
-  owner_login: pydantic
-  owner_html_url: https://github.com/pydantic
-- name: dynaconf
-  html_url: https://github.com/dynaconf/dynaconf
-  stars: 4310
-  owner_login: dynaconf
-  owner_html_url: https://github.com/dynaconf
-- name: chatgpt-web-share
-  html_url: https://github.com/chatpire/chatgpt-web-share
-  stars: 4269
-  owner_login: chatpire
-  owner_html_url: https://github.com/chatpire
-- name: huma
-  html_url: https://github.com/danielgtaylor/huma
-  stars: 4203
-  owner_login: danielgtaylor
-  owner_html_url: https://github.com/danielgtaylor
-- name: atrilabs-engine
-  html_url: https://github.com/Atri-Labs/atrilabs-engine
-  stars: 4071
-  owner_login: Atri-Labs
-  owner_html_url: https://github.com/Atri-Labs
-- name: mcp-context-forge
-  html_url: https://github.com/IBM/mcp-context-forge
-  stars: 3989
-  owner_login: IBM
-  owner_html_url: https://github.com/IBM
-- name: datamodel-code-generator
-  html_url: https://github.com/koxudaxi/datamodel-code-generator
-  stars: 3952
-  owner_login: koxudaxi
-  owner_html_url: https://github.com/koxudaxi
-- name: LitServe
-  html_url: https://github.com/Lightning-AI/LitServe
-  stars: 3901
-  owner_login: Lightning-AI
-  owner_html_url: https://github.com/Lightning-AI
-- name: fastapi-admin
-  html_url: https://github.com/fastapi-admin/fastapi-admin
-  stars: 3799
-  owner_login: fastapi-admin
-  owner_html_url: https://github.com/fastapi-admin
-- name: tracecat
-  html_url: https://github.com/TracecatHQ/tracecat
-  stars: 3703
-  owner_login: TracecatHQ
-  owner_html_url: https://github.com/TracecatHQ
-- name: farfalle
-  html_url: https://github.com/rashadphz/farfalle
-  stars: 3535
-  owner_login: rashadphz
-  owner_html_url: https://github.com/rashadphz
-- name: Rapid-MLX
-  html_url: https://github.com/raullenchai/Rapid-MLX
-  stars: 3155
-  owner_login: raullenchai
-  owner_html_url: https://github.com/raullenchai
-- name: opyrator
-  html_url: https://github.com/ml-tooling/opyrator
-  stars: 3133
-  owner_login: ml-tooling
-  owner_html_url: https://github.com/ml-tooling
-- name: docarray
-  html_url: https://github.com/docarray/docarray
-  stars: 3121
-  owner_login: docarray
-  owner_html_url: https://github.com/docarray
-- name: fastapi-realworld-example-app
-  html_url: https://github.com/nsidnev/fastapi-realworld-example-app
-  stars: 3109
-  owner_login: nsidnev
-  owner_html_url: https://github.com/nsidnev
-- name: uvicorn-gunicorn-fastapi-docker
-  html_url: https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
-  stars: 2914
-  owner_login: tiangolo
-  owner_html_url: https://github.com/tiangolo
-- name: any-auto-register
-  html_url: https://github.com/lxf746/any-auto-register
-  stars: 2832
-  owner_login: lxf746
-  owner_html_url: https://github.com/lxf746
-- name: FastAPI-template
-  html_url: https://github.com/s3rius/FastAPI-template
-  stars: 2810
-  owner_login: s3rius
-  owner_html_url: https://github.com/s3rius
-- name: YC-Killer
-  html_url: https://github.com/sahibzada-allahyar/YC-Killer
-  stars: 2779
-  owner_login: sahibzada-allahyar
-  owner_html_url: https://github.com/sahibzada-allahyar
-- name: sqladmin
-  html_url: https://github.com/smithyhq/sqladmin
-  stars: 2759
-  owner_login: smithyhq
-  owner_html_url: https://github.com/smithyhq
-- name: best-of-web-python
-  html_url: https://github.com/ml-tooling/best-of-web-python
-  stars: 2731
-  owner_login: ml-tooling
-  owner_html_url: https://github.com/ml-tooling
-- name: NoteDiscovery
-  html_url: https://github.com/gamosoft/NoteDiscovery
-  stars: 2595
-  owner_login: gamosoft
-  owner_html_url: https://github.com/gamosoft
-- name: fastapi-react
-  html_url: https://github.com/Buuntu/fastapi-react
-  stars: 2588
-  owner_login: Buuntu
-  owner_html_url: https://github.com/Buuntu
-- name: supabase-py
-  html_url: https://github.com/supabase/supabase-py
-  stars: 2530
-  owner_login: supabase
-  owner_html_url: https://github.com/supabase
-- name: 30-Days-of-Python
-  html_url: https://github.com/codingforentrepreneurs/30-Days-of-Python
-  stars: 2483
-  owner_login: codingforentrepreneurs
-  owner_html_url: https://github.com/codingforentrepreneurs
-- name: RasaGPT
-  html_url: https://github.com/paulpierre/RasaGPT
-  stars: 2462
-  owner_login: paulpierre
-  owner_html_url: https://github.com/paulpierre
-- name: fastapi-langgraph-agent-production-ready-template
-  html_url: https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template
-  stars: 2456
-  owner_login: wassim249
-  owner_html_url: https://github.com/wassim249
-- name: AIstudioProxyAPI
-  html_url: https://github.com/CJackHwang/AIstudioProxyAPI
-  stars: 2445
-  owner_login: CJackHwang
-  owner_html_url: https://github.com/CJackHwang
-- name: nextpy
-  html_url: https://github.com/dot-agent/nextpy
-  stars: 2341
-  owner_login: dot-agent
-  owner_html_url: https://github.com/dot-agent
-- name: langserve
-  html_url: https://github.com/langchain-ai/langserve
-  stars: 2329
-  owner_login: langchain-ai
-  owner_html_url: https://github.com/langchain-ai
-- name: fastapi-best-architecture
-  html_url: https://github.com/fastapi-practices/fastapi-best-architecture
-  stars: 2318
-  owner_login: fastapi-practices
-  owner_html_url: https://github.com/fastapi-practices
-- name: fastapi-utils
-  html_url: https://github.com/fastapiutils/fastapi-utils
-  stars: 2308
-  owner_login: fastapiutils
-  owner_html_url: https://github.com/fastapiutils
-- name: vue-fastapi-admin
-  html_url: https://github.com/mizhexiaoxiao/vue-fastapi-admin
-  stars: 2184
-  owner_login: mizhexiaoxiao
-  owner_html_url: https://github.com/mizhexiaoxiao
-- name: solara
-  html_url: https://github.com/widgetti/solara
-  stars: 2166
-  owner_login: widgetti
-  owner_html_url: https://github.com/widgetti
-- name: mangum
-  html_url: https://github.com/Kludex/mangum
-  stars: 2125
-  owner_login: Kludex
-  owner_html_url: https://github.com/Kludex
-- name: codex-lb
-  html_url: https://github.com/Soju06/codex-lb
-  stars: 2122
-  owner_login: Soju06
-  owner_html_url: https://github.com/Soju06
-- name: kiro-gateway
-  html_url: https://github.com/jwadow/kiro-gateway
-  stars: 2068
-  owner_login: jwadow
-  owner_html_url: https://github.com/jwadow
-- name: open-wearables
-  html_url: https://github.com/the-momentum/open-wearables
-  stars: 2036
-  owner_login: the-momentum
-  owner_html_url: https://github.com/the-momentum
-- name: slowapi
-  html_url: https://github.com/laurentS/slowapi
-  stars: 2022
-  owner_login: laurentS
-  owner_html_url: https://github.com/laurentS
-- name: xhs_ai_publisher
-  html_url: https://github.com/BetaStreetOmnis/xhs_ai_publisher
-  stars: 2004
-  owner_login: BetaStreetOmnis
-  owner_html_url: https://github.com/BetaStreetOmnis
-- name: FastAPI-boilerplate
-  html_url: https://github.com/benavlabs/FastAPI-boilerplate
-  stars: 1984
-  owner_login: benavlabs
-  owner_html_url: https://github.com/benavlabs
-- name: openapi-python-client
-  html_url: https://github.com/openapi-generators/openapi-python-client
-  stars: 1967
-  owner_login: openapi-generators
-  owner_html_url: https://github.com/openapi-generators
-- name: agentkit
-  html_url: https://github.com/BCG-X-Official/agentkit
-  stars: 1944
-  owner_login: BCG-X-Official
-  owner_html_url: https://github.com/BCG-X-Official
-- name: piccolo
-  html_url: https://github.com/piccolo-orm/piccolo
-  stars: 1922
-  owner_login: piccolo-orm
-  owner_html_url: https://github.com/piccolo-orm
-- name: manage-fastapi
-  html_url: https://github.com/ycd/manage-fastapi
-  stars: 1905
-  owner_login: ycd
-  owner_html_url: https://github.com/ycd
-- name: fastapi-cache
-  html_url: https://github.com/long2ice/fastapi-cache
-  stars: 1866
-  owner_login: long2ice
-  owner_html_url: https://github.com/long2ice
-- name: ormar
-  html_url: https://github.com/ormar-orm/ormar
-  stars: 1806
-  owner_login: ormar-orm
-  owner_html_url: https://github.com/ormar-orm
-- name: python-week-2022
-  html_url: https://github.com/rochacbruno/python-week-2022
-  stars: 1806
-  owner_login: rochacbruno
-  owner_html_url: https://github.com/rochacbruno
-- name: WebRPA
-  html_url: https://github.com/pmh1314520/WebRPA
-  stars: 1781
-  owner_login: pmh1314520
-  owner_html_url: https://github.com/pmh1314520
-- name: termpair
-  html_url: https://github.com/cs01/termpair
-  stars: 1735
-  owner_login: cs01
-  owner_html_url: https://github.com/cs01
-- name: fastapi-crudrouter
-  html_url: https://github.com/awtkns/fastapi-crudrouter
-  stars: 1694
-  owner_login: awtkns
-  owner_html_url: https://github.com/awtkns
-- name: bracket
-  html_url: https://github.com/evroon/bracket
-  stars: 1694
-  owner_login: evroon
-  owner_html_url: https://github.com/evroon
-- name: fastapi-pagination
-  html_url: https://github.com/uriyyo/fastapi-pagination
-  stars: 1670
-  owner_login: uriyyo
-  owner_html_url: https://github.com/uriyyo
-- name: langchain-serve
-  html_url: https://github.com/jina-ai/langchain-serve
-  stars: 1640
-  owner_login: jina-ai
-  owner_html_url: https://github.com/jina-ai
-- name: awesome-fastapi-projects
-  html_url: https://github.com/Kludex/awesome-fastapi-projects
-  stars: 1608
-  owner_login: Kludex
-  owner_html_url: https://github.com/Kludex
-- name: coronavirus-tracker-api
-  html_url: https://github.com/ExpDev07/coronavirus-tracker-api
-  stars: 1568
-  owner_login: ExpDev07
-  owner_html_url: https://github.com/ExpDev07
-- name: fastapi-amis-admin
-  html_url: https://github.com/amisadmin/fastapi-amis-admin
-  stars: 1559
-  owner_login: amisadmin
-  owner_html_url: https://github.com/amisadmin
-- name: fastcrud
-  html_url: https://github.com/benavlabs/fastcrud
-  stars: 1531
-  owner_login: benavlabs
-  owner_html_url: https://github.com/benavlabs
-- name: tavily-key-generator
-  html_url: https://github.com/skernelx/tavily-key-generator
-  stars: 1526
-  owner_login: skernelx
-  owner_html_url: https://github.com/skernelx
-- name: fastapi-boilerplate
-  html_url: https://github.com/teamhide/fastapi-boilerplate
-  stars: 1491
-  owner_login: teamhide
-  owner_html_url: https://github.com/teamhide
-- name: full-stack-ai-agent-template
-  html_url: https://github.com/vstorm-co/full-stack-ai-agent-template
-  stars: 1484
-  owner_login: vstorm-co
-  owner_html_url: https://github.com/vstorm-co
-- name: prometheus-fastapi-instrumentator
-  html_url: https://github.com/trallnag/prometheus-fastapi-instrumentator
-  stars: 1471
-  owner_login: trallnag
-  owner_html_url: https://github.com/trallnag
-- name: awesome-python-resources
-  html_url: https://github.com/DjangoEx/awesome-python-resources
-  stars: 1451
-  owner_login: DjangoEx
-  owner_html_url: https://github.com/DjangoEx
-- name: aktools
-  html_url: https://github.com/akfamily/aktools
-  stars: 1431
-  owner_login: akfamily
-  owner_html_url: https://github.com/akfamily
-- name: RuoYi-Vue3-FastAPI
-  html_url: https://github.com/insistence/RuoYi-Vue3-FastAPI
-  stars: 1419
-  owner_login: insistence
-  owner_html_url: https://github.com/insistence
-- name: fastapi-tutorial
-  html_url: https://github.com/liaogx/fastapi-tutorial
-  stars: 1418
-  owner_login: liaogx
-  owner_html_url: https://github.com/liaogx
-- name: fastapi-code-generator
-  html_url: https://github.com/koxudaxi/fastapi-code-generator
-  stars: 1396
-  owner_login: koxudaxi
-  owner_html_url: https://github.com/koxudaxi
-- name: yubal
-  html_url: https://github.com/guillevc/yubal
-  stars: 1388
-  owner_login: guillevc
-  owner_html_url: https://github.com/guillevc
-- name: budgetml
-  html_url: https://github.com/ebhy/budgetml
-  stars: 1343
-  owner_login: ebhy
-  owner_html_url: https://github.com/ebhy
-- name: Chatterbox-TTS-Server
-  html_url: https://github.com/devnen/Chatterbox-TTS-Server
-  stars: 1328
-  owner_login: devnen
-  owner_html_url: https://github.com/devnen
-- name: restish
-  html_url: https://github.com/rest-sh/restish
-  stars: 1321
-  owner_login: rest-sh
-  owner_html_url: https://github.com/rest-sh
+repos:
+  - name: headroom
+    html_url: https://github.com/headroomlabs-ai/headroom
+    stars: 55017
+    owner_login: headroomlabs-ai
+    owner_html_url: https://github.com/headroomlabs-ai
+  - name: full-stack-fastapi-template
+    html_url: https://github.com/fastapi/full-stack-fastapi-template
+    stars: 43994
+    owner_login: fastapi
+    owner_html_url: https://github.com/fastapi
+  - name: Hello-Python
+    html_url: https://github.com/mouredev/Hello-Python
+    stars: 36226
+    owner_login: mouredev
+    owner_html_url: https://github.com/mouredev
+  - name: serve
+    html_url: https://github.com/jina-ai/serve
+    stars: 21862
+    owner_login: jina-ai
+    owner_html_url: https://github.com/jina-ai
+  - name: HivisionIDPhotos
+    html_url: https://github.com/Zeyi-Lin/HivisionIDPhotos
+    stars: 21212
+    owner_login: Zeyi-Lin
+    owner_html_url: https://github.com/Zeyi-Lin
+  - name: Douyin_TikTok_Download_API
+    html_url: https://github.com/Evil0ctal/Douyin_TikTok_Download_API
+    stars: 18599
+    owner_login: Evil0ctal
+    owner_html_url: https://github.com/Evil0ctal
+  - name: sqlmodel
+    html_url: https://github.com/fastapi/sqlmodel
+    stars: 18156
+    owner_login: fastapi
+    owner_html_url: https://github.com/fastapi
+  - name: fastapi-best-practices
+    html_url: https://github.com/zhanymkanov/fastapi-best-practices
+    stars: 17608
+    owner_login: zhanymkanov
+    owner_html_url: https://github.com/zhanymkanov
+  - name: SurfSense
+    html_url: https://github.com/MODSetter/SurfSense
+    stars: 15161
+    owner_login: MODSetter
+    owner_html_url: https://github.com/MODSetter
+  - name: machine-learning-zoomcamp
+    html_url: https://github.com/DataTalksClub/machine-learning-zoomcamp
+    stars: 13445
+    owner_login: DataTalksClub
+    owner_html_url: https://github.com/DataTalksClub
+  - name: peewee
+    html_url: https://github.com/coleifer/peewee
+    stars: 11976
+    owner_login: coleifer
+    owner_html_url: https://github.com/coleifer
+  - name: fastapi_mcp
+    html_url: https://github.com/tadata-org/fastapi_mcp
+    stars: 11932
+    owner_login: tadata-org
+    owner_html_url: https://github.com/tadata-org
+  - name: XHS-Downloader
+    html_url: https://github.com/JoeanAmier/XHS-Downloader
+    stars: 11768
+    owner_login: JoeanAmier
+    owner_html_url: https://github.com/JoeanAmier
+  - name: awesome-fastapi
+    html_url: https://github.com/mjhea0/awesome-fastapi
+    stars: 11478
+    owner_login: mjhea0
+    owner_html_url: https://github.com/mjhea0
+  - name: polar
+    html_url: https://github.com/polarsource/polar
+    stars: 9999
+    owner_login: polarsource
+    owner_html_url: https://github.com/polarsource
+  - name: pycaret
+    html_url: https://github.com/pycaret/pycaret
+    stars: 9818
+    owner_login: pycaret
+    owner_html_url: https://github.com/pycaret
+  - name: FastUI
+    html_url: https://github.com/pydantic/FastUI
+    stars: 8970
+    owner_login: pydantic
+    owner_html_url: https://github.com/pydantic
+  - name: FileCodeBox
+    html_url: https://github.com/vastsa/FileCodeBox
+    stars: 8376
+    owner_login: vastsa
+    owner_html_url: https://github.com/vastsa
+  - name: nonebot2
+    html_url: https://github.com/nonebot/nonebot2
+    stars: 7593
+    owner_login: nonebot
+    owner_html_url: https://github.com/nonebot
+  - name: hatchet
+    html_url: https://github.com/hatchet-dev/hatchet
+    stars: 7441
+    owner_login: hatchet-dev
+    owner_html_url: https://github.com/hatchet-dev
+  - name: fastapi-users
+    html_url: https://github.com/fastapi-users/fastapi-users
+    stars: 6182
+    owner_login: fastapi-users
+    owner_html_url: https://github.com/fastapi-users
+  - name: Yuxi
+    html_url: https://github.com/xerrors/Yuxi
+    stars: 5926
+    owner_login: xerrors
+    owner_html_url: https://github.com/xerrors
+  - name: serge
+    html_url: https://github.com/serge-chat/serge
+    stars: 5723
+    owner_login: serge-chat
+    owner_html_url: https://github.com/serge-chat
+  - name: honcho
+    html_url: https://github.com/plastic-labs/honcho
+    stars: 5680
+    owner_login: plastic-labs
+    owner_html_url: https://github.com/plastic-labs
+  - name: Kokoro-FastAPI
+    html_url: https://github.com/remsky/Kokoro-FastAPI
+    stars: 5085
+    owner_login: remsky
+    owner_html_url: https://github.com/remsky
+  - name: devpush
+    html_url: https://github.com/hunvreus/devpush
+    stars: 4693
+    owner_login: hunvreus
+    owner_html_url: https://github.com/hunvreus
+  - name: strawberry
+    html_url: https://github.com/strawberry-graphql/strawberry
+    stars: 4677
+    owner_login: strawberry-graphql
+    owner_html_url: https://github.com/strawberry-graphql
+  - name: poem
+    html_url: https://github.com/poem-web/poem
+    stars: 4415
+    owner_login: poem-web
+    owner_html_url: https://github.com/poem-web
+  - name: logfire
+    html_url: https://github.com/pydantic/logfire
+    stars: 4340
+    owner_login: pydantic
+    owner_html_url: https://github.com/pydantic
+  - name: dynaconf
+    html_url: https://github.com/dynaconf/dynaconf
+    stars: 4310
+    owner_login: dynaconf
+    owner_html_url: https://github.com/dynaconf
+  - name: chatgpt-web-share
+    html_url: https://github.com/chatpire/chatgpt-web-share
+    stars: 4269
+    owner_login: chatpire
+    owner_html_url: https://github.com/chatpire
+  - name: huma
+    html_url: https://github.com/danielgtaylor/huma
+    stars: 4203
+    owner_login: danielgtaylor
+    owner_html_url: https://github.com/danielgtaylor
+  - name: atrilabs-engine
+    html_url: https://github.com/Atri-Labs/atrilabs-engine
+    stars: 4071
+    owner_login: Atri-Labs
+    owner_html_url: https://github.com/Atri-Labs
+  - name: mcp-context-forge
+    html_url: https://github.com/IBM/mcp-context-forge
+    stars: 3989
+    owner_login: IBM
+    owner_html_url: https://github.com/IBM
+  - name: datamodel-code-generator
+    html_url: https://github.com/koxudaxi/datamodel-code-generator
+    stars: 3952
+    owner_login: koxudaxi
+    owner_html_url: https://github.com/koxudaxi
+  - name: LitServe
+    html_url: https://github.com/Lightning-AI/LitServe
+    stars: 3901
+    owner_login: Lightning-AI
+    owner_html_url: https://github.com/Lightning-AI
+  - name: fastapi-admin
+    html_url: https://github.com/fastapi-admin/fastapi-admin
+    stars: 3799
+    owner_login: fastapi-admin
+    owner_html_url: https://github.com/fastapi-admin
+  - name: tracecat
+    html_url: https://github.com/TracecatHQ/tracecat
+    stars: 3703
+    owner_login: TracecatHQ
+    owner_html_url: https://github.com/TracecatHQ
+  - name: farfalle
+    html_url: https://github.com/rashadphz/farfalle
+    stars: 3535
+    owner_login: rashadphz
+    owner_html_url: https://github.com/rashadphz
+  - name: Rapid-MLX
+    html_url: https://github.com/raullenchai/Rapid-MLX
+    stars: 3155
+    owner_login: raullenchai
+    owner_html_url: https://github.com/raullenchai
+  - name: opyrator
+    html_url: https://github.com/ml-tooling/opyrator
+    stars: 3133
+    owner_login: ml-tooling
+    owner_html_url: https://github.com/ml-tooling
+  - name: docarray
+    html_url: https://github.com/docarray/docarray
+    stars: 3121
+    owner_login: docarray
+    owner_html_url: https://github.com/docarray
+  - name: fastapi-realworld-example-app
+    html_url: https://github.com/nsidnev/fastapi-realworld-example-app
+    stars: 3109
+    owner_login: nsidnev
+    owner_html_url: https://github.com/nsidnev
+  - name: uvicorn-gunicorn-fastapi-docker
+    html_url: https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker
+    stars: 2914
+    owner_login: tiangolo
+    owner_html_url: https://github.com/tiangolo
+  - name: any-auto-register
+    html_url: https://github.com/lxf746/any-auto-register
+    stars: 2832
+    owner_login: lxf746
+    owner_html_url: https://github.com/lxf746
+  - name: FastAPI-template
+    html_url: https://github.com/s3rius/FastAPI-template
+    stars: 2810
+    owner_login: s3rius
+    owner_html_url: https://github.com/s3rius
+  - name: YC-Killer
+    html_url: https://github.com/sahibzada-allahyar/YC-Killer
+    stars: 2779
+    owner_login: sahibzada-allahyar
+    owner_html_url: https://github.com/sahibzada-allahyar
+  - name: sqladmin
+    html_url: https://github.com/smithyhq/sqladmin
+    stars: 2759
+    owner_login: smithyhq
+    owner_html_url: https://github.com/smithyhq
+  - name: best-of-web-python
+    html_url: https://github.com/ml-tooling/best-of-web-python
+    stars: 2731
+    owner_login: ml-tooling
+    owner_html_url: https://github.com/ml-tooling
+  - name: NoteDiscovery
+    html_url: https://github.com/gamosoft/NoteDiscovery
+    stars: 2595
+    owner_login: gamosoft
+    owner_html_url: https://github.com/gamosoft
+  - name: fastapi-react
+    html_url: https://github.com/Buuntu/fastapi-react
+    stars: 2588
+    owner_login: Buuntu
+    owner_html_url: https://github.com/Buuntu
+  - name: supabase-py
+    html_url: https://github.com/supabase/supabase-py
+    stars: 2530
+    owner_login: supabase
+    owner_html_url: https://github.com/supabase
+  - name: 30-Days-of-Python
+    html_url: https://github.com/codingforentrepreneurs/30-Days-of-Python
+    stars: 2483
+    owner_login: codingforentrepreneurs
+    owner_html_url: https://github.com/codingforentrepreneurs
+  - name: RasaGPT
+    html_url: https://github.com/paulpierre/RasaGPT
+    stars: 2462
+    owner_login: paulpierre
+    owner_html_url: https://github.com/paulpierre
+  - name: fastapi-langgraph-agent-production-ready-template
+    html_url: https://github.com/wassim249/fastapi-langgraph-agent-production-ready-template
+    stars: 2456
+    owner_login: wassim249
+    owner_html_url: https://github.com/wassim249
+  - name: AIstudioProxyAPI
+    html_url: https://github.com/CJackHwang/AIstudioProxyAPI
+    stars: 2445
+    owner_login: CJackHwang
+    owner_html_url: https://github.com/CJackHwang
+  - name: nextpy
+    html_url: https://github.com/dot-agent/nextpy
+    stars: 2341
+    owner_login: dot-agent
+    owner_html_url: https://github.com/dot-agent
+  - name: langserve
+    html_url: https://github.com/langchain-ai/langserve
+    stars: 2329
+    owner_login: langchain-ai
+    owner_html_url: https://github.com/langchain-ai
+  - name: fastapi-best-architecture
+    html_url: https://github.com/fastapi-practices/fastapi-best-architecture
+    stars: 2318
+    owner_login: fastapi-practices
+    owner_html_url: https://github.com/fastapi-practices
+  - name: fastapi-utils
+    html_url: https://github.com/fastapiutils/fastapi-utils
+    stars: 2308
+    owner_login: fastapiutils
+    owner_html_url: https://github.com/fastapiutils
+  - name: vue-fastapi-admin
+    html_url: https://github.com/mizhexiaoxiao/vue-fastapi-admin
+    stars: 2184
+    owner_login: mizhexiaoxiao
+    owner_html_url: https://github.com/mizhexiaoxiao
+  - name: solara
+    html_url: https://github.com/widgetti/solara
+    stars: 2166
+    owner_login: widgetti
+    owner_html_url: https://github.com/widgetti
+  - name: mangum
+    html_url: https://github.com/Kludex/mangum
+    stars: 2125
+    owner_login: Kludex
+    owner_html_url: https://github.com/Kludex
+  - name: codex-lb
+    html_url: https://github.com/Soju06/codex-lb
+    stars: 2122
+    owner_login: Soju06
+    owner_html_url: https://github.com/Soju06
+  - name: kiro-gateway
+    html_url: https://github.com/jwadow/kiro-gateway
+    stars: 2068
+    owner_login: jwadow
+    owner_html_url: https://github.com/jwadow
+  - name: open-wearables
+    html_url: https://github.com/the-momentum/open-wearables
+    stars: 2036
+    owner_login: the-momentum
+    owner_html_url: https://github.com/the-momentum
+  - name: slowapi
+    html_url: https://github.com/laurentS/slowapi
+    stars: 2022
+    owner_login: laurentS
+    owner_html_url: https://github.com/laurentS
+  - name: xhs_ai_publisher
+    html_url: https://github.com/BetaStreetOmnis/xhs_ai_publisher
+    stars: 2004
+    owner_login: BetaStreetOmnis
+    owner_html_url: https://github.com/BetaStreetOmnis
+  - name: FastAPI-boilerplate
+    html_url: https://github.com/benavlabs/FastAPI-boilerplate
+    stars: 1984
+    owner_login: benavlabs
+    owner_html_url: https://github.com/benavlabs
+  - name: openapi-python-client
+    html_url: https://github.com/openapi-generators/openapi-python-client
+    stars: 1967
+    owner_login: openapi-generators
+    owner_html_url: https://github.com/openapi-generators
+  - name: agentkit
+    html_url: https://github.com/BCG-X-Official/agentkit
+    stars: 1944
+    owner_login: BCG-X-Official
+    owner_html_url: https://github.com/BCG-X-Official
+  - name: piccolo
+    html_url: https://github.com/piccolo-orm/piccolo
+    stars: 1922
+    owner_login: piccolo-orm
+    owner_html_url: https://github.com/piccolo-orm
+  - name: manage-fastapi
+    html_url: https://github.com/ycd/manage-fastapi
+    stars: 1905
+    owner_login: ycd
+    owner_html_url: https://github.com/ycd
+  - name: fastapi-cache
+    html_url: https://github.com/long2ice/fastapi-cache
+    stars: 1866
+    owner_login: long2ice
+    owner_html_url: https://github.com/long2ice
+  - name: ormar
+    html_url: https://github.com/ormar-orm/ormar
+    stars: 1806
+    owner_login: ormar-orm
+    owner_html_url: https://github.com/ormar-orm
+  - name: python-week-2022
+    html_url: https://github.com/rochacbruno/python-week-2022
+    stars: 1806
+    owner_login: rochacbruno
+    owner_html_url: https://github.com/rochacbruno
+  - name: WebRPA
+    html_url: https://github.com/pmh1314520/WebRPA
+    stars: 1781
+    owner_login: pmh1314520
+    owner_html_url: https://github.com/pmh1314520
+  - name: termpair
+    html_url: https://github.com/cs01/termpair
+    stars: 1735
+    owner_login: cs01
+    owner_html_url: https://github.com/cs01
+  - name: fastapi-crudrouter
+    html_url: https://github.com/awtkns/fastapi-crudrouter
+    stars: 1694
+    owner_login: awtkns
+    owner_html_url: https://github.com/awtkns
+  - name: bracket
+    html_url: https://github.com/evroon/bracket
+    stars: 1694
+    owner_login: evroon
+    owner_html_url: https://github.com/evroon
+  - name: fastapi-pagination
+    html_url: https://github.com/uriyyo/fastapi-pagination
+    stars: 1670
+    owner_login: uriyyo
+    owner_html_url: https://github.com/uriyyo
+  - name: langchain-serve
+    html_url: https://github.com/jina-ai/langchain-serve
+    stars: 1640
+    owner_login: jina-ai
+    owner_html_url: https://github.com/jina-ai
+  - name: awesome-fastapi-projects
+    html_url: https://github.com/Kludex/awesome-fastapi-projects
+    stars: 1608
+    owner_login: Kludex
+    owner_html_url: https://github.com/Kludex
+  - name: coronavirus-tracker-api
+    html_url: https://github.com/ExpDev07/coronavirus-tracker-api
+    stars: 1568
+    owner_login: ExpDev07
+    owner_html_url: https://github.com/ExpDev07
+  - name: fastapi-amis-admin
+    html_url: https://github.com/amisadmin/fastapi-amis-admin
+    stars: 1559
+    owner_login: amisadmin
+    owner_html_url: https://github.com/amisadmin
+  - name: fastcrud
+    html_url: https://github.com/benavlabs/fastcrud
+    stars: 1531
+    owner_login: benavlabs
+    owner_html_url: https://github.com/benavlabs
+  - name: tavily-key-generator
+    html_url: https://github.com/skernelx/tavily-key-generator
+    stars: 1526
+    owner_login: skernelx
+    owner_html_url: https://github.com/skernelx
+  - name: fastapi-boilerplate
+    html_url: https://github.com/teamhide/fastapi-boilerplate
+    stars: 1491
+    owner_login: teamhide
+    owner_html_url: https://github.com/teamhide
+  - name: full-stack-ai-agent-template
+    html_url: https://github.com/vstorm-co/full-stack-ai-agent-template
+    stars: 1484
+    owner_login: vstorm-co
+    owner_html_url: https://github.com/vstorm-co
+  - name: prometheus-fastapi-instrumentator
+    html_url: https://github.com/trallnag/prometheus-fastapi-instrumentator
+    stars: 1471
+    owner_login: trallnag
+    owner_html_url: https://github.com/trallnag
+  - name: awesome-python-resources
+    html_url: https://github.com/DjangoEx/awesome-python-resources
+    stars: 1451
+    owner_login: DjangoEx
+    owner_html_url: https://github.com/DjangoEx
+  - name: aktools
+    html_url: https://github.com/akfamily/aktools
+    stars: 1431
+    owner_login: akfamily
+    owner_html_url: https://github.com/akfamily
+  - name: RuoYi-Vue3-FastAPI
+    html_url: https://github.com/insistence/RuoYi-Vue3-FastAPI
+    stars: 1419
+    owner_login: insistence
+    owner_html_url: https://github.com/insistence
+  - name: fastapi-tutorial
+    html_url: https://github.com/liaogx/fastapi-tutorial
+    stars: 1418
+    owner_login: liaogx
+    owner_html_url: https://github.com/liaogx
+  - name: fastapi-code-generator
+    html_url: https://github.com/koxudaxi/fastapi-code-generator
+    stars: 1396
+    owner_login: koxudaxi
+    owner_html_url: https://github.com/koxudaxi
+  - name: yubal
+    html_url: https://github.com/guillevc/yubal
+    stars: 1388
+    owner_login: guillevc
+    owner_html_url: https://github.com/guillevc
+  - name: budgetml
+    html_url: https://github.com/ebhy/budgetml
+    stars: 1343
+    owner_login: ebhy
+    owner_html_url: https://github.com/ebhy
+  - name: Chatterbox-TTS-Server
+    html_url: https://github.com/devnen/Chatterbox-TTS-Server
+    stars: 1328
+    owner_login: devnen
+    owner_html_url: https://github.com/devnen
+  - name: restish
+    html_url: https://github.com/rest-sh/restish
+    stars: 1321
+    owner_login: rest-sh
+    owner_html_url: https://github.com/rest-sh

--- a/docs/en/docs/external-links.md
+++ b/docs/en/docs/external-links.md
@@ -23,7 +23,7 @@ But now that FastAPI is the backend framework with the most GitHub stars across 
 
 Most starred [GitHub repositories with the topic `fastapi`](https://github.com/topics/fastapi):
 
-{% for repo in topic_repos %}
+{% for repo in topic_repos.repos %}
 
 <a href={{repo.html_url}} target="_blank">★ {{repo.stars}} - {{repo.name}}</a> by <a href={{repo.owner_html_url}} target="_blank">@{{repo.owner_login}}</a>.
 

--- a/docs/en/docs/fastapi-people.md
+++ b/docs/en/docs/fastapi-people.md
@@ -97,7 +97,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% for user in people.last_month_experts[:10] %}
 
-{% if user.login not in skip_users %}
+{% if user.login not in skip_users.users %}
 
 <div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
@@ -115,7 +115,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% for user in people.three_months_experts[:10] %}
 
-{% if user.login not in skip_users %}
+{% if user.login not in skip_users.users %}
 
 <div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
@@ -133,7 +133,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% for user in people.six_months_experts[:10] %}
 
-{% if user.login not in skip_users %}
+{% if user.login not in skip_users.users %}
 
 <div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
@@ -151,7 +151,7 @@ These are the users that have been [helping others the most with questions in Gi
 
 {% for user in people.one_year_experts[:20] %}
 
-{% if user.login not in skip_users %}
+{% if user.login not in skip_users.users %}
 
 <div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
@@ -171,7 +171,7 @@ These are the users that have [helped others the most with questions in GitHub](
 
 {% for user in people.experts[:50] %}
 
-{% if user.login not in skip_users %}
+{% if user.login not in skip_users.users %}
 
 <div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Questions replied: {{ user.count }}</div></div>
 
@@ -193,7 +193,7 @@ They have contributed source code, documentation, etc. 📦
 
 {% for user in (contributors.values() | list)[:50] %}
 
-{% if user.login not in skip_users %}
+{% if user.login not in skip_users.users %}
 
 <div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Pull Requests: {{ user.count }}</div></div>
 
@@ -214,7 +214,7 @@ Translation reviewers have the **power to approve translations** of the document
 <div class="user-list user-list-center">
 {% for user in (translation_reviewers.values() | list)[:50] %}
 
-{% if user.login not in skip_users %}
+{% if user.login not in skip_users.users %}
 
 <div class="user"><a href="{{ user.url }}"><div class="avatar-wrapper"><img src="{{ user.avatarUrl }}"/></div><div class="title">@{{ user.login }}</div></a> <div class="count">Reviews: {{ user.count }}</div></div>
 

--- a/scripts/topic_repos.py
+++ b/scripts/topic_repos.py
@@ -44,7 +44,7 @@ def main() -> None:
                 owner_html_url=repo.owner.html_url,
             )
         )
-    data = [repo.model_dump() for repo in final_repos]
+    data = {"repos": [repo.model_dump() for repo in final_repos]}
 
     # Local development
     # repos_path = Path("../docs/en/data/topic_repos.yml")


### PR DESCRIPTION
## Description

We have 2 regressions in docs after we switched to Zensical:
* topic repository list is not displayed: https://fastapi.tiangolo.com/external-links/#github-repositories
* lists of users in FastAPI People are not being filtered with `skip_users` list, so we can see Dependabot, GitHub actions in top contributors: https://fastapi.tiangolo.com/fastapi-people/#top-contributors

The reason is that `macros` plugin doesn't support files with top level lists.
To resolve the issue we can convert data files to be mappings

## AI Disclaimer

Used AI for investigating things

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.

Checked by running `scripts/topic_repos.py` script locally that it produces correct data file
