### PR TITLE
fix: set X-Accel-Buffering: no on JSONL streaming responses

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -679,6 +679,8 @@ def get_request_handler(
                     media_type="application/jsonl",
                     **response_args,
                 )
+                # For Nginx proxies to not buffer JSONL streaming responses
+                response.headers["X-Accel-Buffering"] = "no"
                 response.headers.raw.extend(solved_result.response.headers.raw)
             elif _is_async_gen_callable(dependant.call) or _is_gen_callable(
                 dependant.call


### PR DESCRIPTION
Fixes #15813

**Problem**: the SSE branch sets `X-Accel-Buffering: no` (so streaming survives buffering proxies, added in #15030), but the JSONL streaming branch (yield-based `application/jsonl`) does not — buffering proxies can delay JSONL streaming.

**Fix**: set `response.headers["X-Accel-Buffering"] = "no"` on the JSONL `StreamingResponse` too, mirroring the SSE branch.