### PR TITLE
🐛 Fix `format_sse_event` dropping the event terminator when no field is set

### DIFF
--- a/fastapi/sse.py
+++ b/fastapi/sse.py
@@ -228,9 +228,11 @@ def format_sse_event(
     if retry is not None:
         lines.append(f"retry: {retry}")
 
-    lines.append("")
-    lines.append("")
-    return "\n".join(lines).encode("utf-8")
+    # Terminate the event with a blank line. The terminator is appended to the
+    # joined field lines instead of being added as two empty lines, so that it
+    # is still emitted when no fields were set at all, which is the case for an
+    # empty `ServerSentEvent()`.
+    return ("\n".join(lines) + "\n\n").encode("utf-8")
 
 
 # Keep-alive comment, per the SSE spec recommendation

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -396,6 +396,33 @@ def test_format_sse_event_splitlines_behavior_in_comment():
     assert format_sse_event(comment="hi\n") == b": hi\n: \n\n"
 
 
+def test_format_sse_event_without_fields_is_terminated():
+    # Without any field the result is still terminated by a blank line,
+    # instead of a single "\n".
+    assert format_sse_event() == b"\n\n"
+
+
+empty_event_app = FastAPI()
+
+
+@empty_event_app.get("/empty-event", response_class=EventSourceResponse)
+async def empty_event_stream():
+    yield ServerSentEvent(data="first")
+    yield ServerSentEvent()
+    yield ServerSentEvent(data="second")
+
+
+def test_empty_server_sent_event_is_terminated():
+    client = TestClient(empty_event_app)
+    response = client.get("/empty-event")
+    assert response.status_code == 200
+    assert response.text == (
+        'data: "first"\n\n'  # first event
+        "\n\n"  # empty event, terminated on its own
+        'data: "second"\n\n'  # last event, not merged with the empty one
+    )
+
+
 # default_response_class tests
 
 


### PR DESCRIPTION
## Bug

`format_sse_event()` documents that:

> The result always ends with `\n\n` (the event terminator).

It doesn't, when no field is set. The terminator is built by appending two empty entries to the list of field lines and then joining them with `\n`:

```python
lines.append("")
lines.append("")
return "\n".join(lines).encode("utf-8")
```

When `lines` is empty the join produces a single `"\n"` instead of `"\n\n"`:

```pycon
>>> from fastapi.sse import format_sse_event
>>> format_sse_event()
b'\n'                # expected b'\n\n'
>>> format_sse_event(data_str='"x"')
b'data: "x"\n\n'     # correct
```

This is reachable from user code by yielding an empty `ServerSentEvent()` from an SSE *path operation*:

```python
@app.get("/stream", response_class=EventSourceResponse)
async def stream():
    yield ServerSentEvent(data="first")
    yield ServerSentEvent()
    yield ServerSentEvent(data="second")
```

The empty event is emitted as a bare `\n` rather than a properly terminated (empty) event:

```pycon
>>> # before
'data: "first"\n\n' '\n'   'data: "second"\n\n'
>>> # after
'data: "first"\n\n' '\n\n' 'data: "second"\n\n'
```

## Fix

Append the terminator to the joined field lines instead of adding it as two list entries, so it is emitted unconditionally.

Output is byte-for-byte unchanged for every event that sets at least one field (`data`, `event`, `id`, `retry` or `comment`) — the only behavior change is the previously unterminated empty event.

## Tests

Two tests added to `tests/test_sse.py`, both of which fail on `master`:

* `test_format_sse_event_without_fields_is_terminated` — unit level.
* `test_empty_server_sent_event_is_terminated` — end to end through an SSE *path operation*.
