### PR TITLE
fix(encoders): use errors='replace' when decoding bytes in jsonable_encoder

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -82,7 +82,7 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
+    bytes: lambda o: o.decode(errors="replace"),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -329,3 +329,9 @@ def test_encode_color(module_path):
 
     data = {"color": Color("blue")}
     assert jsonable_encoder(data) == {"color": "blue"}
+
+
+def test_encode_bytes_invalid_utf8():
+    data = {"bytes": b"\x80\x81"}
+    encoded = jsonable_encoder(data)
+    assert isinstance(encoded["bytes"], str)


### PR DESCRIPTION
## Description
This PR prevents `UnicodeDecodeError` crashes in `jsonable_encoder` by using `errors='replace'` when decoding `bytes` objects.

## Details
- Prevents unhandled `UnicodeDecodeError` when `bytes` objects containing invalid or non-UTF-8 octets (e.g., binary payloads) are passed to `jsonable_encoder`.
- Adds unit test `test_encode_bytes_invalid_utf8` in `tests/test_jsonable_encoder.py`.