### PR TITLE
Fix SSE data payload dropping trailing newlines

### DIFF
--- a/fastapi/sse.py
+++ b/fastapi/sse.py
@@ -1,3 +1,4 @@
+import re
 from typing import Annotated, Any
 
 from annotated_doc import Doc
@@ -156,6 +157,13 @@ class ServerSentEvent(BaseModel):
         return self
 
 
+# Line terminators recognized by the SSE wire format: CR LF, CR, or LF
+# (see the WHATWG stream parsing spec). Unlike ``str.splitlines()`` this
+# does not treat other Unicode separators (e.g. \v, \f, \x1c-\x1e, \x85,
+# \u2028, \u2029) as line breaks, and it preserves a trailing empty field.
+_SSE_LINE_TERMINATORS = re.compile(r"\r\n|\r|\n")
+
+
 def format_sse_event(
     *,
     data_str: Annotated[
@@ -213,7 +221,7 @@ def format_sse_event(
         lines.append(f"event: {event}")
 
     if data_str is not None:
-        for line in data_str.splitlines():
+        for line in _SSE_LINE_TERMINATORS.split(data_str):
             lines.append(f"data: {line}")
 
     if id is not None:

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -6,7 +6,7 @@ import fastapi.routing
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
-from fastapi.sse import ServerSentEvent
+from fastapi.sse import ServerSentEvent, format_sse_event
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
@@ -262,6 +262,29 @@ def test_data_and_raw_data_mutually_exclusive():
     """Cannot set both data and raw_data."""
     with pytest.raises(ValueError, match="Cannot set both"):
         ServerSentEvent(data="json", raw_data="raw")
+
+
+def test_format_sse_event_data_line_splitting():
+    """data is split on SSE line terminators (CRLF/CR/LF) only.
+
+    ``str.splitlines()`` silently drops a trailing newline and splits on
+    additional Unicode separators that the SSE wire format does not treat
+    as line breaks, corrupting the payload a client reconstructs.
+    """
+    # A trailing newline must be preserved: it becomes a second, empty
+    # ``data:`` field so the client rebuilds "line1\n", not "line1".
+    assert format_sse_event(data_str="line1\n") == b"data: line1\ndata: \n\n"
+    # Empty data still emits a data field.
+    assert format_sse_event(data_str="") == b"data: \n\n"
+    # Multi-line data is unchanged.
+    assert format_sse_event(data_str="a\nb") == b"data: a\ndata: b\n\n"
+    # CRLF and lone CR are SSE line terminators.
+    assert format_sse_event(data_str="a\r\nb") == b"data: a\ndata: b\n\n"
+    assert format_sse_event(data_str="a\rb") == b"data: a\ndata: b\n\n"
+    # Other Unicode/control separators are NOT line breaks in SSE and must
+    # pass through untouched (str.splitlines would wrongly split these).
+    assert format_sse_event(data_str="a\x0bb") == b"data: a\x0bb\n\n"
+    assert format_sse_event(data_str="a\x0cb") == b"data: a\x0cb\n\n"
 
 
 def test_sse_on_router_included_in_app(client: TestClient):


### PR DESCRIPTION
### Summary

`format_sse_event` splits the data payload with `str.splitlines()` before writing each `data:` field. This silently drops a **trailing** newline, so a `ServerSentEvent` whose data ends in `\n` is sent one field short and a client reconstructs the payload without its final newline.

`str.splitlines()` also treats characters as line breaks that the SSE wire format does **not** recognize (`\v`, `\f`, `\x1c`–`\x1e`, `\x85`, ` `, ` `), so those characters inside `raw_data` — documented as sent "as-is" — get wrongly split into separate `data:` fields.

### Reproduction

```python
from fastapi.sse import format_sse_event

format_sse_event(data_str="line1\n")
# actual:   b'data: line1\n\n'          -> client rebuilds "line1"  (trailing "\n" lost)
# expected: b'data: line1\ndata: \n\n'  -> client rebuilds "line1\n"

format_sse_event(data_str="a\x0bb")
# actual:   b'data: a\ndata: b\n\n'     -> "\x0b" turned into a line break
# expected: b'data: a\x0bb\n\n'         -> "\x0b" sent as-is
```

Per the [WHATWG event-stream format](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), a stream is split into lines on **CR LF, CR, or LF only**, and a `data:` value is joined back with `\n` on the client. To transmit `"line1\n"` the server must emit `data: line1` followed by an empty `data:` field.

### Fix

Split the payload on the SSE line terminators (`\r\n`, `\r`, `\n`) and keep the trailing empty field, instead of using `str.splitlines()`. Multi-line data, CR, and CRLF continue to encode exactly as before.

A unit test covering the trailing-newline, empty, multi-line, CR/CRLF, and non-SSE-separator cases is added. `fastapi/sse.py` stays at 100% coverage.
