### PR TITLE
feat(middleware): add Request Body Size Limit middleware (413 Payload Too Large)

### DIFF
--- a/fastapi/middleware/__init__.py
+++ b/fastapi/middleware/__init__.py
@@ -1,1 +1,2 @@
 from starlette.middleware import Middleware as Middleware
+from .bodysize import BodySizeLimitMiddleware as BodySizeLimitMiddleware

--- a/fastapi/middleware/__init__.py
+++ b/fastapi/middleware/__init__.py
@@ -1,2 +1,3 @@
 from starlette.middleware import Middleware as Middleware
+
 from .bodysize import BodySizeLimitMiddleware as BodySizeLimitMiddleware

--- a/fastapi/middleware/bodysize.py
+++ b/fastapi/middleware/bodysize.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import List
+from starlette.types import ASGIApp, Receive, Scope, Send, Message
+
+
+class BodySizeLimitMiddleware:
+    """ASGI middleware to enforce a maximum request body size.
+
+    - Applies to HTTP requests only.
+    - Pre-reads up to the configured limit; if exceeded, responds 413 and does not invoke the app.
+    - Otherwise, replays the buffered body to the downstream app.
+    """
+
+    def __init__(self, app: ASGIApp, max_body_size: int) -> None:
+        self.app = app
+        self.max_body_size = int(max_body_size)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        total = 0
+        chunks: List[bytes] = []
+        more_body = True
+
+        # Read the incoming body in chunks, enforcing the limit.
+        while more_body:
+            message = await receive()
+            if message.get("type") != "http.request":
+                # Pass through non-body messages (e.g., http.disconnect) to app behavior by aborting early.
+                # In practice, FastAPI/Starlette don't expect them here before body, so we bail out.
+                break
+            body = message.get("body", b"")
+            if body:
+                total += len(body)
+                if total > self.max_body_size:
+                    # Drain the remaining body to allow the server to cleanly finish reading the request.
+                    while message.get("more_body", False):
+                        message = await receive()
+                    await send({
+                        "type": "http.response.start",
+                        "status": 413,
+                        "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+                    })
+                    await send({
+                        "type": "http.response.body",
+                        "body": b"Payload Too Large",
+                        "more_body": False,
+                    })
+                    return
+                chunks.append(body)
+            more_body = message.get("more_body", False)
+
+        buffered = b"".join(chunks)
+        sent_once = False
+
+        async def cached_receive() -> Message:
+            nonlocal sent_once
+            if not sent_once:
+                sent_once = True
+                return {"type": "http.request", "body": buffered, "more_body": False}
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await self.app(scope, cached_receive, send)

--- a/fastapi/middleware/bodysize.py
+++ b/fastapi/middleware/bodysize.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import List
-from starlette.types import ASGIApp, Receive, Scope, Send, Message
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class BodySizeLimitMiddleware:
@@ -22,7 +21,7 @@ class BodySizeLimitMiddleware:
             return
 
         total = 0
-        chunks: List[bytes] = []
+        chunks: list[bytes] = []
         more_body = True
 
         # Read the incoming body in chunks, enforcing the limit.
@@ -39,16 +38,22 @@ class BodySizeLimitMiddleware:
                     # Drain the remaining body to allow the server to cleanly finish reading the request.
                     while message.get("more_body", False):
                         message = await receive()
-                    await send({
-                        "type": "http.response.start",
-                        "status": 413,
-                        "headers": [(b"content-type", b"text/plain; charset=utf-8")],
-                    })
-                    await send({
-                        "type": "http.response.body",
-                        "body": b"Payload Too Large",
-                        "more_body": False,
-                    })
+                    await send(
+                        {
+                            "type": "http.response.start",
+                            "status": 413,
+                            "headers": [
+                                (b"content-type", b"text/plain; charset=utf-8")
+                            ],
+                        }
+                    )
+                    await send(
+                        {
+                            "type": "http.response.body",
+                            "body": b"Payload Too Large",
+                            "more_body": False,
+                        }
+                    )
                     return
                 chunks.append(body)
             more_body = message.get("more_body", False)

--- a/tests/test_middleware_bodysize.py
+++ b/tests/test_middleware_bodysize.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.middleware import BodySizeLimitMiddleware
+from starlette.testclient import TestClient
+
+
+def make_app(limit: int) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_body_size=limit)
+
+    @app.post("/echo")
+    async def echo(request: Request):
+        data = await request.body()
+        return {"len": len(data)}
+
+    return app
+
+
+def test_small_body_passes():
+    app = make_app(limit=16)
+    client = TestClient(app)
+    r = client.post("/echo", data=b"x" * 8)
+    assert r.status_code == 200
+    assert r.json()["len"] == 8
+
+
+def test_large_body_rejected_with_413():
+    app = make_app(limit=16)
+    client = TestClient(app)
+    r = client.post("/echo", data=b"x" * 64)
+    assert r.status_code == 413
+    assert b"Payload Too Large" in r.content

--- a/tests/test_middleware_bodysize.py
+++ b/tests/test_middleware_bodysize.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi import FastAPI, Request
 from fastapi.middleware import BodySizeLimitMiddleware
 from starlette.testclient import TestClient


### PR DESCRIPTION
This adds an opt-in ASGI middleware to enforce a maximum HTTP request body size, returning 413 Payload Too Large when exceeded. The middleware pre-reads up to the configured limit, short-circuits on overflow, and includes unit tests verifying acceptance and rejection paths. This provides a first-class safety guard aligned with production needs without impacting existing apps unless enabled.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>