### PR TITLE
🐛 Preserve pytest exit code in regression check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,7 +262,8 @@ jobs:
           git apply "$RUNNER_TEMP/tests.patch"
           uv sync --locked --no-dev --group tests --extra all
           set +e
-          xargs -0 uv run --no-sync pytest -- < "$RUNNER_TEMP/changed-tests"
+          mapfile -d '' -t changed_tests < "$RUNNER_TEMP/changed-tests"
+          uv run --no-sync pytest -- "${changed_tests[@]}"
           status=$?
           set -e
           if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- replace `xargs` with a Bash array when invoking the changed tests
- preserve pytest's actual exit code in the regression check
- keep NUL-delimited filename handling

## Root cause

GNU `xargs` converts a child command's exit code `1` into its own exit code `123`. The regression check therefore treated the expected base-test failure as an inconclusive run and failed, as seen in https://github.com/fastapi/fastapi/actions/runs/30362747816/job/90286229952?pr=14874.

## Validation

- reproduced `xargs` translating exit code `1` to `123`
- verified the Bash array invocation preserves exit code `1`
- repository commit hooks passed, including YAML validation and `zizmor`
- `git diff --check` passed

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.