### PR TITLE
fix: add skip marker for fastapi-cli subprocess test when CLI is not installed

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -42,9 +42,7 @@ except ImportError:  # pragma: no cover
 
 try:
     # Supporting the new Color format for newer versions of Pydantic
-    from pydantic_extra_types.color import (  # type: ignore[import-not-found]
-        Color as PyExtraColor,
-    )
+    from pydantic_extra_types.color import Color as PyExtraColor
 except ImportError:  # pragma: no cover
 
     class PyExtraColor:  # type: ignore[no-redef]

--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -42,7 +42,9 @@ except ImportError:  # pragma: no cover
 
 try:
     # Supporting the new Color format for newer versions of Pydantic
-    from pydantic_extra_types.color import Color as PyExtraColor
+    from pydantic_extra_types.color import (  # type: ignore[import-not-found]
+        Color as PyExtraColor,
+    )
 except ImportError:  # pragma: no cover
 
     class PyExtraColor:  # type: ignore[no-redef]

--- a/tests/test_fastapi_cli.py
+++ b/tests/test_fastapi_cli.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 import fastapi.cli
 import pytest
 
+needs_fastapi_cli = pytest.mark.skipif(
+    fastapi.cli.cli_main is None, reason="fastapi-cli is not installed"
+)
 
+
+@needs_fastapi_cli
 def test_fastapi_cli():
     result = subprocess.run(
         [


### PR DESCRIPTION
### Summary
This PR adds a skip marker to `test_fastapi_cli()` when `fastapi-cli` is not installed.

### Key Changes
1. **`tests/test_fastapi_cli.py`**:
   - Added `@needs_fastapi_cli` (`pytest.mark.skipif(fastapi.cli.cli_main is None, ...)`) to `test_fastapi_cli()` so that running tests in minimal environments where `fastapi-cli` is not installed gracefully skips the CLI subprocess test instead of asserting on an uninstalled error message.

### Validation
- `uv run ruff check .` -> All checks passed!
- `uv run mypy fastapi` -> Success: no issues found in 48 source files!
- `uv run ty check` -> All checks passed!
- `uv run pytest` -> 3341 passed, 18 skipped, 5 xfailed in 31s