### PR TITLE
fix(sse): preserve empty data strings and trailing newlines in format_sse_event

### DIFF
--- a/fastapi/sse.py
+++ b/fastapi/sse.py
@@ -206,14 +206,14 @@ def format_sse_event(
     lines: list[str] = []
 
     if comment is not None:
-        for line in comment.splitlines():
+        for line in comment.split("\n"):
             lines.append(f": {line}")
 
     if event is not None:
         lines.append(f"event: {event}")
 
     if data_str is not None:
-        for line in data_str.splitlines():
+        for line in data_str.split("\n"):
             lines.append(f"data: {line}")
 
     if id is not None:


### PR DESCRIPTION
## Description
This PR resolves line-splitting issues in `format_sse_event()` in `fastapi/sse.py` by replacing `.splitlines()` with `.split('\n')`.

## Details
- Prevents empty data payload strings (`data_str=''`) or strings with trailing newlines from being stripped by `.splitlines()`.
- Complies strictly with the W3C SSE specification section 9.2.6.