### PR TITLE
♻️ Drop circular references to dependency_cache values

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -580,7 +580,6 @@ class SolvedDependency:
     errors: list[Any]
     background_tasks: StarletteBackgroundTasks | None
     response: Response
-    dependency_cache: dict[DependencyCacheKey, Any]
 
 
 async def solve_dependencies(
@@ -727,7 +726,6 @@ async def solve_dependencies(
         errors=errors,
         background_tasks=background_tasks,
         response=response,
-        dependency_cache=dependency_cache,
     )
 
 


### PR DESCRIPTION
## Pull Request

## Description

This code block:
https://github.com/fastapi/fastapi/blob/98b12fe56f97107e71a20fc1cf334ccfa590efb5/fastapi/dependencies/utils.py#L680

creates a circular reference:
```python
dependency_cache[key] = SolvedDependency(dependency_cache=dependency_cache)
```

This adds work for CPython garbage collector which could be avoided.

`dependency_cache` is already passed down the recursive `await solve_dependency()` call, so cache items are visible from the top of call stack to the bottom, and this field is not needed in `SolvedDependency` at all.

## AI Disclaimer

No AI used.

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
