### PR TITLE
Inherit Starlette router dispatch

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -2535,6 +2535,8 @@ class APIRouter(routing.Router):
             default=default,
             lifespan=lifespan_context,
         )
+        self._default = self.default
+        self.default = self._handle_no_match
         if prefix:
             assert prefix.startswith("/"), "A path prefix must start with '/'"
             assert not prefix.endswith("/"), (
@@ -2716,48 +2718,9 @@ class APIRouter(routing.Router):
         )
         self._mark_routes_changed()
 
-    async def app(self, scope: Scope, receive: Receive, send: Send) -> None:
-        assert scope["type"] in ("http", "websocket", "lifespan")
-
-        if "router" not in scope:
-            scope["router"] = self
-
-        if scope["type"] == "lifespan":
-            await self.lifespan(scope, receive, send)
-            return
-
-        partial: tuple[BaseRoute, Scope] | None = None
-        for route in self.routes:
-            match, child_scope = route.matches(scope)
-            if match == Match.FULL:
-                scope.update(child_scope)
-                await route.handle(scope, receive, send)
-                return
-            if match == Match.PARTIAL and partial is None:
-                partial = (route, child_scope)
-
-        if partial is not None:
-            route, child_scope = partial
-            scope.update(child_scope)
-            await route.handle(scope, receive, send)
-            return
-
-        route_path = get_route_path(scope)
-        if scope["type"] == "http" and self.redirect_slashes and route_path != "/":
-            redirect_scope = dict(scope)
-            if route_path.endswith("/"):
-                redirect_scope["path"] = redirect_scope["path"].rstrip("/")
-            else:
-                redirect_scope["path"] = redirect_scope["path"] + "/"
-
-            for route in self.routes:
-                match, _ = route.matches(redirect_scope)
-                if match != Match.NONE:
-                    redirect_url = URL(scope=redirect_scope)
-                    response = RedirectResponse(url=str(redirect_url))
-                    await response(scope, receive, send)
-                    return
-
+    async def _handle_no_match(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
         (
             low_priority_match,
             low_priority_scope,
@@ -2778,7 +2741,7 @@ class APIRouter(routing.Router):
             await low_priority_route.handle(scope, receive, send)
             return
 
-        await self.default(scope, receive, send)
+        await self._default(scope, receive, send)
 
     async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:
         included_router = _get_scope_included_router(scope)


### PR DESCRIPTION
## Summary

Remove FastAPI's copy of `Router.app()` and express low-priority frontend routing through Starlette's existing `default` callback.

Starlette remains responsible for lifespan handling, normal route matching, partial matches, and slash redirects. FastAPI handles low-priority routes only after Starlette finds no regular route or redirect, then delegates to the original default application.

This works with FastAPI's minimum supported Starlette version, 0.46.0. Once [Starlette PR #3339](https://github.com/Kludex/starlette/pull/3339) is available, FastAPI inherits its trie-backed candidate selection without another routing change.

## Benchmark

The benchmark compares FastAPI `master` with this PR while both use the same Starlette trie branch at `3bfc970`. It dispatches requests directly through the public FastAPI ASGI application. Results are median microseconds per request across four processes, with 2,000 requests per round and seven rounds per process. Lower is better.

| Routes | First route | Last route | Missing route | Method not allowed |
| ---: | ---: | ---: | ---: | ---: |
| 10 | 12.4 -> 12.9 us | 17.5 -> 12.8 us (1.4x) | 17.8 -> 9.1 us (2.0x) | 13.8 -> 9.6 us (1.4x) |
| 100 | 12.6 -> 13.1 us | 63.9 -> 13.0 us (4.9x) | 106.7 -> 11.1 us (9.6x) | 60.8 -> 9.6 us (6.4x) |
| 500 | 12.3 -> 12.9 us | 266.4 -> 12.8 us (20.7x) | 503.1 -> 19.1 us (26.3x) | 261.6 -> 9.5 us (27.6x) |

The first route remains approximately 13 us. The improvement grows with route count for late matches, misses, and `405 Method Not Allowed` responses. These gains apply when FastAPI is used with the trie-backed Starlette change.

## Tests

- `scripts/test.sh -q` - 3348 passed, 17 skipped, 5 xfailed
- `scripts/lint.sh`
- `tests/test_frontend.py` against Starlette 0.46.0 - 93 passed

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
