### PR TITLE
Fix route field generation with frozen time

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -3306,10 +3306,12 @@ class APIRouter(routing.Router):
             include_in_schema=include_in_schema,
             generate_unique_id_function=generate_unique_id_function,
         )
-        self.routes.append(
-            _IncludedRouter(original_router=router, include_context=include_context)
+        included_router = _IncludedRouter(
+            original_router=router, include_context=include_context
         )
+        self.routes.append(included_router)
         self._mark_routes_changed()
+        included_router.effective_candidates()
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/tests/test_include_router_freeze_time.py
+++ b/tests/test_include_router_freeze_time.py
@@ -1,0 +1,24 @@
+from datetime import date
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, FastAPI, Query
+from fastapi.testclient import TestClient
+from freezegun import freeze_time
+
+
+def test_include_router_builds_fields_before_first_request():
+    router = APIRouter()
+
+    @router.get("/m")
+    def handler(from_date: Annotated[Optional[date], Query()] = None):
+        return {"from_date": str(from_date)}
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    with freeze_time("2024-05-13"):
+        response = client.get("/api/m")
+
+    assert response.status_code == 200

--- a/tests/test_include_router_freeze_time.py
+++ b/tests/test_include_router_freeze_time.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Annotated, Optional
+from typing import Annotated
 
 from fastapi import APIRouter, FastAPI, Query
 from fastapi.testclient import TestClient
@@ -10,7 +10,7 @@ def test_include_router_builds_fields_before_first_request():
     router = APIRouter()
 
     @router.get("/m")
-    def handler(from_date: Annotated[Optional[date], Query()] = None):
+    def handler(from_date: Annotated[date | None, Query()] = None):
         return {"from_date": str(from_date)}
 
     app = FastAPI()

--- a/tests/test_include_router_freeze_time.py
+++ b/tests/test_include_router_freeze_time.py
@@ -1,9 +1,8 @@
 from datetime import date
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, FastAPI, Query
-from fastapi.testclient import TestClient
-from freezegun import freeze_time
+from fastapi.routing import _IncludedRouter
 
 
 def test_include_router_builds_fields_before_first_request():
@@ -16,9 +15,6 @@ def test_include_router_builds_fields_before_first_request():
     app = FastAPI()
     app.include_router(router, prefix="/api")
 
-    client = TestClient(app, raise_server_exceptions=False)
+    included_router = cast(_IncludedRouter, app.router.routes[-1])
 
-    with freeze_time("2024-05-13"):
-        response = client.get("/api/m")
-
-    assert response.status_code == 200
+    assert included_router._effective_candidates

--- a/tests/test_router_include_context.py
+++ b/tests/test_router_include_context.py
@@ -932,6 +932,35 @@ def test_included_router_candidate_cache_is_thread_safe():
     assert TestClient(app).get("/items/0").json() == {"index": 0}
 
 
+def test_included_router_candidate_cache_rechecks_version_after_lock(monkeypatch):
+    router = APIRouter()
+    app = FastAPI()
+    app.include_router(router)
+    included_router = cast(_IncludedRouter, app.router.routes[-1])
+    included_router._effective_candidates_version = None
+    routes_version = router._get_routes_version()
+    version_checked = threading.Event()
+
+    def get_routes_version() -> int:
+        version_checked.set()
+        return routes_version
+
+    monkeypatch.setattr(router, "_get_routes_version", get_routes_version)
+    result: list[Sequence[object]] = []
+
+    def build_candidates() -> None:
+        result.append(included_router.effective_candidates())
+
+    with included_router._effective_routes_lock:
+        thread = threading.Thread(target=build_candidates)
+        thread.start()
+        assert version_checked.wait(timeout=1)
+        included_router._effective_candidates_version = routes_version
+    thread.join()
+
+    assert result == [[]]
+
+
 def test_included_router_low_priority_cache_rechecks_version_after_lock(monkeypatch):
     router = APIRouter()
     app = FastAPI()


### PR DESCRIPTION
## Pull Request

## Description

Fixes an issue where including an `APIRouter` could leave its effective route candidates unbuilt until the first request.

If the first request to the included router is made while time is frozen, route field generation can happen under the frozen time context and cause the request to fail with a `500 Internal Server Error`.

The fix builds the included router's effective candidates when the router is included, before the first request.

Also adds a regression test covering the candidate cache version recheck after acquiring the lock.

## AI Disclaimer

I used ChatGPT for technical guidance and clarification while working on this contribution. The implementation and testing were performed and verified locally.

## Checklist

- [ ] This PR links to a GitHub Discussion for the proposed code change.
- [x] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.