### PR TITLE
⏪️ Restore `commit_in_place` input in `translate.yml`

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: ""
+      commit_in_place:
+        description: Commit changes directly instead of making a PR
+        type: boolean
+        required: false
+        default: false
       max:
         description: Maximum number of items to translate (e.g. 10)
         type: number

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -421,6 +421,9 @@ def make_pr(
     command: Annotated[str | None, typer.Option(envvar="COMMAND")] = None,
     github_token: Annotated[str, typer.Option(envvar="GITHUB_TOKEN")],
     github_repository: Annotated[str, typer.Option(envvar="GITHUB_REPOSITORY")],
+    commit_in_place: Annotated[
+        bool, typer.Option(envvar="COMMIT_IN_PLACE", show_default=True)
+    ] = False,
 ) -> None:
     print("Setting up GitHub Actions git user")
     repo = git.Repo(Path(__file__).absolute().parent.parent)
@@ -432,14 +435,22 @@ def make_pr(
         ["git", "config", "user.email", "pr-submit[bot]@users.noreply.github.com"],
         check=True,
     )
-    branch_name = "translate"
-    if language:
-        branch_name += f"-{language}"
-    if command:
-        branch_name += f"-{command}"
-    branch_name += f"-{secrets.token_hex(4)}"
-    print(f"Creating a new branch {branch_name}")
-    subprocess.run(["git", "checkout", "-b", branch_name], check=True)
+    current_branch = repo.active_branch.name
+    if current_branch == "master" and commit_in_place:
+        print("Can't commit directly to master")
+        raise typer.Exit(code=1)
+    if not commit_in_place:
+        branch_name = "translate"
+        if language:
+            branch_name += f"-{language}"
+        if command:
+            branch_name += f"-{command}"
+        branch_name += f"-{secrets.token_hex(4)}"
+        print(f"Creating a new branch {branch_name}")
+        subprocess.run(["git", "checkout", "-b", branch_name], check=True)
+    else:
+        branch_name = current_branch
+        print(f"Committing in place on branch {branch_name}")
     print("Adding updated files")
     git_path = Path("docs")
     subprocess.run(["git", "add", str(git_path)], check=True)
@@ -452,17 +463,20 @@ def make_pr(
     subprocess.run(["git", "commit", "-m", message], check=True)
     print("Pushing branch")
     subprocess.run(["git", "push", "origin", branch_name], check=True)
-    print("Creating PR")
-    g = Github(github_token)
-    gh_repo = g.get_repo(github_repository)
-    body = (
-        message
-        + "\n\nThis PR was created automatically using LLMs."
-        + f"\n\nIt uses the prompt file https://github.com/fastapi/fastapi/blob/master/docs/{language}/llm-prompt.md."
-        + "\n\nIn most cases, it's better to make PRs updating that file so that the LLM can do a better job generating the translations than suggesting changes in this PR."
-    )
-    pr = gh_repo.create_pull(title=message, body=body, base="master", head=branch_name)
-    print(f"Created PR: {pr.number}")
+    if not commit_in_place:
+        print("Creating PR")
+        g = Github(github_token)
+        gh_repo = g.get_repo(github_repository)
+        body = (
+            message
+            + "\n\nThis PR was created automatically using LLMs."
+            + f"\n\nIt uses the prompt file https://github.com/fastapi/fastapi/blob/master/docs/{language}/llm-prompt.md."
+            + "\n\nIn most cases, it's better to make PRs updating that file so that the LLM can do a better job generating the translations than suggesting changes in this PR."
+        )
+        pr = gh_repo.create_pull(
+            title=message, body=body, base="master", head=branch_name
+        )
+        print(f"Created PR: {pr.number}")
     print("Finished")
 
 


### PR DESCRIPTION
## Description

The `commit_in_place` input parameter was removed by PR https://github.com/fastapi/fastapi/pull/16168

I think that was made by mistake. We still need it when there are more than 10 files changed (workflow has `max=10` by default) or when we merge `master` into translation PR branch and need to sync recently updated pages.

## AI Disclaimer

Didn't use AI for this.

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
