### PR TITLE
🐛 Infer body params for custom classes with object-shaped Pydantic schemas

### DIFF
--- a/fastapi/_compat/__init__.py
+++ b/fastapi/_compat/__init__.py
@@ -1,5 +1,8 @@
 from .shared import PYDANTIC_VERSION_MINOR_TUPLE as PYDANTIC_VERSION_MINOR_TUPLE
 from .shared import annotation_is_pydantic_v1 as annotation_is_pydantic_v1
+from .shared import (
+    field_annotation_is_custom_object_type as field_annotation_is_custom_object_type,
+)
 from .shared import field_annotation_is_scalar as field_annotation_is_scalar
 from .shared import (
     field_annotation_is_scalar_sequence as field_annotation_is_scalar_sequence,

--- a/fastapi/_compat/shared.py
+++ b/fastapi/_compat/shared.py
@@ -4,6 +4,7 @@ import warnings
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import is_dataclass
+from functools import lru_cache
 from typing import (
     Annotated,
     Any,
@@ -15,7 +16,8 @@ from typing import (
 )
 
 from fastapi.types import UnionType
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
+from pydantic.json_schema import PydanticJsonSchemaWarning
 from pydantic.version import VERSION as PYDANTIC_VERSION
 from starlette.datastructures import UploadFile
 
@@ -108,6 +110,55 @@ def field_annotation_is_complex(annotation: type[Any] | None) -> bool:
 def field_annotation_is_scalar(annotation: Any) -> bool:
     # handle Ellipsis here to make tuple[int, ...] work nicely
     return annotation is Ellipsis or not field_annotation_is_complex(annotation)
+
+
+@lru_cache
+def _type_has_object_json_schema(annotation: type[Any]) -> bool:
+    try:
+        with warnings.catch_warnings():
+            # Schema generation can warn while still succeeding, e.g. for a
+            # non-JSON-serializable default value.
+            warnings.simplefilter("ignore", PydanticJsonSchemaWarning)
+            json_schema = TypeAdapter(annotation).json_schema()
+    except Exception:
+        # Assume non-object if we can't retrieve a JSON schema at all.
+        return False
+    # Self-referencing types put their body in $defs behind a top-level $ref.
+    ref = json_schema.get("$ref")
+    if ref is not None:
+        json_schema = json_schema.get("$defs", {}).get(ref.removeprefix("#/$defs/"), {})
+    return json_schema.get("type") == "object"
+
+
+def _class_is_custom_object_type(annotation: Any) -> bool:
+    if not isinstance(annotation, type):
+        return False
+    if not (
+        hasattr(annotation, "__pydantic_core_schema__")
+        or hasattr(annotation, "__get_pydantic_core_schema__")
+    ):
+        return False
+    return _type_has_object_json_schema(annotation)
+
+
+def field_annotation_is_custom_object_type(annotation: Any) -> bool:
+    """Check if the annotation is a non-BaseModel class that implements the
+    Pydantic custom-schema protocol with an object-shaped JSON schema.
+
+    Such types validate from a JSON object, so they are
+    treated as body parameters, matching the behavior of `BaseModel` subclasses.
+
+    Custom types with scalar-shaped JSON schemas (e.g. `SecretStr`, `AnyUrl`)
+    are not affected and are treated as query parameters.
+    """
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        return any(
+            field_annotation_is_custom_object_type(arg) for arg in get_args(annotation)
+        )
+    if origin is Annotated:
+        return field_annotation_is_custom_object_type(get_args(annotation)[0])
+    return _class_is_custom_object_type(annotation)
 
 
 def field_annotation_is_scalar_sequence(annotation: type[Any] | None) -> bool:

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -34,6 +34,7 @@ from fastapi._compat import (
     copy_field_info,
     create_body_model,
     evaluate_forwardref,
+    field_annotation_is_custom_object_type,
     field_annotation_is_scalar,
     field_annotation_is_scalar_sequence,
     field_annotation_is_sequence,
@@ -499,7 +500,9 @@ def analyze_param(
             type_annotation
         ) or is_uploadfile_sequence_annotation(type_annotation):
             field_info = params.File(annotation=use_annotation, default=default_value)
-        elif not field_annotation_is_scalar(annotation=type_annotation):
+        elif not field_annotation_is_scalar(
+            annotation=type_annotation
+        ) or field_annotation_is_custom_object_type(type_annotation):
             field_info = params.Body(annotation=use_annotation, default=default_value)
         else:
             field_info = params.Query(annotation=use_annotation, default=default_value)

--- a/tests/test_infer_body_custom_pydantic_types.py
+++ b/tests/test_infer_body_custom_pydantic_types.py
@@ -1,0 +1,230 @@
+from typing import Annotated, Any, Generic, TypeVar
+
+from fastapi import FastAPI
+from fastapi._compat import field_annotation_is_custom_object_type
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, GetCoreSchemaHandler, SecretStr
+from pydantic_core import CoreSchema, core_schema
+
+T = TypeVar("T")
+
+
+def _point_schema(cls: Any) -> CoreSchema:
+    return core_schema.no_info_wrap_validator_function(
+        lambda value, handler: (
+            value if isinstance(value, cls) else cls(**handler(value))
+        ),
+        core_schema.typed_dict_schema(
+            {
+                "x": core_schema.typed_dict_field(core_schema.int_schema()),
+                "y": core_schema.typed_dict_field(core_schema.int_schema()),
+            }
+        ),
+        serialization=core_schema.plain_serializer_function_ser_schema(
+            lambda point: {"x": point.x, "y": point.y}
+        ),
+    )
+
+
+class Point:
+    """Object-shaped custom type: validates from a JSON object."""
+
+    def __init__(self, x: int = 0, y: int = 0) -> None:
+        self.x = x
+        self.y = y
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return _point_schema(cls)
+
+
+class GenericPoint(Generic[T]):
+    """Same shape, but generic, to check bare vs parameterized consistency."""
+
+    def __init__(self, x: int = 0, y: int = 0) -> None:
+        self.x = x
+        self.y = y
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return _point_schema(cls)
+
+
+class Token:
+    """Scalar-shaped custom type: validates from a JSON string."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.str_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda token: token.value
+            ),
+        )
+
+
+class Opaque:
+    """Custom type whose JSON schema can't be generated."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.is_instance_schema(cls)
+
+
+class RecursiveModel(BaseModel):
+    children: list["RecursiveModel"] = []
+
+
+class WarnsDuringSchemaGeneration:
+    """Object-shaped custom type whose JSON schema generation emits a
+    PydanticJsonSchemaWarning (non-JSON-serializable default) but succeeds."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.typed_dict_schema(
+            {
+                "x": core_schema.typed_dict_field(
+                    core_schema.with_default_schema(
+                        core_schema.any_schema(), default=object()
+                    )
+                )
+            }
+        )
+
+
+app = FastAPI()
+
+
+@app.post("/points/")
+def create_point(point: Point) -> Point:
+    return Point(x=point.x + 1, y=point.y + 1)
+
+
+@app.post("/generic-points/")
+def create_generic_point(point: GenericPoint[int]) -> dict[str, int]:
+    return {"x": point.x, "y": point.y}
+
+
+@app.post("/bare-generic-points/")
+def create_bare_generic_point(point: GenericPoint) -> dict[str, int]:
+    return {"x": point.x, "y": point.y}
+
+
+@app.post("/optional-points/")
+def create_optional_point(point: Point | None = None) -> dict[str, Any]:
+    if point is None:
+        return {"point": None}
+    return {"point": {"x": point.x, "y": point.y}}
+
+
+@app.get("/tokens/")
+def read_token(token: Token) -> dict[str, str]:
+    return {"token": token.value}
+
+
+@app.get("/secrets/")
+def read_secret(secret: SecretStr) -> dict[str, int]:
+    return {"length": len(secret.get_secret_value())}
+
+
+client = TestClient(app)
+
+
+def test_custom_object_type_is_a_body_param():
+    response = client.post("/points/", json={"x": 1, "y": 2})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"x": 2, "y": 3}
+
+
+def test_custom_object_type_validation_error():
+    response = client.post("/points/", json={"x": "not-an-int", "y": 2})
+    assert response.status_code == 422, response.text
+
+
+def test_bare_and_parameterized_generic_are_both_body_params():
+    # A bare class and its parameterized form must classify the same way.
+    for path in ("/generic-points/", "/bare-generic-points/"):
+        response = client.post(path, json={"x": 1, "y": 2})
+        assert response.status_code == 200, response.text
+        assert response.json() == {"x": 1, "y": 2}
+
+
+def test_optional_custom_object_type_is_a_body_param():
+    response = client.post("/optional-points/", json={"x": 1, "y": 2})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"point": {"x": 1, "y": 2}}
+
+    response = client.post("/optional-points/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"point": None}
+
+
+def test_scalar_shaped_custom_type_is_still_a_query_param():
+    response = client.get("/tokens/", params={"token": "abc"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"token": "abc"}
+
+
+def test_secret_str_is_still_a_query_param():
+    response = client.get("/secrets/", params={"secret": "hunter2"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"length": 7}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+
+    point_post = paths["/points/"]["post"]
+    assert "requestBody" in point_post
+    assert "parameters" not in point_post
+
+    optional_post = paths["/optional-points/"]["post"]
+    assert "requestBody" in optional_post
+    assert "parameters" not in optional_post
+
+    token_get = paths["/tokens/"]["get"]
+    assert "requestBody" not in token_get
+    assert [param["in"] for param in token_get["parameters"]] == ["query"]
+
+    secret_get = paths["/secrets/"]["get"]
+    assert "requestBody" not in secret_get
+    assert [param["in"] for param in secret_get["parameters"]] == ["query"]
+
+
+def test_field_annotation_is_custom_object_type():
+    assert field_annotation_is_custom_object_type(Point)
+    assert field_annotation_is_custom_object_type(GenericPoint)
+    assert field_annotation_is_custom_object_type(Point | None)
+    assert field_annotation_is_custom_object_type(Point | Token)
+    assert field_annotation_is_custom_object_type(Annotated[Point, "meta"])
+    # Self-referencing types hide their body behind a top-level $ref.
+    assert field_annotation_is_custom_object_type(RecursiveModel)
+    # Schema generation warnings don't affect classification (this test module
+    # runs under `filterwarnings = error`, so an unsuppressed warning would
+    # raise and misclassify).
+    assert field_annotation_is_custom_object_type(WarnsDuringSchemaGeneration)
+
+    assert not field_annotation_is_custom_object_type(Token)
+    assert not field_annotation_is_custom_object_type(SecretStr)
+    assert not field_annotation_is_custom_object_type(Token | None)
+    assert not field_annotation_is_custom_object_type(int)
+    assert not field_annotation_is_custom_object_type(str)
+    assert not field_annotation_is_custom_object_type(None)
+    # No JSON schema available: classification is left unchanged.
+    assert not field_annotation_is_custom_object_type(Opaque)


### PR DESCRIPTION
## Pull Request

<!--
Please start with a GitHub Discussion.

Once a team member asks you to open a PR, create it and link the discussion here.

Typos, grammar issues, broken links and other small docs improvements should be reported in the pinned Discussion thread "✏️ Report small docs improvements, including typos or broken links".
Please do not open a PR for these yourself.
-->

Discussion: https://github.com/fastapi/fastapi/discussions/16153

## Description

Check pydantic json schema for object type to determine a body parameter rather than just the presence of `__get_pydantic_core_schema__` attributes. Scalar types also have that attribute, and are currently treated as query only due to a seemingly buggy behavior of checking for the attribute only for the origin of a type (generic parameter), not the type itself. 

## AI Disclaimer

Used AI and then reviewed every changed line and cleaned up comments

## Checklist

- [X] This PR links to a GitHub Discussion for the proposed code change.
- [X] I added tests for the change.
- [X] The new or updated tests fail on the main branch and pass on this PR.
- [X] Coverage stays at 100%.
- [X] The documentation explains the change if needed.
