### PR TITLE
🐛 Fix PEP 695 sequence aliases in form models

### DIFF
--- a/fastapi/_compat/shared.py
+++ b/fastapi/_compat/shared.py
@@ -18,6 +18,7 @@ from fastapi.types import UnionType
 from pydantic import BaseModel
 from pydantic.version import VERSION as PYDANTIC_VERSION
 from starlette.datastructures import UploadFile
+from typing_inspection.typing_objects import is_typealiastype
 
 _T = TypeVar("_T")
 
@@ -62,6 +63,9 @@ def _annotation_is_sequence(annotation: type[Any] | None) -> bool:
 
 
 def field_annotation_is_sequence(annotation: type[Any] | None) -> bool:
+    if is_typealiastype(annotation):
+        return field_annotation_is_sequence(annotation.__value__)
+
     origin = get_origin(annotation)
 
     if origin is Annotated:

--- a/tests/test_forms_single_model.py
+++ b/tests/test_forms_single_model.py
@@ -3,8 +3,11 @@ from typing import Annotated
 from fastapi import FastAPI, Form
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field
+from typing_extensions import TypeAliasType
 
 app = FastAPI()
+
+Friends = TypeAliasType("Friends", list[str])
 
 
 class FormModel(BaseModel):
@@ -12,6 +15,7 @@ class FormModel(BaseModel):
     lastname: str
     age: int | None = None
     tags: list[str] = ["foo", "bar"]
+    friends: Friends = ["baz", "quux"]
     alias_with: str = Field(alias="with", default="nothing")
 
 
@@ -42,6 +46,7 @@ def test_send_all_data():
             "lastname": "Sanchez",
             "age": "70",
             "tags": ["plumbus", "citadel"],
+            "friends": ["Birbperson", "Swuanchy"],
             "with": "something",
         },
     )
@@ -51,6 +56,7 @@ def test_send_all_data():
         "lastname": "Sanchez",
         "age": 70,
         "tags": ["plumbus", "citadel"],
+        "friends": ["Birbperson", "Swuanchy"],
         "with": "something",
     }
 
@@ -63,6 +69,7 @@ def test_defaults():
         "lastname": "Sanchez",
         "age": None,
         "tags": ["foo", "bar"],
+        "friends": ["baz", "quux"],
         "with": "nothing",
     }
 
@@ -99,13 +106,21 @@ def test_no_data():
                 "type": "missing",
                 "loc": ["body", "username"],
                 "msg": "Field required",
-                "input": {"tags": ["foo", "bar"], "with": "nothing"},
+                "input": {
+                    "tags": ["foo", "bar"],
+                    "friends": ["baz", "quux"],
+                    "with": "nothing",
+                },
             },
             {
                 "type": "missing",
                 "loc": ["body", "lastname"],
                 "msg": "Field required",
-                "input": {"tags": ["foo", "bar"], "with": "nothing"},
+                "input": {
+                    "tags": ["foo", "bar"],
+                    "friends": ["baz", "quux"],
+                    "with": "nothing",
+                },
             },
         ]
     }


### PR DESCRIPTION
## Summary

PEP 695 type aliases that resolve to sequence types are classified as scalar annotations when extracting form data. FastAPI consequently calls `FormData.get()` instead of `FormData.getlist()`, so only the final repeated value reaches Pydantic.

This change unwraps `TypeAliasType` before sequence detection and extends the existing form-model tests to cover both plain and aliased list fields.

Related discussion: #16100
