### PR TITLE
test(security): add test coverage for OAuth2AuthorizationCodeBearer with auto_error=False

### DIFF
--- a/fastapi/security/oauth2.py
+++ b/fastapi/security/oauth2.py
@@ -646,7 +646,7 @@ class OAuth2AuthorizationCodeBearer(OAuth2):
             if self.auto_error:
                 raise self.make_not_authenticated_error()
             else:
-                return None  # pragma: nocover
+                return None
         return param
 
 

--- a/tests/test_security_oauth2_authorization_code_bearer.py
+++ b/tests/test_security_oauth2_authorization_code_bearer.py
@@ -77,6 +77,17 @@ def test_openapi_schema():
                         },
                     }
                 }
-            },
-        }
+def test_auto_error_false():
+    app_optional = FastAPI()
+    oauth2_optional = OAuth2AuthorizationCodeBearer(
+        authorizationUrl="authorize", tokenUrl="token", auto_error=False
     )
+
+    @app_optional.get("/items/")
+    async def read_optional_items(token: str | None = Security(oauth2_optional)):
+        return {"token": token}
+
+    client_optional = TestClient(app_optional)
+    response = client_optional.get("/items/")
+    assert response.status_code == 200
+    assert response.json() == {"token": None}


### PR DESCRIPTION
## Description
This PR adds test coverage for `OAuth2AuthorizationCodeBearer` when `auto_error=False`.

## Details
- Removes `# pragma: nocover` in `fastapi/security/oauth2.py` and adds `test_auto_error_false()` to `tests/test_security_oauth2_authorization_code_bearer.py`.