### PR TITLE
Update include syntax for docs/en/docs/advanced/templates.md

### DIFF
--- a/docs/en/docs/advanced/templates.md
+++ b/docs/en/docs/advanced/templates.md
@@ -56,7 +56,7 @@ You could also use `from starlette.templating import Jinja2Templates`.
 Then you can write a template at `templates/item.html` with, for example:
 
 ```jinja hl_lines="7"
-{!../../docs_src/templates/templates/item.html!}
+{* ../../docs_src/templates/templates/item.html *}
 ```
 
 ### Template Context Values { #template-context-values }
@@ -110,13 +110,13 @@ For example, with an ID of `42`, this would render:
 You can also use `url_for()` inside of the template, and use it, for example, with the `StaticFiles` you mounted with the `name="static"`.
 
 ```jinja hl_lines="4"
-{!../../docs_src/templates/templates/item.html!}
+{* ../../docs_src/templates/templates/item.html *}
 ```
 
 In this example, it would link to a CSS file at `static/styles.css` with:
 
 ```CSS hl_lines="4"
-{!../../docs_src/templates/static/styles.css!}
+{* ../../docs_src/templates/static/styles.css *}
 ```
 
 And because you are using `StaticFiles`, that CSS file would be served automatically by your **FastAPI** application at the URL `/static/styles.css`.


### PR DESCRIPTION
This PR updates the include syntax in `docs/en/docs/advanced/templates.md` to the new `{* ... *}` format.

I verified the change locally and kept it limited to a single docs page, as requested.