### PR TITLE
docs: fix type annotation mismatch in sub-dependencies tutorial example

### DIFF
--- a/docs_src/dependencies/tutorial005_an_py310.py
+++ b/docs_src/dependencies/tutorial005_an_py310.py
@@ -10,7 +10,7 @@ def query_extractor(q: str | None = None):
 
 
 def query_or_cookie_extractor(
-    q: Annotated[str, Depends(query_extractor)],
+    q: Annotated[str | None, Depends(query_extractor)],
     last_query: Annotated[str | None, Cookie()] = None,
 ):
     if not q:
@@ -20,6 +20,6 @@ def query_or_cookie_extractor(
 
 @app.get("/items/")
 async def read_query(
-    query_or_default: Annotated[str, Depends(query_or_cookie_extractor)],
+    query_or_default: Annotated[str | None, Depends(query_or_cookie_extractor)],
 ):
     return {"q_or_cookie": query_or_default}

--- a/docs_src/dependencies/tutorial005_py310.py
+++ b/docs_src/dependencies/tutorial005_py310.py
@@ -8,7 +8,8 @@ def query_extractor(q: str | None = None):
 
 
 def query_or_cookie_extractor(
-    q: str = Depends(query_extractor), last_query: str | None = Cookie(default=None)
+    q: str | None = Depends(query_extractor),
+    last_query: str | None = Cookie(default=None),
 ):
     if not q:
         return last_query
@@ -16,5 +17,5 @@ def query_or_cookie_extractor(
 
 
 @app.get("/items/")
-async def read_query(query_or_default: str = Depends(query_or_cookie_extractor)):
+async def read_query(query_or_default: str | None = Depends(query_or_cookie_extractor)):
     return {"q_or_cookie": query_or_default}


### PR DESCRIPTION
### Description
In the Sub-dependencies tutorial example (\docs_src/dependencies/tutorial005_an_py310.py\ and \	utorial005_py310.py\), \query_extractor\ has the signature:

\\\python
def query_extractor(q: str | None = None):
    return q
\\\`n
Because \query_extractor\ can return \None\, the sub-dependency \query_or_cookie_extractor\ receiving \q: Annotated[str, Depends(query_extractor)]\ previously had a type annotation mismatch with static type checkers because \q\ can be \None\. Furthermore, since \query_or_cookie_extractor\ returns \q\ or \last_query\ (both can be \None\), \ead_query\ receiving \query_or_default\ was also typed as \str\ instead of \str | None\.

This PR updates the annotations to \str | None\ to be accurate with static type checkers (\mypy\ / \pyright\).

### Checklist
- [x] The documentation examples were updated.
- [x] Unit tests pass cleanly.