### PR TITLE
Fix SSE intro example to align with tutorial's Item model

### DIFF
--- a/docs/en/docs/tutorial/server-sent-events.md
+++ b/docs/en/docs/tutorial/server-sent-events.md
@@ -19,9 +19,9 @@ Each event is a small text block with "fields" like `data`, `event`, `id`, and `
 It looks like this:
 
 ```
-data: {"name": "Portal Gun", "price": 999.99}
+data: {"name": "Plumbus", "description": "A multi-purpose household device."}
 
-data: {"name": "Plumbus", "price": 32.99}
+data: {"name": "Portal Gun", "description": "A portal opening device."}
 
 ```
 


### PR DESCRIPTION
## Summary

Small documentation consistency fix in the **Server-Sent Events (SSE)** tutorial.

The introductory *"What are Server-Sent Events?"* section shows an illustrative SSE output block. It used a `price` field:

```
data: {"name": "Portal Gun", "price": 999.99}

data: {"name": "Plumbus", "price": 32.99}
```

However, the very next section (*"Stream SSE with FastAPI"*) embeds [`docs_src/server_sent_events/tutorial001_py310.py`](https://github.com/fastapi/fastapi/blob/master/docs_src/server_sent_events/tutorial001_py310.py), whose `Item` model has `name` and `description` (not `price`), and whose sample data is:

```python
items = [
    Item(name="Plumbus", description="A multi-purpose household device."),
    Item(name="Portal Gun", description="A portal opening device."),
    ...
]
```

So the intro output block did not match the first runnable example a reader encounters on the page. This PR updates the intro block to use the same fields and the same first two items as `tutorial001`:

```
data: {"name": "Plumbus", "description": "A multi-purpose household device."}

data: {"name": "Portal Gun", "description": "A portal opening device."}
```

## Notes

- Docs-only change: a single illustrative fenced code block in `docs/en/docs/tutorial/server-sent-events.md`.
- No code, no public API, and no snippet line references change.
- The SSE tutorial tests still pass locally (`tests/test_tutorial/test_server_sent_events/`, `tests/test_sse.py`  54 passed).