### PR TITLE
🐛 Fix OpenAPI response body schema check for response classes with default status code

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -416,7 +416,7 @@ def get_openapi_path(
             operation.setdefault("responses", {}).setdefault(status_code, {})[
                 "description"
             ] = route.response_description
-            if is_body_allowed_for_status_code(route.status_code):
+            if is_body_allowed_for_status_code(status_code):
                 # Check for JSONL streaming (generator endpoints)
                 if route.is_json_stream:
                     jsonl_content: dict[str, Any] = {}

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI
+from typing import Any
+
+from fastapi import FastAPI, Response
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
@@ -20,6 +22,24 @@ class JsonApiError(BaseModel):
     errors: list[Error]
 
 
+class NoContentResponse(Response):
+    def __init__(
+        self,
+        content: bytes = b"",
+        status_code: int = 204,
+        headers: dict | None = None,
+        media_type: str | None = None,
+        background: Any = None,
+    ):
+        super().__init__(
+            content=content,
+            status_code=status_code,
+            headers=headers,
+            media_type=media_type,
+            background=background,
+        )
+
+
 @app.get(
     "/a",
     status_code=204,
@@ -32,6 +52,11 @@ async def a():
 
 @app.get("/b", responses={204: {"description": "No Content"}})
 async def b():
+    pass  # pragma: no cover
+
+
+@app.get("/c", response_class=NoContentResponse)
+async def c():
     pass  # pragma: no cover
 
 
@@ -83,6 +108,15 @@ def test_openapi_schema():
                         },
                         "summary": "B",
                         "operationId": "b_b_get",
+                    }
+                },
+                "/c": {
+                    "get": {
+                        "responses": {
+                            "204": {"description": "Successful Response"},
+                        },
+                        "summary": "C",
+                        "operationId": "c_c_get",
                     }
                 },
             },

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -69,6 +69,11 @@ def test_get_response():
     assert "content-length" not in response.headers
     assert response.content == b""
 
+    response = client.get("/c")
+    assert response.status_code == 204, response.text
+    assert "content-length" not in response.headers
+    assert response.content == b""
+
 
 def test_openapi_schema():
     response = client.get("/openapi.json")

--- a/tests/test_response_code_no_body.py
+++ b/tests/test_response_code_no_body.py
@@ -23,6 +23,8 @@ class JsonApiError(BaseModel):
 
 
 class NoContentResponse(Response):
+    media_type = "application/json"
+
     def __init__(
         self,
         content: bytes = b"",


### PR DESCRIPTION
### 🐛 Fix OpenAPI response body schema check for response classes with default status code

#### Description
When an endpoint doesn't explicitly specify `status_code` in the decorator (e.g. `@app.get("/items", response_class=NoContentResponse)`), `route.status_code` is `None`. 

In `fastapi/openapi/utils.py`, `status_code` is correctly extracted from the `response_class.__init__` signature (e.g. `"204"` or `"304"`), but the subsequent check called `is_body_allowed_for_status_code(route.status_code)`. Because `route.status_code` was `None`, `is_body_allowed_for_status_code(None)` returned `True`.

This caused FastAPI to generate a response body (`content: {"application/json": ...}`) under `"204"` / `"304"` in OpenAPI schemas, which violates HTTP and OpenAPI specifications.

#### Changes
- In `fastapi/openapi/utils.py`, changed `is_body_allowed_for_status_code(route.status_code)` to `is_body_allowed_for_status_code(status_code)`.
- Added test coverage in `tests/test_response_code_no_body.py` for response classes with a default `204` status code and verified OpenAPI snapshot.

#### Checklist
- [x] Ran `pytest` suite
- [x] Ran `ruff check` and `ruff format`
