### PR TITLE
⬆️ Bump Typer min version to 0.26.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ tests = [
     "sqlmodel >=0.0.31",
     "strawberry-graphql >=0.200.0,<1.0.0",
     "ty>=0.0.25",
-    "typer >=0.24.1",
+    "typer >=0.26.1",
     "a2wsgi >=1.9.0,<=2.0.0",
     "pytest-xdist[psutil]>=3.0.2",
     "pytest-cov>=4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ dev = [
     { name = "strawberry-graphql", specifier = ">=0.200.0,<1.0.0" },
     { name = "ty", specifier = ">=0.0.25" },
     { name = "typer", specifier = ">=0.21.1" },
-    { name = "typer", specifier = ">=0.24.1" },
+    { name = "typer", specifier = ">=0.26.1" },
     { name = "zensical", specifier = ">=0.0.42" },
     { name = "zizmor", specifier = ">=1.23.1" },
 ]
@@ -1132,7 +1132,7 @@ tests = [
     { name = "sqlmodel", specifier = ">=0.0.31" },
     { name = "strawberry-graphql", specifier = ">=0.200.0,<1.0.0" },
     { name = "ty", specifier = ">=0.0.25" },
-    { name = "typer", specifier = ">=0.24.1" },
+    { name = "typer", specifier = ">=0.26.1" },
 ]
 translations = [
     { name = "gitpython", specifier = ">=3.1.46" },


### PR DESCRIPTION
## Description

Tests in CI are currently failing with uv resolution `lowest-direct` (see [workflow run logs](https://github.com/fastapi/fastapi/actions/runs/32990434147/job/98246517448)):

<details>

```
+ bash scripts/test.sh --cov --cov-context=test
+ export PYTHONPATH=./docs_src
+ PYTHONPATH=./docs_src
+ pytest -n auto --dist loadgroup tests scripts/tests/ --cov --cov-context=test
ImportError while loading conftest '/Users/runner/work/fastapi/fastapi/scripts/tests/test_translation_fixer/conftest.py'.
scripts/tests/test_translation_fixer/conftest.py:9: in <module>
    from typer.testing import CliRunner
.venv/lib/python3.10/site-packages/typer/__init__.py:24: in <module>
    from click.utils import get_binary_stream as get_binary_stream
.venv/lib/python3.10/site-packages/click/utils.py:681: in __getattr__
    warnings.warn(
E   DeprecationWarning: 'click.utils.get_binary_stream' is deprecated and will be removed in Click 9.0.
Error: Process completed with exit code 4.
```

</details>

Bumping min Typer version to 0.26.0 to resolve this



## AI Disclaimer

Didn't use AI

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
