### PR TITLE
🐛 Support PEP 695 TypeAliasType in Query, Form, Sequence parameters, and OpenAPI extraction

### DIFF
--- a/fastapi/_compat/shared.py
+++ b/fastapi/_compat/shared.py
@@ -18,6 +18,7 @@ from fastapi.types import UnionType
 from pydantic import BaseModel
 from pydantic.version import VERSION as PYDANTIC_VERSION
 from starlette.datastructures import UploadFile
+from typing_inspection.typing_objects import is_typealiastype
 
 _T = TypeVar("_T")
 
@@ -43,6 +44,12 @@ sequence_annotation_to_type = {
 sequence_types: tuple[type[Any], ...] = tuple(sequence_annotation_to_type.keys())
 
 
+def _unwrap_typealiastype(annotation: Any) -> Any:
+    while is_typealiastype(annotation):
+        annotation = annotation.__value__
+    return annotation
+
+
 # Copy of Pydantic: pydantic/_internal/_utils.py with added TypeGuard
 def lenient_issubclass(
     cls: Any, class_or_tuple: type[_T] | tuple[type[_T], ...] | None
@@ -62,6 +69,7 @@ def _annotation_is_sequence(annotation: type[Any] | None) -> bool:
 
 
 def field_annotation_is_sequence(annotation: type[Any] | None) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     origin = get_origin(annotation)
 
     if origin is Annotated:
@@ -90,6 +98,7 @@ def _annotation_is_complex(annotation: type[Any] | None) -> bool:
 
 
 def field_annotation_is_complex(annotation: type[Any] | None) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     origin = get_origin(annotation)
     if origin is Union or origin is UnionType:
         return any(field_annotation_is_complex(arg) for arg in get_args(annotation))
@@ -111,6 +120,7 @@ def field_annotation_is_scalar(annotation: Any) -> bool:
 
 
 def field_annotation_is_scalar_sequence(annotation: type[Any] | None) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     origin = get_origin(annotation)
 
     if origin is Annotated:
@@ -132,6 +142,7 @@ def field_annotation_is_scalar_sequence(annotation: type[Any] | None) -> bool:
 
 
 def is_bytes_or_nonable_bytes_annotation(annotation: Any) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     if lenient_issubclass(annotation, bytes):
         return True
     origin = get_origin(annotation)
@@ -143,6 +154,7 @@ def is_bytes_or_nonable_bytes_annotation(annotation: Any) -> bool:
 
 
 def is_uploadfile_or_nonable_uploadfile_annotation(annotation: Any) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     if lenient_issubclass(annotation, UploadFile):
         return True
     origin = get_origin(annotation)
@@ -154,6 +166,7 @@ def is_uploadfile_or_nonable_uploadfile_annotation(annotation: Any) -> bool:
 
 
 def is_bytes_sequence_annotation(annotation: Any) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     origin = get_origin(annotation)
     if origin is Union or origin is UnionType:
         at_least_one = False
@@ -169,6 +182,7 @@ def is_bytes_sequence_annotation(annotation: Any) -> bool:
 
 
 def is_uploadfile_sequence_annotation(annotation: Any) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     origin = get_origin(annotation)
     if origin is Union or origin is UnionType:
         at_least_one = False
@@ -208,6 +222,7 @@ def is_pydantic_v1_model_class(cls: Any) -> bool:
 
 
 def annotation_is_pydantic_v1(annotation: Any) -> bool:
+    annotation = _unwrap_typealiastype(annotation)
     if is_pydantic_v1_model_class(annotation):
         return True
     origin = get_origin(annotation)

--- a/fastapi/_compat/v2.py
+++ b/fastapi/_compat/v2.py
@@ -364,12 +364,14 @@ def copy_field_info(*, field_info: FieldInfo, annotation: Any) -> FieldInfo:
 
 
 def serialize_sequence_value(*, field: ModelField, value: Any) -> Sequence[Any]:
-    origin_type = get_origin(field.field_info.annotation) or field.field_info.annotation
+    annotation = shared._unwrap_typealiastype(field.field_info.annotation)
+    origin_type = get_origin(annotation) or annotation
     if origin_type is Union or origin_type is UnionType:  # Handle optional sequences
-        union_args = get_args(field.field_info.annotation)
+        union_args = get_args(annotation)
         for union_arg in union_args:
             if union_arg is type(None):
                 continue
+            union_arg = shared._unwrap_typealiastype(union_arg)
             origin_type = get_origin(union_arg) or union_arg
             break
     assert issubclass(origin_type, shared.sequence_types)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
@@ -446,6 +448,7 @@ def get_flat_models_from_model(
 def get_flat_models_from_annotation(
     annotation: Any, known_models: TypeModelSet
 ) -> TypeModelSet:
+    annotation = shared._unwrap_typealiastype(annotation)
     origin = get_origin(annotation)
     if origin is not None:
         for arg in get_args(annotation):
@@ -462,7 +465,7 @@ def get_flat_models_from_annotation(
 def get_flat_models_from_field(
     field: ModelField, known_models: TypeModelSet
 ) -> TypeModelSet:
-    field_type = field.field_info.annotation
+    field_type = shared._unwrap_typealiastype(field.field_info.annotation)
     if lenient_issubclass(field_type, BaseModel):
         if field_type in known_models:
             return known_models

--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -259,6 +259,8 @@ _STREAM_ORIGINS = {
 
 
 def get_stream_item_type(annotation: Any) -> Any | None:
+    while is_typealiastype(annotation):
+        annotation = annotation.__value__
     origin = get_origin(annotation)
     if origin is not None and origin in _STREAM_ORIGINS:
         type_args = get_args(annotation)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -159,3 +159,39 @@ def test_typealiastype_sequence_introspection_and_serialization():
     result = v2.serialize_sequence_value(field=field, value=["a", "b"])
     assert result == ["a", "b"]
     assert isinstance(result, list)
+
+
+def test_typealiastype_helpers_and_flat_models():
+    from collections.abc import AsyncGenerator
+
+    from fastapi._compat import shared, v2
+    from fastapi.dependencies.utils import get_stream_item_type
+    from pydantic import BaseModel
+    from starlette.datastructures import UploadFile
+    from typing_extensions import TypeAliasType
+
+    class InnerModel(BaseModel):
+        x: int
+
+    BytesAlias = TypeAliasType("BytesAlias", bytes)
+    BytesSeqAlias = TypeAliasType("BytesSeqAlias", list[bytes])
+    UploadAlias = TypeAliasType("UploadAlias", UploadFile)
+    UploadSeqAlias = TypeAliasType("UploadSeqAlias", list[UploadFile])
+    ScalarSeqAlias = TypeAliasType("ScalarSeqAlias", list[str])
+    ModelAlias = TypeAliasType("ModelAlias", InnerModel)
+    StreamAlias = TypeAliasType("StreamAlias", AsyncGenerator[str, None])
+
+    assert shared.is_bytes_or_nonable_bytes_annotation(BytesAlias)
+    assert shared.is_bytes_sequence_annotation(BytesSeqAlias)
+    assert shared.is_uploadfile_or_nonable_uploadfile_annotation(UploadAlias)
+    assert shared.is_uploadfile_sequence_annotation(UploadSeqAlias)
+    assert shared.field_annotation_is_scalar_sequence(ScalarSeqAlias)
+    assert not shared.annotation_is_pydantic_v1(ModelAlias)
+    assert get_stream_item_type(StreamAlias) is str
+
+    # Flat models extraction
+    ListModelAlias = TypeAliasType("ListModelAlias", list[InnerModel])
+    assert InnerModel in v2.get_flat_models_from_annotation(ListModelAlias, set())
+    field_info = FieldInfo(annotation=cast(Any, ModelAlias))
+    field = v2.ModelField(name="inner", field_info=field_info)
+    assert InnerModel in v2.get_flat_models_from_field(field, set())

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -138,3 +138,24 @@ def test_serialize_sequence_value_with_none_first_in_union():
     result = v2.serialize_sequence_value(field=field, value=["x", "y"])
     assert result == ["x", "y"]
     assert isinstance(result, list)
+
+
+def test_typealiastype_sequence_introspection_and_serialization():
+    from fastapi._compat import shared, v2
+    from typing_extensions import TypeAliasType
+
+    ListAlias = TypeAliasType("ListAlias", list[str])
+    SetAlias = TypeAliasType("SetAlias", set[int])
+    UnionAlias = TypeAliasType("UnionAlias", list[str] | None)
+
+    assert shared.field_annotation_is_sequence(ListAlias)
+    assert shared.field_annotation_is_sequence(SetAlias)
+    assert shared.field_annotation_is_sequence(UnionAlias)
+    assert shared.field_annotation_is_complex(ListAlias)
+    assert not shared.field_annotation_is_scalar(ListAlias)
+
+    field_info = FieldInfo(annotation=cast(Any, ListAlias))
+    field = v2.ModelField(name="items", field_info=field_info)
+    result = v2.serialize_sequence_value(field=field, value=["a", "b"])
+    assert result == ["a", "b"]
+    assert isinstance(result, list)

--- a/tests/test_pep695_params.py
+++ b/tests/test_pep695_params.py
@@ -1,0 +1,159 @@
+from typing import Annotated
+
+from fastapi import FastAPI, File, Form, Query, UploadFile
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from typing_extensions import TypeAliasType
+
+StrListAlias = TypeAliasType("StrListAlias", list[str])
+IntSetAlias = TypeAliasType("IntSetAlias", set[int])
+UploadFileListAlias = TypeAliasType("UploadFileListAlias", list[UploadFile])
+BytesListAlias = TypeAliasType("BytesListAlias", list[bytes])
+OptionalStrListAlias = TypeAliasType("OptionalStrListAlias", list[str] | None)
+ChainedListAlias = TypeAliasType("ChainedListAlias", StrListAlias)
+
+
+class ItemModel(BaseModel):
+    tags: StrListAlias
+    counts: IntSetAlias
+
+
+app = FastAPI()
+
+
+@app.get("/query-list")
+def get_query_list(q: Annotated[StrListAlias, Query()]):
+    return {"q": q}
+
+
+@app.get("/query-chained")
+def get_query_chained(q: Annotated[ChainedListAlias, Query()]):
+    return {"q": q}
+
+
+@app.get("/query-set")
+def get_query_set(s: Annotated[IntSetAlias, Query()]):
+    return {"s": sorted(s)}
+
+
+@app.get("/query-optional")
+def get_query_optional(q: Annotated[OptionalStrListAlias, Query()] = None):
+    return {"q": q}
+
+
+@app.post("/form-model")
+def post_form_model(item: Annotated[ItemModel, Form()]):
+    return {"tags": item.tags, "counts": sorted(item.counts)}
+
+
+@app.post("/upload-files")
+async def post_upload_files(files: Annotated[UploadFileListAlias, File()]):
+    return {"filenames": [f.filename for f in files]}
+
+
+@app.post("/upload-bytes")
+async def post_upload_bytes(files: Annotated[BytesListAlias, File()]):
+    return {"sizes": [len(b) for b in files]}
+
+
+client = TestClient(app)
+
+
+def test_query_list_pep695():
+    response = client.get("/query-list", params=[("q", "a"), ("q", "b"), ("q", "c")])
+    assert response.status_code == 200, response.text
+    assert response.json() == {"q": ["a", "b", "c"]}
+
+
+def test_query_chained_alias_pep695():
+    response = client.get("/query-chained", params=[("q", "1"), ("q", "2")])
+    assert response.status_code == 200, response.text
+    assert response.json() == {"q": ["1", "2"]}
+
+
+def test_query_set_pep695():
+    response = client.get(
+        "/query-set", params=[("s", "1"), ("s", "2"), ("s", "2"), ("s", "3")]
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"s": [1, 2, 3]}
+
+
+def test_query_optional_pep695():
+    response = client.get("/query-optional")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"q": None}
+
+    response = client.get("/query-optional", params=[("q", "a"), ("q", "b")])
+    assert response.status_code == 200, response.text
+    assert response.json() == {"q": ["a", "b"]}
+
+
+def test_form_model_pep695():
+    response = client.post(
+        "/form-model", data={"tags": ["tag1", "tag2"], "counts": ["1", "2"]}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"tags": ["tag1", "tag2"], "counts": [1, 2]}
+
+
+def test_upload_files_pep695():
+    response = client.post(
+        "/upload-files",
+        files=[
+            ("files", ("test1.txt", b"hello", "text/plain")),
+            ("files", ("test2.txt", b"world", "text/plain")),
+        ],
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"filenames": ["test1.txt", "test2.txt"]}
+
+
+def test_upload_bytes_pep695():
+    response = client.post(
+        "/upload-bytes",
+        files=[
+            ("files", ("b1.bin", b"12345", "application/octet-stream")),
+            ("files", ("b2.bin", b"123", "application/octet-stream")),
+        ],
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"sizes": [5, 3]}
+
+
+def test_openapi_schema_pep695():
+    schema = app.openapi()
+    assert "/query-list" in schema["paths"]
+    query_param = schema["paths"]["/query-list"]["get"]["parameters"][0]
+    assert query_param["name"] == "q"
+    assert query_param["in"] == "query"
+    assert "StrListAlias" in schema["components"]["schemas"]
+
+
+def test_native_pep695_syntax_on_python312():
+    import sys
+
+    if sys.version_info < (3, 12):
+        return
+
+    code = """
+type NativeList = list[str]
+
+native_app = FastAPI()
+
+@native_app.get("/native-query")
+def get_native_query(tags: Annotated[NativeList, Query()]):
+    return {"tags": tags}
+
+native_client = TestClient(native_app)
+resp = native_client.get("/native-query", params=[("tags", "one"), ("tags", "two")])
+assert resp.status_code == 200
+assert resp.json() == {"tags": ["one", "two"]}
+"""
+    local_ns = {
+        "FastAPI": FastAPI,
+        "Annotated": Annotated,
+        "Query": Query,
+        "TestClient": TestClient,
+    }
+    exec(code, local_ns)


### PR DESCRIPTION
### Description
When using Python 3.12+ PEP 695 type aliases (e.g. `type Tags = list[str]`) or `typing_extensions.TypeAliasType` as parameter annotations:

- `field_annotation_is_sequence()` classified the alias as a scalar instead of a sequence because `get_origin()` returned `None` and `isinstance(TypeAliasType, type)` is `False`.
- Query and Form parameters called `.get(param)` instead of `.getlist(param)`, dropping repeated values and failing validation with HTTP 422.
- `serialize_sequence_value()` raised `TypeError: issubclass() arg 1 must be a class` when invoked on `TypeAliasType`.
- OpenAPI flat model extraction missed nested models wrapped in type aliases.

```python
type Tags = list[str]

@app.get("/items/")
def read_items(tags: Annotated[Tags, Query()]):
    return {"tags": tags}  # Previously treated as scalar or failed serialization
