### PR TITLE
fix(docs): strip HTML tags from termynal copy content

### DIFF
--- a/docs/en/docs/js/custom.js
+++ b/docs/en/docs/js/custom.js
@@ -83,7 +83,11 @@ function setupTermynal() {
                 saveBuffer();
                 const inputCommands = useLines
                     .filter(line => line.type === "input")
-                    .map(line => line.value)
+                    .map(line => {
+                        const tmp = document.createElement("div");
+                        tmp.innerHTML = line.value;
+                        return tmp.textContent;
+                    })
                     .join("\n");
                 node.textContent = inputCommands;
                 const div = document.createElement("div");


### PR DESCRIPTION
Fixes #15941 — termynal copy button copied tags vialine.valueHTML. Now extractstextContentviatmp.innerHTMLfor clipboard while preserving visual HTML. Onlydocs/en/docs/js/custom.js changed.