### PR TITLE
fix: close broken markdown links in Query() docstrings

### DIFF
--- a/fastapi/param_functions.py
+++ b/fastapi/param_functions.py
@@ -518,7 +518,7 @@ def Query(  # noqa: N802
             RegEx pattern for strings.
 
             Read more about it in the
-            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#add-regular-expressions
+            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#add-regular-expressions)
             """
         ),
     ] = None,
@@ -639,7 +639,7 @@ def Query(  # noqa: N802
             This affects the generated OpenAPI (e.g. visible at `/docs`).
 
             Read more about it in the
-            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#exclude-parameters-from-openapi
+            [FastAPI docs about Query parameters](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#exclude-parameters-from-openapi)
             """
         ),
     ] = True,


### PR DESCRIPTION
## Description

The `Query()` function docstrings had two broken markdown links - missing closing parentheses `)` for the URLs.

- Line 521: `#add-regular-expressions` link was missing closing `)`
- Line 642: `#exclude-parameters-from-openapi` link was missing closing `)`

## Changes

- Added missing closing parentheses to both markdown links in `fastapi/param_functions.py`

## Impact

Fixes broken link rendering in generated documentation.