### PR TITLE
🐛 Fix WebSocket paths in route contexts

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -1555,6 +1555,8 @@ class RouteContext:
     @property
     def _effective_route(self) -> BaseRoute | _EffectiveRouteContext:
         if self._route_context is not None:
+            if self._route_context.starlette_route is not None:
+                return self._route_context.starlette_route
             return self._route_context
         return self.route
 

--- a/tests/test_router_include_context.py
+++ b/tests/test_router_include_context.py
@@ -55,6 +55,28 @@ def test_iter_route_contexts_returns_direct_route_context():
     assert contexts[0].endpoint is read_item
 
 
+def test_iter_route_contexts_returns_effective_websocket_path():
+    router = APIRouter()
+
+    @router.websocket("/stream/{job_id}", name="stream")
+    async def stream():  # pragma: no cover
+        pass
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+
+    context = next(
+        context
+        for context in iter_route_contexts(app.routes)
+        if context.original_route is router.routes[0]
+    )
+
+    assert context.path == "/api/v1/stream/{job_id}"
+    assert context.path_format == "/api/v1/stream/{job_id}"
+    assert context.name == "stream"
+    assert context.endpoint is stream
+
+
 def test_iter_route_contexts_supports_nested_conflict_detection():
     existing_router = APIRouter()
     nested_router = APIRouter()


### PR DESCRIPTION
Fixes #16244

Included non-HTTP routes already have an effective Starlette route with the router prefix applied. Make RouteContext expose metadata from that effective route, so included WebSocket contexts report the mounted path, path format, name, and endpoint.

Adds regression coverage for a prefixed APIWebSocketRoute.

Tests:
- uv run pytest tests/test_router_include_context.py -q
- uv run ruff check fastapi/routing.py tests/test_router_include_context.py
- uv run ruff format --check fastapi/routing.py tests/test_router_include_context.py
- uv run mypy fastapi
- uv run ty check