### PR TITLE
👷 Disable saving Zensical's `.cache` in `build-docs.yml`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -103,10 +103,6 @@ jobs:
         run: uv sync --locked --no-dev --group docs
       - name: Update Languages
         run: uv run ./scripts/docs.py update-languages
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          key: zensical-${{ matrix.lang }}-${{ github.ref }}
-          path: site_zensical_src/${{ matrix.lang }}/.cache
       - name: Build Docs
         run: | # zizmor: ignore[template-injection] - comes from trusted source
           uv run ./scripts/docs.py build-lang ${{ matrix.lang }}


### PR DESCRIPTION
## Description

Disable saving Zensical's `.cache` in `build-docs.yml`.
It's currently useless because we remove directory with `.cache` before running `zensical build` in `scripts/docs.py` ([see code](https://github.com/fastapi/fastapi/blob/a375f6b948b99fa4260129856bbf11d037f363ef/scripts/docs.py#L220)).

I attempted to fix it by modifying the script to not delete `.cache`, but after some investigation I realized that it's fragile - Zensical's cache invalidation logic doesn't take into account `docs_src` or `.yaml`-files in data. So, it will generate outdated content if we change them.

## AI Disclaimer

Used Claude Code (Opus 5) to investigate and confirm the solution

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
