### PR TITLE
🌐 Add Chinese translation for contributing.md and newsletter.md

### DIFF
--- a/docs/zh/docs/contributing.md
+++ b/docs/zh/docs/contributing.md
@@ -1,0 +1,7 @@
+# 贡献 { #contributing }
+
+首先，你可能想了解[帮助 FastAPI 和获取帮助](help-fastapi.md)的基本方式。
+
+## 开发 { #developing }
+
+如需为本项目贡献代码，请遵循 [tiangolo.com - Contributing](https://tiangolo.com/open-source/contributing/) 中的指南。

--- a/docs/zh/docs/newsletter.md
+++ b/docs/zh/docs/newsletter.md
@@ -1,0 +1,5 @@
+# FastAPI 及相关项目新闻邮件 { #fastapi-and-friends-newsletter }
+
+<iframe data-w-type="embedded" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://xr4n4.mjt.lu/wgt/xr4n4/hj5/form?c=40a44fa4" width="100%" style="height: 800px;"></iframe>
+
+<script type="text/javascript" src="https://app.mailjet.com/pas-nc-embedded-v1.js"></script>


### PR DESCRIPTION
## Description

Adds Chinese translations for `docs/zh/docs/contributing.md` and `docs/zh/docs/newsletter.md`.

This also resolves the broken link to `newsletter.md` in `docs/zh/docs/help-fastapi.md`.