### PR TITLE
📝 Fix variable name discrepancy in Query Parameters tutorial 015

### DIFF
--- a/docs_src/query_params_str_validations/tutorial015_an_py310.py
+++ b/docs_src/query_params_str_validations/tutorial015_an_py310.py
@@ -24,7 +24,7 @@ async def read_items(
     id: Annotated[str | None, AfterValidator(check_valid_id)] = None,
 ):
     if id:
-        item = data.get(id)
+        name = data.get(id)
     else:
-        id, item = random.choice(list(data.items()))
-    return {"id": id, "name": item}
+        id, name = random.choice(list(data.items()))
+    return {"id": id, "name": name}


### PR DESCRIPTION
## Pull Request

This PR links to [Discussion #15849](https://github.com/fastapi/fastapi/discussions/15849#discussioncomment-14059798).

## Description

In the tutorial section **"Query Parameters and String Validations"** (`docs/en/docs/tutorial/query-params-str-validations.md`), the subsection **"A Random Item"** explains:

> Then with `random.choice()` we can get a **random value** from the list, so, we get a tuple with `(id, name)`. It will be something like `("imdb-tt0371724", "The Hitchhiker's Guide to the Galaxy")`.
>
> Then we **assign those two values** of the tuple to the variables `id` and `name`.

However, the accompanying code snippet `docs_src/query_params_str_validations/tutorial015_an_py310.py` used `item` instead of `name` (`item = data.get(id)`, `id, item = random.choice(...)`, and `return {"id": id, "name": item}`).

This PR updates `item` to `name` in `tutorial015_an_py310.py` to match the tutorial explanation and the returned dictionary format `{"id": id, "name": name}`.

## Checklist

- [x] This PR is an obvious typo/docs fix, or it links to a GitHub Discussion for the proposed code change.
- [x] All existing tests continue to pass.
- [x] The documentation matches the code example.