### PR TITLE
🐛 Fix optional Json[list[T]] parameters treated as repeated values

### DIFF
--- a/fastapi/dependencies/utils.py
+++ b/fastapi/dependencies/utils.py
@@ -67,7 +67,7 @@ from fastapi.dependencies.models import (
 from fastapi.exceptions import DependencyScopeError
 from fastapi.logger import logger
 from fastapi.security.oauth2 import SecurityScopes
-from fastapi.types import DependencyCacheKey
+from fastapi.types import DependencyCacheKey, UnionType
 from fastapi.utils import create_model_field, get_path_param_names
 from pydantic import BaseModel, Json
 from pydantic.fields import FieldInfo
@@ -742,8 +742,20 @@ def _validate_value_with_model_field(
     return field.validate(value, values, loc=loc)
 
 
+def _annotation_has_json(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        args = get_args(annotation)
+        return any(type(m) is Json for m in args[1:]) or _annotation_has_json(args[0])
+    if origin is Union or origin is UnionType:
+        return any(_annotation_has_json(arg) for arg in get_args(annotation))
+    return False
+
+
 def _is_json_field(field: ModelField) -> bool:
-    return any(type(item) is Json for item in field.field_info.metadata)
+    return any(type(item) is Json for item in field.field_info.metadata) or (
+        _annotation_has_json(field.field_info.annotation)
+    )
 
 
 def _get_multidict_value(

--- a/tests/test_json_type.py
+++ b/tests/test_json_type.py
@@ -3,9 +3,14 @@ from typing import Annotated
 
 from fastapi import Cookie, FastAPI, Form, Header, Query
 from fastapi.testclient import TestClient
-from pydantic import Json
+from pydantic import BaseModel, Json
 
 app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    number: int
 
 
 @app.post("/form-json-list")
@@ -13,8 +18,36 @@ def form_json_list(items: Annotated[Json[list[str]], Form()]) -> list[str]:
     return items
 
 
+@app.post("/form-json-list-optional")
+def form_json_list_optional(
+    items: Annotated[Json[list[str]] | None, Form()] = None,
+) -> list[str] | None:
+    return items
+
+
+@app.post("/form-json-item-list-optional")
+def form_json_item_list_optional(
+    items: Annotated[Json[list[Item]] | None, Form()] = None,
+) -> list[str]:
+    return [item.name for item in items or []]
+
+
+@app.post("/form-json-item-optional")
+def form_json_item_optional(
+    item: Annotated[Json[Item] | None, Form()] = None,
+) -> Item | None:
+    return item
+
+
 @app.get("/query-json-list")
 def query_json_list(items: Annotated[Json[list[str]], Query()]) -> list[str]:
+    return items
+
+
+@app.get("/query-json-list-optional")
+def query_json_list_optional(
+    items: Annotated[Json[list[str]] | None, Query()] = None,
+) -> list[str] | None:
     return items
 
 
@@ -23,8 +56,22 @@ def header_json_list(x_items: Annotated[Json[list[str]], Header()]) -> list[str]
     return x_items
 
 
+@app.get("/header-json-list-optional")
+def header_json_list_optional(
+    x_items: Annotated[Json[list[str]] | None, Header()] = None,
+) -> list[str] | None:
+    return x_items
+
+
 @app.get("/cookie-json-list")
 def cookie_json_list(items: Annotated[Json[list[str]], Cookie()]) -> list[str]:
+    return items
+
+
+@app.get("/cookie-json-list-optional")
+def cookie_json_list_optional(
+    items: Annotated[Json[list[str]] | None, Cookie()] = None,
+) -> list[str] | None:
     return items
 
 
@@ -39,12 +86,58 @@ def test_form_json_list():
     assert response.json() == ["abc", "def"]
 
 
+def test_form_json_list_optional():
+    response = client.post(
+        "/form-json-list-optional", data={"items": json.dumps(["abc", "def"])}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == ["abc", "def"]
+
+
+def test_form_json_list_optional_omitted():
+    response = client.post("/form-json-list-optional")
+    assert response.status_code == 200, response.text
+    assert response.json() is None
+
+
+def test_form_json_item_list_optional():
+    payload = json.dumps(
+        [{"name": "first", "number": 1}, {"name": "second", "number": 2}]
+    )
+    response = client.post("/form-json-item-list-optional", data={"items": payload})
+    assert response.status_code == 200, response.text
+    assert response.json() == ["first", "second"]
+
+
+def test_form_json_item_optional():
+    response = client.post(
+        "/form-json-item-optional",
+        data={"item": json.dumps({"name": "first", "number": 1})},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"name": "first", "number": 1}
+
+
 def test_query_json_list():
     response = client.get(
         "/query-json-list", params={"items": json.dumps(["abc", "def"])}
     )
     assert response.status_code == 200, response.text
     assert response.json() == ["abc", "def"]
+
+
+def test_query_json_list_optional():
+    response = client.get(
+        "/query-json-list-optional", params={"items": json.dumps(["abc", "def"])}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == ["abc", "def"]
+
+
+def test_query_json_list_optional_omitted():
+    response = client.get("/query-json-list-optional")
+    assert response.status_code == 200, response.text
+    assert response.json() is None
 
 
 def test_header_json_list():
@@ -55,9 +148,26 @@ def test_header_json_list():
     assert response.json() == ["abc", "def"]
 
 
+def test_header_json_list_optional():
+    response = client.get(
+        "/header-json-list-optional",
+        headers={"x-items": json.dumps(["abc", "def"])},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == ["abc", "def"]
+
+
 def test_cookie_json_list():
     client.cookies.set("items", json.dumps(["abc", "def"]))
     response = client.get("/cookie-json-list")
+    assert response.status_code == 200, response.text
+    assert response.json() == ["abc", "def"]
+    client.cookies.clear()
+
+
+def test_cookie_json_list_optional():
+    client.cookies.set("items", json.dumps(["abc", "def"]))
+    response = client.get("/cookie-json-list-optional")
     assert response.status_code == 200, response.text
     assert response.json() == ["abc", "def"]
     client.cookies.clear()


### PR DESCRIPTION
Optional `Json[list[T]]` parameters (`Json[list[T]] | None`) were treated as repeated sequence fields after 0.140.10.

`_is_json_field()` only inspected top-level `field_info.metadata`. Pydantic hoists the `Json` marker there for required fields, but leaves it nested in the union arm for `Json[list[T]] | None`. Meanwhile `field_annotation_is_sequence()` now unwraps `Annotated`, so `_get_multidict_value()` called `.getlist()` and wrapped the JSON string in a list. Pydantic then rejected it with `json_type`.

This change walks union and `Annotated` annotations for `Json` markers so Form, Query, Header, and Cookie fields keep using `.get()`. Required `Json[list[T]]` behavior is unchanged.

Fixes https://github.com/fastapi/fastapi/discussions/16220