### PR TITLE
🐛 Fix Sponsors Git authentication

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -59,4 +59,4 @@ jobs:
           uv run ./scripts/sponsors.py
         env:
           SPONSORS_TOKEN: ${{ secrets.SPONSORS_TOKEN }} # zizmor: ignore[secrets-outside-env]
-          PR_TOKEN: ${{ steps.pr-submit.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.pr-submit.outputs.token }}

--- a/scripts/sponsors.py
+++ b/scripts/sponsors.py
@@ -84,7 +84,7 @@ class SponsorsResponse(BaseModel):
 
 class Settings(BaseSettings):
     sponsors_token: SecretStr
-    pr_token: SecretStr
+    github_token: SecretStr
     github_repository: str
     httpx_timeout: int = 30
 
@@ -160,7 +160,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     settings = Settings()
     logging.info(f"Using config: {settings.model_dump_json()}")
-    g = Github(settings.pr_token.get_secret_value())
+    g = Github(settings.github_token.get_secret_value())
     repo = g.get_repo(settings.github_repository)
 
     tiers = get_individual_sponsors(settings=settings)


### PR DESCRIPTION
Expose the PR Submit token as `GITHUB_TOKEN`, which is recognized by both `gh auth setup-git` and the Sponsors script.

This fixes the workflow failure after the token exchange succeeded.

## AI Disclaimer

Created with gpt-5.6-sol and reviewed by hand.
