### PR TITLE
fix: use proper tuple-based version comparison instead of string comparison

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -105,7 +105,7 @@ def ensure_multipart_is_installed() -> None:
         from python_multipart import __version__
 
         # Import an attribute that can be mocked/deleted in testing
-        assert __version__ > "0.0.12"
+        assert tuple(int(x) for x in __version__.split(".")) > (0, 0, 12)
     except (ImportError, AssertionError):
         try:
             # __version__ is available in both multiparts, and can be mocked


### PR DESCRIPTION
## Description

In `fastapi/dependencies/utils.py`, the `ensure_multipart_is_installed()` function uses string comparison for version checking:

```python
assert __version__ > "0.0.12"
```

This is incorrect for semantic versioning. For example, `"0.0.9" > "0.0.12"` evaluates to `True` (because `"9" > "1"` in lexicographic order), even though version 0.0.9 is actually older than 0.0.12.

## Changes

- Replace string comparison with proper tuple-based version comparison:
  ```python
  assert tuple(int(x) for x in __version__.split(".")) > (0, 0, 12)
  ```

## Impact

Ensures correct version comparison for semantic versioning.