### PR TITLE
🐛 Fix `response_class=EventSourceResponse` sending an empty body for non-generator endpoints

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -389,6 +389,7 @@ def get_request_handler(
     strict_content_type: bool | DefaultPlaceholder = Default(True),
     stream_item_field: ModelField | None = None,
     is_json_stream: bool = False,
+    is_sse_stream: bool = False,
 ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
     assert dependant.call is not None, "dependant.call must be a function"
     is_coroutine = _is_coroutine_callable(dependant.call)
@@ -397,7 +398,6 @@ def get_request_handler(
         actual_response_class: type[Response] = response_class.value
     else:
         actual_response_class = response_class
-    is_sse_stream = lenient_issubclass(actual_response_class, EventSourceResponse)
     if isinstance(strict_content_type, DefaultPlaceholder):
         actual_strict_content_type: bool = strict_content_type.value
     else:
@@ -1246,6 +1246,7 @@ class APIRoute(routing.Route):
             strict_content_type=route.strict_content_type,
             stream_item_field=route.stream_item_field,
             is_json_stream=route.is_json_stream,
+            is_sse_stream=route.is_sse_stream,
         )
 
     def matches(self, scope: Scope) -> tuple[Match, Scope]:

--- a/tests/test_sse_non_generator.py
+++ b/tests/test_sse_non_generator.py
@@ -1,0 +1,65 @@
+from collections.abc import AsyncIterable
+
+from fastapi import FastAPI
+from fastapi.responses import EventSourceResponse
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+
+@app.get("/returned-response", response_class=EventSourceResponse)
+async def returned_response() -> EventSourceResponse:
+    async def gen() -> AsyncIterable[bytes]:
+        yield b"data: hi\n\n"
+
+    return EventSourceResponse(gen())
+
+
+@app.get("/async-endpoint", response_class=EventSourceResponse)
+async def async_endpoint():
+    return {"msg": "hello"}
+
+
+@app.get("/sync-endpoint", response_class=EventSourceResponse)
+def sync_endpoint():
+    return {"msg": "hello"}
+
+
+@app.get("/generator", response_class=EventSourceResponse)
+async def generator() -> AsyncIterable[str]:
+    yield "a"
+
+
+client = TestClient(app)
+
+
+def test_returned_event_source_response():
+    """A non-generator endpoint may return an `EventSourceResponse` directly."""
+    response = client.get("/returned-response")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.text == "data: hi\n\n"
+
+
+def test_non_generator_endpoint_does_not_crash():
+    """A non-generator endpoint must not be pushed through the SSE producer."""
+    response = client.get("/async-endpoint")
+    assert response.status_code == 200, response.text
+
+
+def test_sync_non_generator_endpoint_is_not_iterated():
+    """A sync non-generator must not have its return value iterated as SSE events.
+
+    Unlike the async case, this one fails silently: the return value is passed to
+    `iterate_in_threadpool`, so a returned dict streams its *keys* as events.
+    """
+    response = client.get("/sync-endpoint")
+    assert response.status_code == 200, response.text
+    assert "data:" not in response.text
+
+
+def test_generator_endpoint_still_streams_sse():
+    response = client.get("/generator")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.text == 'data: "a"\n\n'

--- a/tests/test_sse_non_generator.py
+++ b/tests/test_sse_non_generator.py
@@ -1,10 +1,11 @@
 from collections.abc import AsyncIterable
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
 from fastapi.testclient import TestClient
 
 app = FastAPI()
+router = APIRouter()
 
 
 @app.get("/returned-response", response_class=EventSourceResponse)
@@ -30,6 +31,18 @@ async def generator() -> AsyncIterable[str]:
     yield "a"
 
 
+@router.get("/router-non-generator", response_class=EventSourceResponse)
+async def router_non_generator():
+    return {"msg": "hello"}
+
+
+@router.get("/router-generator", response_class=EventSourceResponse)
+async def router_generator() -> AsyncIterable[str]:
+    yield "a"
+
+
+app.include_router(router)
+
 client = TestClient(app)
 
 
@@ -41,17 +54,23 @@ def test_returned_event_source_response():
     assert response.text == "data: hi\n\n"
 
 
-def test_non_generator_endpoint_does_not_crash():
-    """A non-generator endpoint must not be pushed through the SSE producer."""
+def test_async_non_generator_endpoint_is_not_sse_framed():
+    """A non-generator must not be pushed through the SSE producer.
+
+    Before the fix the coroutine was handed to the producer, which raised
+    `TypeError: 'coroutine' object is not iterable` after the `200` and its headers
+    had already been flushed, leaving an empty body.
+    """
     response = client.get("/async-endpoint")
     assert response.status_code == 200, response.text
+    assert "data:" not in response.text
 
 
-def test_sync_non_generator_endpoint_is_not_iterated():
-    """A sync non-generator must not have its return value iterated as SSE events.
+def test_sync_non_generator_endpoint_is_not_sse_framed():
+    """A sync non-generator must not have its return value framed as SSE events.
 
-    Unlike the async case, this one fails silently: the return value is passed to
-    `iterate_in_threadpool`, so a returned dict streams its *keys* as events.
+    Unlike the async case this one failed silently: the return value was passed to
+    `iterate_in_threadpool`, so a returned dict streamed its *keys* as `data:` events.
     """
     response = client.get("/sync-endpoint")
     assert response.status_code == 200, response.text
@@ -60,6 +79,20 @@ def test_sync_non_generator_endpoint_is_not_iterated():
 
 def test_generator_endpoint_still_streams_sse():
     response = client.get("/generator")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.text == 'data: "a"\n\n'
+
+
+def test_included_router_non_generator_is_not_sse_framed():
+    """The generator check must also hold for routes added via `include_router`."""
+    response = client.get("/router-non-generator")
+    assert response.status_code == 200, response.text
+    assert "data:" not in response.text
+
+
+def test_included_router_generator_still_streams_sse():
+    response = client.get("/router-generator")
     assert response.status_code == 200, response.text
     assert response.headers["content-type"].startswith("text/event-stream")
     assert response.text == 'data: "a"\n\n'


### PR DESCRIPTION
Discussion: https://github.com/fastapi/fastapi/discussions/16107

## Description

A path operation declared with `response_class=EventSourceResponse` that is not a generator is dispatched into the SSE branch anyway, because [`get_request_handler()` recomputes `is_sse_stream` from the response class alone](https://github.com/fastapi/fastapi/blob/f336ff831c4af3d4f625c2593a27b1e0cae93eb7/fastapi/routing.py#L400), with no generator check.

```python
@app.get("/events", response_class=EventSourceResponse)
async def events() -> EventSourceResponse:
    return EventSourceResponse(gen())
# returns 200 text/event-stream with an empty body
```

The [branch is entered](https://github.com/fastapi/fastapi/blob/f336ff831c4af3d4f625c2593a27b1e0cae93eb7/fastapi/routing.py#L520) before the endpoint runs, so `dependant.call(...)` yields a coroutine (or a plain value) where an iterator is expected, and the `200` and `text/event-stream` headers are already flushed by the time it fails. This shows up in two ways, neither of which raises an error to the client:

- `async def` returns `200` with an empty body, plus `RuntimeWarning: coroutine ... was never awaited`. It's even worse when running under uvicorn: `iterate_in_threadpool()` raises `TypeError: 'coroutine' object is not iterable` mid-response, the connection truncates, and the client gets `RemoteProtocolError: peer closed connection without sending complete message body`.
- `sync def` returns `200` streaming the *iteration* of the return value with no error at all, so an endpoint returning `{"msg": "hello"}` puts `data: "msg"` on the wire.

The same value is already computed correctly on the route, with the generator check fused in, [right beside its JSONL sibling](https://github.com/fastapi/fastapi/blob/f336ff831c4af3d4f625c2593a27b1e0cae93eb7/fastapi/routing.py#L1075):

```python
route.is_sse_stream = is_generator and lenient_issubclass(
    response_class, EventSourceResponse
)
route.is_json_stream = is_generator and isinstance(response_class, DefaultPlaceholder)
```

but only [`is_json_stream` is passed down](https://github.com/fastapi/fastapi/blob/f336ff831c4af3d4f625c2593a27b1e0cae93eb7/fastapi/routing.py#L1248), so the two disagree for every non-generator endpoint.

This PR removes the local recomputation and threads `route.is_sse_stream` through as a parameter, exactly as `route.is_json_stream` already was, so both flags are derived in one place.

The deleted line unwrapped the `DefaultPlaceholder` before checking it, which is why it was there. However, this isn't needed at the route level. `add_api_route()` already passes `response_class` through `get_value_or_default()`. So, when `default_response_class` is set, it is already a real class when `route.is_sse_stream` is computed. When it isn't set, it remains a placeholder and correctly results in `False`.

I verified this with both app-level and router-level `default_response_class=EventSourceResponse`. In both cases, `route.is_sse_stream` remains `True`, and OpenAPI still correctly documents the response as `text/event-stream`.

Present since SSE was added in `0.135.0`; verified against stock `0.135.0` and `0.141.0`.

Adds `tests/test_sse_non_generator.py` covering:

- a non-generator returning an `EventSourceResponse` directly
- an async non-generator returning a plain value
- a sync non-generator returning a plain value (the silent-corruption case)
- the same non-generator case reached through `include_router()`
- a generator, at app level and through `include_router()`, as the control cases for normal SSE streaming

Four of the six fail on `master`, three with `TypeError: 'coroutine' object is not iterable`, and the sync one with a plain assertion showing `data: "msg"` on the wire.

As @LeonardoSanBenitez pointed out on this PR, this fixes the dispatch only. A non-generator under `response_class=EventSourceResponse` still has its return value iterated by `StreamingResponse`, so `{"a": 1}` reaches the wire as `ab` rather than as JSON. Whether that combination should instead be a startup-time error is the open question on the discussion, and is not addressed here.

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
