### PR TITLE
📝 Add Library Skills documentation

### DIFF
--- a/docs/en/docs/tutorial/index.md
+++ b/docs/en/docs/tutorial/index.md
@@ -112,6 +112,24 @@ Read the [Virtual Environments guide](https://tiangolo.com/guides/virtual-enviro
 
 ///
 
+## AI Agent Skills { #ai-agent-skills }
+
+FastAPI includes an official skill for AI coding agents. It is bundled with the package, so its guidance stays aligned with the version of FastAPI installed in your project and updates when you update FastAPI.
+
+After installing FastAPI in your project, you can install the skill with <a href="https://library-skills.io">Library Skills</a>:
+
+```bash
+uvx library-skills
+```
+
+/// note
+
+`uvx` is an alias for `uv tool run`. It runs Library Skills in a temporary, isolated environment while Library Skills scans the packages installed in your project.
+
+///
+
+The skill is compatible with Codex, Claude Code, Cursor, GitHub Copilot, Gemini CLI, Pi, OpenCode, and most other coding agents. For Claude Code, select `.claude/skills` when asked where to install the skill.
+
 ## Advanced User Guide { #advanced-user-guide }
 
 There is also an **Advanced User Guide** that you can read later after this **Tutorial - User Guide**.


### PR DESCRIPTION
## Summary

- document the official FastAPI AI agent skill in the installation flow
- show the optional `uvx library-skills` command and explain its relationship to `uv tool run`
- note compatibility with popular coding agents and the Claude Code installation target

## Validation

- `uv run ./scripts/docs.py build-lang en`

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.