### PR TITLE
tests: add test_fastapi_cli_installed to verify CLI invocation when available

### DIFF
--- a/tests/test_fastapi_cli.py
+++ b/tests/test_fastapi_cli.py
@@ -32,3 +32,9 @@ def test_fastapi_cli_not_installed():
         with pytest.raises(RuntimeError) as exc_info:
             fastapi.cli.main()
         assert "To use the fastapi command, please install" in str(exc_info.value)
+
+
+def test_fastapi_cli_installed():
+    with patch.object(fastapi.cli, "cli_main") as mock_cli_main:
+        fastapi.cli.main()
+        mock_cli_main.assert_called_once()


### PR DESCRIPTION
### Summary
- In `tests/test_fastapi_cli.py`, add `test_fastapi_cli_installed` to test that `fastapi.cli.main()` invokes `cli_main()` when available.