### PR TITLE
Add test coverage for app-level `default_response_class + dump_json` fast path interaction

### DIFF
--- a/tests/test_dump_json_fast_path.py
+++ b/tests/test_dump_json_fast_path.py
@@ -49,3 +49,33 @@ def test_explicit_response_class_uses_json_dumps():
     assert response.status_code == 200
     assert response.json() == {"name": "widget", "price": 9.99}
     mock_dumps.assert_called_once()
+
+
+class CustomJSONResponse(JSONResponse):
+    media_type = "application/vnd.custom+json"
+
+
+app_custom_default = FastAPI(default_response_class=CustomJSONResponse)
+
+
+@app_custom_default.get("/default")
+def get_default_custom() -> Item:
+    return Item(name="widget", price=9.99)
+
+
+client_custom_default = TestClient(app_custom_default)
+
+
+def test_app_level_default_response_class_skips_fast_path():
+    """When a custom default_response_class is set at the app level (not
+    per-route), the fast path must NOT be used, so the custom response
+    class's own rendering (and media_type) is respected instead of being
+    bypassed by the generic dump_json Response."""
+    with patch(
+        "starlette.responses.json.dumps", wraps=__import__("json").dumps
+    ) as mock_dumps:
+        response = client_custom_default.get("/default")
+    assert response.status_code == 200
+    assert response.json() == {"name": "widget", "price": 9.99}
+    assert response.headers["content-type"] == "application/vnd.custom+json"
+    mock_dumps.assert_called_once()


### PR DESCRIPTION
### What I found

`tests/test_dump_json_fast_path.py` currently covers two cases for the dump_json fast path in `fastapi/routing.py`:

- no `response_class` set at all → fast path used
- `response_class` set explicitly on the route → fast path skipped

The fast path is gated by:

```python
use_dump_json = response_field is not None and isinstance(
    response_class, DefaultPlaceholder
)
```

There's a third, officially documented pattern that isn't covered: setting a custom response class **app-wide** via `FastAPI(default_response_class=...)` instead of per-route.

### What I checked

I traced through `get_value_or_default` (in `fastapi/utils.py`) and the route construction in `add_api_route` to see how this interacts with the fast path. When a user passes `default_response_class=SomeCustomResponse` at the app level, it's stored as a plain class (not wrapped in `Default(...)`), so `get_value_or_default(response_class, self.default_response_class)` correctly unwraps to that plain class — meaning `response_class` is no longer a `DefaultPlaceholder` by the time it reaches `get_request_handler`, so `use_dump_json` correctly evaluates to `False`.

I confirmed this locally:

```python
class CustomJSONResponse(JSONResponse):
    media_type = "application/vnd.custom+json"

app = FastAPI(default_response_class=CustomJSONResponse)

@app.get("/default")
def get_default() -> Item:
    return Item(name="widget", price=9.99)
```

Result: `json.dumps` is called (fast path correctly skipped), and `content-type` correctly comes back as `application/vnd.custom+json`, not `application/json`.

So the current behavior is correct. The problem is there's **no test** protecting it — a future refactor of `get_value_or_default` or the `DefaultPlaceholder` unwrapping logic could silently break this, causing a custom `default_response_class` (e.g. `ORJSONResponse`, or anything with custom `media_type`/serialization) to be bypassed by the generic fast-path `Response` without any test catching it.

### Proposed change

Add one test to `tests/test_dump_json_fast_path.py`:

```python
class CustomJSONResponse(JSONResponse):
    media_type = "application/vnd.custom+json"


app_custom_default = FastAPI(default_response_class=CustomJSONResponse)


@app_custom_default.get("/default")
def get_default_custom() -> Item:
    return Item(name="widget", price=9.99)


client_custom_default = TestClient(app_custom_default)


def test_app_level_default_response_class_skips_fast_path():
    """When a custom default_response_class is set at the app level (not
    per-route), the fast path must NOT be used, so the custom response
    class's own rendering (and media_type) is respected instead of being
    bypassed by the generic dump_json Response."""
    with patch(
        "starlette.responses.json.dumps", wraps=__import__("json").dumps
    ) as mock_dumps:
        response = client_custom_default.get("/default")
    assert response.status_code == 200
    assert response.json() == {"name": "widget", "price": 9.99}
    assert response.headers["content-type"] == "application/vnd.custom+json"
    mock_dumps.assert_called_once()
```

Test-only change, no production code touched. I ran the full file locally and all tests pass.

###

Happy to open a PR if this seems like a useful addition — let me know if the approach looks right or if I'm missing an existing test/issue that already covers this.