### PR TITLE
Fix: Add missing docstring in utils.py

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -41,6 +41,9 @@ def is_body_allowed_for_status_code(status_code: int | str | None) -> bool:
 
 
 def get_path_param_names(path: str) -> set[str]:
+    """
+    Extract path parameter names from a path string.
+    """
     return set(re.findall("{(.*?)}", path))
 
 


### PR DESCRIPTION
Fixes #16240. Added the missing docstring in \astapi/utils.py\ to improve code readability and maintainability. Let me know if any further changes are required!