### PR TITLE
fix: preserve model_fields_set for Form models

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -773,6 +773,10 @@ def _get_multidict_value(
         if field.field_info.is_required():
             return
         else:
+            # For FormData, don't inject defaults: Pydantic should only see
+            # fields actually provided in the form, so model_fields_set stays accurate
+            if type(values).__name__ == "FormData":
+                return None
             return deepcopy(field.default)
     return value
 


### PR DESCRIPTION
Fixes #14574

**Problem**: when using Form models, `_get_multidict_value()` returns the field default for fields not present in the form data. That default is then passed to Pydantic, so every field appears in `model_fields_set` even when it was not provided, and validation is enforced on unprovided defaults.

**Fix**: when `values` is `FormData`, return `None` for unprovided fields instead of the default, so Pydantic only records fields actually provided in the form.