### PR TITLE
fix: strip path converter suffix in get_path_param_names

### DIFF
--- a/fastapi/utils.py
+++ b/fastapi/utils.py
@@ -41,7 +41,7 @@ def is_body_allowed_for_status_code(status_code: int | str | None) -> bool:
 
 
 def get_path_param_names(path: str) -> set[str]:
-    return set(re.findall("{(.*?)}", path))
+    return {param.split(":")[0] for param in re.findall("{(.*?)}", path)}
 
 
 _invalid_args_message = (


### PR DESCRIPTION
Fixes #14883

**Problem**: `get_path_param_names()` uses `re.findall("{(.*?)}", path)`, so a route like `/{param:path}` extracts `param:path` (including the converter suffix). When the parameter is declared implicitly (without `Path()`), it is not recognized as a path parameter and the request fails.

**Fix**: strip everything after `:` in each extracted name, so `{param:path}` is recognized as `param`. Plain `{param}` is unaffected.