### PR TITLE
fix: add format: binary to bytes schema for OAS 3.0 compatibility

### DIFF
--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -58,7 +58,7 @@ class GenerateJsonSchema(_GenerateJsonSchema):
     # TODO: remove when this is merged (or equivalent): https://github.com/pydantic/pydantic/pull/12841
     # and dropping support for any version of Pydantic before that one (so, in a very long time)
     def bytes_schema(self, schema: CoreSchema) -> JsonSchemaValue:
-        json_schema = {"type": "string", "contentMediaType": "application/octet-stream"}
+        json_schema = {"type": "string", "format": "binary", "contentMediaType": "application/octet-stream"}
         bytes_mode = (
             self._config.ser_json_bytes
             if self.mode == "serialization"

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -58,7 +58,11 @@ class GenerateJsonSchema(_GenerateJsonSchema):
     # TODO: remove when this is merged (or equivalent): https://github.com/pydantic/pydantic/pull/12841
     # and dropping support for any version of Pydantic before that one (so, in a very long time)
     def bytes_schema(self, schema: CoreSchema) -> JsonSchemaValue:
-        json_schema = {"type": "string", "format": "binary", "contentMediaType": "application/octet-stream"}
+        json_schema = {
+            "type": "string",
+            "format": "binary",
+            "contentMediaType": "application/octet-stream",
+        }
         bytes_mode = (
             self._config.ser_json_bytes
             if self.mode == "serialization"


### PR DESCRIPTION
Fixes #15069

**Problem**: #14953 aligned the `bytes` field schema with OAS 3.1 (type: string + contentMediaType: application/octet-stream), but Swagger UI doesn't fully support it — multiple file upload fields render as text instead of file pickers.

**Fix**: add `"format": "binary"` to the bytes schema, which OAS 3.0 handles well in Swagger UI (file picker) and OAS 3.1+ ignores.