### PR TITLE
📝 Add docs and tutorial for Kubernetes probes (liveness, readiness, s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ env
 docs_build
 site_build
 venv
+.venv
 docs.zip
 archive.zip
 

--- a/docs/en/docs/deployment/kubernetes-probes.md
+++ b/docs/en/docs/deployment/kubernetes-probes.md
@@ -1,0 +1,118 @@
+# Kubernetes Probes - Liveness, Readiness, and Startup { #kubernetes-probes-liveness-readiness-and-startup }
+
+When deploying a **FastAPI** application to **Kubernetes** (or other container orchestrators like Nomad, Docker Swarm, or AWS ECS), the orchestrator needs to know the **health and state** of your application containers.
+
+Kubernetes uses **Probes** (health checks) to automate lifecycle tasks like restarting failed containers or routing incoming traffic only to instances that are ready to serve requests. 🚀
+
+---
+
+## The Three Types of Kubernetes Probes { #the-three-types-of-kubernetes-probes }
+
+Kubernetes supports three main probe types:
+
+1. **Liveness Probe (`livenessProbe`)**:
+    * **Purpose**: Checks if the container process is still running and able to process HTTP requests (i.e., the Python event loop is alive and not deadlocked).
+    * **Action on Failure**: Kubernetes **kills and restarts** the container.
+    * **Golden Rule**: Keep it minimal and fast. **Do not** check external dependencies (databases, third-party APIs, queues) here!
+
+2. **Readiness Probe (`readinessProbe`)**:
+    * **Purpose**: Checks if the application is currently ready to receive traffic from users (e.g., database connection pool is healthy, caches are connected).
+    * **Action on Failure**: Kubernetes **temporarily stops sending traffic** to this Pod by removing it from the Service endpoints / load balancer. The container is **not** restarted.
+    * **Golden Rule**: Check essential dependencies with short timeouts. Return `200 OK` when ready, or `503 Service Unavailable` when not ready.
+
+3. **Startup Probe (`startupProbe`)**:
+    * **Purpose**: Checks if the application has completed its initial warmup/initialization.
+    * **Action on Failure**: Disables liveness and readiness checks until the startup probe succeeds (useful for slow startup tasks like loading large ML models or pre-warming caches).
+
+---
+
+## Common Production Trap: Cascading Restarts { #common-production-trap-cascading-restarts }
+
+/// warning
+
+A very common mistake is checking external dependencies (such as PostgreSQL or Redis) inside the **Liveness Probe**.
+
+If your database experiences a brief network blip or temporary overload:
+
+1. The liveness probe fails across **all** application replicas simultaneously.
+2. Kubernetes restarts **every container** at the same time.
+3. Upon restarting, all containers attempt to reconnect to the database simultaneously, creating a **thundering herd / restart storm** and causing complete system downtime.
+
+**Always check downstream dependencies in the Readiness Probe, never in the Liveness Probe.**
+
+///
+
+---
+
+## FastAPI Implementation Example { #fastapi-implementation-example }
+
+Here is a practical, production-ready example using FastAPI, `lifespan`, and standard health status responses:
+
+{* ../../docs_src/kubernetes_probes/tutorial001_py310.py *}
+
+### Code Breakdown { #code-breakdown }
+
+* **`lifespan`**: Sets `app_state.is_ready = True` once the application startup tasks complete.
+* **`/livez` endpoint**: Returns a simple `{"status": "ok"}`. It does not hit the database. If this fails, the process is deadlocked or crashed, so a container restart is warranted.
+* **`/readyz` endpoint**: Checks `app_state.is_ready` and validates the database connection with `check_database()`. If any check fails, it raises an `HTTPException` with status code `503 Service Unavailable`.
+
+---
+
+## Kubernetes Deployment Manifest Example { #kubernetes-deployment-manifest-example }
+
+In your Kubernetes `Deployment` YAML file, configure the probes to point to your FastAPI endpoints:
+
+```yaml hl_lines="13-29"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastapi-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: fastapi-app
+  template:
+    metadata:
+      labels:
+        app: fastapi-app
+    spec:
+      containers:
+        - name: fastapi-app
+          image: my-fastapi-app:latest
+          ports:
+            - containerPort: 8000
+          # Liveness: Restart the container if the event loop / process hangs
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          # Readiness: Remove from load balancer if database/dependencies are unhealthy
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 2
+```
+
+### Parameter Guidelines { #parameter-guidelines }
+
+* **`initialDelaySeconds`**: Time to wait before executing the first probe after the container starts.
+* **`periodSeconds`**: How often (in seconds) to perform the probe.
+* **`timeoutSeconds`**: Number of seconds after which the probe times out (keep this short, e.g. 2–3 seconds).
+* **`failureThreshold`**: Number of consecutive failures before Kubernetes takes action (restarting for liveness, removing from traffic for readiness).
+
+---
+
+## Summary { #summary }
+
+* Use `/livez` for process health and `/readyz` for traffic readiness.
+* Never check external services in `/livez` to prevent cascading pod restarts.
+* Use FastAPI's `lifespan` context manager to manage startup/warmup state cleanly.

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
     - deployment/cloud.md
     - deployment/server-workers.md
     - deployment/docker.md
+    - deployment/kubernetes-probes.md
   - "":
     - how-to/index.md
     - how-to/general.md

--- a/docs_src/kubernetes_probes/__init__.py
+++ b/docs_src/kubernetes_probes/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/docs_src/kubernetes_probes/tutorial001_py310.py
+++ b/docs_src/kubernetes_probes/tutorial001_py310.py
@@ -1,0 +1,76 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel
+
+
+class HealthStatus(BaseModel):
+    status: str
+
+
+class ReadinessStatus(BaseModel):
+    status: str
+    database: bool
+
+
+class AppState:
+    def __init__(self) -> None:
+        self.is_ready: bool = False
+        self.db_healthy: bool = True
+
+
+app_state = AppState()
+
+
+async def check_database() -> bool:
+    # In a real application, you would run a lightweight query (e.g. SELECT 1)
+    return app_state.db_healthy
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    # Perform startup tasks (e.g. initialize connection pools, warm caches)
+    app_state.is_ready = True
+    yield
+    # Perform shutdown cleanup
+    app_state.is_ready = False
+
+
+app = FastAPI(title="Kubernetes Probes Example", lifespan=lifespan)
+
+
+@app.get(
+    "/livez",
+    tags=["health"],
+    response_model=HealthStatus,
+    summary="Liveness Probe",
+)
+async def liveness_probe() -> HealthStatus:
+    """Check whether the application process is alive and responsive."""
+    return HealthStatus(status="ok")
+
+
+@app.get(
+    "/readyz",
+    tags=["health"],
+    response_model=ReadinessStatus,
+    summary="Readiness Probe",
+    responses={status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Service Unavailable"}},
+)
+async def readiness_probe() -> ReadinessStatus:
+    """Check whether the application and its dependencies are ready to accept traffic."""
+    if not app_state.is_ready:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Application is still starting up",
+        )
+
+    db_ok = await check_database()
+    if not db_ok:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database connection is unhealthy",
+        )
+
+    return ReadinessStatus(status="ready", database=True)

--- a/docs_src/kubernetes_probes/tutorial001_py310.py
+++ b/docs_src/kubernetes_probes/tutorial001_py310.py
@@ -56,7 +56,9 @@ async def liveness_probe() -> HealthStatus:
     tags=["health"],
     response_model=ReadinessStatus,
     summary="Readiness Probe",
-    responses={status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Service Unavailable"}},
+    responses={
+        status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Service Unavailable"}
+    },
 )
 async def readiness_probe() -> ReadinessStatus:
     """Check whether the application and its dependencies are ready to accept traffic."""

--- a/tests/test_tutorial/test_kubernetes_probes/__init__.py
+++ b/tests/test_tutorial/test_kubernetes_probes/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/tests/test_tutorial/test_kubernetes_probes/test_tutorial001.py
+++ b/tests/test_tutorial/test_kubernetes_probes/test_tutorial001.py
@@ -1,0 +1,64 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(
+    name="client_and_mod",
+    params=[
+        pytest.param("tutorial001_py310"),
+    ],
+)
+def get_client_and_mod(request: pytest.FixtureRequest):
+    mod = importlib.import_module(f"docs_src.kubernetes_probes.{request.param}")
+    # Reset state
+    mod.app_state.is_ready = False
+    mod.app_state.db_healthy = True
+    return mod
+
+
+def test_liveness_probe(client_and_mod):
+    mod = client_and_mod
+    with TestClient(mod.app) as client:
+        response = client.get("/livez")
+        assert response.status_code == 200, response.text
+        assert response.json() == {"status": "ok"}
+
+
+def test_readiness_probe_success(client_and_mod):
+    mod = client_and_mod
+    with TestClient(mod.app) as client:
+        response = client.get("/readyz")
+        assert response.status_code == 200, response.text
+        assert response.json() == {"status": "ready", "database": True}
+
+
+def test_readiness_probe_db_unhealthy(client_and_mod):
+    mod = client_and_mod
+    with TestClient(mod.app) as client:
+        mod.app_state.db_healthy = False
+        response = client.get("/readyz")
+        assert response.status_code == 503, response.text
+        assert response.json() == {"detail": "Database connection is unhealthy"}
+
+
+def test_readiness_probe_startup_not_ready(client_and_mod):
+    mod = client_and_mod
+    mod.app_state.is_ready = False
+    # Use client without entering lifespan context manager
+    client = TestClient(mod.app)
+    response = client.get("/readyz")
+    assert response.status_code == 503, response.text
+    assert response.json() == {"detail": "Application is still starting up"}
+
+
+def test_openapi_schema(client_and_mod):
+    mod = client_and_mod
+    with TestClient(mod.app) as client:
+        response = client.get("/openapi.json")
+        assert response.status_code == 200, response.text
+        schema = response.json()
+        assert "/livez" in schema["paths"]
+        assert "/readyz" in schema["paths"]
+        assert "503" in schema["paths"]["/readyz"]["get"]["responses"]


### PR DESCRIPTION
Discussion: https://github.com/fastapi/fastapi/discussions/16239

## Description

This PR addresses the open roadmap item in #10370:
> - [ ] Docs for liveness and readiness for Kubernetes and others

### What this PR adds:
1. **New Deployment Guide (`docs/en/docs/deployment/kubernetes-probes.md`)**:
   - Explains the purpose and distinct behavior of `livenessProbe`, `readinessProbe`, and `startupProbe` in Kubernetes and container orchestrators.
   - Highlights the common production trap of checking external downstream dependencies (e.g. database, Redis) in the liveness probe, which leads to cascading pod restart storms during transient network/DB blips.
   - Provides a realistic Kubernetes `Deployment` YAML manifest example with proper probe parameters (`initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`).

2. **Executable Code Example (`docs_src/kubernetes_probes/tutorial001_py310.py`)**:
   - Demonstrates a lightweight `/livez` endpoint (for process responsiveness).
   - Demonstrates a resilient `/readyz` endpoint integrated with `lifespan` state and database dependency checks, returning `503 Service Unavailable` when not ready.

3. **Automated Tests (`tests/test_tutorial/test_kubernetes_probes/test_tutorial001.py`)**:
   - Comprehensive unit tests covering liveness (`200 OK`), readiness success (`200 OK`), readiness failure on unhealthy dependency (`503 Service Unavailable`), startup state verification, and OpenAPI schema generation.

4. **Navigation Update**:
   - Registered `deployment/kubernetes-probes.md` under the Deployment section in `docs/en/mkdocs.yml`.

## AI Disclaimer

Prompt/Model: Pair-programmed and structured with Google Antigravity IDE (Gemini 3.7 Flash). All code examples, tests, and documentation was reviewed, refined, and validated locally against the FastAPI test suite.

<details>
<summary>AI transcript</summary>

Assisted in drafting the tutorial structure, creating the `docs_src` code sample, setting up `pytest` test assertions for liveness/readiness edge cases, and authoring the English documentation guide according to FastAPI documentation conventions.

</details>

## Checklist

- [x] This PR links to a GitHub Discussion for the proposed code change.
- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [x] The documentation explains the change if needed.
