### PR TITLE
🐛 Fix response_model_include/exclude ignored for ServerSentEvent data

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -531,9 +531,18 @@ def get_request_handler(
                             data_str: str | None = item.raw_data
                         elif item.data is not None:
                             if hasattr(item.data, "model_dump_json"):
-                                data_str = item.data.model_dump_json()
+                                data_str = item.data.model_dump_json(
+                                    include=response_model_include,
+                                    exclude=response_model_exclude,
+                                )
                             else:
-                                data_str = json.dumps(jsonable_encoder(item.data))
+                                data_str = json.dumps(
+                                    jsonable_encoder(
+                                        item.data,
+                                        include=response_model_include,
+                                        exclude=response_model_exclude,
+                                    )
+                                )
                         else:
                             data_str = None
                         return format_sse_event(

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -88,6 +88,77 @@ async def sse_items_raw():
     yield ServerSentEvent(raw_data="cpu,87.3,1709145600", event="csv")
 
 
+@app.get(
+    "/items/stream-sse-event-include",
+    response_class=EventSourceResponse,
+    response_model_include={"name"},
+)
+async def sse_items_event_include():
+    yield ServerSentEvent(
+        data=Item(name="Plumbus", description="A multi-purpose household device.")
+    )
+
+
+@app.get(
+    "/items/stream-sse-event-exclude",
+    response_class=EventSourceResponse,
+    response_model_exclude={"description"},
+)
+async def sse_items_event_exclude():
+    yield ServerSentEvent(
+        data=Item(name="Plumbus", description="A multi-purpose household device.")
+    )
+
+
+@app.get(
+    "/items/stream-sse-event-dict-include",
+    response_class=EventSourceResponse,
+    response_model_include={"name"},
+)
+async def sse_items_event_dict_include():
+    yield ServerSentEvent(
+        data={"name": "Plumbus", "description": "A multi-purpose household device."}
+    )
+
+
+@app.get(
+    "/items/stream-sse-event-dict-exclude",
+    response_class=EventSourceResponse,
+    response_model_exclude={"description"},
+)
+async def sse_items_event_dict_exclude():
+    yield ServerSentEvent(
+        data={"name": "Plumbus", "description": "A multi-purpose household device."}
+    )
+
+
+@app.get(
+    "/items/stream-mixed-include",
+    response_class=EventSourceResponse,
+    response_model_include={"name"},
+)
+async def sse_items_mixed_include() -> AsyncIterable[Item]:
+    yield Item(name="Plumbus", description="A multi-purpose household device.")
+    yield ServerSentEvent(
+        data=Item(name="Portal Gun", description="A portal opening device.")
+    )
+
+
+@app.get(
+    "/items/stream-sse-event-include-with-meta",
+    response_class=EventSourceResponse,
+    response_model_include={"name"},
+)
+async def sse_items_event_include_with_meta():
+    yield ServerSentEvent(
+        data=Item(name="Plumbus", description="A multi-purpose household device."),
+        event="item",
+        id="1",
+        retry=1000,
+        comment="keep include/exclude away from meta fields",
+    )
+
+
 router = APIRouter()
 
 
@@ -263,6 +334,74 @@ def test_raw_data_sent_without_json_encoding(client: TestClient):
 
     assert "event: csv\n" in text
     assert "data: cpu,87.3,1709145600\n" in text
+
+
+def test_server_sent_event_data_include(client: TestClient):
+    """`response_model_include` is applied to `ServerSentEvent(data=model)`."""
+    response = client.get("/items/stream-sse-event-include")
+    assert response.status_code == 200
+    assert response.text == 'data: {"name":"Plumbus"}\n\n'
+    assert "description" not in response.text
+
+
+def test_server_sent_event_data_exclude(client: TestClient):
+    """`response_model_exclude` is applied to `ServerSentEvent(data=model)`."""
+    response = client.get("/items/stream-sse-event-exclude")
+    assert response.status_code == 200
+    assert response.text == 'data: {"name":"Plumbus"}\n\n'
+    assert "description" not in response.text
+
+
+def test_server_sent_event_dict_data_include(client: TestClient):
+    """`response_model_include` is applied to dict data via jsonable_encoder."""
+    response = client.get("/items/stream-sse-event-dict-include")
+    assert response.status_code == 200
+    assert response.text == 'data: {"name": "Plumbus"}\n\n'
+    assert "description" not in response.text
+
+
+def test_server_sent_event_dict_data_exclude(client: TestClient):
+    """`response_model_exclude` is applied to dict data via jsonable_encoder."""
+    response = client.get("/items/stream-sse-event-dict-exclude")
+    assert response.status_code == 200
+    assert response.text == 'data: {"name": "Plumbus"}\n\n'
+    assert "description" not in response.text
+
+
+def test_server_sent_event_and_plain_item_include_match(client: TestClient):
+    """Directly yielded models and `ServerSentEvent`-wrapped models honor the same
+    `response_model_include` setting."""
+    response = client.get("/items/stream-mixed-include")
+    assert response.status_code == 200
+    data_lines = [
+        line for line in response.text.strip().split("\n") if line.startswith("data: ")
+    ]
+    assert len(data_lines) == 2
+    assert data_lines[0] == 'data: {"name":"Plumbus"}'
+    assert data_lines[1] == 'data: {"name":"Portal Gun"}'
+    assert "description" not in response.text
+
+
+def test_server_sent_event_include_preserves_event_meta_and_raw(client: TestClient):
+    """Include/exclude only affect serialized `data`; meta fields and raw_data stay intact."""
+    response = client.get("/items/stream-sse-event-include-with-meta")
+    assert response.status_code == 200
+    text = response.text
+    assert ": keep include/exclude away from meta fields\n" in text
+    assert "event: item\n" in text
+    assert "id: 1\n" in text
+    assert "retry: 1000\n" in text
+    assert 'data: {"name":"Plumbus"}\n' in text
+    assert "description" not in text
+
+    raw_response = client.get("/items/stream-raw")
+    assert raw_response.status_code == 200
+    assert "data: plain text without quotes\n" in raw_response.text
+    assert 'data: "plain text without quotes"' not in raw_response.text
+
+    string_response = client.get("/items/stream-string")
+    assert string_response.status_code == 200
+    assert 'data: "plain text data"\n' in string_response.text
 
 
 def test_data_and_raw_data_mutually_exclusive():


### PR DESCRIPTION
## Problem

`ServerSentEvent(data=...)` serializes payloads via `model_dump_json()` /
`jsonable_encoder()` without forwarding route-level
`response_model_include` or `response_model_exclude`.

Plain stream items already pass these options through
`ModelField.serialize_json()`, so the same model can serialize differently
depending on how it is yielded:

```python
class Item(BaseModel):
    name: str
    description: str | None = None

@app.get("/a", response_class=EventSourceResponse, response_model_include={"name"})
async def a() -> AsyncIterable[Item]:
    yield Item(name="x", description="hidden")
    # data: {"name":"x"}

@app.get("/b", response_class=EventSourceResponse, response_model_include={"name"})
async def b():
    yield ServerSentEvent(data=Item(name="x", description="hidden"))
    # data: {"name":"x","description":"hidden"}  ← include ignored
```

## Fix

Forward `include=response_model_include` and `exclude=response_model_exclude`
in the explicit `ServerSentEvent` branch for both:

- Pydantic models → `model_dump_json(...)`
- non-model data → `jsonable_encoder(...)`

`raw_data`, strings, event metadata (`event` / `id` / `retry` / `comment`),
and non-SSE response serialization are unchanged.

This is intentionally scoped to include/exclude only, so it can coexist with:

- #16144 (`response_model_by_alias`)
- #16145 (`response_model_exclude_unset` / `exclude_defaults` / `exclude_none`)

## Tests

Added regressions in `tests/test_sse.py` covering:

- `response_model_include` on `ServerSentEvent(data=model)`
- `response_model_exclude` on `ServerSentEvent(data=model)`
- include/exclude for dict payloads via `jsonable_encoder`
- plain yield vs `ServerSentEvent`-wrapped parity
- event meta / `raw_data` / string data unchanged

The new tests fail on current `master` and pass with this change.

## Checks

```bash
uv run --no-sync pytest -q tests/test_sse.py
uv run --no-sync ruff check fastapi/routing.py tests/test_sse.py
uv run --no-sync ruff format fastapi/routing.py tests/test_sse.py --check
uv run --no-sync mypy fastapi/routing.py
uv run --no-sync ty check fastapi/routing.py
```

## Checklist

- [x] The changes fail on the main branch and pass on this PR
- [x] I added tests covering the bug
- [x] Coverage / focused checks pass locally
- [ ] Docs update not needed (behavior aligns existing `response_model_*` options)