### PR TITLE
docs: rename read_items to update_item in extra data types example 

### DIFF
--- a/docs_src/extra_data_types/tutorial001_an_py310.py
+++ b/docs_src/extra_data_types/tutorial001_an_py310.py
@@ -8,7 +8,7 @@ app = FastAPI()
 
 
 @app.put("/items/{item_id}")
-async def read_items(
+async def update_item(
     item_id: UUID,
     start_datetime: Annotated[datetime, Body()],
     end_datetime: Annotated[datetime, Body()],

--- a/docs_src/extra_data_types/tutorial001_py310.py
+++ b/docs_src/extra_data_types/tutorial001_py310.py
@@ -7,7 +7,7 @@ app = FastAPI()
 
 
 @app.put("/items/{item_id}")
-async def read_items(
+async def update_item(
     item_id: UUID,
     start_datetime: datetime = Body(),
     end_datetime: datetime = Body(),

--- a/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
+++ b/tests/test_tutorial/test_extra_data_types/test_tutorial001.py
@@ -68,8 +68,8 @@ def test_openapi_schema(client: TestClient):
                                 },
                             },
                         },
-                        "summary": "Read Items",
-                        "operationId": "read_items_items__item_id__put",
+                        "summary": "Update Item",
+                        "operationId": "update_item_items__item_id__put",
                         "parameters": [
                             {
                                 "required": True,
@@ -87,7 +87,7 @@ def test_openapi_schema(client: TestClient):
                             "content": {
                                 "application/json": {
                                     "schema": {
-                                        "$ref": "#/components/schemas/Body_read_items_items__item_id__put"
+                                        "$ref": "#/components/schemas/Body_update_item_items__item_id__put"
                                     }
                                 }
                             },
@@ -97,8 +97,8 @@ def test_openapi_schema(client: TestClient):
             },
             "components": {
                 "schemas": {
-                    "Body_read_items_items__item_id__put": {
-                        "title": "Body_read_items_items__item_id__put",
+                    "Body_update_item_items__item_id__put": {
+                        "title": "Body_update_item_items__item_id__put",
                         "type": "object",
                         "properties": {
                             "start_datetime": {


### PR DESCRIPTION
 ## Pull Request

Discussion: https://github.com/fastapi/fastapi/discussions/16226

## Description

Renamed the function from `read_items` to `update_item` in the `extra_data_types` tutorial example. Since this is a `PUT` request to `/items/{item_id}`, the name `read_items` is confusing as it updates a single item instead of reading multiple items. Updated the corresponding tests and OpenAPI schema snapshots as well.

## AI Disclaimer

I used the Google Antigravity coding assistant (Gemini 3.5 Flash) to help me locate the files, update the tests, and verify them using pytest.

<details>
<summary>AI transcript</summary>

- Located `docs_src/extra_data_types/tutorial001_an_py310.py` and `docs_src/extra_data_types/tutorial001_py310.py`.
- Renamed function `read_items` to `update_item`.
- Updated expected openapi schema in `tests/test_tutorial/test_extra_data_types/test_tutorial001.py`.
- Ran tests via `uv run pytest` and verified all 4 tests pass.

</details>

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed.