### PR TITLE
fix: remove dead 'is not None' check for getsourcelines()

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -287,8 +287,8 @@ def _extract_endpoint_context(func: Any) -> EndpointContext:
 
         if (source_file := inspect.getsourcefile(func)) is not None:
             ctx["file"] = source_file
-        if (line_number := inspect.getsourcelines(func)[1]) is not None:
-            ctx["line"] = line_number
+        line_number = inspect.getsourcelines(func)[1]
+        ctx["line"] = line_number
         if (func_name := getattr(func, "__name__", None)) is not None:
             ctx["function"] = func_name
     except Exception:


### PR DESCRIPTION
## Description

In `fastapi/routing.py`, the `_extract_endpoint_context()` function has a dead code path:

```python
if (line_number := inspect.getsourcelines(func)[1]) is not None:
    ctx["line"] = line_number
```

`inspect.getsourcelines()` never returns `None` - it raises `OSError` or `TypeError` if the source cannot be found. The `is not None` check will always be `True` when reached, making it a dead code path that provides no safety.

## Changes

- Remove the unnecessary `is not None` check and the walrus operator, directly assigning the result:
  ```python
  line_number = inspect.getsourcelines(func)[1]
  ctx["line"] = line_number
  ```

## Impact

Removes dead code and simplifies the logic without changing behavior.