### PR TITLE
🐛 Accept any base test failure as regression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,20 +262,16 @@ jobs:
           git apply "$RUNNER_TEMP/tests.patch"
           uv sync --locked --no-dev --group tests --extra all
           set +e
-          mapfile -d '' -t changed_tests < "$RUNNER_TEMP/changed-tests"
-          uv run --no-sync pytest -- "${changed_tests[@]}"
+          xargs -0 uv run --no-sync pytest -- < "$RUNNER_TEMP/changed-tests"
           status=$?
           set -e
           if [ "$status" -eq 0 ]; then
             echo "::warning::The changed tests already pass on the base revision. Check whether the fix is still needed."
             echo "### Regression proof: base already passes :warning:" >> "$GITHUB_STEP_SUMMARY"
             echo "The changed tests pass without the pull request's code changes." >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$status" -eq 1 ]; then
-            echo "The changed tests fail on the base revision as expected."
-            echo "### Regression proof: base fails as expected :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "::error::The base test run was inconclusive (pytest exit code $status)."
-            exit "$status"
+            echo "The changed tests fail on the base revision as expected (pytest exit code $status)."
+            echo "### Regression proof: base fails as expected :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"
           fi
   coverage-combine:
     needs:


### PR DESCRIPTION
## Summary

- treat every nonzero result from the changed tests on the base revision as a demonstrated regression
- retain the warning when those tests return zero and already pass on the base revision
- restore the NUL-safe `xargs` invocation because the exact nonzero exit code no longer matters

## Root cause

The regression check assumed a valid regression would always produce pytest exit code `1`. In https://github.com/fastapi/fastapi/actions/runs/30363892756/job/90290086433?pr=14874, the bug prevented the test module from being collected, so pytest exited with code `2`. A test that cannot start on the base revision but succeeds with the pull request still demonstrates the underlying bug.

## Validation

- verified `xargs` exit code `123` is accepted as a base failure
- verified all nonzero statuses follow the successful regression-proof branch
- workflow YAML structure passed
- repository commit hooks passed, including `zizmor`
- `git diff --check` passed

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.