### PR TITLE
fix: invalidate included router cache on direct APIRouter.routes mutation (#16301)

### DIFF
--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -2715,7 +2715,6 @@ class APIRouter(routing.Router):
             name=name,
             include_in_schema=include_in_schema,
         )
-        self._mark_routes_changed()
 
     def add_websocket_route(
         self,
@@ -2724,7 +2723,6 @@ class APIRouter(routing.Router):
         name: str | None = None,
     ) -> None:
         super().add_websocket_route(path, endpoint, name=name)
-        self._mark_routes_changed()
 
     def frontend(
         self,
@@ -3067,7 +3065,6 @@ class APIRouter(routing.Router):
             ),
         )
         self.routes.append(route)
-        self._mark_routes_changed()
 
     def api_route(
         self,
@@ -3151,7 +3148,6 @@ class APIRouter(routing.Router):
             dependency_overrides_provider=self.dependency_overrides_provider,
         )
         self.routes.append(route)
-        self._mark_routes_changed()
 
     def websocket(
         self,
@@ -3408,7 +3404,6 @@ class APIRouter(routing.Router):
         self.routes.append(
             _IncludedRouter(original_router=router, include_context=include_context)
         )
-        self._mark_routes_changed()
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/fastapi/routing.py
+++ b/fastapi/routing.py
@@ -17,6 +17,7 @@ from collections.abc import (
     Collection,
     Coroutine,
     Generator,
+    Iterable,
     Iterator,
     Mapping,
     Sequence,
@@ -35,8 +36,10 @@ from typing import (
     Any,
     Literal,
     Protocol,
+    SupportsIndex,
     TypeVar,
     cast,
+    overload,
 )
 
 import anyio
@@ -2252,7 +2255,89 @@ class _FrontendRouteGroup(BaseRoute):
                 scope["fastapi_function_astack"] = previous_function_astack
 
 
+class _RoutesList(list[BaseRoute]):
+    def __init__(
+        self,
+        iterable: Iterable[BaseRoute] = (),
+        *,
+        on_change: Callable[[], None] | None = None,
+    ) -> None:
+        super().__init__(iterable)
+        self._on_change = on_change
+
+    def _notify(self) -> None:
+        if self._on_change is not None:
+            self._on_change()
+
+    def append(self, item: BaseRoute) -> None:
+        super().append(item)
+        self._notify()
+
+    def extend(self, iterable: Iterable[BaseRoute]) -> None:
+        super().extend(iterable)
+        self._notify()
+
+    def insert(self, index: SupportsIndex, item: BaseRoute) -> None:
+        super().insert(index, item)
+        self._notify()
+
+    def pop(self, index: SupportsIndex = -1) -> BaseRoute:
+        val = super().pop(index)
+        self._notify()
+        return val
+
+    def remove(self, value: BaseRoute) -> None:
+        super().remove(value)
+        self._notify()
+
+    def clear(self) -> None:
+        super().clear()
+        self._notify()
+
+    def sort(self, *, key: Any = None, reverse: bool = False) -> None:
+        super().sort(key=key, reverse=reverse)
+        self._notify()
+
+    def reverse(self) -> None:
+        super().reverse()
+        self._notify()
+
+    @overload
+    def __setitem__(self, key: SupportsIndex, value: BaseRoute) -> None: ...
+
+    @overload
+    def __setitem__(self, key: slice, value: Iterable[BaseRoute]) -> None: ...
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        super().__setitem__(key, value)
+        self._notify()
+
+    @overload
+    def __delitem__(self, key: SupportsIndex) -> None: ...
+
+    @overload
+    def __delitem__(self, key: slice) -> None: ...
+
+    def __delitem__(self, key: Any) -> None:
+        super().__delitem__(key)
+        self._notify()
+
+    def __iadd__(self, other: Iterable[BaseRoute]) -> "_RoutesList":
+        super().__iadd__(other)
+        self._notify()
+        return self
+
+    def __imul__(self, value: SupportsIndex) -> "_RoutesList":
+        super().__imul__(value)
+        self._notify()
+        return self
+
+    def copy(self) -> list[BaseRoute]:
+        return list(self)
+
+
 class APIRouter(routing.Router):
+    _routes_version: int = 0
     """
     `APIRouter` class, used to group *path operations*, for example to structure
     an app in multiple files. It would then be included in the `FastAPI` app, or
@@ -2529,6 +2614,8 @@ class APIRouter(routing.Router):
             lifespan_context = lifespan
         self.lifespan_context = lifespan_context
 
+        self._routes_version = 0
+        self._routes: _RoutesList = _RoutesList(on_change=self._mark_routes_changed)
         super().__init__(
             routes=routes,
             redirect_slashes=redirect_slashes,
@@ -2566,6 +2653,18 @@ class APIRouter(routing.Router):
         self._routes_version = 0
         self._low_priority_routes: list[BaseRoute] = []
         self._frontend_routes: _FrontendRouteGroup | None = None
+
+    @property
+    def routes(self) -> list[BaseRoute]:
+        return self._routes
+
+    @routes.setter
+    def routes(self, value: Sequence[BaseRoute] | None) -> None:
+        self._routes = _RoutesList(
+            value or [],
+            on_change=self._mark_routes_changed,
+        )
+        self._mark_routes_changed()
 
     def _mark_routes_changed(self) -> None:
         self._routes_version += 1

--- a/tests/test_router_cache_invalidation.py
+++ b/tests/test_router_cache_invalidation.py
@@ -290,3 +290,21 @@ def test_routes_mutation_invalidates_openapi_schema_cache():
     schema2 = app.openapi()
     assert "/api/first" in schema2["paths"]
     assert "/api/second" in schema2["paths"]
+
+
+def test_route_registration_increments_version_exactly_once():
+    router = APIRouter()
+    initial_version = router._routes_version
+
+    @router.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    assert router._routes_version == initial_version + 1
+
+    router.add_api_route("/second", lambda: {"msg": "second"})
+    assert router._routes_version == initial_version + 2
+
+    other = APIRouter()
+    router.include_router(other, prefix="/sub")
+    assert router._routes_version == initial_version + 3

--- a/tests/test_router_cache_invalidation.py
+++ b/tests/test_router_cache_invalidation.py
@@ -1,0 +1,292 @@
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+
+def test_child_routes_append_invalidates_parent_cache():
+    child = APIRouter()
+
+    @child.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    # Initial dispatch caches effective routes
+    res = client.get("/api/first")
+    assert res.status_code == 200
+    assert res.json() == {"msg": "first"}
+
+    res = client.get("/api/second")
+    assert res.status_code == 404
+
+    # Directly mutate child.routes via append
+    def second():
+        return {"msg": "second"}
+
+    child.routes.append(APIRoute("/second", second))
+
+    # Dispatch should now recognize the newly appended route without stale cache
+    res = client.get("/api/second")
+    assert res.status_code == 200
+    assert res.json() == {"msg": "second"}
+
+
+def test_child_routes_remove_invalidates_parent_cache():
+    child = APIRouter()
+
+    @child.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    @child.get("/second")
+    def second():
+        return {"msg": "second"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    # Initial dispatch
+    res = client.get("/api/first")
+    assert res.status_code == 200
+    res = client.get("/api/second")
+    assert res.status_code == 200
+
+    # Remove the first route directly
+    first_route = child.routes[0]
+    child.routes.remove(first_route)
+
+    # Dispatch should not have ghost route for /first
+    res = client.get("/api/first")
+    assert res.status_code == 404
+    res = client.get("/api/second")
+    assert res.status_code == 200
+
+
+def test_child_routes_pop_and_clear_invalidates_parent_cache():
+    child = APIRouter()
+
+    @child.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    @child.get("/second")
+    def second():
+        return {"msg": "second"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    assert client.get("/api/second").status_code == 200
+    child.routes.pop()
+    assert client.get("/api/second").status_code == 404
+    assert client.get("/api/first").status_code == 200
+
+    child.routes.clear()
+    assert client.get("/api/first").status_code == 404
+
+
+def test_child_routes_extend_and_insert_invalidates_parent_cache():
+    child = APIRouter()
+
+    @child.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    assert client.get("/api/first").status_code == 200
+
+    def r2():
+        return {"msg": "r2"}
+
+    def r3():
+        return {"msg": "r3"}
+
+    child.routes.extend([APIRoute("/r2", r2), APIRoute("/r3", r3)])
+
+    assert client.get("/api/r2").status_code == 200
+    assert client.get("/api/r3").status_code == 200
+
+    def r0():
+        return {"msg": "r0"}
+
+    child.routes.insert(0, APIRoute("/r0", r0))
+    assert client.get("/api/r0").status_code == 200
+
+
+def test_child_routes_item_assignment_and_deletion_invalidates_parent_cache():
+    child = APIRouter()
+
+    @child.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    assert client.get("/api/first").status_code == 200
+
+    def replaced():
+        return {"msg": "replaced"}
+
+    # Replace via __setitem__
+    child.routes[0] = APIRoute("/replaced", replaced)
+    assert client.get("/api/first").status_code == 404
+    assert client.get("/api/replaced").status_code == 200
+
+    # Delete via __delitem__
+    del child.routes[0]
+    assert client.get("/api/replaced").status_code == 404
+
+
+def test_child_routes_slice_assignment_and_deletion_invalidates_parent_cache():
+    child = APIRouter()
+
+    @child.get("/a")
+    def a():
+        return {"msg": "a"}
+
+    @child.get("/b")
+    def b():
+        return {"msg": "b"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    assert client.get("/api/a").status_code == 200
+    assert client.get("/api/b").status_code == 200
+
+    def c():
+        return {"msg": "c"}
+
+    def d():
+        return {"msg": "d"}
+
+    child.routes[0:2] = [APIRoute("/c", c), APIRoute("/d", d)]
+    assert client.get("/api/a").status_code == 404
+    assert client.get("/api/b").status_code == 404
+    assert client.get("/api/c").status_code == 200
+    assert client.get("/api/d").status_code == 200
+
+    del child.routes[0:1]
+    assert client.get("/api/c").status_code == 404
+    assert client.get("/api/d").status_code == 200
+
+
+def test_child_routes_iadd_and_assignment_invalidates_parent_cache():
+    child = APIRouter()
+
+    @child.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    assert client.get("/api/first").status_code == 200
+
+    def second():
+        return {"msg": "second"}
+
+    child.routes += [APIRoute("/second", second)]
+    assert client.get("/api/second").status_code == 200
+
+    def third():
+        return {"msg": "third"}
+
+    child.routes = [APIRoute("/third", third)]
+    assert client.get("/api/first").status_code == 404
+    assert client.get("/api/second").status_code == 404
+    assert client.get("/api/third").status_code == 200
+
+
+def test_deeply_nested_router_routes_mutation_invalidates_cache():
+    grandchild = APIRouter()
+
+    @grandchild.get("/leaf")
+    def leaf():
+        return {"msg": "leaf"}
+
+    child = APIRouter()
+    child.include_router(grandchild, prefix="/nested")
+
+    parent = APIRouter()
+    parent.include_router(child, prefix="/sub")
+
+    app = FastAPI()
+    app.include_router(parent, prefix="/root")
+    client = TestClient(app)
+
+    assert client.get("/root/sub/nested/leaf").status_code == 200
+
+    # Add a route to grandchild directly
+    def leaf2():
+        return {"msg": "leaf2"}
+
+    grandchild.routes.append(APIRoute("/leaf2", leaf2))
+    assert client.get("/root/sub/nested/leaf2").status_code == 200
+
+    # Remove the original route from grandchild
+    grandchild.routes.pop(0)
+    assert client.get("/root/sub/nested/leaf").status_code == 404
+    assert client.get("/root/sub/nested/leaf2").status_code == 200
+
+
+def test_child_starlette_route_mutation_invalidates_parent_cache():
+    child = APIRouter()
+
+    def starlette_handler(request):
+        return PlainTextResponse("starlette")
+
+    child.routes.append(Route("/starlette", starlette_handler))
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+    client = TestClient(app)
+
+    res = client.get("/api/starlette")
+    assert res.status_code == 200
+    assert res.text == "starlette"
+
+    child.routes.clear()
+    res = client.get("/api/starlette")
+    assert res.status_code == 404
+
+
+def test_routes_mutation_invalidates_openapi_schema_cache():
+    child = APIRouter()
+
+    @child.get("/first")
+    def first():
+        return {"msg": "first"}
+
+    app = FastAPI()
+    app.include_router(child, prefix="/api")
+
+    # Initial openapi schema generation
+    schema1 = app.openapi()
+    assert "/api/first" in schema1["paths"]
+    assert "/api/second" not in schema1["paths"]
+
+    # Mutate child routes directly
+    def second():
+        return {"msg": "second"}
+
+    child.routes.append(APIRoute("/second", second))
+
+    # OpenAPI schema should be refreshed
+    schema2 = app.openapi()
+    assert "/api/first" in schema2["paths"]
+    assert "/api/second" in schema2["paths"]


### PR DESCRIPTION
### Description
When \APIRouter.routes\ was directly mutated (e.g., via \.append()\, \.remove()\, \.pop()\, \.clear()\, \.extend()\, \__setitem__\, \__delitem__\, in-place \+=\, or reassignment \outer.routes = [...]\), the router's internal \_routes_version\ was not incremented. Consequently, \_IncludedRouter.effective_candidates()\ (and OpenAPI schema cache) served stale or ghost routes from its cache.

### Changes
- Implemented \_RoutesList\ subclassing \list[BaseRoute]\ with mutation notifications triggering \_mark_routes_changed()\.
- Added property getter and setter for \APIRouter.routes\ to wrap routes in \_RoutesList\ and ensure assignments increment \_routes_version\.
- Added regression tests in \	ests/test_router_cache_invalidation.py\ covering direct route addition, removal, popping, clearing, slicing, deletion, reassignment, nested router propagation, Starlette Route mutation, and OpenAPI schema cache invalidation.

Fixes #16301