### PR TITLE
🐛 Fix header parameter case-sensitivity for Pydantic models with uppercase aliases

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -821,11 +821,17 @@ def request_params_to_args(
         value = _get_multidict_value(field, received_params, alias=alias)
         if value is not None:
             params_to_process[get_validation_alias(field)] = value
-        processed_keys.add(alias or get_validation_alias(field))
-        # For headers with convert_underscores=True, mark both the converted
-        # header name and the original field alias as processed to avoid
-        # accepting the original alias as an extra header.
-        processed_keys.add(get_validation_alias(field))
+        target_key = alias or get_validation_alias(field)
+        val_key = get_validation_alias(field)
+        if isinstance(received_params, Headers):
+            processed_keys.add(target_key.lower())
+            processed_keys.add(val_key.lower())
+        else:
+            processed_keys.add(target_key)
+            # For headers with convert_underscores=True, mark both the converted
+            # header name and the original field alias as processed to avoid
+            # accepting the original alias as an extra header.
+            processed_keys.add(val_key)
 
     for key in received_params.keys():
         if key not in processed_keys:

--- a/tests/test_query_cookie_header_model_extra_params.py
+++ b/tests/test_query_cookie_header_model_extra_params.py
@@ -138,3 +138,110 @@ def test_cookie_pass_extra_list():
     resp_json = resp.json()
     assert "param2" in resp_json
     assert resp_json["param2"] == "789"  # Cookies only keep the last value
+
+
+def test_header_model_extra_forbid_with_uppercase_aliases():
+    from pydantic import ConfigDict, Field
+
+    class ForbiddenHeaderModel(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        api_key: str = Field(..., alias="X-API-Key")
+        user_agent: str = Field(..., alias="User-Agent")
+        host: str
+        accept: str
+        accept_encoding: str = Field(..., alias="accept-encoding")
+        connection: str
+
+    app_forbid = FastAPI()
+
+    @app_forbid.get("/test")
+    def endpoint(headers: ForbiddenHeaderModel = Header()):
+        return headers
+
+    client = TestClient(app_forbid)
+    response = client.get("/test", headers={"X-API-Key": "secret123"})
+    assert response.status_code == 200
+    assert response.json()["X-API-Key"] == "secret123"
+
+
+def test_header_model_lowercase_aliases_and_convert_underscores():
+    from pydantic import ConfigDict, Field
+
+    class HeaderModelConvertTrue(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        custom_header: str = Field(..., alias="x-custom-header")
+        user_token: str
+        host: str
+        user_agent: str = Field(..., alias="user-agent")
+        accept: str
+        accept_encoding: str = Field(..., alias="accept-encoding")
+        connection: str
+
+    class HeaderModelConvertFalse(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        custom_header: str = Field(..., alias="x-custom-header")
+        user_token: str
+        host: str
+        user_agent: str = Field(..., alias="user-agent")
+        accept: str
+        accept_encoding: str = Field(..., alias="accept-encoding")
+        connection: str
+
+    app_convert = FastAPI()
+
+    @app_convert.get("/convert-true")
+    def endpoint_true(
+        headers: HeaderModelConvertTrue = Header(convert_underscores=True),
+    ):
+        return headers
+
+    @app_convert.get("/convert-false")
+    def endpoint_false(
+        headers: HeaderModelConvertFalse = Header(convert_underscores=False),
+    ):
+        return headers
+
+    client = TestClient(app_convert)
+
+    res_true = client.get(
+        "/convert-true",
+        headers={"X-Custom-Header": "val1", "User-Token": "val2"},
+    )
+    assert res_true.status_code == 200
+    assert res_true.json()["x-custom-header"] == "val1"
+    assert res_true.json()["user_token"] == "val2"
+
+    res_false = client.get(
+        "/convert-false",
+        headers={"X-Custom-Header": "val1", "user_token": "val2"},
+    )
+    assert res_false.status_code == 200
+    assert res_false.json()["x-custom-header"] == "val1"
+    assert res_false.json()["user_token"] == "val2"
+
+
+def test_header_model_repeated_values():
+    from pydantic import ConfigDict, Field
+
+    class MultiHeaderModel(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        x_keys: list[str] = Field(..., alias="X-Keys")
+        host: str
+        user_agent: str = Field(..., alias="user-agent")
+        accept: str
+        accept_encoding: str = Field(..., alias="accept-encoding")
+        connection: str
+
+    app_multi = FastAPI()
+
+    @app_multi.get("/multi")
+    def endpoint_multi(headers: MultiHeaderModel = Header()):
+        return headers
+
+    client = TestClient(app_multi)
+    response = client.get(
+        "/multi",
+        headers=[("X-Keys", "key1"), ("X-Keys", "key2")],
+    )
+    assert response.status_code == 200
+    assert response.json()["X-Keys"] == ["key1", "key2"]


### PR DESCRIPTION
### Bug Description

When declaring headers via a Pydantic model (`def endpoint(headers: HeaderModel = Header())`), fields with uppercase or mixed-case aliases (e.g., `Field(..., alias="X-API-Key")` or `Field(..., alias="User-Agent")`) cause valid requests to fail with HTTP 422 `extra_forbidden` when the model has `model_config = ConfigDict(extra="forbid")`.

### Root Cause

In `request_params_to_args` (`fastapi/dependencies/utils.py`):
1. FastAPI records processed keys in `processed_keys` using the field's declared alias (e.g., `"X-API-Key"`).
2. Starlette's `Headers.keys()` returns lowercased header names (e.g., `"x-api-key"`).
3. The check `if key not in processed_keys` is case-sensitive in Python (`"x-api-key" != "X-API-Key"`).
4. Lowercased header names were treated as unprocessed extra headers and added to `params_to_process["x-api-key"]`, causing Pydantic to raise an `extra_forbidden` error.

### Solution

Normalize keys added to `processed_keys` to lowercase when `received_params` is an instance of Starlette `Headers`. Query, cookie, and path parameters remain unaffected.

### Testing

Added regression tests in `tests/test_query_cookie_header_model_extra_params.py` covering:
- `extra="forbid"` models with uppercase/mixed-case aliases (`X-API-Key`, `User-Agent`).
- Lowercase aliases.
- `convert_underscores=True` and `convert_underscores=False`.
- Sequence/list headers (`list[str]`).
- Verification that all header test cases pass cleanly.
