### PR TITLE
📝 Add Chinese terminology for HTTP headers

### DIFF
--- a/docs/zh/llm-prompt.md
+++ b/docs/zh/llm-prompt.md
@@ -31,6 +31,8 @@ Use the following preferred translations when they apply in documentation prose:
 
 - request (HTTP): 请求
 - response (HTTP): 响应
+- HTTP header(s): 请求头
+- Header parameter(s): `Header` 参数
 - path operation: 路径操作
 - path operation function: 路径操作函数
 


### PR DESCRIPTION
Add preferred Simplified Chinese terminology for generic HTTP headers and FastAPI `Header` parameters.

This avoids inconsistent translations such as `header`, `headers`, `标头`, and `头部` when pages are regenerated.

Discussed and invited in https://github.com/fastapi/fastapi/discussions/9188#discussioncomment-17696650