### PR TITLE
Replace user-facing assert with FastAPIError exceptions

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -11,7 +11,11 @@ from fastapi.exception_handlers import (
     request_validation_exception_handler,
     websocket_request_validation_exception_handler,
 )
-from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
+from fastapi.exceptions import (
+    FastAPIError,
+    RequestValidationError,
+    WebSocketRequestValidationError,
+)
 from fastapi.logger import logger
 from fastapi.middleware.asyncexitstack import AsyncExitStackMiddleware
 from fastapi.openapi.docs import (
@@ -924,8 +928,14 @@ class FastAPI(Starlette):
         self.openapi_schema: dict[str, Any] | None = None
         self._openapi_routes_version: int | None = None
         if self.openapi_url:
-            assert self.title, "A title must be provided for OpenAPI, e.g.: 'My API'"
-            assert self.version, "A version must be provided for OpenAPI, e.g.: '2.1.0'"
+            if not self.title:
+                raise FastAPIError(
+                    "A title must be provided for OpenAPI, e.g.: 'My API'"
+                )
+            if not self.version:
+                raise FastAPIError(
+                    "A version must be provided for OpenAPI, e.g.: '2.1.0'"
+                )
         # TODO: remove when discarding the openapi_prefix parameter
         if openapi_prefix:
             logger.warning(

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -443,7 +443,9 @@ def analyze_param(
                 )
             if value is not inspect.Signature.empty:
                 if is_path_param:
-                    raise FastAPIError("Path parameters cannot have default values")  # pragma: no cover
+                    raise FastAPIError(
+                        "Path parameters cannot have default values"
+                    )  # pragma: no cover
                 field_info.default = value
             else:
                 field_info.default = RequiredParam

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -547,9 +547,7 @@ def analyze_param(
         )
         if is_path_param:
             if not is_scalar_field(field=field):
-                raise FastAPIError(
-                    "Path params must be of one of the supported types"
-                )
+                raise FastAPIError("Path params must be of one of the supported types")
         elif isinstance(field_info, params.Query):
             if not (
                 is_scalar_field(field)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -336,12 +336,12 @@ def get_dependant(
             dependant=dependant,
         ):
             if param_details.field is not None:
-                raise FastAPIError(
+                raise FastAPIError(  # pragma: no cover
                     f"Cannot specify multiple FastAPI annotations for {param_name!r}"
                 )
             continue
         if param_details.field is None:
-            raise FastAPIError(
+            raise FastAPIError(  # pragma: no cover
                 f"Cannot specify multiple FastAPI annotations for {param_name!r}"
             )
         if isinstance(param_details.field.field_info, params.Body):
@@ -443,7 +443,7 @@ def analyze_param(
                 )
             if value is not inspect.Signature.empty:
                 if is_path_param:
-                    raise FastAPIError("Path parameters cannot have default values")
+                    raise FastAPIError("Path parameters cannot have default values")  # pragma: no cover
                 field_info.default = value
             else:
                 field_info.default = RequiredParam
@@ -572,7 +572,7 @@ def add_param_to_fields(*, field: ModelField, dependant: Dependant) -> None:
         dependant.header_params.append(field)
     else:
         if field_info_in != params.ParamTypes.cookie:
-            raise FastAPIError(
+            raise FastAPIError(  # pragma: no cover
                 f"non-body parameters must be in path, query, header or cookie: {field.name}"
             )
         dependant.cookie_params.append(field)

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -64,7 +64,7 @@ from fastapi.dependencies.models import (
     _is_gen_callable,
     _UsesScopesCache,
 )
-from fastapi.exceptions import DependencyScopeError
+from fastapi.exceptions import DependencyScopeError, FastAPIError
 from fastapi.logger import logger
 from fastapi.security.oauth2 import SecurityScopes
 from fastapi.types import DependencyCacheKey
@@ -335,11 +335,15 @@ def get_dependant(
             type_annotation=param_details.type_annotation,
             dependant=dependant,
         ):
-            assert param_details.field is None, (
+            if param_details.field is not None:
+                raise FastAPIError(
+                    f"Cannot specify multiple FastAPI annotations for {param_name!r}"
+                )
+            continue
+        if param_details.field is None:
+            raise FastAPIError(
                 f"Cannot specify multiple FastAPI annotations for {param_name!r}"
             )
-            continue
-        assert param_details.field is not None
         if isinstance(param_details.field.field_info, params.Body):
             dependant.body_params.append(param_details.field)
         else:
@@ -429,14 +433,17 @@ def analyze_param(
                 field_info=fastapi_annotation,
                 annotation=use_annotation,
             )
-            assert (
-                field_info.default == Undefined or field_info.default == RequiredParam
-            ), (
-                f"`{field_info.__class__.__name__}` default value cannot be set in"
-                f" `Annotated` for {param_name!r}. Set the default value with `=` instead."
-            )
+            if (
+                field_info.default is not Undefined
+                and field_info.default is not RequiredParam
+            ):
+                raise FastAPIError(
+                    f"`{field_info.__class__.__name__}` default value cannot be set in"
+                    f" `Annotated` for {param_name!r}. Set the default value with `=` instead."
+                )
             if value is not inspect.Signature.empty:
-                assert not is_path_param, "Path parameters cannot have default values"
+                if is_path_param:
+                    raise FastAPIError("Path parameters cannot have default values")
                 field_info.default = value
             else:
                 field_info.default = RequiredParam
@@ -445,21 +452,24 @@ def analyze_param(
             depends = fastapi_annotation
     # Get Depends from default value
     if isinstance(value, params.Depends):
-        assert depends is None, (
-            "Cannot specify `Depends` in `Annotated` and default value"
-            f" together for {param_name!r}"
-        )
-        assert field_info is None, (
-            "Cannot specify a FastAPI annotation in `Annotated` and `Depends` as a"
-            f" default value together for {param_name!r}"
-        )
+        if depends is not None:
+            raise FastAPIError(
+                "Cannot specify `Depends` in `Annotated` and default value"
+                f" together for {param_name!r}"
+            )
+        if field_info is not None:
+            raise FastAPIError(
+                "Cannot specify a FastAPI annotation in `Annotated` and `Depends` as a"
+                f" default value together for {param_name!r}"
+            )
         depends = value
     # Get FieldInfo from default value
     elif isinstance(value, FieldInfo):
-        assert field_info is None, (
-            "Cannot specify FastAPI annotations in `Annotated` and default value"
-            f" together for {param_name!r}"
-        )
+        if field_info is not None:
+            raise FastAPIError(
+                "Cannot specify FastAPI annotations in `Annotated` and default value"
+                f" together for {param_name!r}"
+            )
         field_info = value
         if isinstance(field_info, FieldInfo):
             field_info.annotation = type_annotation
@@ -484,9 +494,10 @@ def analyze_param(
             SecurityScopes,
         ),
     ):
-        assert field_info is None, (
-            f"Cannot specify FastAPI annotation for type {type_annotation!r}"
-        )
+        if field_info is not None:
+            raise FastAPIError(
+                f"Cannot specify FastAPI annotation for type {type_annotation!r}"
+            )
     # Handle default assignations, neither field_info nor depends was not found in Annotated nor default value
     elif field_info is None and depends is None:
         default_value = value if value is not inspect.Signature.empty else RequiredParam
@@ -509,10 +520,11 @@ def analyze_param(
     if field_info is not None:
         # Handle field_info.in_
         if is_path_param:
-            assert isinstance(field_info, params.Path), (
-                f"Cannot use `{field_info.__class__.__name__}` for path param"
-                f" {param_name!r}"
-            )
+            if not isinstance(field_info, params.Path):
+                raise FastAPIError(
+                    f"Cannot use `{field_info.__class__.__name__}` for path param"
+                    f" {param_name!r}"
+                )
         elif (
             isinstance(field_info, params.Param)
             and getattr(field_info, "in_", None) is None
@@ -534,15 +546,19 @@ def analyze_param(
             field_info=field_info,
         )
         if is_path_param:
-            assert is_scalar_field(field=field), (
-                "Path params must be of one of the supported types"
-            )
+            if not is_scalar_field(field=field):
+                raise FastAPIError(
+                    "Path params must be of one of the supported types"
+                )
         elif isinstance(field_info, params.Query):
-            assert (
+            if not (
                 is_scalar_field(field)
                 or field_annotation_is_scalar_sequence(field.field_info.annotation)
                 or lenient_issubclass(field.field_info.annotation, BaseModel)
-            ), f"Query parameter {param_name!r} must be one of the supported types"
+            ):
+                raise FastAPIError(
+                    f"Query parameter {param_name!r} must be one of the supported types"
+                )
 
     return ParamDetails(type_annotation=type_annotation, depends=depends, field=field)
 
@@ -557,9 +573,10 @@ def add_param_to_fields(*, field: ModelField, dependant: Dependant) -> None:
     elif field_info_in == params.ParamTypes.header:
         dependant.header_params.append(field)
     else:
-        assert field_info_in == params.ParamTypes.cookie, (
-            f"non-body parameters must be in path, query, header or cookie: {field.name}"
-        )
+        if field_info_in != params.ParamTypes.cookie:
+            raise FastAPIError(
+                f"non-body parameters must be in path, query, header or cookie: {field.name}"
+            )
         dependant.cookie_params.append(field)
 
 

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Annotated, Any, Literal
 
-from fastapi.exceptions import FastAPIDeprecationWarning
+from fastapi.exceptions import FastAPIError, FastAPIDeprecationWarning
 from fastapi.openapi.models import Example
 from pydantic import AliasChoices, AliasPath
 from pydantic.fields import FieldInfo
@@ -182,7 +182,8 @@ class Path(Param):  # type: ignore[misc]
         json_schema_extra: dict[str, Any] | None = None,
         **extra: Any,
     ):
-        assert default is ..., "Path parameters cannot have a default value"
+        if default is not ...:
+            raise FastAPIError("Path parameters cannot have a default value")
         self.in_ = self.in_
         super().__init__(
             default=default,

--- a/fastapi/params.py
+++ b/fastapi/params.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Annotated, Any, Literal
 
-from fastapi.exceptions import FastAPIError, FastAPIDeprecationWarning
+from fastapi.exceptions import FastAPIDeprecationWarning, FastAPIError
 from fastapi.openapi.models import Example
 from pydantic import AliasChoices, AliasPath
 from pydantic.fields import FieldInfo

--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -62,7 +62,8 @@ class UJSONResponse(JSONResponse):
     """
 
     def render(self, content: Any) -> bytes:
-        assert ujson is not None, "ujson must be installed to use UJSONResponse"
+        if ujson is None:
+            raise ImportError("ujson must be installed to use UJSONResponse")
         return ujson.dumps(content, ensure_ascii=False).encode("utf-8")
 
 
@@ -92,7 +93,8 @@ class ORJSONResponse(JSONResponse):
     """
 
     def render(self, content: Any) -> bytes:
-        assert orjson is not None, "orjson must be installed to use ORJSONResponse"
+        if orjson is None:
+            raise ImportError("orjson must be installed to use ORJSONResponse")
         return orjson.dumps(
             content, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
         )

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1037,12 +1037,14 @@ def _populate_api_route_state(
     route.description = route.description.split("\f")[0].strip()
     response_fields = {}
     for additional_status_code, response in route.responses.items():
-        assert isinstance(response, dict), "An additional response must be a dict"
+        if not isinstance(response, dict):
+            raise FastAPIError("An additional response must be a dict")
         model = response.get("model")
         if model:
-            assert is_body_allowed_for_status_code(additional_status_code), (
-                f"Status code {additional_status_code} must not have a response body"
-            )
+            if not is_body_allowed_for_status_code(additional_status_code):
+                raise FastAPIError(
+                    f"Status code {additional_status_code} must not have a response body"
+                )
             response_name = f"Response_{additional_status_code}_{route.unique_id}"
             response_field = create_model_field(
                 name=response_name, type_=model, mode="serialization"
@@ -1053,7 +1055,8 @@ def _populate_api_route_state(
     else:
         route.response_fields = {}
 
-    assert callable(endpoint), "An endpoint must be a callable"
+    if not callable(endpoint):
+        raise FastAPIError("An endpoint must be a callable")
     (
         route.dependant,
         body_params,
@@ -1101,9 +1104,10 @@ def _populate_api_route_state(
                 response_model = return_annotation
     route.response_model = response_model
     if route.response_model:
-        assert is_body_allowed_for_status_code(status_code), (
-            f"Status code {status_code} must not have a response body"
-        )
+        if not is_body_allowed_for_status_code(status_code):
+            raise FastAPIError(
+                f"Status code {status_code} must not have a response body"
+            )
         response_name = "Response_" + route.unique_id
         route.response_field = create_model_field(
             name=response_name,
@@ -2536,10 +2540,12 @@ class APIRouter(routing.Router):
             lifespan=lifespan_context,
         )
         if prefix:
-            assert prefix.startswith("/"), "A path prefix must start with '/'"
-            assert not prefix.endswith("/"), (
-                "A path prefix must not end with '/', as the routes will start with '/'"
-            )
+            if not prefix.startswith("/"):
+                raise FastAPIError("A path prefix must start with '/'")
+            if prefix.endswith("/"):
+                raise FastAPIError(
+                    "A path prefix must not end with '/', as the routes will start with '/'"
+                )
 
         # Handle on_startup/on_shutdown locally since Starlette removed support
         # Ref: https://github.com/Kludex/starlette/pull/3117
@@ -3265,19 +3271,23 @@ class APIRouter(routing.Router):
         app.include_router(internal_router)
         ```
         """
-        assert self is not router, (
-            "Cannot include the same APIRouter instance into itself. "
-            "Did you mean to include a different router?"
-        )
-        assert not router._contains_router(self), (
-            "Cannot include an APIRouter instance that already includes this router. "
-            "Did you mean to include a different router?"
-        )
-        if prefix:
-            assert prefix.startswith("/"), "A path prefix must start with '/'"
-            assert not prefix.endswith("/"), (
-                "A path prefix must not end with '/', as the routes will start with '/'"
+        if self is router:
+            raise FastAPIError(
+                "Cannot include the same APIRouter instance into itself. "
+                "Did you mean to include a different router?"
             )
+        if router._contains_router(self):
+            raise FastAPIError(
+                "Cannot include an APIRouter instance that already includes this router. "
+                "Did you mean to include a different router?"
+            )
+        if prefix:
+            if not prefix.startswith("/"):
+                raise FastAPIError("A path prefix must start with '/'")
+            if prefix.endswith("/"):
+                raise FastAPIError(
+                    "A path prefix must not end with '/', as the routes will start with '/'"
+                )
         else:
             for route, route_context in _iter_routes_with_context(router.routes):
                 if route_context is None:

--- a/tests/test_ambiguous_params.py
+++ b/tests/test_ambiguous_params.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 import pytest
 from fastapi import Depends, FastAPI, Path
+from fastapi.exceptions import FastAPIError
 from fastapi.param_functions import Query
 from fastapi.testclient import TestClient
 
@@ -10,7 +11,7 @@ app = FastAPI()
 
 def test_no_annotated_defaults():
     with pytest.raises(
-        AssertionError, match="Path parameters cannot have a default value"
+        FastAPIError, match="Path parameters cannot have a default value"
     ):
 
         @app.get("/items/{item_id}/")
@@ -18,7 +19,7 @@ def test_no_annotated_defaults():
             pass  # pragma: nocover
 
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match=(
             "`Query` default value cannot be set in `Annotated` for 'item_id'. Set the"
             " default value with `=` instead."
@@ -39,7 +40,7 @@ def test_multiple_annotations():
         return foo
 
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match=(
             "Cannot specify `Depends` in `Annotated` and default value"
             " together for 'foo'"
@@ -51,7 +52,7 @@ def test_multiple_annotations():
             pass  # pragma: nocover
 
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match=(
             "Cannot specify a FastAPI annotation in `Annotated` and `Depends` as a"
             " default value together for 'foo'"

--- a/tests/test_assert_replacement_coverage.py
+++ b/tests/test_assert_replacement_coverage.py
@@ -1,7 +1,6 @@
 import pytest
 from fastapi import APIRouter, FastAPI, Path, Query
 from fastapi.exceptions import FastAPIError
-from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 

--- a/tests/test_assert_replacement_coverage.py
+++ b/tests/test_assert_replacement_coverage.py
@@ -11,7 +11,7 @@ def test_additional_response_not_a_dict():
 
     with pytest.raises(FastAPIError, match="An additional response must be a dict"):
 
-        @app.get("/items", responses={200: "not a dict"})
+        @app.get("/items", responses={200: "not a dict"})  # ty: ignore[invalid-argument-type]
         async def get_items():
             pass  # pragma: no cover
 
@@ -36,7 +36,7 @@ def test_callable_endpoint_check():
     app = FastAPI()
 
     with pytest.raises(FastAPIError, match="An endpoint must be a callable"):
-        app.router.add_api_route("/items", endpoint="not a callable")
+        app.router.add_api_route("/items", endpoint="not a callable")  # ty: ignore[invalid-argument-type]
 
 
 def test_response_model_on_no_body_status():

--- a/tests/test_assert_replacement_coverage.py
+++ b/tests/test_assert_replacement_coverage.py
@@ -1,0 +1,201 @@
+import pytest
+from fastapi import APIRouter, FastAPI, Path, Query
+from fastapi.exceptions import FastAPIError
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+def test_additional_response_not_a_dict():
+    app = FastAPI()
+
+    with pytest.raises(FastAPIError, match="An additional response must be a dict"):
+
+        @app.get("/items", responses={200: "not a dict"})
+        async def get_items():
+            pass  # pragma: no cover
+
+
+def test_additional_response_body_not_allowed():
+    app = FastAPI()
+
+    class Item(BaseModel):
+        name: str
+
+    with pytest.raises(
+        FastAPIError,
+        match="Status code 204 must not have a response body",
+    ):
+
+        @app.get("/items", responses={204: {"model": Item}})
+        async def get_items():
+            pass  # pragma: no cover
+
+
+def test_callable_endpoint_check():
+    app = FastAPI()
+
+    with pytest.raises(FastAPIError, match="An endpoint must be a callable"):
+        app.router.add_api_route("/items", endpoint="not a callable")
+
+
+def test_response_model_on_no_body_status():
+    app = FastAPI()
+
+    class Item(BaseModel):
+        name: str
+
+    with pytest.raises(
+        FastAPIError,
+        match="Status code 204 must not have a response body",
+    ):
+
+        @app.get("/items", response_model=Item, status_code=204)
+        async def get_items():
+            pass  # pragma: no cover
+
+
+def test_apirouter_prefix_not_starting_with_slash():
+    with pytest.raises(FastAPIError, match="A path prefix must start with '/'"):
+        APIRouter(prefix="items")
+
+
+def test_apirouter_prefix_ending_with_slash():
+    with pytest.raises(
+        FastAPIError,
+        match="A path prefix must not end with '/'",
+    ):
+        APIRouter(prefix="/items/")
+
+
+def test_include_router_prefix_not_starting_with_slash():
+    router = APIRouter()
+    child = APIRouter()
+    with pytest.raises(FastAPIError, match="A path prefix must start with '/'"):
+        router.include_router(child, prefix="items")
+
+
+def test_include_router_prefix_ending_with_slash():
+    router = APIRouter()
+    child = APIRouter()
+    with pytest.raises(
+        FastAPIError,
+        match="A path prefix must not end with '/'",
+    ):
+        router.include_router(child, prefix="/items/")
+
+
+def test_fastapi_missing_title_for_openapi():
+    with pytest.raises(
+        FastAPIError,
+        match="A title must be provided for OpenAPI",
+    ):
+        FastAPI(title="", version="1.0.0")
+
+
+def test_fastapi_missing_version_for_openapi():
+    with pytest.raises(
+        FastAPIError,
+        match="A version must be provided for OpenAPI",
+    ):
+        FastAPI(title="My API", version="")
+
+
+def test_path_param_with_default_in_annotated():
+    app = FastAPI()
+
+    with pytest.raises(
+        FastAPIError,
+        match="Path parameters cannot have a default value",
+    ):
+
+        @app.get("/items/{item_id}")
+        async def get_item(item_id: Annotated[int, Path(default=1)]):
+            pass  # pragma: no cover
+
+
+def test_annotated_annotation_with_fieldinfo_default():
+    app = FastAPI()
+
+    with pytest.raises(
+        FastAPIError,
+        match="Cannot specify FastAPI annotations in `Annotated` and default value",
+    ):
+
+        @app.get("/items")
+        async def get_items(item_id: Annotated[int, Query()] = Query(default=1)):
+            pass  # pragma: no cover
+
+
+def test_query_for_path_param():
+    app = FastAPI()
+
+    with pytest.raises(
+        FastAPIError,
+        match="Cannot use `Query` for path param",
+    ):
+
+        @app.get("/items/{item_id}")
+        async def get_item(item_id: Annotated[int, Query()]):
+            pass  # pragma: no cover
+
+
+def test_ujson_response_without_ujson():
+    import fastapi.responses as responses_module
+
+    original = responses_module.ujson
+    try:
+        responses_module.ujson = None
+        with pytest.raises(ImportError, match="ujson must be installed"):
+            responses_module.UJSONResponse.render(
+                object.__new__(responses_module.UJSONResponse), {"key": "value"}
+            )
+    finally:
+        responses_module.ujson = original
+
+
+def test_orjson_response_without_orjson():
+    import fastapi.responses as responses_module
+
+    original = responses_module.orjson
+    try:
+        responses_module.orjson = None
+        with pytest.raises(ImportError, match="orjson must be installed"):
+            responses_module.ORJSONResponse.render(
+                object.__new__(responses_module.ORJSONResponse), {"key": "value"}
+            )
+    finally:
+        responses_module.orjson = original
+
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+
+def test_fastapi_annotation_on_request_type():
+    app = FastAPI()
+
+    with pytest.raises(
+        FastAPIError,
+        match="Cannot specify FastAPI annotation for type",
+    ):
+
+        @app.get("/items")
+        async def get_items(request: Annotated[Request, Query()]):
+            pass  # pragma: no cover
+
+
+def test_depends_and_fieldinfo_default_together():
+    app = FastAPI()
+
+    async def dep():
+        return 1  # pragma: no cover
+
+    with pytest.raises(
+        FastAPIError,
+        match="Cannot specify `Depends` in `Annotated` and default value together",
+    ):
+
+        @app.get("/items")
+        async def get_items(foo: Annotated[int, Depends(dep)] = Depends(dep)):
+            pass  # pragma: no cover

--- a/tests/test_assert_replacement_coverage.py
+++ b/tests/test_assert_replacement_coverage.py
@@ -1,5 +1,7 @@
+from typing import Annotated
+
 import pytest
-from fastapi import APIRouter, FastAPI, Path, Query
+from fastapi import APIRouter, Depends, FastAPI, Path, Query, Request
 from fastapi.exceptions import FastAPIError
 from pydantic import BaseModel
 
@@ -164,11 +166,6 @@ def test_orjson_response_without_orjson():
             )
     finally:
         responses_module.orjson = original
-
-
-from typing import Annotated
-
-from fastapi import Depends, Request
 
 
 def test_fastapi_annotation_on_request_type():

--- a/tests/test_invalid_path_param.py
+++ b/tests/test_invalid_path_param.py
@@ -1,10 +1,11 @@
 import pytest
 from fastapi import FastAPI
+from fastapi.exceptions import FastAPIError
 from pydantic import BaseModel
 
 
 def test_invalid_sequence():
-    with pytest.raises(AssertionError):
+    with pytest.raises(FastAPIError):
         app = FastAPI()
 
         class Item(BaseModel):
@@ -16,7 +17,7 @@ def test_invalid_sequence():
 
 
 def test_invalid_tuple():
-    with pytest.raises(AssertionError):
+    with pytest.raises(FastAPIError):
         app = FastAPI()
 
         class Item(BaseModel):
@@ -28,7 +29,7 @@ def test_invalid_tuple():
 
 
 def test_invalid_dict():
-    with pytest.raises(AssertionError):
+    with pytest.raises(FastAPIError):
         app = FastAPI()
 
         class Item(BaseModel):
@@ -40,7 +41,7 @@ def test_invalid_dict():
 
 
 def test_invalid_simple_list():
-    with pytest.raises(AssertionError):
+    with pytest.raises(FastAPIError):
         app = FastAPI()
 
         @app.get("/items/{id}")
@@ -49,7 +50,7 @@ def test_invalid_simple_list():
 
 
 def test_invalid_simple_tuple():
-    with pytest.raises(AssertionError):
+    with pytest.raises(FastAPIError):
         app = FastAPI()
 
         @app.get("/items/{id}")
@@ -58,7 +59,7 @@ def test_invalid_simple_tuple():
 
 
 def test_invalid_simple_set():
-    with pytest.raises(AssertionError):
+    with pytest.raises(FastAPIError):
         app = FastAPI()
 
         @app.get("/items/{id}")
@@ -67,7 +68,7 @@ def test_invalid_simple_set():
 
 
 def test_invalid_simple_dict():
-    with pytest.raises(AssertionError):
+    with pytest.raises(FastAPIError):
         app = FastAPI()
 
         @app.get("/items/{id}")

--- a/tests/test_invalid_sequence_param.py
+++ b/tests/test_invalid_sequence_param.py
@@ -1,11 +1,12 @@
 import pytest
 from fastapi import FastAPI, Query
+from fastapi.exceptions import FastAPIError
 from pydantic import BaseModel
 
 
 def test_invalid_sequence():
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match="Query parameter 'q' must be one of the supported types",
     ):
         app = FastAPI()
@@ -20,7 +21,7 @@ def test_invalid_sequence():
 
 def test_invalid_tuple():
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match="Query parameter 'q' must be one of the supported types",
     ):
         app = FastAPI()
@@ -35,7 +36,7 @@ def test_invalid_tuple():
 
 def test_invalid_dict():
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match="Query parameter 'q' must be one of the supported types",
     ):
         app = FastAPI()
@@ -50,7 +51,7 @@ def test_invalid_dict():
 
 def test_invalid_simple_dict():
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match="Query parameter 'q' must be one of the supported types",
     ):
         app = FastAPI()

--- a/tests/test_router_circular_import.py
+++ b/tests/test_router_circular_import.py
@@ -1,12 +1,13 @@
 import pytest
 from fastapi import APIRouter
+from fastapi.exceptions import FastAPIError
 
 
 def test_router_circular_import():
     router = APIRouter()
 
     with pytest.raises(
-        AssertionError,
+        FastAPIError,
         match="Cannot include the same APIRouter instance into itself. Did you mean to include a different router?",
     ):
         router.include_router(router)

--- a/tests/test_router_include_context.py
+++ b/tests/test_router_include_context.py
@@ -343,7 +343,7 @@ def test_indirect_router_inclusion_cycles_are_rejected():
 
     parent_router.include_router(child_router, prefix="/child")
 
-    with pytest.raises(AssertionError, match="already includes this router"):
+    with pytest.raises(FastAPIError, match="already includes this router"):
         child_router.include_router(parent_router, prefix="/parent")
 
     parent_router = APIRouter()
@@ -353,7 +353,7 @@ def test_indirect_router_inclusion_cycles_are_rejected():
     parent_router.include_router(child_router, prefix="/child")
     child_router.include_router(grandchild_router, prefix="/grandchild")
 
-    with pytest.raises(AssertionError, match="already includes this router"):
+    with pytest.raises(FastAPIError, match="already includes this router"):
         grandchild_router.include_router(parent_router, prefix="/parent")
 
 


### PR DESCRIPTION
Replace assert statements that validate user input with explicit FastAPIError raises. This ensures validation errors survive Python -O optimization and provide consistent exception types instead of AssertionError.

Changed files:
- fastapi/params.py: Path parameter default value check
- fastapi/applications.py: OpenAPI title/version validation
- fastapi/routing.py: Endpoint callable, prefix, response, and router circular inclusion checks
- fastapi/responses.py: ujson/orjson installation checks (ImportError)
- fastapi/dependencies/utils.py: Parameter annotation, type, and dependency conflict checks

Updated 5 test files to catch FastAPIError instead of AssertionError.