### PR TITLE
🐛 Fix handling sequences with nested Annotated types

### DIFF
--- a/fastapi/_compat/shared.py
+++ b/fastapi/_compat/shared.py
@@ -68,6 +68,8 @@ def field_annotation_is_sequence(annotation: type[Any] | None) -> bool:
             if field_annotation_is_sequence(arg):
                 return True
         return False
+    if origin is Annotated:
+        return field_annotation_is_sequence(get_args(annotation)[0])
     return _annotation_is_sequence(annotation) or _annotation_is_sequence(
         get_origin(annotation)
     )
@@ -117,6 +119,8 @@ def field_annotation_is_scalar_sequence(annotation: type[Any] | None) -> bool:
             elif not field_annotation_is_scalar(arg):
                 return False
         return at_least_one_scalar_sequence
+    if origin is Annotated:
+        return field_annotation_is_scalar_sequence(get_args(annotation)[0])
     return field_annotation_is_sequence(annotation) and all(
         field_annotation_is_scalar(sub_annotation)
         for sub_annotation in get_args(annotation)
@@ -154,6 +158,8 @@ def is_bytes_sequence_annotation(annotation: Any) -> bool:
                 at_least_one = True
                 continue
         return at_least_one
+    if origin is Annotated:
+        return is_bytes_sequence_annotation(get_args(annotation)[0])
     return field_annotation_is_sequence(annotation) and all(
         is_bytes_or_nonable_bytes_annotation(sub_annotation)
         for sub_annotation in get_args(annotation)
@@ -169,6 +175,8 @@ def is_uploadfile_sequence_annotation(annotation: Any) -> bool:
                 at_least_one = True
                 continue
         return at_least_one
+    if origin is Annotated:
+        return is_uploadfile_sequence_annotation(get_args(annotation)[0])
     return field_annotation_is_sequence(annotation) and all(
         is_uploadfile_or_nonable_uploadfile_annotation(sub_annotation)
         for sub_annotation in get_args(annotation)

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -118,6 +118,39 @@ def test_nested_router():
     assert response.json() == {"foo": "bar"}
 
 
+def test_nested_annotated_sequence_in_query():
+    """
+    Test that nested Annotated types with sequences work correctly.
+
+    Regression test for https://github.com/fastapi/fastapi/issues/14874
+    """
+    from pydantic import Field
+
+    MaxSizedSet = Annotated[set[str], Field(max_length=3)]
+
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root(foo: Annotated[MaxSizedSet | None, Query()] = None):
+        return {"foo": foo}
+
+    client = TestClient(app)
+
+    # No query param should return None
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"foo": None}
+
+    # Valid values should be returned (order not guaranteed for sets)
+    response = client.get("/", params={"foo": ["bar", "baz"]})
+    assert response.status_code == 200
+    assert set(response.json()["foo"]) == {"bar", "baz"}
+
+    # Exceeding max_length should fail validation
+    response = client.get("/", params={"foo": ["a", "b", "c", "d"]})
+    assert response.status_code == 422
+
+
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200


### PR DESCRIPTION
## Description

Fixes #14874

When using nested `Annotated` types with sequences (e.g. `Annotated[set[str], Field(max_length=3)]`), functions like `field_annotation_is_sequence` and `field_annotation_is_scalar_sequence` failed to unwrap the `Annotated` wrapper, causing an `AssertionError` on startup.

## Changes

- **`fastapi/_compat/shared.py`**: Added `Annotated` unwrapping to four functions, following the established pattern from `field_annotation_is_complex`:
  - `field_annotation_is_sequence`
  - `field_annotation_is_scalar_sequence`
  - `is_bytes_sequence_annotation` (consistency)
  - `is_uploadfile_sequence_annotation` (consistency)
- **`tests/test_annotated.py`**: Added `test_nested_annotated_sequence_in_query` that tests the exact reproduction case from the issue, including validation of `max_length`

## Verification

- All 33 related tests pass with zero regressions