### PR TITLE
refactor(encoders): include PurePath in ENCODERS_BY_TYPE mapping

### DIFF
--- a/fastapi/encoders.py
+++ b/fastapi/encoders.py
@@ -102,6 +102,7 @@ ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
     IPv6Network: str,
     NameEmail: str,
     Path: str,
+    PurePath: str,
     Pattern: lambda o: o.pattern,
     SecretBytes: str,
     SecretStr: str,

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -343,3 +343,11 @@ def test_encode_color(module_path):
 
     data = {"color": Color("blue")}
     assert jsonable_encoder(data) == {"color": "blue"}
+
+
+def test_encoders_by_type_contains_pure_path():
+    from fastapi.encoders import ENCODERS_BY_TYPE
+
+    assert PurePath in ENCODERS_BY_TYPE
+    assert ENCODERS_BY_TYPE[PurePath] is str
+

--- a/tests/test_jsonable_encoder.py
+++ b/tests/test_jsonable_encoder.py
@@ -350,4 +350,3 @@ def test_encoders_by_type_contains_pure_path():
 
     assert PurePath in ENCODERS_BY_TYPE
     assert ENCODERS_BY_TYPE[PurePath] is str
-


### PR DESCRIPTION
## Summary

Includes `PurePath` in `ENCODERS_BY_TYPE` in `fastapi/encoders.py`:
- `PurePath` is already imported from `pathlib` alongside `Path`, but was missing from the `ENCODERS_BY_TYPE` dictionary.
- Adding `PurePath: str` allows direct type-mapping lookups for `PurePath` instances without requiring subclass iteration.
- Added unit test `test_encoders_by_type_contains_pure_path` in `tests/test_jsonable_encoder.py`.

## Changes

- `fastapi/encoders.py`: Added `PurePath: str` to `ENCODERS_BY_TYPE`.
- `tests/test_jsonable_encoder.py`: Added verification test for `ENCODERS_BY_TYPE[PurePath]`.

## Tests

- Added `test_encoders_by_type_contains_pure_path`.
