### PR TITLE
Re-raise ClientDisconnect during request body reading instead of converting to HTTP 400

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -94,7 +94,7 @@ from starlette._utils import get_route_path, is_async_callable
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import URL, FormData, URLPath
 from starlette.exceptions import HTTPException
-from starlette.requests import Request
+from starlette.requests import ClientDisconnect, Request
 from starlette.responses import (
     JSONResponse,
     PlainTextResponse,
@@ -465,6 +465,9 @@ def get_request_handler(
             raise validation_error from e
         except HTTPException:
             # If a middleware raises an HTTPException, it should be raised again
+            raise
+        except ClientDisconnect:
+            # If a client disconnects while reading the body, propagate the disconnect
             raise
         except Exception as e:
             http_error = HTTPException(

--- a/tests/test_client_disconnect.py
+++ b/tests/test_client_disconnect.py
@@ -1,0 +1,255 @@
+import pytest
+from fastapi import Body, FastAPI, File, Form, Request, UploadFile
+from pydantic import BaseModel
+from starlette.requests import ClientDisconnect
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_json_body():
+    app = FastAPI()
+
+    @app.post("/items")
+    async def create_item(item: Item):
+        return item
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "path": "/items",
+        "raw_path": b"/items",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", b"100"),
+        ],
+    }
+
+    events = []
+
+    async def send(event):
+        events.append(event)
+
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_raw_body():
+    app = FastAPI()
+
+    @app.post("/raw")
+    async def create_raw(body: bytes = Body()):
+        return {"length": len(body)}
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "path": "/raw",
+        "raw_path": b"/raw",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"text/plain"),
+            (b"content-length", b"100"),
+        ],
+    }
+
+    events = []
+
+    async def send(event):
+        events.append(event)
+
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_form_body():
+    app = FastAPI()
+
+    @app.post("/form")
+    async def create_form(username: str = Form()):
+        return {"username": username}
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "path": "/form",
+        "raw_path": b"/form",
+        "query_string": b"",
+        "headers": [
+            (
+                b"content-type",
+                b"application/x-www-form-urlencoded",
+            ),
+            (b"content-length", b"100"),
+        ],
+    }
+
+    events = []
+
+    async def send(event):
+        events.append(event)
+
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_file_upload():
+    app = FastAPI()
+
+    @app.post("/upload")
+    async def upload_file(file: UploadFile = File()):
+        return {"filename": file.filename}
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "path": "/upload",
+        "raw_path": b"/upload",
+        "query_string": b"",
+        "headers": [
+            (
+                b"content-type",
+                b"multipart/form-data; boundary=----WebKitFormBoundarytest",
+            ),
+            (b"content-length", b"100"),
+        ],
+    }
+
+    events = []
+
+    async def send(event):
+        events.append(event)
+
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_request_direct():
+    app = FastAPI()
+
+    @app.post("/direct")
+    async def direct(request: Request):
+        await request.body()
+        return {"status": "ok"}
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "path": "/direct",
+        "raw_path": b"/direct",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", b"100"),
+        ],
+    }
+
+    events = []
+
+    async def send(event):
+        events.append(event)
+
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+
+
+@pytest.mark.anyio
+async def test_body_parsing_generic_error_returns_400():
+    app = FastAPI()
+
+    @app.post("/items")
+    async def create_item(item: Item):
+        return item
+
+    async def receive():
+        raise RuntimeError("Custom stream error")
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "path": "/items",
+        "raw_path": b"/items",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", b"100"),
+        ],
+    }
+
+    events = []
+
+    async def send(event):
+        events.append(event)
+
+    await app(scope, receive, send)
+    assert events[0]["type"] == "http.response.start"
+    assert events[0]["status"] == 400
+    assert events[1]["type"] == "http.response.body"
+    assert b"There was an error parsing the body" in events[1]["body"]
+
+
+@pytest.mark.anyio
+async def test_body_parsing_http_exception_reraised():
+    from fastapi import HTTPException
+
+    app = FastAPI()
+
+    @app.post("/items")
+    async def create_item(item: Item):
+        return item
+
+    async def receive():
+        raise HTTPException(status_code=418, detail="Custom HTTP Error")
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "path": "/items",
+        "raw_path": b"/items",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", b"100"),
+        ],
+    }
+
+    events = []
+
+    async def send(event):
+        events.append(event)
+
+    await app(scope, receive, send)
+    assert events[0]["type"] == "http.response.start"
+    assert events[0]["status"] == 418
+    assert events[1]["type"] == "http.response.body"
+    assert b"Custom HTTP Error" in events[1]["body"]


### PR DESCRIPTION
Fixes #15312

When a client disconnects while FastAPI is reading the request body, Starlette raises `starlette.requests.ClientDisconnect`. Previously, `routing.py` caught this under a general `except Exception` and converted it into an `HTTPException(400)`, which resulted in attempts to send responses over dead sockets and false 400 error alerts in monitoring. This PR explicitly re-raises `ClientDisconnect` so it can propagate naturally to ASGI middleware.