### PR TITLE
fix: make _fallback_file_exists async to avoid blocking event loop with sync I/O

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1959,13 +1959,13 @@ class _FrontendStaticFiles(StaticFiles):
             return self.file_response(full_path, stat_result, scope)
 
         if self.fallback == "404.html" or (
-            self.fallback == "auto" and self._fallback_file_exists("404.html")
+            self.fallback == "auto" and await self._fallback_file_exists("404.html")
         ):
             return await self._fallback_response("404.html", scope, status_code=404)
 
         if (
             self.fallback == "index.html"
-            or (self.fallback == "auto" and self._fallback_file_exists("index.html"))
+            or (self.fallback == "auto" and await self._fallback_file_exists("index.html"))
         ) and _is_frontend_navigation_request(scope):
             return await self._fallback_response("index.html", scope, status_code=200)
 
@@ -1998,8 +1998,8 @@ class _FrontendStaticFiles(StaticFiles):
                 return full_path, stat_result, True
         return None
 
-    def _fallback_file_exists(self, fallback: str) -> bool:
-        _, stat_result = self.lookup_path(fallback)
+    async def _fallback_file_exists(self, fallback: str) -> bool:
+        _, stat_result = await run_in_threadpool(self.lookup_path, fallback)
         return stat_result is not None and stat.S_ISREG(stat_result.st_mode)
 
     async def _fallback_response(

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1965,7 +1965,10 @@ class _FrontendStaticFiles(StaticFiles):
 
         if (
             self.fallback == "index.html"
-            or (self.fallback == "auto" and await self._fallback_file_exists("index.html"))
+            or (
+                self.fallback == "auto"
+                and await self._fallback_file_exists("index.html")
+            )
         ) and _is_frontend_navigation_request(scope):
             return await self._fallback_response("index.html", scope, status_code=200)
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1408,6 +1408,7 @@ def test_included_low_priority_routes_can_store_non_frontend_routes():
 
 def test_fallback_file_exists_is_async_and_non_blocking(tmp_path: Path):
     import inspect
+
     from fastapi.routing import _FrontendStaticFiles
 
     static_files = _FrontendStaticFiles(
@@ -1417,4 +1418,3 @@ def test_fallback_file_exists_is_async_and_non_blocking(tmp_path: Path):
     )
 
     assert inspect.iscoroutinefunction(static_files._fallback_file_exists)
-

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1404,3 +1404,17 @@ def test_included_low_priority_routes_can_store_non_frontend_routes():
 
     assert response.status_code == 200
     assert response.text == "low"
+
+
+def test_fallback_file_exists_is_async_and_non_blocking(tmp_path: Path):
+    import inspect
+    from fastapi.routing import _FrontendStaticFiles
+
+    static_files = _FrontendStaticFiles(
+        directory=tmp_path,
+        fallback="auto",
+        check_dir=False,
+    )
+
+    assert inspect.iscoroutinefunction(static_files._fallback_file_exists)
+


### PR DESCRIPTION
 Fixes the event loop blocking issue discussed in #16213.

### Description
The `_fallback_file_exists` helper in `_FrontendStaticFiles` is called during the request path when `fallback="auto"` is configured. However, it was calling the synchronous `lookup_path` method directly on the asyncio event loop thread. 

This PR converts `_fallback_file_exists` into an `async def` coroutine and offloads the synchronous file system checks to a worker thread using `run_in_threadpool`, ensuring the event loop is never blocked by fallback existence checks.

### Checklist
- [x] This PR links to a GitHub Discussion for the proposed code change (#16213).
- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed.