### PR TITLE
⬆️ Bump Typer min version to `0.26.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ docs = [
     "pillow >=11.3.0",
     "python-slugify >=8.0.4",
     "pyyaml >=5.3.1,<7.0.0",
-    "typer >=0.21.1",
+    "typer >=0.26.1",
     "zensical >=0.0.42",
 ]
 docs-tests = [

--- a/uv.lock
+++ b/uv.lock
@@ -1073,7 +1073,7 @@ dev = [
     { name = "sqlmodel", specifier = ">=0.0.31" },
     { name = "strawberry-graphql", specifier = ">=0.200.0,<1.0.0" },
     { name = "ty", specifier = ">=0.0.25" },
-    { name = "typer", specifier = ">=0.21.1" },
+    { name = "typer", specifier = ">=0.26.1" },
     { name = "typer", specifier = ">=0.26.1" },
     { name = "zensical", specifier = ">=0.0.42" },
     { name = "zizmor", specifier = ">=1.23.1" },
@@ -1093,7 +1093,7 @@ docs = [
     { name = "python-slugify", specifier = ">=8.0.4" },
     { name = "pyyaml", specifier = ">=5.3.1,<7.0.0" },
     { name = "ruff", specifier = ">=0.14.14" },
-    { name = "typer", specifier = ">=0.21.1" },
+    { name = "typer", specifier = ">=0.26.1" },
     { name = "zensical", specifier = ">=0.0.42" },
 ]
 docs-tests = [


### PR DESCRIPTION
Tests in CI are currently failing with uv resolution `lowest-direct`. Bumping min Typer version to 0.26.0 to resolve this

🤖 This pull request was created with the help of AI.