### PR TITLE
♻️ Update the lru_cache limit for dependencies to account for large apps

### DIFF
--- a/fastapi/dependencies/models.py
+++ b/fastapi/dependencies/models.py
@@ -52,6 +52,7 @@ class Dependant:
 
 
 _UsesScopesCache = dict[int, tuple[Dependant, bool]]
+_CALLABLE_CLASSIFICATION_CACHE_SIZE = 4096
 
 
 class _CallIdentity:
@@ -137,7 +138,7 @@ def _get_security_dependencies(*, dependant: Dependant) -> list[Dependant]:
     return [dep for dep in dependant.dependencies if _is_security_scheme(dependant=dep)]
 
 
-@lru_cache(maxsize=1024)
+@lru_cache(maxsize=_CALLABLE_CLASSIFICATION_CACHE_SIZE)
 def _is_gen_callable_cached(call_identity: _CallIdentity) -> bool:
     call = call_identity.call
     if inspect.isgeneratorfunction(_impartial(call)) or inspect.isgeneratorfunction(
@@ -167,7 +168,7 @@ def _is_gen_callable(call: Callable[..., Any] | None) -> bool:
     return _is_gen_callable_cached(_CallIdentity(call))
 
 
-@lru_cache(maxsize=1024)
+@lru_cache(maxsize=_CALLABLE_CLASSIFICATION_CACHE_SIZE)
 def _is_async_gen_callable_cached(call_identity: _CallIdentity) -> bool:
     call = call_identity.call
     if inspect.isasyncgenfunction(_impartial(call)) or inspect.isasyncgenfunction(
@@ -197,7 +198,7 @@ def _is_async_gen_callable(call: Callable[..., Any] | None) -> bool:
     return _is_async_gen_callable_cached(_CallIdentity(call))
 
 
-@lru_cache(maxsize=1024)
+@lru_cache(maxsize=_CALLABLE_CLASSIFICATION_CACHE_SIZE)
 def _is_coroutine_callable_cached(call_identity: _CallIdentity) -> bool:
     call = call_identity.call
     if inspect.isroutine(_impartial(call)) and iscoroutinefunction(_impartial(call)):

--- a/tests/test_dependency_models.py
+++ b/tests/test_dependency_models.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 from typing import Any
 
 from fastapi.dependencies.models import (
@@ -93,7 +93,27 @@ def test_callable_classification_is_shared_by_call() -> None:
         cache_info = cached_function.cache_info()
         assert cache_info.hits == 1
         assert cache_info.misses == 1
-        assert cache_info.maxsize == 1024
+        assert cache_info.maxsize == 4096
+
+
+def test_callable_classification_cache_supports_large_apps() -> None:
+    callables: list[Callable[[], None]] = [lambda: None for _ in range(3000)]
+
+    for classifier, cached_classifier in (
+        (_is_gen_callable, _is_gen_callable_cached),
+        (_is_async_gen_callable, _is_async_gen_callable_cached),
+        (_is_coroutine_callable, _is_coroutine_callable_cached),
+    ):
+        cached_classifier.cache_clear()
+
+        for _ in range(2):
+            assert all(not classifier(call) for call in callables)
+
+        cache_info = cached_classifier.cache_info()
+        assert cache_info.hits == len(callables)
+        assert cache_info.misses == len(callables)
+        assert cache_info.maxsize == 4096
+        cached_classifier.cache_clear()
 
 
 def test_unhashable_callable_classification() -> None:


### PR DESCRIPTION
## Pull Request

♻️ Update the lru_cache limit for dependencies to account for large apps

Some users reported a number of dependencies larger than 1024, this should account for larger apps. I'll wait to see if anyone requests an even larger bump, for now this should work.

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Typos, grammar issues, broken links and other small docs improvements should be reported in the pinned Discussion thread "✏️ Report small docs improvements, including typos or broken links".
Please do not open a PR for these yourself.
-->

Discussion: <!-- Link to the GitHub Discussion -->

## Description

<!-- Write the description of your PR here -->

## AI Disclaimer

Codex with gpt-5.6-sol. Based on feedback from users on https://github.com/fastapi/fastapi/pull/16049#discussion_r3649928915 and shared in private messages.

<!-- If using AI, write here the prompt and model used -->

<details>
<summary>AI transcript</summary>

<!-- Paste here the entire AI transcript -->

</details>

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
