### PR TITLE
Fix UnboundLocalError in OpenAPI generation for custom response classes

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -337,6 +337,7 @@ def get_openapi_path(
                         )
                         callbacks[callback.name] = {callback.path: cb_path}
                 operation["callbacks"] = callbacks
+            status_code = "200"
             if route.status_code is not None:
                 status_code = str(route.status_code)
             else:


### PR DESCRIPTION
## Problem

In `get_openapi_path` (`fastapi/openapi/utils.py`), `status_code` is assigned **only inside** the branches, then used unconditionally as a dict key:

```python
if route.status_code is not None:
    status_code = str(route.status_code)
else:
    response_signature = inspect.signature(current_response_class.__init__)
    status_code_param = response_signature.parameters.get("status_code")
    if status_code_param is not None:
        if isinstance(status_code_param.default, int):
            status_code = str(status_code_param.default)
operation.setdefault("responses", {}).setdefault(status_code, {})["description"] = route.response_description
```

When `route.status_code is None` **and** the response class's `__init__` has no `status_code` parameter (or its default isn't an `int`), `status_code` is never bound → `UnboundLocalError` on the `setdefault(status_code, ...)` line.

## Impact

`get_openapi_path` → `get_openapi` → `Application.openapi()`, so this doesn't just affect one route — it crashes **the whole schema generation**, taking down `/openapi.json`, `/docs`, and `/redoc` for the entire app.

It's reachable with a common wrapper pattern: a custom `response_class` whose `__init__` is `def __init__(self, *args, **kwargs)` (or types `status_code` as `int | None = None`).

## Reproduction

```python
from fastapi import FastAPI
from fastapi.responses import JSONResponse

class MyResponse(JSONResponse):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

app = FastAPI()

@app.get("/x", response_class=MyResponse)
def x():
    return {"a": 1}

app.openapi()   # before: UnboundLocalError at openapi/utils.py; after: works
```

## Fix

Bind a fallback (`"200"`, FastAPI's default route status) before the branches so `status_code` is always defined. The existing (working) paths are unchanged — they still overwrite it.

```python
status_code = "200"
if route.status_code is not None:
    ...
```
