### PR TITLE
🐛 Fix response_model_* params ignored for non-generator Iterable endpoints

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -991,9 +991,9 @@ def _populate_api_route_state(
                 # endpoint is an actual generator. Non-generator endpoints
                 # returning Iterable[T] should still have a response_model for
                 # proper serialization with response_model_* params.
-                if inspect.isasyncgenfunction(
+                if inspect.isasyncgenfunction(endpoint) or inspect.isgeneratorfunction(
                     endpoint
-                ) or inspect.isgeneratorfunction(endpoint):
+                ):
                     # Extract item type for JSONL or SSE streaming when
                     # response_class is DefaultPlaceholder (JSONL) or
                     # EventSourceResponse (SSE).

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -987,18 +987,27 @@ def _populate_api_route_state(
         else:
             stream_item = get_stream_item_type(return_annotation)
             if stream_item is not None:
-                # Extract item type for JSONL or SSE streaming when
-                # response_class is DefaultPlaceholder (JSONL) or
-                # EventSourceResponse (SSE).
-                # ServerSentEvent is excluded: it's a transport
-                # wrapper, not a data model, so it shouldn't feed
-                # into validation or OpenAPI schema generation.
-                if (
-                    isinstance(response_class, DefaultPlaceholder)
-                    or lenient_issubclass(response_class, EventSourceResponse)
-                ) and not lenient_issubclass(stream_item, ServerSentEvent):
-                    route.stream_item_type = stream_item
-                response_model = None
+                # Only treat Iterable/AsyncIterable/etc. as a stream when the
+                # endpoint is an actual generator. Non-generator endpoints
+                # returning Iterable[T] should still have a response_model for
+                # proper serialization with response_model_* params.
+                if inspect.isasyncgenfunction(
+                    endpoint
+                ) or inspect.isgeneratorfunction(endpoint):
+                    # Extract item type for JSONL or SSE streaming when
+                    # response_class is DefaultPlaceholder (JSONL) or
+                    # EventSourceResponse (SSE).
+                    # ServerSentEvent is excluded: it's a transport
+                    # wrapper, not a data model, so it shouldn't feed
+                    # into validation or OpenAPI schema generation.
+                    if (
+                        isinstance(response_class, DefaultPlaceholder)
+                        or lenient_issubclass(response_class, EventSourceResponse)
+                    ) and not lenient_issubclass(stream_item, ServerSentEvent):
+                        route.stream_item_type = stream_item
+                    response_model = None
+                else:
+                    response_model = return_annotation
             else:
                 response_model = return_annotation
     route.response_model = response_model

--- a/tests/test_response_model_as_return_annotation.py
+++ b/tests/test_response_model_as_return_annotation.py
@@ -508,6 +508,37 @@ def test_invalid_response_model_field():
     assert "parameter response_model=None" in e.value.args[0]
 
 
+def test_iterable_return_type_response_model_inferred():
+    """
+    Test that non-generator endpoints with Iterable return type
+    correctly infer the response model from the return annotation.
+
+    Regression test for https://github.com/fastapi/fastapi/issues/15093
+    """
+    from typing import Iterable as TypingIterable
+
+    app = FastAPI()
+
+    class ItemOut(BaseModel):
+        name: str
+        price: float | None = None
+
+    @app.get(
+        "/items-iterable",
+        response_model_exclude_none=True,
+    )
+    def get_items() -> TypingIterable[ItemOut]:
+        return [ItemOut(name="Foo", price=None), ItemOut(name="Bar", price=42.0)]
+
+    client = TestClient(app)
+
+    response = client.get("/items-iterable")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    # response_model_exclude_none should exclude the None price field
+    assert data == [{"name": "Foo"}, {"name": "Bar", "price": 42.0}]
+
+
 def test_openapi_schema():
     response = client.get("/openapi.json")
     assert response.status_code == 200, response.text

--- a/tests/test_response_model_as_return_annotation.py
+++ b/tests/test_response_model_as_return_annotation.py
@@ -515,7 +515,7 @@ def test_iterable_return_type_response_model_inferred():
 
     Regression test for https://github.com/fastapi/fastapi/issues/15093
     """
-    from typing import Iterable as TypingIterable
+    from collections.abc import Iterable as TypingIterable
 
     app = FastAPI()
 


### PR DESCRIPTION
## Description

Fixes #15093

Non-generator endpoints with `Iterable[T]` return type had `response_model` set to `None` because `get_stream_item_type()` matched `Iterable` as a stream origin (it's in `_STREAM_ORIGINS`). This caused `serialize_response()` to fall back to `jsonable_encoder()`, ignoring `response_model_*` params like `exclude_none`, `exclude_unset`, and `exclude_defaults`.

## Changes

- **`fastapi/routing.py`**: Added `inspect.isasyncgenfunction/isgeneratorfunction` check before treating the return type as a stream in `_populate_api_route_state`. Non-generator endpoints with `Iterable[T]` now correctly use the return annotation as the response model.
- **`tests/test_response_model_as_return_annotation.py`**: Added `test_iterable_return_type_response_model_inferred` verifying that `response_model_exclude_none` works for non-generator endpoints returning `Iterable[ItemOut]`

## Verification
- All 69 related tests pass (stream, SSE, response_model) with zero regressions