### PR TITLE
👷 Fix branch name in `zizmor.yml` workflow (`main` -> `master`)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,7 @@ name: Zizmor
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

The default branch in this repo is `master`, not `main`. It was my mistake.

## AI Disclaimer

AI highlighted this while I was working on another task

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
