### PR TITLE
fix: compare multipart version numerically in ensure_multipart_is_installed

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -105,8 +105,8 @@ def ensure_multipart_is_installed() -> None:
         from python_multipart import __version__
 
         # Import an attribute that can be mocked/deleted in testing
-        assert __version__ > "0.0.12"
-    except (ImportError, AssertionError):
+        assert tuple(int(part) for part in __version__.split(".")) >= (0, 0, 12)
+    except (ImportError, AssertionError, ValueError):
         try:
             # __version__ is available in both multiparts, and can be mocked
             from multipart import (  # type: ignore[no-redef,import-untyped]


### PR DESCRIPTION
Fixes #15226

**Problem**: `ensure_multipart_is_installed()` compared `__version__` as a string (`assert __version__ > "0.0.12"`), so a valid `python-multipart` like `0.0.100` compared less than `0.0.12` and was treated as broken.

**Fix**: compare the version numerically by parsing each part to int (`tuple(int(part) for part in __version__.split(".")) >= (0, 0, 12)`), and treat non-numeric version strings as invalid (`ValueError` falls through to the `multipart` fallback).