### PR TITLE
🐛 Fix `Form()` with an `Optional` Pydantic model silently discarding submitted data

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -871,7 +871,11 @@ def request_params_to_args(
 
 
 def is_union_of_base_models(field_type: Any) -> bool:
-    """Check if field type is a Union where all members are BaseModel subclasses."""
+    """Check if field type is a Union where all members are BaseModel subclasses.
+
+    `None` members are ignored, so `Optional[SomeModel]` (i.e. `SomeModel | None`)
+    is still treated as a top-level model union.
+    """
     from fastapi.types import UnionType
 
     origin = get_origin(field_type)
@@ -882,11 +886,17 @@ def is_union_of_base_models(field_type: Any) -> bool:
 
     union_args = get_args(field_type)
 
+    found_base_model = False
     for arg in union_args:
+        # Ignore `None`, so that `Optional[SomeModel]` keeps being treated as a
+        # top-level model union instead of being forced to embed.
+        if arg is type(None):
+            continue
         if not lenient_issubclass(arg, BaseModel):
             return False
+        found_base_model = True
 
-    return True
+    return found_base_model
 
 
 def _should_embed_body_fields(fields: list[ModelField]) -> bool:

--- a/tests/test_union_forms.py
+++ b/tests/test_union_forms.py
@@ -23,6 +23,23 @@ def post_union_form(data: Annotated[UserForm | CompanyForm, Form()]):
     return {"received": data}
 
 
+@app.post("/form-optional-required/")
+def post_optional_required_form(data: Annotated[UserForm | None, Form()]):
+    return {"received": data}
+
+
+@app.post("/form-optional/")
+def post_optional_form(data: Annotated[UserForm | None, Form()] = None):
+    return {"received": data}
+
+
+@app.post("/form-optional-union/")
+def post_optional_union_form(
+    data: Annotated[UserForm | CompanyForm | None, Form()] = None,
+):
+    return {"received": data}
+
+
 client = TestClient(app)
 
 
@@ -56,6 +73,61 @@ def test_invalid_form_data():
 
 def test_empty_form():
     response = client.post("/form-union/")
+    assert response.status_code == 422, response.text
+
+
+def test_post_optional_required_form():
+    # `UserForm | None` without a default is still required, but its top-level
+    # fields must be collected into the model instead of being silently dropped.
+    response = client.post(
+        "/form-optional-required/",
+        data={"name": "John Doe", "email": "john@example.com"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "received": {"name": "John Doe", "email": "john@example.com"}
+    }
+
+
+def test_post_optional_required_form_missing():
+    response = client.post("/form-optional-required/")
+    assert response.status_code == 422, response.text
+
+
+def test_post_optional_form():
+    # `UserForm | None = None`: submitted fields must still populate the model
+    # (previously they were silently discarded and the value resolved to `None`).
+    response = client.post(
+        "/form-optional/", data={"name": "Jane Doe", "email": "jane@example.com"}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "received": {"name": "Jane Doe", "email": "jane@example.com"}
+    }
+
+
+def test_post_optional_form_empty():
+    # An empty form is equivalent to an empty object (`{}`), so the required model
+    # fields are still validated (mirroring a JSON `{}` body), giving a 422.
+    response = client.post("/form-optional/")
+    assert response.status_code == 422, response.text
+
+
+def test_post_optional_union_form():
+    response = client.post(
+        "/form-optional-union/",
+        data={"company_name": "Tech Corp", "industry": "Technology"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "received": {"company_name": "Tech Corp", "industry": "Technology"}
+    }
+
+
+def test_post_optional_union_form_empty():
+    # As above, an empty form validates the (required) members, so it is a 422
+    # rather than silently resolving to the `None` default.
+    response = client.post("/form-optional-union/")
     assert response.status_code == 422, response.text
 
 
@@ -104,7 +176,116 @@ def test_openapi_schema():
                             },
                         },
                     }
-                }
+                },
+                "/form-optional-required/": {
+                    "post": {
+                        "summary": "Post Optional Required Form",
+                        "operationId": "post_optional_required_form_form_optional_required__post",
+                        "requestBody": {
+                            "content": {
+                                "application/x-www-form-urlencoded": {
+                                    "schema": {
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/UserForm"},
+                                            {"type": "null"},
+                                        ],
+                                        "title": "Data",
+                                    }
+                                }
+                            },
+                            "required": True,
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
+                        },
+                    }
+                },
+                "/form-optional/": {
+                    "post": {
+                        "summary": "Post Optional Form",
+                        "operationId": "post_optional_form_form_optional__post",
+                        "requestBody": {
+                            "content": {
+                                "application/x-www-form-urlencoded": {
+                                    "schema": {
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/UserForm"},
+                                            {"type": "null"},
+                                        ],
+                                        "title": "Data",
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
+                        },
+                    }
+                },
+                "/form-optional-union/": {
+                    "post": {
+                        "summary": "Post Optional Union Form",
+                        "operationId": "post_optional_union_form_form_optional_union__post",
+                        "requestBody": {
+                            "content": {
+                                "application/x-www-form-urlencoded": {
+                                    "schema": {
+                                        "anyOf": [
+                                            {"$ref": "#/components/schemas/UserForm"},
+                                            {
+                                                "$ref": "#/components/schemas/CompanyForm"
+                                            },
+                                            {"type": "null"},
+                                        ],
+                                        "title": "Data",
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {}}},
+                            },
+                            "422": {
+                                "description": "Validation Error",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/HTTPValidationError"
+                                        }
+                                    }
+                                },
+                            },
+                        },
+                    }
+                },
             },
             "components": {
                 "schemas": {


### PR DESCRIPTION
### Bug

A form body parameter typed as `Optional[SomeModel]` (`SomeModel | None`) silently drops the submitted fields and resolves to `None` with **no validation error** — while the equivalent JSON body parses correctly. Simply adding `| None` to an otherwise-working `Annotated[SomeModel, Form()]` parameter breaks it.

```python
from typing import Annotated
from fastapi import FastAPI, Form
from pydantic import BaseModel

class UserForm(BaseModel):
    username: str

app = FastAPI()

@app.post("/x")
def x(data: Annotated[UserForm | None, Form()] = None):
    return data

# POST /x  with form field  username=alice  ->  returns null  (data silently lost)
# The same endpoint with Annotated[UserForm, Form()] returns {"username": "alice"}
```

### Cause

`is_union_of_base_models()` returns `False` for `SomeModel | None` because `NoneType` is not a `BaseModel` subclass. That makes `_should_embed_body_fields()` force-embed the field, so the top-level form fields are never expanded into the model and the value falls back to the default (`None`). The `None` member case was not considered when this helper was introduced in #13827 (`tests/test_union_forms.py` only covered `UserForm | CompanyForm`).

### Fix

Ignore `None` members when checking a union of models, so `Optional[SomeModel]` (and `A | B | None`) keeps being treated as a top-level model union. An empty form still validates the required fields (a `422`), which is consistent with how an empty JSON `{}` body behaves.

### Tests

Added regression tests to `tests/test_union_forms.py` covering the required, defaulted, and multi-member-union optional cases, and updated the OpenAPI snapshot (which now correctly shows `anyOf: [SomeModel, {"type": "null"}]`).
