### PR TITLE
Fix invalid Markdown links in Query docstrings

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -518,7 +518,7 @@ def Query(  # noqa: N802
             RegEx pattern for strings.
 
             Read more about it in the
-            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#add-regular-expressions
+            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#add-regular-expressions)
             """
         ),
     ] = None,
@@ -639,7 +639,7 @@ def Query(  # noqa: N802
             This affects the generated OpenAPI (e.g. visible at `/docs`).
 
             Read more about it in the
-            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#exclude-parameters-from-openapi
+            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#exclude-parameters-from-openapi)
             """
         ),
     ] = True,


### PR DESCRIPTION
## Pull Request

Discussion: Not applicable. This is a source code docstring fix.

## Description

Fix two invalid Markdown links in the `Query` function docstrings.

The links are part of the source code and are used in generated API documentation. The missing closing parentheses caused the Markdown links to be malformed.

## AI Disclaimer

No AI-generated code was used.

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [x] The documentation explains the change if needed.