### PR TITLE
Fix/16034 freeze time route field build

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -3306,10 +3306,12 @@ class APIRouter(routing.Router):
             include_in_schema=include_in_schema,
             generate_unique_id_function=generate_unique_id_function,
         )
-        self.routes.append(
-            _IncludedRouter(original_router=router, include_context=include_context)
+        included_router = _IncludedRouter(
+            original_router=router, include_context=include_context
         )
+        self.routes.append(included_router)
         self._mark_routes_changed()
+        included_router.effective_candidates()
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ github-actions = [
 tests = [
     { include-group = "docs-tests" },
     "anyio[trio] >=3.2.1,<5.0.0",
+    "freezegun >=1.5.0",
     "coverage[toml] >=7.13,<8.0",
     "dirty-equals >=0.9.0",
     "flask >=3.0.0,<4.0.0",

--- a/tests/test_include_router_freeze_time.py
+++ b/tests/test_include_router_freeze_time.py
@@ -1,0 +1,24 @@
+from datetime import date
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, FastAPI, Query
+from fastapi.testclient import TestClient
+from freezegun import freeze_time
+
+
+def test_include_router_builds_fields_before_first_request():
+    router = APIRouter()
+
+    @router.get("/m")
+    def handler(from_date: Annotated[Optional[date], Query()] = None):
+        return {"from_date": str(from_date)}
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    with freeze_time("2024-05-13"):
+        response = client.get("/api/m")
+
+    assert response.status_code == 200

--- a/tests/test_include_router_freeze_time.py
+++ b/tests/test_include_router_freeze_time.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Annotated, Optional
+from typing import Annotated
 
 from fastapi import APIRouter, FastAPI, Query
 from fastapi.testclient import TestClient
@@ -10,7 +10,7 @@ def test_include_router_builds_fields_before_first_request():
     router = APIRouter()
 
     @router.get("/m")
-    def handler(from_date: Annotated[Optional[date], Query()] = None):
+    def handler(from_date: Annotated[date | None, Query()] = None):
         return {"from_date": str(from_date)}
 
     app = FastAPI()

--- a/tests/test_router_include_context.py
+++ b/tests/test_router_include_context.py
@@ -932,6 +932,35 @@ def test_included_router_candidate_cache_is_thread_safe():
     assert TestClient(app).get("/items/0").json() == {"index": 0}
 
 
+def test_included_router_candidate_cache_rechecks_version_after_lock(monkeypatch):
+    router = APIRouter()
+    app = FastAPI()
+    app.include_router(router)
+    included_router = cast(_IncludedRouter, app.router.routes[-1])
+    included_router._effective_candidates_version = None
+    routes_version = router._get_routes_version()
+    version_checked = threading.Event()
+
+    def get_routes_version() -> int:
+        version_checked.set()
+        return routes_version
+
+    monkeypatch.setattr(router, "_get_routes_version", get_routes_version)
+    result: list[Sequence[object]] = []
+
+    def build_candidates() -> None:
+        result.append(included_router.effective_candidates())
+
+    with included_router._effective_routes_lock:
+        thread = threading.Thread(target=build_candidates)
+        thread.start()
+        assert version_checked.wait(timeout=1)
+        included_router._effective_candidates_version = routes_version
+    thread.join()
+
+    assert result == [[]]
+
+
 def test_included_router_low_priority_cache_rechecks_version_after_lock(monkeypatch):
     router = APIRouter()
     app = FastAPI()

--- a/uv.lock
+++ b/uv.lock
@@ -901,6 +901,7 @@ dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "dirty-equals" },
     { name = "flask" },
+    { name = "freezegun" },
     { name = "gitpython" },
     { name = "griffe-typingdoc" },
     { name = "griffe-warnings-deprecated" },
@@ -972,6 +973,7 @@ tests = [
     { name = "coverage", extra = ["toml"] },
     { name = "dirty-equals" },
     { name = "flask" },
+    { name = "freezegun" },
     { name = "httpx" },
     { name = "httpx2" },
     { name = "inline-snapshot" },
@@ -1043,6 +1045,7 @@ dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.13,<8.0" },
     { name = "dirty-equals", specifier = ">=0.9.0" },
     { name = "flask", specifier = ">=3.0.0,<4.0.0" },
+    { name = "freezegun", specifier = ">=1.5.0" },
     { name = "gitpython", specifier = ">=3.1.46" },
     { name = "griffe-typingdoc", specifier = ">=0.3.0" },
     { name = "griffe-warnings-deprecated", specifier = ">=1.1.0" },
@@ -1115,6 +1118,7 @@ tests = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.13,<8.0" },
     { name = "dirty-equals", specifier = ">=0.9.0" },
     { name = "flask", specifier = ">=3.0.0,<4.0.0" },
+    { name = "freezegun", specifier = ">=1.5.0" },
     { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
     { name = "httpx2", specifier = ">=2.0.0" },
     { name = "inline-snapshot", specifier = ">=0.21.1" },
@@ -1341,6 +1345,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Pull Request

Discussion: No GitHub Discussion was provided for this contribution. I independently implemented and tested this change.

## Description

### Problem

When an `APIRouter` is included in a FastAPI application, the route's effective candidates and dependent fields are not built until they are needed.

If the first request to the included router is made inside a `freezegun.freeze_time()` context, route field generation can happen while time is frozen. This can cause the request to fail with a `500 Internal Server Error`.

The issue was reproduced with a route containing an optional `date` query parameter.

Before this fix, the reproduced request returned:

`STATUS: 500`

### Solution

The included router is now stored in an `included_router` variable when `include_router()` is called.

After the router is added to the application's routes, its effective candidates are built immediately by calling:

`included_router.effective_candidates()`

This eagerly builds the router's effective candidates and dependent fields when the router is included, instead of delaying this work until the first request.

The change also includes tests covering the candidate-cache version recheck and the frozen-time route-field generation scenario.

## AI Disclaimer

I used ChatGPT to better understand the reported bug, the relevant FastAPI routing behavior, and some implementation details while working on the contribution.

The AI was used for technical guidance and clarification while working on the contribution.

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [x] I added tests for the change.
- [x] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.