### PR TITLE
🐛 Fix implicit path params with Starlette URL converters not recognized

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -41,7 +41,7 @@ def is_body_allowed_for_status_code(status_code: int | str | None) -> bool:
 
 
 def get_path_param_names(path: str) -> set[str]:
-    return set(re.findall("{(.*?)}", path))
+    return {param.split(":")[0] for param in re.findall(r"{(.*?)}", path)}
 
 
 _invalid_args_message = (

--- a/tests/test_starlette_urlconvertors.py
+++ b/tests/test_starlette_urlconvertors.py
@@ -61,3 +61,45 @@ def test_url_path_for_path_convertor():
     assert (
         app.url_path_for("path_convertor", param="some/example") == "/path/some/example"
     )
+
+
+def test_implicit_path_param_with_converters():
+    # Test that converters work with implicit path parameters (without Path())
+    app_implicit = FastAPI()
+
+    @app_implicit.get("/int/{param:int}")
+    def implicit_int_convertor(param: int):
+        return {"int": param}
+
+    @app_implicit.get("/float/{param:float}")
+    def implicit_float_convertor(param: float):
+        return {"float": param}
+
+    @app_implicit.get("/path/{param:path}")
+    def implicit_path_convertor(param: str):
+        return {"path": param}
+
+    client_implicit = TestClient(app_implicit)
+
+    # Test integer conversion
+    response = client_implicit.get("/int/5")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"int": 5}
+
+    # Test float conversion
+    response = client_implicit.get("/float/25.5")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"float": 25.5}
+
+    # Test path conversion
+    response = client_implicit.get("/path/some/example")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"path": "some/example"}
+
+    # Test url_path_for with implicit converters
+    assert app_implicit.url_path_for("implicit_int_convertor", param=5) == "/int/5"
+    assert app_implicit.url_path_for("implicit_float_convertor", param=25.5) == "/float/25.5"
+    assert (
+        app_implicit.url_path_for("implicit_path_convertor", param="some/example")
+        == "/path/some/example"
+    )

--- a/tests/test_starlette_urlconvertors.py
+++ b/tests/test_starlette_urlconvertors.py
@@ -98,7 +98,10 @@ def test_implicit_path_param_with_converters():
 
     # Test url_path_for with implicit converters
     assert app_implicit.url_path_for("implicit_int_convertor", param=5) == "/int/5"
-    assert app_implicit.url_path_for("implicit_float_convertor", param=25.5) == "/float/25.5"
+    assert (
+        app_implicit.url_path_for("implicit_float_convertor", param=25.5)
+        == "/float/25.5"
+    )
     assert (
         app_implicit.url_path_for("implicit_path_convertor", param="some/example")
         == "/path/some/example"


### PR DESCRIPTION
## Description

Fixes #14883

When using Starlette URL converters like `{param:int}` without an explicit `Path()` annotation, `get_path_param_names()` was returning the full converter pattern (e.g. `param:int`) instead of just the parameter name (`param`). This caused FastAPI to not recognize the parameter as a path parameter.

## Changes

- **`fastapi/utils.py`**: Updated `get_path_param_names()` to strip converter suffixes by splitting on `:`
- **`tests/test_starlette_urlconvertors.py`**: Added `test_implicit_path_param_with_converters` that tests `:int`, `:float`, and `:path` converters with implicit parameters, including `url_path_for` verification

## Verification

- All 6 tests in `test_starlette_urlconvertors.py` pass
- 99 related path parameter tests pass with zero regressions